### PR TITLE
graph_from_graphnel wasn't being exported

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -456,7 +456,8 @@ as_adj_edge_list <- function(graph, mode=c("all", "out", "in", "total")) {
 #' g4 <- graph_from_graphnel(GNEL2)
 #' g4
 #' }
-#' #' @export
+#' 
+#' @export
 
 graph_from_graphnel <- function(graphNEL, name=TRUE, weight=TRUE,
                                  unlist.attrs=TRUE) {


### PR DESCRIPTION
Somehow looks like a typo got introduced, and the export directive on this function was lost, which means it was not available to others to use