### PR TITLE
Added condition so that SIOCGIFHWADDR block is excluded for SmartOS(Solaris 11)

### DIFF
--- a/tools/uuid/gen_uuid.c
+++ b/tools/uuid/gen_uuid.c
@@ -187,7 +187,7 @@ static int get_node_id(unsigned char *node_id)
 	for (i = 0; i < n; i+= ifreq_size(*ifrp) ) {
 		ifrp = (struct ifreq *)((char *) ifc.ifc_buf+i);
 		strncpy(ifr.ifr_name, ifrp->ifr_name, IFNAMSIZ);
-#ifdef SIOCGIFHWADDR
+#ifdef SIOCGIFHWADDR && !defined(__sun)
 		if (ioctl(sd, SIOCGIFHWADDR, &ifr) < 0)
 			continue;
 		a = (unsigned char *) &ifr.ifr_hwaddr.sa_data;

--- a/tools/uuid/gen_uuid.c
+++ b/tools/uuid/gen_uuid.c
@@ -187,7 +187,8 @@ static int get_node_id(unsigned char *node_id)
 	for (i = 0; i < n; i+= ifreq_size(*ifrp) ) {
 		ifrp = (struct ifreq *)((char *) ifc.ifc_buf+i);
 		strncpy(ifr.ifr_name, ifrp->ifr_name, IFNAMSIZ);
-#ifdef SIOCGIFHWADDR && !defined(__sun)
+#ifdef SIOCGIFHWADDR
+	if (!defined(__sun))
 		if (ioctl(sd, SIOCGIFHWADDR, &ifr) < 0)
 			continue;
 		a = (unsigned char *) &ifr.ifr_hwaddr.sa_data;

--- a/tools/uuid/gen_uuid.c
+++ b/tools/uuid/gen_uuid.c
@@ -187,8 +187,7 @@ static int get_node_id(unsigned char *node_id)
 	for (i = 0; i < n; i+= ifreq_size(*ifrp) ) {
 		ifrp = (struct ifreq *)((char *) ifc.ifc_buf+i);
 		strncpy(ifr.ifr_name, ifrp->ifr_name, IFNAMSIZ);
-#ifdef SIOCGIFHWADDR
-	if (!defined(__sun__))
+#if defined(SIOCGIFHWADDR) && (!defined(__sun__))
 		if (ioctl(sd, SIOCGIFHWADDR, &ifr) < 0)
 			continue;
 		a = (unsigned char *) &ifr.ifr_hwaddr.sa_data;

--- a/tools/uuid/gen_uuid.c
+++ b/tools/uuid/gen_uuid.c
@@ -188,7 +188,7 @@ static int get_node_id(unsigned char *node_id)
 		ifrp = (struct ifreq *)((char *) ifc.ifc_buf+i);
 		strncpy(ifr.ifr_name, ifrp->ifr_name, IFNAMSIZ);
 #ifdef SIOCGIFHWADDR
-	if (!defined(__sun))
+	if (!defined(__sun__))
 		if (ioctl(sd, SIOCGIFHWADDR, &ifr) < 0)
 			continue;
 		a = (unsigned char *) &ifr.ifr_hwaddr.sa_data;


### PR DESCRIPTION
This pull request is for the issue https://github.com/igraph/rigraph/issues/127

This fix will allow us to compile igraph sucessfully on Solaris 11 and SmartOS operating systems
