### PR TITLE
Export of the as_graphnel function

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -456,7 +456,7 @@ as_adj_edge_list <- function(graph, mode=c("all", "out", "in", "total")) {
 #' g4 <- graph_from_graphnel(GNEL2)
 #' g4
 #' }
-#' #' @export
+#' @export
 
 graph_from_graphnel <- function(graphNEL, name=TRUE, weight=TRUE,
                                  unlist.attrs=TRUE) {


### PR DESCRIPTION
The export-tag for the graphnel function was commented twice withe #'. Therefore the function isn't exported and the tag is just displayed in the examples.