### PR TITLE
Speed up `as_adj_list` if igraph_opt("return.vs.es") is false

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -367,7 +367,12 @@ as.undirected <- function(graph, mode=c("collapse", "each", "mutual"), edge.attr
 #' to include in the lists. \sQuote{\code{out}} is for outgoing edges/vertices,
 #' \sQuote{\code{in}} is for incoming edges/vertices, \sQuote{\code{all}} is
 #' for both. This argument is ignored for undirected graphs.
-#' @return A list of numeric vectors.
+#' @return A list of \code{igraph.vs} or a list of numeric vectors depending on
+#' the value of \code{igraph_opt("return.vs.es")}, see details for performance
+#' characteristics.
+#' @details If \code{igraph_opt("return.vs.es")} is true (default), the numeric
+#' vectors of the adjacency lists are coerced to \code{igraph.vs}, this can be
+#' a very expensive operation on large graphs.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
 #' @seealso \code{\link{as_edgelist}}, \code{\link{as_adj}}
 #' @export
@@ -387,7 +392,12 @@ as_adj_list <- function(graph, mode=c("all", "out", "in", "total")) {
   mode <- as.numeric(switch(mode, "out"=1, "in"=2, "all"=3, "total"=3))
   on.exit( .Call(C_R_igraph_finalizer) )
   res <- .Call(C_R_igraph_get_adjlist, graph, mode)
-  res <- lapply(res, function(x) V(graph)[x + 1])
+  res <- lapply(res, `+`, 1)
+
+  if (igraph_opt("return.vs.es")) {
+    res <- lapply(res, create_vs, graph = graph)
+  }
+  
   if (is_named(graph)) names(res) <- V(graph)$name
   res
 }

--- a/R/structural.properties.R
+++ b/R/structural.properties.R
@@ -1656,13 +1656,15 @@ ego_size <- function(graph, order = 1, nodes=V(graph),
 #' steps are counted. \sQuote{"all"} ignores the direction of the edges. This
 #' argument is ignored for undirected graphs.
 #' @param mindist The minimum distance to include the vertex in the result.
-#' @return \code{ego_size} returns with an integer vector.
-#' 
-#' \code{ego} returns with a list of integer vectors.
-#' 
-#' \code{make_ego_graph} returns with a list of graphs.
-#' 
-#' \code{connect} returns with a new graph object.
+#' @return
+#' \itemize{
+#'   \item{\code{ego_size} returns with an integer vector.}
+#'   \item{\code{ego} returns A list of \code{igraph.vs} or a list of numeric
+#'         vectors depending on the value of \code{igraph_opt("return.vs.es")},
+#'         see details for performance characteristics.}
+#'   \item{\code{make_ego_graph} returns with a list of graphs.}
+#'   \item{\code{connect} returns with a new graph object.}
+#' }
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}, the first version was
 #' done by Vincent Matossian
 #' @export


### PR DESCRIPTION
Also updates the docs to point out that this option exists. Not a fully satisfying solution to #194, but provides a simple work around.