### PR TITLE
DOC: typo weight instead of weigth

### DIFF
--- a/R/centrality.R
+++ b/R/centrality.R
@@ -562,7 +562,7 @@ diversity <- diversity
 #' scores. If the graph has a \code{weight} edge attribute, then this is used
 #' by default.
 #' This function interprets edge weights as connection strengths. In the
-#' random surfer model, an edge with a larger weigth is more likely to be
+#' random surfer model, an edge with a larger weight is more likely to be
 #' selected by the surfer.
 #' @param options A named list, to override some ARPACK options. See
 #' \code{\link{arpack}} for details.
@@ -612,7 +612,7 @@ hub_score <- hub_score
 #' scores. If the graph has a \code{weight} edge attribute, then this is used
 #' by default.
 #' This function interprets edge weights as connection strengths. In the
-#' random surfer model, an edge with a larger weigth is more likely to be
+#' random surfer model, an edge with a larger weight is more likely to be
 #' selected by the surfer.
 #' @param options A named list, to override some ARPACK options. See
 #' \code{\link{arpack}} for details.
@@ -712,7 +712,7 @@ authority_score <- authority_score
 #' the graph has a \code{weights} edge attribute. If this is \code{NA}, then no
 #' edge weights are used (even if the graph has a \code{weight} edge attribute.
 #' This function interprets edge weights as connection strengths. In the
-#' random surfer model, an edge with a larger weigth is more likely to be
+#' random surfer model, an edge with a larger weight is more likely to be
 #' selected by the surfer.
 #' @param options Either a named list, to override some ARPACK options. See
 #' \code{\link{arpack}} for details; or a named list to override the default

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -99,7 +99,7 @@
 #'     have to be \sQuote{weight}: \preformatted{  graph[1, 2, attr="weight"]<- 5
 #' graph[from=1:3, to=c(2,3,5)] <- c(1,-1,4)}
 #'     If an edge is already present in the network, then only its
-#'     weigths or other attribute are updated. If the graph is already
+#'     weights or other attribute are updated. If the graph is already
 #'     weighted, then the \code{attr="weight"} setting is implicit, and
 #'     one does not need to give it explicitly.
 #'   \item Deleting edges. The replacement syntax allow the deletion of


### PR DESCRIPTION
there may also be a typo of similar nature in inst/benchmarks/local.scan.R