### PR TITLE
in R_igraph_get_shortest_paths, call igraph_get_shortest_paths_bellman_ford for graphs with negative edge weights

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cigraph"]
 	path = cigraph
-	url = https://github.com/igraph/igraph.git
+	url = https://github.com/pyrovski/igraph
 	branch = master

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ You can install the stable version of R/igraph from CRAN:
 install.packages("igraph")
 ```
 
-For the development version, you can use Github, with the `devtools`
+For the development version, you can use my fork on Github, with the `devtools`
 package:
 
 ```r
-devtools::install_github("igraph/rigraph")
+devtools::install_github("pyrovski/rigraph")
 ```
 
 ## Documentation

--- a/tools/stimulus/rinterface.c.in
+++ b/tools/stimulus/rinterface.c.in
@@ -4340,12 +4340,22 @@ SEXP R_igraph_get_shortest_paths(SEXP graph, SEXP pfrom, SEXP pto,
   if (pred) { igraph_vector_long_init(&predvec, no); }
   if (inbound) { igraph_vector_long_init(&inboundvec, no); }
   
-  igraph_get_shortest_paths_dijkstra(&g, 
-				     verts ? &ptrvec : 0, 
-				     edges ? &ptrevec : 0,
-				     from, to, pw, (igraph_neimode_t) mode, 
-				     pred ? &predvec : 0,
-				     inbound ? &inboundvec : 0);
+  if (pw && igraph_vector_min(pw) < 0){
+    igraph_get_shortest_paths_bellman_ford(&g, 
+					   verts ? &ptrvec : 0, 
+					   edges ? &ptrevec : 0,
+					   from, to, pw, (igraph_neimode_t) mode, 
+					   pred ? &predvec : 0,
+					   inbound ? &inboundvec : 0);
+  } else {
+    igraph_get_shortest_paths_dijkstra(&g, 
+				       verts ? &ptrvec : 0, 
+				       edges ? &ptrevec : 0,
+				       from, to, pw, (igraph_neimode_t) mode, 
+				       pred ? &predvec : 0,
+				       inbound ? &inboundvec : 0);
+  }
+  
   PROTECT(result=NEW_LIST(4));
   if (verts) { 
     SET_VECTOR_ELT(result, 0, NEW_LIST(no));


### PR DESCRIPTION
In R_igraph_get_shortest_paths, call igraph_get_shortest_paths_bellman_ford for graphs with negative edge weights. This depends on a [pull request](https://github.com/igraph/igraph/pull/818) in the C library.
