### PR TITLE
Added support for make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,4 +194,19 @@ igraph_$(VERSION).tar.gz: $(CSRC) $(CINC2) $(PARSER2) $(RSRC) $(RGEN) \
 	Rscript -e 'devtools::build(path = ".")'
 #############
 
-.PHONY: all igraph force
+clean:
+	@rm -f  DESCRIPTION
+	@rm -f  NAMESPACE
+	@rm -f  R/auto.R
+	@rm -rf autom4te.cache/
+	@rm -f  config.log
+	@rm -f  config.status
+	@rm -f  configure
+	@rm -f  igraph_*.tar.gz
+	@rm -rf man/*.Rd
+	@rm -f  object_files
+	@rm -rf src/
+	@rm -rf version_number
+	@rm -f  configure.ac
+
+.PHONY: all igraph force clean


### PR DESCRIPTION
Existing Makefile did not have any ability to cleanup after itself. The files that are removed come from the exclusions listed in .gitignore (other than printr.R which seems like it shouldn't be there).

This change requires pull request #144 to prevent the current Rd files from being incorrectly deleted.
