### PR TITLE
R: fix bug plotting named graphs with marked groups

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -158,6 +158,8 @@ plot.igraph <- function(x,
   if (!is.list(mark.groups) && is.numeric(mark.groups)) {
     mark.groups <- list(mark.groups)
   }
+  
+  if (is_named(x)) rownames(layout) <- V(x)$name
 
   mark.shape  <- rep(mark.shape,  length=length(mark.groups))
   mark.border <- rep(mark.border, length=length(mark.groups))


### PR DESCRIPTION
Plotting marked groups works fine with unnamed graphs:

```r
karate <- graph.famous("Zachary")
plot.igraph(karate, mark.groups = list(grp = c(33, 34)))
```
![Plot marked groups in unnamed graph](https://cloud.githubusercontent.com/assets/1067915/7962688/c587a9f0-09dc-11e5-9b8d-3870e59935f9.png)

But fails with named graphs:

```r
V(karate)$name <- paste0("v", 1:vcount(karate))
plot.igraph(karate, mark.groups = list(grp = c("v33", "v34")))
```

```
## Error in layout[v, , drop = FALSE] : no 'dimnames' attribute for array
```

