### PR TITLE
Fixes #113 default argument for layout_as_tree

### DIFF
--- a/R/layout.R
+++ b/R/layout.R
@@ -439,8 +439,8 @@ as_star <- function(...) layout_spec(layout_as_star, ...)
 #'                                            rootlevel=c(2,1)))
 
 layout_as_tree <- function(graph, root=numeric(), circular=FALSE,
-                                    rootlevel=numeric(), mode="out",
-                                    flip.y=TRUE) {
+                           rootlevel=numeric(), mode=c("out", "in", "all"),
+                           flip.y=TRUE) {
 
   if (!is_igraph(graph)) {
     stop("Not a graph object")


### PR DESCRIPTION
adds "in" and "all" to the options so that match.arg does not fall over.