### PR TITLE
Add .vertex_attr() for developers

### DIFF
--- a/R/attributes.R
+++ b/R/attributes.R
@@ -186,6 +186,11 @@ vertex_attr <- function(graph, name, index=V(graph)) {
   }
 }
 
+# lightweight version for developers
+.vertex_attr <- function(graph) {
+  .Call(C_R_igraph_mybracket2, graph, 9L, 3L)
+}
+
 #' Set one or more vertex attributes
 #'
 #' @param graph The graph.


### PR DESCRIPTION
Both `vertex_attr()` and `vertex.attributes()` use `V(graph)` and/or `as.igraph.vs()`, which have non-negligible impact on performance. This commit provides a minimal function to get vertex attributes. I hope this function will be named properly and exported in the future.

The starting point of this PR was that I found a tautologic usage of `V()` and `vertex_attr()`, i.e., `V()` uses `vertex_attr()`, and `vertex_attr()` uses `V()`. I am curious why they are working without any problem. Anyway we can (should) simplify `vertex_attr()` and `vertex.attributes()`.

https://github.com/igraph/rigraph/blob/5e7a689afde1864c2f36b2a7825db24f2f89b22b/R/attributes.R#L168
https://github.com/igraph/rigraph/blob/5e7a689afde1864c2f36b2a7825db24f2f89b22b/R/iterators.R#L192-L203
