### PR TITLE
Corrected check on NA for weights and capacities.

### DIFF
--- a/R/community.R
+++ b/R/community.R
@@ -456,10 +456,13 @@ modularity_matrix <- function(graph, weights=NULL) {
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
   weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-  weights <- as.numeric(weights)
-  } else {
-  weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -930,10 +933,13 @@ cluster_spinglass <- function(graph, weights=NULL, vertex=NULL, spins=25,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
 
   update.rule <- igraph.match.arg(update.rule)
@@ -1027,17 +1033,23 @@ cluster_leiden <- function(graph, objective_function=c("CPM", "modularity"),
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
 
   # Parse initial_membership argument
-  if (!is.null(initial_membership) && !any(is.na(initial_membership))) {
-    initial_membership <- as.numeric(initial_membership)
-  } else {
-    initial_membership <- NULL
+  if (!is.null(initial_membership)) {
+      if (!any(is.na(initial_membership))) {
+      initial_membership <- as.numeric(initial_membership)
+    } else {
+      warning("Initial membership vector contains NA elements, ignoring the initial membership vector.")
+      initial_membership <- NULL
+    }
   }
 
   # Parse node weights argument
@@ -1459,11 +1471,15 @@ cluster_leading_eigen <- function(graph, steps=-1, weights=NULL,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
+
   if (!is.null(start)) { start <- as.numeric(start)-1 }
   options.tmp <- arpack_defaults; options.tmp[ names(options) ] <- options ; options <- options.tmp
 
@@ -1545,11 +1561,15 @@ cluster_label_prop <- function(graph, weights=NULL, initial=NULL,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
   weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-  weights <- as.numeric(weights)
-  } else {
-  weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
+
   if (!is.null(initial)) initial <- as.numeric(initial)
   if (!is.null(fixed)) fixed <- as.logical(fixed)
 
@@ -1627,10 +1647,13 @@ cluster_louvain <- function(graph, weights=NULL) {
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
   weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-  weights <- as.numeric(weights)
-  } else {
-  weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+    weights <- as.numeric(weights)
+    } else {
+    warning("Weights vector contains NA elements, ignoring the weights vector.")
+    weights <- NULL
+    }
   }
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -1714,10 +1737,13 @@ cluster_optimal <- function(graph, weights=NULL) {
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -1793,18 +1819,24 @@ cluster_infomap <- function(graph, e.weights=NULL, v.weights=NULL,
   if (is.null(e.weights) && "weight" %in% edge_attr_names(graph)) {
     e.weights <- E(graph)$weight
   }
-  if (!is.null(e.weights) && !any(is.na(e.weights))) {
-    e.weights <- as.numeric(e.weights)
-  } else {
-    e.weights <- NULL
+  if (!is.null(e.weights)) {
+    if (!any(is.na(e.weights))) {
+      e.weights <- as.numeric(e.weights)
+    } else {
+      warning("e.weights vector contains NA elements, ignoring the e.weights vector.")
+      e.weights <- NULL
+    }
   }
   if (is.null(v.weights) && "weight" %in% vertex_attr_names(graph)) {
     v.weights <- V(graph)$weight
   }
-  if (!is.null(v.weights) && !any(is.na(v.weights))) {
-    v.weights <- as.numeric(v.weights)
-  } else {
-    v.weights <- NULL
+  if (!is.null(v.weights)) {
+    if (!any(is.na(v.weights))) {
+      v.weights <- as.numeric(v.weights)
+    } else {
+      warning("v.weights vector contains NA elements, ignoring the v.weights vector.")
+      v.weights <- NULL
+    }
   }
   nb.trials <- as.integer(nb.trials)
 

--- a/R/community.R
+++ b/R/community.R
@@ -456,7 +456,7 @@ modularity_matrix <- function(graph, weights=NULL) {
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
   weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
   weights <- as.numeric(weights)
   } else {
   weights <- NULL
@@ -930,7 +930,7 @@ cluster_spinglass <- function(graph, weights=NULL, vertex=NULL, spins=25,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
     weights <- as.numeric(weights)
   } else {
     weights <- NULL
@@ -1459,7 +1459,7 @@ cluster_leading_eigen <- function(graph, steps=-1, weights=NULL,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
     weights <- as.numeric(weights)
   } else {
     weights <- NULL
@@ -1545,7 +1545,7 @@ cluster_label_prop <- function(graph, weights=NULL, initial=NULL,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
   weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
   weights <- as.numeric(weights)
   } else {
   weights <- NULL
@@ -1627,7 +1627,7 @@ cluster_louvain <- function(graph, weights=NULL) {
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
   weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
   weights <- as.numeric(weights)
   } else {
   weights <- NULL
@@ -1714,7 +1714,7 @@ cluster_optimal <- function(graph, weights=NULL) {
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
     weights <- as.numeric(weights)
   } else {
     weights <- NULL
@@ -1793,7 +1793,7 @@ cluster_infomap <- function(graph, e.weights=NULL, v.weights=NULL,
   if (is.null(e.weights) && "weight" %in% edge_attr_names(graph)) {
     e.weights <- E(graph)$weight
   }
-  if (!is.null(e.weights) && any(!is.na(e.weights))) {
+  if (!is.null(e.weights) && !any(is.na(e.weights))) {
     e.weights <- as.numeric(e.weights)
   } else {
     e.weights <- NULL
@@ -1801,7 +1801,7 @@ cluster_infomap <- function(graph, e.weights=NULL, v.weights=NULL,
   if (is.null(v.weights) && "weight" %in% vertex_attr_names(graph)) {
     v.weights <- V(graph)$weight
   }
-  if (!is.null(v.weights) && any(!is.na(v.weights))) {
+  if (!is.null(v.weights) && !any(is.na(v.weights))) {
     v.weights <- as.numeric(v.weights)
   } else {
     v.weights <- NULL

--- a/R/glet.R
+++ b/R/glet.R
@@ -1,20 +1,20 @@
 
 #' Graphlet decomposition of a graph
-#' 
+#'
 #' Graphlet decomposition models a weighted undirected graph via the union of
 #' potentially overlapping dense social groups.  This is done by a two-step
 #' algorithm. In the first step a candidate set of groups (a candidate basis)
 #' is created by finding cliques if the thresholded input graph. In the second
 #' step these the graph is projected on the candidate basis, resulting a weight
 #' coefficient for each clique in the candidate basis.
-#' 
+#'
 #' igraph contains three functions for performing the graph decomponsition of a
 #' graph. The first is \code{graphlets}, which performed both steps on the
 #' method and returns a list of subgraphs, with their corresponding weights.
 #' The second and third functions correspond to the first and second steps of
 #' the algorithm, and they are useful if the user wishes to perform them
 #' individually: \code{graphlet_basis} and \code{graphlet_proj}.
-#' 
+#'
 #' @aliases graphlets graphlets.project graphlet_proj graphlet_basis
 #' graphlets.candidate.basis
 #' @param graph The input graph, edge directions are ignored. Only simple graph
@@ -30,16 +30,16 @@
 #' list of subgraphs, the candidate graphlet basis. Each subgraph is give by a
 #' vector of vertex ids.} \item{Mu}{The weights of the subgraphs in graphlet
 #' basis.}
-#' 
+#'
 #' \code{graphlet_basis} returns a list of two elements: \item{cliques}{A list
 #' of subgraphs, the candidate graphlet basis. Each subgraph is give by a
 #' vector of vertex ids.} \item{thresholds}{The weight thresholds used for
 #' finding the subgraphs.}
-#' 
+#'
 #' \code{graphlet_proj} return a numeric vector, the weights of the graphlet
 #' basis subgraphs.
 #' @examples
-#' 
+#'
 #' ## Create an example graph first
 #' D1 <- matrix(0, 5, 5)
 #' D2 <- matrix(0, 5, 5)
@@ -47,7 +47,7 @@
 #' D1[1:3, 1:3] <- 2
 #' D2[3:5, 3:5] <- 3
 #' D3[2:5, 2:5] <- 1
-#'   
+#'
 #' g <- simplify(graph_from_adjacency_matrix(D1 + D2 + D3,
 #'       mode="undirected", weighted=TRUE))
 #' V(g)$color <- "white"
@@ -58,10 +58,10 @@
 #' co <- layout_with_kk(g)
 #' par(mar=c(1,1,1,1))
 #' plot(g, layout=co)
-#' 
+#'
 #' ## Calculate graphlets
 #' gl <- graphlets(g, niter=1000)
-#' 
+#'
 #' ## Plot graphlets
 #' for (i in 1:length(gl$cliques)) {
 #'   sel <- gl$cliques[[i]]
@@ -83,7 +83,7 @@ graphlet_basis <- function(graph, weights=NULL) {
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
     weights <- as.numeric(weights)
   } else {
     weights <- NULL
@@ -110,7 +110,7 @@ graphlet_proj <- function(graph, weights=NULL, cliques, niter=1000,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
     weights <- as.numeric(weights)
   } else {
     weights <- NULL
@@ -130,7 +130,7 @@ graphlet_proj <- function(graph, weights=NULL, cliques, niter=1000,
 
 function() {
   library(igraph)
-  
+
   fitandplot <- function(g, gl) {
     g <- simplify(g)
     V(g)$color <- "white"
@@ -162,7 +162,7 @@ function() {
   D1[1:3, 1:3] <- 2
   D2[3:5, 3:5] <- 3
   D3[2:5, 2:5] <- 1
-  
+
   g <- graph_from_adjacency_matrix(D1 + D2 + D3, mode="undirected", weighted=TRUE)
   gl <- graphlets(g, iter=1000)
 
@@ -173,6 +173,6 @@ function() {
   g2 <- set_edge_attr(g, "weight", value=sample(E(g)$weight))
   gl2 <- graphlet_proj(g2, gl$Bc, 1000)
   fitandplot(g2, gl2)
-  
+
 }
 

--- a/R/glet.R
+++ b/R/glet.R
@@ -83,10 +83,13 @@ graphlet_basis <- function(graph, weights=NULL) {
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
 
   ## Drop all attributes, we don't want to deal with them, TODO
@@ -110,10 +113,13 @@ graphlet_proj <- function(graph, weights=NULL, cliques, niter=1000,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
   Mu <- as.numeric(Mu)
   niter <- as.integer(niter)

--- a/R/layout.R
+++ b/R/layout.R
@@ -1043,7 +1043,7 @@ layout_with_fr <- function(graph, coords=NULL, dim=2,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
     weights <- as.numeric(weights)
   } else {
     weights <- NULL
@@ -1336,7 +1336,7 @@ layout_with_kk <- function(graph, coords=NULL, dim=2,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
     weights <- as.numeric(weights)
   } else {
     weights <- NULL
@@ -1720,7 +1720,7 @@ with_mds <- function(...) layout_spec(layout_with_mds, ...)
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
     weights <- as.numeric(weights)
   } else {
     weights <- NULL

--- a/R/layout.R
+++ b/R/layout.R
@@ -1043,11 +1043,15 @@ layout_with_fr <- function(graph, coords=NULL, dim=2,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
+
   if (!is.null(minx)) minx <- as.numeric(minx)
   if (!is.null(maxx)) maxx <- as.numeric(maxx)
   if (!is.null(miny)) miny <- as.numeric(miny)
@@ -1336,11 +1340,15 @@ layout_with_kk <- function(graph, coords=NULL, dim=2,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
+
   if (!is.null(minx)) minx <- as.numeric(minx)
   if (!is.null(maxx)) maxx <- as.numeric(maxx)
   if (!is.null(miny)) miny <- as.numeric(miny)
@@ -1720,11 +1728,15 @@ with_mds <- function(...) layout_spec(layout_with_mds, ...)
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
+
   attributes <- igraph.match.arg(attributes)
 
   on.exit(.Call(C_R_igraph_finalizer) )

--- a/R/structural.properties.R
+++ b/R/structural.properties.R
@@ -1,7 +1,7 @@
 #   IGraph R package
 #   Copyright (C) 2005-2012  Gabor Csardi <csardi.gabor@gmail.com>
 #   334 Harvard street, Cambridge, MA 02139 USA
-#   
+#
 #   This program is free software; you can redistribute it and/or modify
 #   it under the terms of the GNU General Public License as published by
 #   the Free Software Foundation; either version 2 of the License, or
@@ -11,7 +11,7 @@
 #   but WITHOUT ANY WARRANTY; without even the implied warranty of
 #   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #   GNU General Public License for more details.
-#   
+#
 #   You should have received a copy of the GNU General Public License
 #   along with this program; if not, write to the Free Software
 #   Foundation, Inc.,  51 Franklin Street, Fifth Floor, Boston, MA
@@ -26,18 +26,18 @@
 
 
 #' Diameter of a graph
-#' 
+#'
 #' The diameter of a graph is the length of the longest geodesic.
-#' 
+#'
 #' The diameter is calculated by using a breadth-first search like method.
-#' 
+#'
 #' \code{get_diameter} returns a path with the actual diameter. If there are
 #' many shortest paths of the length of the diameter, then it returns the first
 #' one found.
-#' 
+#'
 #' \code{farthest_vertices} returns two vertex ids, the vertices which are
 #' connected by the diameter path.
-#' 
+#'
 #' @aliases diameter get.diameter farthest.nodes farthest_vertices get_diameter
 #' @param graph The graph to analyze.
 #' @param directed Logical, whether directed or undirected paths are to be
@@ -61,12 +61,12 @@
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- make_ring(10)
 #' g2 <- delete_edges(g, c(1,2,1,10))
 #' diameter(g2, unconnected=TRUE)
 #' diameter(g2, unconnected=FALSE)
-#' 
+#'
 #' ## Weighted diameter
 #' set.seed(1)
 #' g <- make_ring(10)
@@ -75,9 +75,9 @@
 #' get_diameter(g)
 #' diameter(g, weights=NA)
 #' get_diameter(g, weights=NA)
-#' 
+#'
 diameter <- function(graph, directed=TRUE, unconnected=TRUE, weights=NULL) {
-  
+
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
@@ -85,12 +85,12 @@ diameter <- function(graph, directed=TRUE, unconnected=TRUE, weights=NULL) {
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
     weights <- as.numeric(weights)
   } else {
     weights <- NULL
   }
-  
+
   on.exit( .Call(C_R_igraph_finalizer) )
   .Call(C_R_igraph_diameter, graph, as.logical(directed),
         as.logical(unconnected), weights)
@@ -108,7 +108,7 @@ get_diameter <- function(graph, directed=TRUE, unconnected=TRUE,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
     weights <- as.numeric(weights)
   } else {
     weights <- NULL
@@ -137,12 +137,12 @@ farthest_vertices <- function(graph, directed=TRUE, unconnected=TRUE,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
     weights <- as.numeric(weights)
   } else {
     weights <- NULL
   }
-  
+
   on.exit( .Call(C_R_igraph_finalizer) )
   res <- .Call(C_R_igraph_farthest_points, graph, as.logical(directed),
                as.logical(unconnected), weights)
@@ -153,7 +153,7 @@ farthest_vertices <- function(graph, directed=TRUE, unconnected=TRUE,
   }
 
   res
-}       
+}
 
 #' @export
 #' @rdname distances
@@ -171,11 +171,11 @@ mean_distance <- function(graph, directed=TRUE, unconnected=TRUE) {
 
 
 #' Degree and degree distribution of the vertices
-#' 
+#'
 #' The degree of a vertex is its most basic structural property, the number of
 #' its adjacent edges.
-#' 
-#' 
+#'
+#'
 #' @aliases degree degree.distribution degree_distribution
 #' @param graph The graph to analyze.
 #' @param v The ids of vertices of which the degree will be calculated.
@@ -190,7 +190,7 @@ mean_distance <- function(graph, directed=TRUE, unconnected=TRUE) {
 #' is useful but also \code{v} and \code{loops} make sense.
 #' @return For \code{degree} a numeric vector of the same length as argument
 #' \code{v}.
-#' 
+#'
 #' For \code{degree_distribution} a numeric vector of the same length as the
 #' maximum degree plus one. The first element is the relative frequency zero
 #' degree vertices, the second vertices with degree one, etc.
@@ -198,23 +198,23 @@ mean_distance <- function(graph, directed=TRUE, unconnected=TRUE) {
 #' @keywords graphs
 #' @export
 #' @examples
-#' 
+#'
 #' g <- make_ring(10)
 #' degree(g)
 #' g2 <- sample_gnp(1000, 10/1000)
 #' degree_distribution(g2)
-#' 
+#'
 degree <- function(graph, v=V(graph),
                    mode=c("all", "out", "in", "total"), loops=TRUE,
                    normalized=FALSE){
-  
+
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
   v <- as.igraph.vs(graph, v)
   mode <- igraph.match.arg(mode)
   mode <- switch(mode, "out"=1, "in"=2, "all"=3, "total"=3)
-  
+
   on.exit( .Call(C_R_igraph_finalizer) )
   res <- .Call(C_R_igraph_degree, graph, v-1,
                as.numeric(mode), as.logical(loops))
@@ -232,7 +232,7 @@ degree <- function(graph, v=V(graph),
 #' @importFrom graphics hist
 
 degree_distribution <- function(graph, cumulative=FALSE, ...) {
-  
+
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
@@ -243,23 +243,23 @@ degree_distribution <- function(graph, cumulative=FALSE, ...) {
   } else {
     res <- rev(cumsum(rev(hi)))
   }
-  
+
   res
 }
 
 
 
 #' Shortest (directed or undirected) paths between vertices
-#' 
+#'
 #' \code{distances} calculates the length of all the shortest paths from
 #' or to the vertices in the network. \code{shortest_paths} calculates one
 #' shortest path (the path itself, and not just its length) from or to the
 #' given vertex.
-#' 
+#'
 #' The shortest path, or geodesic between two pair of vertices is a path with
 #' the minimal number of vertices. The functions documented in this manual page
 #' all calculate shortest paths between vertex pairs.
-#' 
+#'
 #' \code{distances} calculates the lengths of pairwise shortest paths from
 #' a set of vertices (\code{from}) to another set of vertices (\code{to}). It
 #' uses different algorithms, depending on the \code{algorithm} argument and
@@ -271,34 +271,34 @@ degree_distribution <- function(graph, cumulative=FALSE, ...) {
 #' (\sQuote{\code{"johnson"}}). The latter two algorithms work with arbitrary
 #' edge weights, but (naturally) only for graphs that don't have a negative
 #' cycle.
-#' 
+#'
 #' igraph can choose automatically between algorithms, and chooses the most
 #' efficient one that is appropriate for the supplied weights (if any). For
 #' automatic algorithm selection, supply \sQuote{\code{automatic}} as the
 #' \code{algorithm} argument. (This is also the default.)
-#' 
+#'
 #' \code{shortest_paths} calculates a single shortest path (i.e. the path
 #' itself, not just its length) between the source vertex given in \code{from},
 #' to the target vertices given in \code{to}. \code{shortest_paths} uses
 #' breadth-first search for unweighted graphs and Dijkstra's algorithm for
 #' weighted graphs. The latter only works if the edge weights are non-negative.
-#' 
+#'
 #' \code{all_shortest_paths} calculates \emph{all} shortest paths between
 #' pairs of vertices. More precisely, between the \code{from} vertex to the
 #' vertices given in \code{to}. It uses a breadth-first search for unweighted
 #' graphs and Dijkstra's algorithm for weighted ones. The latter only supports
 #' non-negative edge weights.
-#' 
+#'
 #' \code{mean_distance} calculates the average path length in a graph, by
 #' calculating the shortest paths between all pairs of vertices (both ways for
 #' directed graphs). This function does not consider edge weights currently and
 #' uses a breadth-first search.
-#' 
+#'
 #' \code{distance_table} calculates a histogram, by calculating the shortest
 #' path length between each pair of vertices. For directed graphs both
 #' directions are considered, so every pair of vertices appears twice in the
 #' histogram.
-#' 
+#'
 #' @aliases shortest.paths get.shortest.paths get.all.shortest.paths distances
 #' mean_distance distance_table average.path.length path.length.hist
 #' all_shortest_paths shortest_paths
@@ -332,7 +332,7 @@ degree_distribution <- function(graph, cumulative=FALSE, ...) {
 #' @return For \code{distances} a numeric matrix with \code{length(to)}
 #' columns and \code{length(v)} rows. The shortest path length from a vertex to
 #' itself is always zero. For unreachable vertices \code{Inf} is included.
-#' 
+#'
 #' For \code{shortest_paths} a named list with four entries is returned:
 #' \item{vpath}{This itself is a list, of length \code{length(to)}; list
 #' element \code{i} contains the vertex ids on the path from vertex \code{from}
@@ -349,14 +349,14 @@ degree_distribution <- function(graph, cumulative=FALSE, ...) {
 #' predecessor of each vertex in the \code{to} argument, or \code{NULL} if it
 #' was not requested.} \item{inbound_edges}{Numeric vector, the inbound edge
 #' for each vertex, or \code{NULL}, if it was not requested.}
-#' 
+#'
 #' For \code{all_shortest_paths} a list is returned, each list element
 #' contains a shortest path from \code{from} to a vertex in \code{to}. The
 #' shortest paths to the same vertex are collected into consecutive elements of
 #' the list.
-#' 
+#'
 #' For \code{mean_distance} a single number is returned.
-#' 
+#'
 #' \code{distance_table} returns a named list with two entries: \code{res} is
 #' a numeric vector, the histogram of distances, \code{unconnected} is a
 #' numeric scalar, the number of pairs for which the first vertex is not
@@ -368,7 +368,7 @@ degree_distribution <- function(graph, cumulative=FALSE, ...) {
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- make_ring(10)
 #' distances(g)
 #' shortest_paths(g, 5)
@@ -381,7 +381,7 @@ degree_distribution <- function(graph, cumulative=FALSE, ...) {
 #'                6,10,3, 8,6,1, 8,9,1, 9,10,4) )
 #' g2 <- add_edges(make_empty_graph(10), t(el[,1:2]), weight=el[,3])
 #' distances(g2, mode="out")
-#' 
+#'
 distances <- function(graph, v=V(graph), to=V(graph),
                            mode=c("all", "out", "in"),
                            weights=NULL,
@@ -394,11 +394,11 @@ distances <- function(graph, v=V(graph), to=V(graph),
   v <- as.igraph.vs(graph, v)
   to <- as.igraph.vs(graph, to)
   mode <- igraph.match.arg(mode)
-  mode <- switch(mode, "out"=1, "in"=2, "all"=3)  
+  mode <- switch(mode, "out"=1, "in"=2, "all"=3)
   algorithm <- igraph.match.arg(algorithm)
   algorithm <- switch(algorithm, "automatic"=0, "unweighted"=1,
                       "dijkstra"=2, "bellman-ford"=3, "johnson"=4)
-  
+
   if (is.null(weights)) {
     if ("weight" %in% edge_attr_names(graph)) {
       weights <- as.numeric(E(graph)$weight)
@@ -415,7 +415,7 @@ distances <- function(graph, v=V(graph), to=V(graph),
     weights <- NULL
     warning("Unweighted algorithm chosen, weights ignored")
   }
-  
+
   on.exit( .Call(C_R_igraph_finalizer) )
   res <- .Call(C_R_igraph_shortest_paths, graph, v-1, to-1,
                as.numeric(mode), weights, as.numeric(algorithm))
@@ -476,7 +476,7 @@ shortest_paths <- function(graph, from, to=V(graph),
       weights <- as.numeric(weights)
     }
   }
-  
+
   to <- as.igraph.vs(graph, to)-1
   on.exit( .Call(C_R_igraph_finalizer) )
   res <- .Call(C_R_igraph_get_shortest_paths, graph,
@@ -549,10 +549,10 @@ all_shortest_paths <- function(graph, from,
                  as.igraph.vs(graph, from)-1, as.igraph.vs(graph, to)-1,
                  as.numeric(mode))
   } else {
-    res <- .Call(C_R_igraph_get_all_shortest_paths_dijkstra, graph, 
+    res <- .Call(C_R_igraph_get_all_shortest_paths_dijkstra, graph,
                  as.igraph.vs(graph, from)-1, as.igraph.vs(graph, to)-1,
                  weights, as.numeric(mode))
-  }       
+  }
 
   if (igraph_opt("return.vs.es")) {
     res$res <- lapply(res$res, create_vs, graph = graph)
@@ -562,12 +562,12 @@ all_shortest_paths <- function(graph, from,
 }
 
 #' In- or out- component of a vertex
-#' 
+#'
 #' Finds all vertices reachable from a given vertex, or the opposite: all
 #' vertices from which a given vertex is reachable via a directed path.
-#' 
+#'
 #' A breadh-first search is conducted starting from vertex \code{v}.
-#' 
+#'
 #' @aliases subcomponent
 #' @param graph The graph to analyze.
 #' @param v The vertex to start the search from.
@@ -583,7 +583,7 @@ all_shortest_paths <- function(graph, from,
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- sample_gnp(100, 1/200)
 #' subcomponent(g, 1, "in")
 #' subcomponent(g, 1, "out")
@@ -609,22 +609,22 @@ subcomponent <- function(graph, v, mode=c("all", "out", "in")) {
 
 
 #' Subgraph of a graph
-#' 
+#'
 #' \code{subgraph} creates a subgraph of a graph, containing only the specified
 #' vertices and all the edges among them.
-#' 
+#'
 #' \code{induced_subgraph} calculates the induced subgraph of a set of vertices
 #' in a graph. This means that exactly the specified vertices and all the edges
 #' between them will be kept in the result graph.
-#' 
+#'
 #' \code{subgraph.edges} calculates the subgraph of a graph. For this function
 #' one can specify the vertices and edges to keep. This function will be
 #' renamed to \code{subgraph} in the next major version of igraph.
-#' 
+#'
 #' The \code{subgraph} function does the same as \code{induced.graph} currently
 #' (assuming \sQuote{\code{auto}} as the \code{impl} argument), but it is
 #' deprecated and will be removed in the next major version of igraph.
-#' 
+#'
 #' @aliases subgraph induced.subgraph subgraph.edges induced_subgraph
 #' @param graph The original graph.
 #' @param v Numeric vector, the vertices of the original graph which will
@@ -634,11 +634,11 @@ subcomponent <- function(graph, v, mode=c("all", "out", "in")) {
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- make_ring(10)
 #' g2 <- induced_subgraph(g, 1:7)
 #' g3 <- subgraph.edges(g, 1:5, 1:5)
-#' 
+#'
 subgraph <- function(graph, v) {
 
   if (!is_igraph(graph)) {
@@ -706,21 +706,21 @@ estimate_betweenness <- function(graph, vids=V(graph), directed=TRUE, cutoff, we
   vids <- as.igraph.vs(graph, vids)
   directed <- as.logical(directed)
   cutoff <- as.numeric(cutoff)
-  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) { 
-  weights <- E(graph)$weight 
-  } 
-  if (!is.null(weights) && any(!is.na(weights))) { 
-  weights <- as.numeric(weights) 
-  } else { 
-  weights <- NULL 
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+  weights <- E(graph)$weight
+  }
+  if (!is.null(weights) && !any(is.na(weights))) {
+  weights <- as.numeric(weights)
+  } else {
+  weights <- NULL
   }
   nobigint <- as.logical(nobigint)
 
   on.exit( .Call(C_R_igraph_finalizer) )
   # Function call
   res <- .Call(C_R_igraph_betweenness_estimate, graph, vids-1, directed, cutoff, weights, nobigint)
-  if (igraph_opt("add.vertex.names") && is_named(graph)) { 
-  names(res) <- vertex_attr(graph, "name", vids) 
+  if (igraph_opt("add.vertex.names") && is_named(graph)) {
+  names(res) <- vertex_attr(graph, "name", vids)
   }
   res
 }
@@ -728,32 +728,32 @@ estimate_betweenness <- function(graph, vids=V(graph), directed=TRUE, cutoff, we
 
 
 #' Vertex and edge betweenness centrality
-#' 
+#'
 #' The vertex and edge betweenness are (roughly) defined by the number of
 #' geodesics (shortest paths) going through a vertex or an edge.
-#' 
+#'
 #' The vertex betweenness of vertex \eqn{v}{\code{v}} is defined by
-#' 
+#'
 #' \deqn{\sum_{i\ne j, i\ne v, j\ne v} g_{ivj}/g_{ij}}{sum( g_ivj / g_ij,
 #' i!=j,i!=v,j!=v)}
-#' 
+#'
 #' The edge betweenness of edge \eqn{e}{\code{e}} is defined by
-#' 
+#'
 #' \deqn{\sum_{i\ne j} g{iej}/g_{ij}.}{sum( g_iej / g_ij, i!=j).}
-#' 
+#'
 #' \code{betweenness} calculates vertex betweenness, \code{edge_betweenness}
 #' calculates edge betweenness.
-#' 
+#'
 #' \code{estimate_betweenness} only considers paths of length \code{cutoff} or
 #' smaller, this can be run for larger graphs, as the running time is not
 #' quadratic (if \code{cutoff} is small). If \code{cutoff} is zero or negative
 #' then the function calculates the exact betweenness scores.
-#' 
+#'
 #' \code{estimate_edge_betweenness} is similar, but for edges.
-#' 
+#'
 #' For calculating the betweenness a similar algorithm to the one proposed by
 #' Brandes (see References) is used.
-#' 
+#'
 #' @aliases betweenness edge.betweenness betweenness.estimate
 #' edge.betweenness.estimate edge_betweenness estimate_betweenness
 #' estimate_edge_betweenness
@@ -776,10 +776,10 @@ estimate_betweenness <- function(graph, vids=V(graph), directed=TRUE, cutoff, we
 #' is the number of vertices in the graph.
 #' @return A numeric vector with the betweenness score for each vertex in
 #' \code{v} for \code{betweenness}.
-#' 
+#'
 #' A numeric vector with the edge betweenness score for each edge in \code{e}
 #' for \code{edge_betweenness}.
-#' 
+#'
 #' \code{estimate_betweenness} returns the estimated betweenness scores for
 #' vertices in \code{vids}, \code{estimate_edge_betweenness} the estimated edge
 #' betweenness score for \emph{all} edges; both in a numeric vector.
@@ -789,20 +789,20 @@ estimate_betweenness <- function(graph, vids=V(graph), directed=TRUE, cutoff, we
 #' @seealso \code{\link{closeness}}, \code{\link{degree}}
 #' @references Freeman, L.C. (1979). Centrality in Social Networks I:
 #' Conceptual Clarification. \emph{Social Networks}, 1, 215-239.
-#' 
+#'
 #' Ulrik Brandes, A Faster Algorithm for Betweenness Centrality. \emph{Journal
 #' of Mathematical Sociology} 25(2):163-177, 2001.
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- sample_gnp(10, 3/10)
 #' betweenness(g)
 #' edge_betweenness(g)
-#' 
+#'
 betweenness <- function(graph, v=V(graph), directed=TRUE, weights=NULL,
                         nobigint=TRUE, normalized=FALSE) {
-  
+
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
@@ -810,7 +810,7 @@ betweenness <- function(graph, v=V(graph), directed=TRUE, weights=NULL,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
     weights <- as.numeric(weights)
   } else {
     weights <- NULL
@@ -835,32 +835,32 @@ betweenness <- function(graph, v=V(graph), directed=TRUE, weights=NULL,
 
 
 #' Transitivity of a graph
-#' 
+#'
 #' Transitivity measures the probability that the adjacent vertices of a vertex
 #' are connected. This is sometimes also called the clustering coefficient.
-#' 
+#'
 #' Note that there are essentially two classes of transitivity measures, one is
 #' a vertex-level, the other a graph level property.
-#' 
+#'
 #' There are several generalizations of transitivity to weighted graphs, here
 #' we use the definition by A. Barrat, this is a local vertex-level quantity,
 #' its formula is
-#' 
+#'
 #' \deqn{C_i^w=\frac{1}{s_i(k_i-1)}\sum_{j,h}\frac{w_{ij}+w_{ih}}{2}a_{ij}a_{ih}a_{jh}}{
 #' weighted C_i = 1/s_i 1/(k_i-1) sum( (w_ij+w_ih)/2 a_ij a_ih a_jh, j, h)}
-#' 
+#'
 #' \eqn{s_i}{s_i} is the strength of vertex \eqn{i}{i}, see
 #' \code{\link{strength}}, \eqn{a_{ij}}{a_ij} are elements of the
 #' adjacency matrix, \eqn{k_i}{k_i} is the vertex degree, \eqn{w_{ij}}{w_ij}
 #' are the weights.
-#' 
+#'
 #' This formula gives back the normal not-weighted local transitivity if all
 #' the edge weights are the same.
-#' 
+#'
 #' The \code{barrat} type of transitivity does not work for graphs with
 #' multiple and/or loop edges. If you want to calculate it for a directed
 #' graph, call \code{\link{as.undirected}} with the \code{collapse} mode first.
-#' 
+#'
 #' @param graph The graph to analyze.
 #' @param type The type of the transitivity to calculate. Possible values:
 #' \describe{ \item{"global"}{The global transitivity of an undirected
@@ -893,32 +893,32 @@ betweenness <- function(graph, v=V(graph), directed=TRUE, weights=NULL,
 #' are included in the averaging, if an average is calculated.
 #' @return For \sQuote{\code{global}} a single number, or \code{NaN} if there
 #' are no connected triples in the graph.
-#' 
+#'
 #' For \sQuote{\code{local}} a vector of transitivity scores, one for each
 #' vertex in \sQuote{\code{vids}}.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
 #' @references Wasserman, S., and Faust, K. (1994). \emph{Social Network
 #' Analysis: Methods and Applications.} Cambridge: Cambridge University Press.
-#' 
+#'
 #' Alain Barrat, Marc Barthelemy, Romualdo Pastor-Satorras, Alessandro
 #' Vespignani: The architecture of complex weighted networks, Proc. Natl. Acad.
 #' Sci. USA 101, 3747 (2004)
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- make_ring(10)
 #' transitivity(g)
 #' g2 <- sample_gnp(1000, 10/1000)
 #' transitivity(g2)   # this is about 10/1000
-#' 
+#'
 #' # Weighted version, the figure from the Barrat paper
 #' gw <- graph_from_literal(A-B:C:D:E, B-C:D, C-D)
 #' E(gw)$weight <- 1
 #' E(gw)[ V(gw)[name == "A"] %--% V(gw)[name == "E" ] ]$weight <- 5
 #' transitivity(gw, vids="A", type="local")
 #' transitivity(gw, vids="A", type="weighted")
-#' 
+#'
 #' # Weighted reduces to "local" if weights are the same
 #' gw2 <- sample_gnp(1000, 10/1000)
 #' E(gw2)$weight <- 1
@@ -926,13 +926,13 @@ betweenness <- function(graph, v=V(graph), directed=TRUE, weights=NULL,
 #' t2 <- transitivity(gw2, type="weighted")
 #' all(is.na(t1) == is.na(t2))
 #' all(na.omit(t1 == t2))
-#' 
+#'
 transitivity <- function(graph, type=c("undirected", "global", "globalundirected",
                                   "localundirected", "local", "average",
                                   "localaverage", "localaverageundirected",
                                   "barrat", "weighted"),
                          vids=NULL, weights=NULL, isolates=c("NaN", "zero")) {
-  
+
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
@@ -945,7 +945,7 @@ transitivity <- function(graph, type=c("undirected", "global", "globalundirected
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && any(!is.na(weights))) {
+  if (!is.null(weights) && !any(is.na(weights))) {
     weights <- as.numeric(weights)
   } else {
     weights <- NULL
@@ -973,7 +973,7 @@ transitivity <- function(graph, type=c("undirected", "global", "globalundirected
     if (is.null(weights)) {
       .Call(C_R_igraph_transitivity_local_undirected, graph, vids,
             isolates)
-    } else { 
+    } else {
       .Call(C_R_igraph_transitivity_barrat, graph, vids, weights,
             isolates)
     }
@@ -986,11 +986,11 @@ transitivity <- function(graph, type=c("undirected", "global", "globalundirected
 ##   if (!is_igraph(graph)) {
 ##     stop("Not a graph object")
 ##   }
-  
+
 ##   on.exit( .Call(C_R_igraph_finalizer) )
 ##   .Call(C_R_igraph_laplacian, graph, as.logical(normalized))
 ## }
-  
+
 ## OLD implementation
 ## laplacian_matrix <- function(graph, normalized=FALSE) {
 
@@ -1011,7 +1011,7 @@ transitivity <- function(graph, type=c("undirected", "global", "globalundirected
 ##     M <- structure(ifelse(M>0, -1/deg, 0))
 ##     diag(M) <- 1
 ##   }
-  
+
 ##   M
 ## }
 
@@ -1028,7 +1028,7 @@ transitivity <- function(graph, type=c("undirected", "global", "globalundirected
 ##   A <- as_adj(graph, attr=attr)
 ##   A <- A[idx, idx]
 ##   n <- sum(idx)
-  
+
 ##   one <- c(rep(1,n))
 ##   CZ <- A + t(A)
 ##   cs <- CZ %*% one                      # degree of vertices
@@ -1064,7 +1064,7 @@ transitivity <- function(graph, type=c("undirected", "global", "globalundirected
 
 ##   for (a in seq(along=nodes)) {
 ##     i <- nodes[a]
-    
+
 ##     first <- not(i, neighbors(graph, i, mode="all"))
 ##     first <- unique(first)
 ##     for (b in seq(along=first)) {
@@ -1080,7 +1080,7 @@ transitivity <- function(graph, type=c("undirected", "global", "globalundirected
 ##         cj <- cj + are_adjacent(graph, i, q) / deg[q+1] / deg[i+1]
 ##         cj <- cj + are_adjacent(graph, q, i) / deg[q+1] / deg[i+1]
 ##       }
-                            
+
 ##       ## Ok, we have the total contribution of j
 ##       res[a] <- res[a] + cj*cj
 ##     }
@@ -1095,7 +1095,7 @@ transitivity <- function(graph, type=c("undirected", "global", "globalundirected
 
 
 #' Burt's constraint
-#' 
+#'
 #' Given a graph, \code{constraint} calculates Burt's constraint for each
 #' vertex.
 #'
@@ -1109,13 +1109,13 @@ transitivity <- function(graph, type=c("undirected", "global", "globalundirected
 #'   V[i], j != i).
 #' }
 #' for a graph of order (ie. number of vertices) \eqn{N}, where
-#' proportional tie strengths are defined as 
+#' proportional tie strengths are defined as
 #' \deqn{p_{ij} = \frac{a_{ij}+a_{ji}}{\sum_{k \in V_i \setminus \{i\}}(a_{ik}+a_{ki})},}{
 #'   p[i,j]=(a[i,j]+a[j,i]) / sum(a[i,k]+a[k,i], k in V[i], k != i),
 #' }
 #' \eqn{a_{ij}}{a[i,j]} are elements of \eqn{A} and the latter being the
 #' graph adjacency matrix. For isolated vertices, constraint is undefined.
-#' 
+#'
 #' @param graph A graph object, the input graph.
 #' @param nodes The vertices for which the constraint will be calculated.
 #' Defaults to all vertices.
@@ -1131,23 +1131,23 @@ transitivity <- function(graph, type=c("undirected", "global", "globalundirected
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- sample_gnp(20, 5/20)
 #' constraint(g)
-#' 
+#'
 constraint <- function(graph, nodes=V(graph), weights=NULL) {
 
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
   nodes <- as.igraph.vs(graph, nodes)
-  
+
   if (is.null(weights)) {
     if ("weight" %in% edge_attr_names(graph)) {
       weights <- E(graph)$weight
     }
   }
-  
+
   on.exit( .Call(C_R_igraph_finalizer) )
   res <- .Call(C_R_igraph_constraint, graph, nodes-1, as.numeric(weights))
   if (igraph_opt("add.vertex.names") && is_named(graph)) {
@@ -1159,9 +1159,9 @@ constraint <- function(graph, nodes=V(graph), weights=NULL) {
 
 
 #' Reciprocity of graphs
-#' 
+#'
 #' Calculates the reciprocity of a directed graph.
-#' 
+#'
 #' The measure of reciprocity defines the proportion of mutual connections, in
 #' a directed graph. It is most commonly defined as the probability that the
 #' opposite counterpart of a directed edge is also included in the graph. Or in
@@ -1169,7 +1169,7 @@ constraint <- function(graph, nodes=V(graph), weights=NULL) {
 #' (A.*A')ij) / sum(i, j, Aij)}, where \eqn{A\cdot A'}{A.*A'} is the
 #' element-wise product of matrix \eqn{A} and its transpose. This measure is
 #' calculated if the \code{mode} argument is \code{default}.
-#' 
+#'
 #' Prior to igraph version 0.6, another measure was implemented, defined as the
 #' probability of mutual connection between a vertex pair, if we know that
 #' there is a (possibly non-mutual) connection between them. In other words,
@@ -1177,7 +1177,7 @@ constraint <- function(graph, nodes=V(graph), weights=NULL) {
 #' not-connected, (2) non-reciprocaly connected, (3) reciprocally connected.
 #' The result is the size of group (3), divided by the sum of group sizes
 #' (2)+(3). This measure is calculated if \code{mode} is \code{ratio}.
-#' 
+#'
 #' @param graph The graph object.
 #' @param ignore.loops Logical constant, whether to ignore loop edges.
 #' @param mode See below.
@@ -1187,10 +1187,10 @@ constraint <- function(graph, nodes=V(graph), weights=NULL) {
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- sample_gnp(20, 5/20, directed=TRUE)
 #' reciprocity(g)
-#' 
+#'
 reciprocity <- function(graph, ignore.loops=TRUE,
                         mode=c("default", "ratio")) {
 
@@ -1211,8 +1211,8 @@ bonpow.dense <- function(graph, nodes=V(graph),
 
   if (!is_igraph(graph)) {
     stop("Not a graph object")
-  }  
-  
+  }
+
   d <- as_adj(graph)
   if (!loops) {
     diag(d) <- 0
@@ -1227,7 +1227,7 @@ bonpow.dense <- function(graph, nodes=V(graph),
     ev <- ev/sum(ev)
   } else {
     ev <- ev*sqrt(n/sum((ev)^2))
-  } 
+  }
   ev[as.numeric(nodes)]
 }
 
@@ -1240,7 +1240,7 @@ bonpow.sparse <- function(graph, nodes=V(graph), loops=FALSE,
   }
 
   vg <- vcount(graph)
-  
+
   ## sparse adjacency matrix
   d <- as_adj(graph, sparse=TRUE)
 
@@ -1262,11 +1262,11 @@ bonpow.sparse <- function(graph, nodes=V(graph), loops=FALSE,
 
 
 #' Find Bonacich Power Centrality Scores of Network Positions
-#' 
+#'
 #' \code{power_centrality} takes a graph (\code{dat}) and returns the Boncich power
 #' centralities of positions (selected by \code{nodes}).  The decay rate for
 #' power contributions is specified by \code{exponent} (1 by default).
-#' 
+#'
 #' Bonacich's power centrality measure is defined by
 #' \eqn{C_{BP}\left(\alpha,\beta\right)=\alpha\left(\mathbf{I}-\beta\mathbf{A}\right)^{-1}\mathbf{A}\mathbf{1}}{C_BP(alpha,beta)=alpha
 #' (I-beta A)^-1 A 1}, where \eqn{\beta}{beta} is an attenuation parameter (set
@@ -1290,7 +1290,7 @@ bonpow.sparse <- function(graph, nodes=V(graph), loops=FALSE,
 #' The magnitude of \eqn{\beta}{beta} controls the influence of distant actors
 #' on ego's centrality score, with larger magnitudes indicating slower rates of
 #' decay.  (High rates, hence, imply a greater sensitivity to edge effects.)
-#' 
+#'
 #' Interpretively, the Bonacich power measure corresponds to the notion that
 #' the power of a vertex is recursively defined by the sum of the power of its
 #' alters.  The nature of the recursion involved is then controlled by the
@@ -1335,13 +1335,13 @@ bonpow.sparse <- function(graph, nodes=V(graph), loops=FALSE,
 #' @references Bonacich, P.  (1972).  ``Factoring and Weighting Approaches to
 #' Status Scores and Clique Identification.'' \emph{Journal of Mathematical
 #' Sociology}, 2, 113-120.
-#' 
+#'
 #' Bonacich, P.  (1987).  ``Power and Centrality: A Family of Measures.''
 #' \emph{American Journal of Sociology}, 92, 1170-1182.
 #' @keywords graphs
 #' @export
 #' @examples
-#' 
+#'
 #' # Generate some test data from Bonacich, 1987:
 #' g.c <- graph( c(1,2,1,3,2,4,3,5), dir=FALSE)
 #' g.d <- graph( c(1,2,1,3,1,4,2,5,3,6,4,7), dir=FALSE)
@@ -1351,19 +1351,19 @@ bonpow.sparse <- function(graph, nodes=V(graph), loops=FALSE,
 #' for (e in seq(-0.5,.5, by=0.1)) {
 #'   print(round(power_centrality(g.c, exp=e)[c(1,2,4)], 2))
 #' }
-#' 
+#'
 #' for (e in seq(-0.4,.4, by=0.1)) {
 #'   print(round(power_centrality(g.d, exp=e)[c(1,2,5)], 2))
 #' }
-#' 
+#'
 #' for (e in seq(-0.4,.4, by=0.1)) {
 #'   print(round(power_centrality(g.e, exp=e)[c(1,2,5)], 2))
 #' }
-#' 
+#'
 #' for (e in seq(-0.4,.4, by=0.1)) {
 #'   print(round(power_centrality(g.f, exp=e)[c(1,2,5)], 2))
 #' }
-#' 
+#'
 power_centrality <- function(graph, nodes=V(graph),
                    loops=FALSE, exponent=1,
                    rescale=FALSE, tol=1e-7, sparse=TRUE){
@@ -1378,7 +1378,7 @@ power_centrality <- function(graph, nodes=V(graph),
   if (igraph_opt("add.vertex.names") && is_named(graph)) {
     names(res) <- vertex_attr(graph, "name", nodes)
   }
-  
+
   res
 }
 
@@ -1401,12 +1401,12 @@ alpha.centrality.dense <- function(graph, nodes=V(graph), alpha=1,
   } else if (is.character(weights) && length(weights)==1) {
     ## name of an edge attribute, nothing to do
     attr <- "weight"
-  } else if (any(!is.na(weights))) {
-    ## weights != NULL and weights != rep(NA, x)
+  } else if (!any(is.na(weights))) {
+    ## weights != NULL and no weights are NA
     graph <- set_edge_attr(graph, "weight", value=as.numeric(weights))
     attr <- "weight"
   } else {
-    ## weights != NULL, but weights == rep(NA, x)
+    ## weights != NULL, but some weights are NA
     attr <- NULL
   }
 
@@ -1417,7 +1417,7 @@ alpha.centrality.dense <- function(graph, nodes=V(graph), alpha=1,
   n <- vcount(graph)
   id <- matrix(0, nrow=n, ncol=n)
   diag(id) <- 1
-  
+
   ev <- solve(id-alpha*d, tol=tol) %*% exo
   ev[as.numeric(nodes)]
 }
@@ -1433,7 +1433,7 @@ alpha.centrality.sparse <- function(graph, nodes=V(graph), alpha=1,
 
   if (!loops) {
     graph <- simplify(graph, remove.multiple=FALSE, remove.loops=TRUE)
-  }  
+  }
 
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     ## weights == NULL and there is a "weight" edge attribute
@@ -1444,18 +1444,18 @@ alpha.centrality.sparse <- function(graph, nodes=V(graph), alpha=1,
   } else if (is.character(weights) && length(weights)==1) {
     ## name of an edge attribute, nothing to do
     attr <- "weight"
-  } else if (any(!is.na(weights))) {
-    ## weights != NULL and weights != rep(NA, x)
+  } else if (!any(is.na(weights))) {
+    ## weights != NULL and no weights are NA
     graph <- set_edge_attr(graph, "weight", value=as.numeric(weights))
     attr <- "weight"
   } else {
-    ## weights != NULL, but weights == rep(NA, x)
+    ## weights != NULL, but some weights are NA
     attr <- NULL
   }
 
   M <- Matrix::t(as_adj(graph, attr = attr, sparse = TRUE))
   M <- as(M, "dgCMatrix")
-  
+
   ## Create an identity matrix
   M2 <- Matrix::sparseMatrix(dims=c(vc, vc), i=1:vc, j=1:vc, x=rep(1, vc))
   M2 <- as(M2, "dgCMatrix")
@@ -1466,21 +1466,21 @@ alpha.centrality.sparse <- function(graph, nodes=V(graph), alpha=1,
   ## Solve the equation
   M3 <- M2-alpha*M
   r <- Matrix::solve(M3, tol=tol, exo)
-  
+
   r[ as.numeric(nodes)]
 }
 
 
 
 #' Find Bonacich alpha centrality scores of network positions
-#' 
+#'
 #' \code{alpha_centrality} calculates the alpha centrality of some (or all)
 #' vertices in a graph.
-#' 
+#'
 #' The alpha centrality measure can be considered as a generalization of
 #' eigenvector centerality to directed graphs. It was proposed by Bonacich in
 #' 2001 (see reference below).
-#' 
+#'
 #' The alpha centrality of the vertices in a graph is defined as the solution
 #' of the following matrix equation: \deqn{x=\alpha A^T x+e,}{x=alpha t(A)x+e,}
 #' where \eqn{A}{A} is the (not neccessarily symmetric) adjacency matrix of the
@@ -1524,7 +1524,7 @@ alpha.centrality.sparse <- function(graph, nodes=V(graph), alpha=1,
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' # The examples from Bonacich's paper
 #' g.1 <- graph( c(1,3,2,3,3,4,4,5) )
 #' g.2 <- graph( c(2,1,3,1,4,1,5,1) )
@@ -1532,7 +1532,7 @@ alpha.centrality.sparse <- function(graph, nodes=V(graph), alpha=1,
 #' alpha_centrality(g.1)
 #' alpha_centrality(g.2)
 #' alpha_centrality(g.3,alpha=0.5)
-#' 
+#'
 alpha_centrality <- function(graph, nodes=V(graph), alpha=1,
                              loops=FALSE, exo=1, weights=NULL,
                              tol=1e-7, sparse=TRUE) {
@@ -1555,10 +1555,10 @@ alpha_centrality <- function(graph, nodes=V(graph), alpha=1,
 
 
 #' Graph density
-#' 
+#'
 #' The density of a graph is the ratio of the number of edges and the number of
 #' possible edges.
-#' 
+#'
 #' Note that this function may return strange results for graph with multiple
 #' edges, density is ill-defined for graphs with multiple edges.
 #'
@@ -1578,23 +1578,23 @@ alpha_centrality <- function(graph, nodes=V(graph), alpha=1,
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g1 <- make_empty_graph(n=10)
 #' g2 <- make_full_graph(n=10)
 #' g3 <- sample_gnp(n=10, 0.4)
-#' 
+#'
 #' # loop edges
 #' g <- graph( c(1,2, 2,2, 2,3) )
 #' edge_density(g, loops=FALSE)              # this is wrong!!!
 #' edge_density(g, loops=TRUE)               # this is right!!!
 #' edge_density(simplify(g), loops=FALSE)    # this is also right, but different
-#' 
+#'
 edge_density <- function(graph, loops=FALSE) {
 
   if (!is_igraph(graph)) {
     stop("Not a graph object")
-  }  
-  
+  }
+
   on.exit( .Call(C_R_igraph_finalizer) )
   .Call(C_R_igraph_density, graph, as.logical(loops))
 }
@@ -1613,7 +1613,7 @@ ego_size <- function(graph, order = 1, nodes=V(graph),
   mindist <- as.integer(mindist)
 
   on.exit( .Call(C_R_igraph_finalizer) )
-  .Call(C_R_igraph_neighborhood_size, graph, 
+  .Call(C_R_igraph_neighborhood_size, graph,
         as.igraph.vs(graph, nodes)-1, as.numeric(order), as.numeric(mode),
         mindist)
 }
@@ -1621,28 +1621,28 @@ ego_size <- function(graph, order = 1, nodes=V(graph),
 
 
 #' Neighborhood of graph vertices
-#' 
+#'
 #' These functions find the vertices not farther than a given limit from
 #' another fixed vertex, these are called the neighborhood of the vertex.
-#' 
+#'
 #' The neighborhood of a given order \code{o} of a vertex \code{v} includes all
 #' vertices which are closer to \code{v} than the order. Ie. order 0 is always
 #' \code{v} itself, order 1 is \code{v} plus its immediate neighbors, order 2
 #' is order 1 plus the immediate neighbors of the vertices in order 1, etc.
-#' 
+#'
 #' \code{ego_size} calculates the size of the neighborhoods for the
 #' given vertices with the given order.
-#' 
+#'
 #' \code{ego} calculates the neighborhoods of the given vertices with
 #' the given order parameter.
-#' 
+#'
 #' \code{make_ego_graph} is creates (sub)graphs from all neighborhoods of
 #' the given vertices with the given order parameter. This function preserves
 #' the vertex, edge and graph attributes.
-#' 
+#'
 #' \code{connect} creates a new graph by connecting each vertex to
 #' all other vertices in its neighborhood.
-#' 
+#'
 #' @aliases neighborhood neighborhood.size graph.neighborhood ego_graph
 #' connect.neighborhood connect ego_size ego
 #' @param graph The input graph.
@@ -1657,18 +1657,18 @@ ego_size <- function(graph, order = 1, nodes=V(graph),
 #' argument is ignored for undirected graphs.
 #' @param mindist The minimum distance to include the vertex in the result.
 #' @return \code{ego_size} returns with an integer vector.
-#' 
+#'
 #' \code{ego} returns with a list of integer vectors.
-#' 
+#'
 #' \code{make_ego_graph} returns with a list of graphs.
-#' 
+#'
 #' \code{connect} returns with a new graph object.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}, the first version was
 #' done by Vincent Matossian
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- make_ring(10)
 #' ego_size(g, order = 0, 1:3)
 #' ego_size(g, order = 1, 1:3)
@@ -1676,18 +1676,18 @@ ego_size <- function(graph, order = 1, nodes=V(graph),
 #' ego(g, order = 0, 1:3)
 #' ego(g, order = 1, 1:3)
 #' ego(g, order = 2, 1:3)
-#' 
+#'
 #' # attributes are preserved
 #' V(g)$name <- c("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")
 #' make_ego_graph(g, order = 2, 1:3)
-#' 
+#'
 #' # connecting to the neighborhood
 #' g <- make_ring(10)
 #' g <- connect(g, 2)
-#' 
+#'
 ego <- function(graph, order = 1, nodes=V(graph),
                          mode=c("all", "out", "in"), mindist=0) {
-  
+
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
@@ -1696,7 +1696,7 @@ ego <- function(graph, order = 1, nodes=V(graph),
   mindist <- as.integer(mindist)
 
   on.exit( .Call(C_R_igraph_finalizer) )
-  res <- .Call(C_R_igraph_neighborhood, graph, 
+  res <- .Call(C_R_igraph_neighborhood, graph,
                as.igraph.vs(graph, nodes)-1, as.numeric(order),
                as.numeric(mode), mindist)
   res <- lapply(res, function(x) x+1)
@@ -1722,7 +1722,7 @@ make_ego_graph <- function(graph, order = 1, nodes=V(graph),
   mindist <- as.integer(mindist)
 
   on.exit( .Call(C_R_igraph_finalizer) )
-  res <- .Call(C_R_igraph_neighborhood_graphs, graph, 
+  res <- .Call(C_R_igraph_neighborhood_graphs, graph,
                as.igraph.vs(graph, nodes)-1, as.numeric(order),
                as.numeric(mode), mindist)
   res
@@ -1731,15 +1731,15 @@ make_ego_graph <- function(graph, order = 1, nodes=V(graph),
 
 
 #' K-core decomposition of graphs
-#' 
+#'
 #' The k-core of graph is a maximal subgraph in which each vertex has at least
 #' degree k. The coreness of a vertex is k if it belongs to the k-core but not
 #' to the (k+1)-core.
-#' 
+#'
 #' The k-core of a graph is the maximal subgraph in which every vertex has at
 #' least degree k. The cores of a graph form layers: the (k+1)-core is always a
 #' subgraph of the k-core.
-#' 
+#'
 #' This function calculates the coreness for each vertex.
 #'
 #' @aliases graph.coreness
@@ -1754,17 +1754,17 @@ make_ego_graph <- function(graph, order = 1, nodes=V(graph),
 #' @seealso \code{\link{degree}}
 #' @references Vladimir Batagelj, Matjaz Zaversnik: An O(m) Algorithm for Cores
 #' Decomposition of Networks, 2002
-#' 
+#'
 #' Seidman S. B. (1983) Network structure and minimum degree, \emph{Social
 #' Networks}, 5, 269--287.
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- make_ring(10)
 #' g <- add_edges(g, c(1,2, 2,3, 1,3))
 #' coreness(g) 		# small core triangle in a ring
-#' 
+#'
 coreness <- function(graph, mode=c("all", "out", "in")) {
 
   if (!is_igraph(graph)) {
@@ -1784,10 +1784,10 @@ coreness <- function(graph, mode=c("all", "out", "in")) {
 
 
 #' Topological sorting of vertices in a graph
-#' 
+#'
 #' A topological sorting of a directed acyclic graph is a linear ordering of
 #' its nodes where each node comes before all nodes to which it has edges.
-#' 
+#'
 #' Every DAG has at least one topological sort, and may have many.  This
 #' function returns a possible topological sort among them. If the graph is not
 #' acyclic (it has at least one cycle), a partial topological sort is returned
@@ -1808,10 +1808,10 @@ coreness <- function(graph, mode=c("all", "out", "in")) {
 #' @keywords graphs
 #' @export
 #' @examples
-#' 
+#'
 #' g <- barabasi.game(100)
 #' topo_sort(g)
-#' 
+#'
 topo_sort <- function(graph, mode=c("out", "all", "in")) {
 
   if (!is_igraph(graph)) {
@@ -1831,18 +1831,18 @@ topo_sort <- function(graph, mode=c("out", "all", "in")) {
 
 
 #' Girth of a graph
-#' 
+#'
 #' The girth of a graph is the length of the shortest circle in it.
-#' 
+#'
 #' The current implementation works for undirected graphs only, directed graphs
 #' are treated as undirected graphs. Loop edges and multiple edges are ignored.
 #' If the graph is a forest (ie. acyclic), then zero is returned.
-#' 
+#'
 #' This implementation is based on Alon Itai and Michael Rodeh: Finding a
 #' minimum circuit in a graph \emph{Proceedings of the ninth annual ACM
 #' symposium on Theory of computing}, 1-10, 1977. The first implementation of
 #' this function was done by Keith Briggs, thanks Keith.
-#' 
+#'
 #' @param graph The input graph. It may be directed, but the algorithm searches
 #' for undirected circles anyway.
 #' @param circle Logical scalar, whether to return the shortest circle itself.
@@ -1856,19 +1856,19 @@ topo_sort <- function(graph, mode=c("out", "all", "in")) {
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' # No circle in a tree
 #' g <- make_tree(1000, 3)
 #' girth(g)
-#' 
+#'
 #' # The worst case running time is for a ring
 #' g <- make_ring(100)
 #' girth(g)
-#' 
+#'
 #' # What about a random graph?
 #' g <- sample_gnp(1000, 1/1000)
 #' girth(g)
-#' 
+#'
 girth <- function(graph, circle=TRUE) {
 
   if (!is_igraph(graph)) {
@@ -1896,29 +1896,29 @@ which_loop <- function(graph, eids=E(graph)) {
 
 
 #' Find the multiple or loop edges in a graph
-#' 
+#'
 #' A loop edge is an edge from a vertex to itself. An edge is a multiple edge
 #' if it has exactly the same head and tail vertices as another edge. A graph
 #' without multiple and loop edges is called a simple graph.
-#' 
+#'
 #' \code{which_loop} decides whether the edges of the graph are loop edges.
-#' 
+#'
 #' \code{any_multiple} decides whether the graph has any multiple edges.
-#' 
+#'
 #' \code{which_multiple} decides whether the edges of the graph are multiple
 #' edges.
-#' 
+#'
 #' \code{count_multiple} counts the multiplicity of each edge of a graph.
-#' 
+#'
 #' Note that the semantics for \code{which_multiple} and \code{count_multiple} is
 #' different. \code{which_multiple} gives \code{TRUE} for all occurences of a
 #' multiple edge except for one. Ie. if there are three \code{i-j} edges in the
 #' graph then \code{which_multiple} returns \code{TRUE} for only two of them while
 #' \code{count_multiple} returns \sQuote{3} for all three.
-#' 
+#'
 #' See the examples for getting rid of multiple edges while keeping their
 #' original multiplicity as an edge attribute.
-#' 
+#'
 #' @aliases has.multiple is.loop is.multiple count.multiple count_multiple
 #'   any_multiple which_loop
 #' @param graph The input graph.
@@ -1932,11 +1932,11 @@ which_loop <- function(graph, eids=E(graph)) {
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' # Loops
 #' g <- graph( c(1,1,2,2,3,3,4,5) )
 #' which_loop(g)
-#' 
+#'
 #' # Multiple edges
 #' g <- barabasi.game(10, m=3, algorithm="bag")
 #' any_multiple(g)
@@ -1944,18 +1944,18 @@ which_loop <- function(graph, eids=E(graph)) {
 #' count_multiple(g)
 #' which_multiple(simplify(g))
 #' all(count_multiple(simplify(g)) == 1)
-#' 
+#'
 #' # Direction of the edge is important
 #' which_multiple(graph( c(1,2, 2,1) ))
 #' which_multiple(graph( c(1,2, 2,1), dir=FALSE ))
-#' 
+#'
 #' # Remove multiple edges but keep multiplicity
 #' g <- barabasi.game(10, m=3, algorithm="bag")
 #' E(g)$weight <- count_multiple(g)
 #' g <- simplify(g)
 #' any(which_multiple(g))
 #' E(g)$weight
-#' 
+#'
 which_multiple <- function(graph, eids=E(graph)) {
 
   if (!is_igraph(graph)) {
@@ -1979,11 +1979,11 @@ count_multiple <- function(graph, eids=E(graph)) {
 
 
 #' Breadth-first search
-#' 
+#'
 #' Breadth-first search is an algorithm to traverse a graph. We start from a
 #' root vertex and spread along every edge \dQuote{simultaneously}.
-#' 
-#' 
+#'
+#'
 #' The callback function must have the following arguments: \describe{
 #' \item{graph}{The input graph is passed to the callback function here.}
 #' \item{data}{A named numeric vector, with the following entries:
@@ -2034,7 +2034,7 @@ count_multiple <- function(graph, eids=E(graph)) {
 #' vertex that was visited after the current one, or 0 if there was no such
 #' vertex.} \item{dist}{Numeric vector, for each vertex its distance from the
 #' root of the search tree.}
-#' 
+#'
 #' Note that \code{order}, \code{rank}, \code{father}, \code{pred}, \code{succ}
 #' and \code{dist} might be \code{NULL} if their corresponding argument is
 #' \code{FALSE}, i.e. if their calculation is not requested.
@@ -2043,12 +2043,12 @@ count_multiple <- function(graph, eids=E(graph)) {
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' ## Two rings
 #' bfs(make_ring(10) %du% make_ring(10), root=1, "out",
 #'           order=TRUE, rank=TRUE, father=TRUE, pred=TRUE,
 #'           succ=TRUE, dist=TRUE)
-#' 
+#'
 #' ## How to use a callback
 #' f <- function(graph, data, extra) {
 #'   print(data)
@@ -2056,15 +2056,15 @@ count_multiple <- function(graph, eids=E(graph)) {
 #' }
 #' tmp <- bfs(make_ring(10) %du% make_ring(10), root=1, "out",
 #'                  callback=f)
-#' 
+#'
 #' ## How to use a callback to stop the search
 #' ## We stop after visiting all vertices in the initial component
 #' f <- function(graph, data, extra) {
 #'  data['succ'] == -1
 #' }
 #' bfs(make_ring(10) %du% make_ring(10), root=1, callback=f)
-#' 
-#' 
+#'
+#'
 bfs <- function(graph, root, neimode=c("out", "in", "all", "total"),
                       unreachable=TRUE, restricted=NULL,
                       order=TRUE, rank=FALSE, father=FALSE,
@@ -2077,7 +2077,7 @@ bfs <- function(graph, root, neimode=c("out", "in", "all", "total"),
 
   if (length(root)==1) {
     root <- as.igraph.vs(graph, root)-1
-    roots <- NULL    
+    roots <- NULL
   } else {
     roots <- as.igraph.vs(graph, root)-1
     root <- 0      # ignored anyway
@@ -2087,14 +2087,14 @@ bfs <- function(graph, root, neimode=c("out", "in", "all", "total"),
   unreachable <- as.logical(unreachable)
   if (!is.null(restricted)) { restricted <- as.igraph.vs(graph, restricted) - 1 }
   if (!is.null(callback)) { callback <- as.function(callback) }
-  
+
   on.exit( .Call(C_R_igraph_finalizer) )
   res <- .Call(C_R_igraph_bfs, graph, root, roots, neimode, unreachable,
                restricted,
                as.logical(order), as.logical(rank), as.logical(father),
                as.logical(pred), as.logical(succ), as.logical(dist),
                callback, extra, rho)
-  
+
   if (order)  res$order  <- res$order+1
   if (rank)   res$rank   <- res$rank+1
   if (father) res$father <- res$father+1
@@ -2122,10 +2122,10 @@ bfs <- function(graph, root, neimode=c("out", "in", "all", "total"),
 
 
 #' Depth-first search
-#' 
+#'
 #' Depth-first search is an algorithm to traverse a graph. It starts from a
 #' root vertex and tries to go quickly as far from as possible.
-#' 
+#'
 #' The callback functions must have the following arguments: \describe{
 #' \item{graph}{The input graph is passed to the callback function here.}
 #' \item{data}{A named numeric vector, with the following entries:
@@ -2168,7 +2168,7 @@ bfs <- function(graph, root, neimode=c("out", "in", "all", "total"),
 #' completion of their subtree.} \item{father}{Numeric vector. The father of
 #' each vertex, i.e. the vertex it was discovered from.} \item{dist}{Numeric
 #' vector, for each vertex its distance from the root of the search tree.}
-#' 
+#'
 #' Note that \code{order}, \code{order.out}, \code{father}, and \code{dist}
 #' might be \code{NULL} if their corresponding argument is \code{FALSE}, i.e.
 #' if their calculation is not requested.
@@ -2177,11 +2177,11 @@ bfs <- function(graph, root, neimode=c("out", "in", "all", "total"),
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' ## A graph with two separate trees
 #' dfs(make_tree(10) %du% make_tree(10), root=1, "out",
 #'           TRUE, TRUE, TRUE, TRUE)
-#' 
+#'
 #' ## How to use a callback
 #' f.in <- function(graph, data, extra) {
 #'   cat("in:", paste(collapse=", ", data), "\n")
@@ -2193,15 +2193,15 @@ bfs <- function(graph, root, neimode=c("out", "in", "all", "total"),
 #' }
 #' tmp <- dfs(make_tree(10), root=1, "out",
 #'                  in.callback=f.in, out.callback=f.out)
-#' 
+#'
 #' ## Terminate after the first component, using a callback
 #' f.out <- function(graph, data, extra) {
 #'  data['vid'] == 1
 #' }
 #' tmp <- dfs(make_tree(10) %du% make_tree(10), root=1,
 #'                  out.callback=f.out)
-#' 
-#' 
+#'
+#'
 dfs <- function(graph, root, neimode=c("out", "in", "all", "total"),
                       unreachable=TRUE,
                       order=TRUE, order.out=FALSE, father=FALSE, dist=FALSE,
@@ -2218,12 +2218,12 @@ dfs <- function(graph, root, neimode=c("out", "in", "all", "total"),
   unreachable <- as.logical(unreachable)
   if (!is.null(in.callback)) { in.callback <- as.function(in.callback) }
   if (!is.null(out.callback)) { out.callback <- as.function(out.callback) }
-  
+
   on.exit( .Call(C_R_igraph_finalizer) )
   res <- .Call(C_R_igraph_dfs, graph, root, neimode, unreachable,
                as.logical(order), as.logical(order.out), as.logical(father),
                as.logical(dist), in.callback, out.callback, extra, rho)
-  
+
   if (order)     res$order     <- res$order+1
   if (order.out) res$order.out <- res$order.out+1
   if (father)    res$father    <- res$father+1
@@ -2252,13 +2252,13 @@ edge_betweenness <- function(graph, e=E(graph),
   if (!is_igraph(graph)) { stop("Not a graph object") }
   e <- as.igraph.es(graph, e)
   directed <- as.logical(directed)
-  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) { 
-  weights <- E(graph)$weight 
-  } 
-  if (!is.null(weights) && any(!is.na(weights))) { 
-  weights <- as.numeric(weights) 
-  } else { 
-  weights <- NULL 
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+  weights <- E(graph)$weight
+  }
+  if (!is.null(weights) && !any(is.na(weights))) {
+  weights <- as.numeric(weights)
+  } else {
+  weights <- NULL
   }
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -2276,13 +2276,13 @@ estimate_edge_betweenness <- function(graph, e=E(graph),
   e <- as.igraph.es(graph, e)
   directed <- as.logical(directed)
   cutoff <- as.numeric(cutoff)
-  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) { 
-  weights <- E(graph)$weight 
-  } 
-  if (!is.null(weights) && any(!is.na(weights))) { 
-  weights <- as.numeric(weights) 
-  } else { 
-  weights <- NULL 
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+  weights <- E(graph)$weight
+  }
+  if (!is.null(weights) && !any(is.na(weights))) {
+  weights <- as.numeric(weights)
+  } else {
+  weights <- NULL
   }
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -2294,25 +2294,25 @@ estimate_edge_betweenness <- function(graph, e=E(graph),
 
 
 #' Connected components of a graph
-#' 
+#'
 #' Calculate the maximal (weakly or strongly) connected components of a graph
-#' 
+#'
 #' \code{is_connected} decides whether the graph is weakly or strongly
 #' connected.
-#' 
+#'
 #' \code{components} finds the maximal (weakly or strongly) connected components
 #' of a graph.
-#' 
+#'
 #' \code{count_components} does almost the same as \code{components} but returns only
 #' the number of clusters found instead of returning the actual clusters.
-#' 
+#'
 #' \code{component_distribution} creates a histogram for the maximal connected
 #' component sizes.
-#' 
+#'
 #' The weakly connected components are found by a simple breadth-first search.
 #' The strongly connected components are implemented by two consecutive
 #' depth-first searches.
-#' 
+#'
 #' @aliases no.clusters clusters is.connected cluster.distribution components
 #'   count_components is_connected
 #' @param graph The graph to analyze.
@@ -2322,14 +2322,14 @@ estimate_edge_betweenness <- function(graph, e=E(graph),
 #' @param \dots Additional attributes to pass to \code{cluster}, right now only
 #' \code{mode} makes sense.
 #' @return For \code{is_connected} a logical constant.
-#' 
+#'
 #' For \code{components} a named list with three components:
 #' \item{membership}{numeric vector giving the cluster id to which each vertex
 #' belongs.} \item{csize}{numeric vector giving the sizes of the clusters.}
 #' \item{no}{numeric constant, the number of clusters.}
-#' 
+#'
 #' For \code{count_components} an integer constant is returned.
-#' 
+#'
 #' For \code{component_distribution} a numeric vector with the relative
 #' frequencies. The length of the vector is the size of the largest component
 #' plus one. Note that (for currently unknown reasons) the first element of the
@@ -2339,11 +2339,11 @@ estimate_edge_betweenness <- function(graph, e=E(graph),
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- sample_gnp(20, 1/20)
 #' clu <- components(g)
 #' groups(clu)
-#' 
+#'
 components <- function(graph, mode=c("weak", "strong")) {
   # Argument checks
   if (!is_igraph(graph)) { stop("Not a graph object") }
@@ -2363,15 +2363,15 @@ components <- function(graph, mode=c("weak", "strong")) {
 
 
 #' Convert a general graph into a forest
-#' 
+#'
 #' Perform a breadth-first search on a graph and convert it into a tree or
 #' forest by replicating vertices that were found more than once.
-#' 
+#'
 #' A forest is a graph, whose components are trees.
-#' 
+#'
 #' The \code{roots} vector can be calculated by simply doing a topological sort
 #' in all components of the graph, see the examples below.
-#' 
+#'
 #' @aliases unfold.tree
 #' @param graph The input graph, it can be either directed or undirected.
 #' @param mode Character string, defined the types of the paths used for the
@@ -2388,13 +2388,13 @@ components <- function(graph, mode=c("weak", "strong")) {
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- make_tree(10) %du% make_tree(10)
 #' V(g)$id <- seq_len(vcount(g))-1
 #' roots <- sapply(decompose(g), function(x) {
 #'             V(x)$id[ topo_sort(x)[1]+1 ] })
 #' tree <- unfold_tree(g, roots=roots)
-#' 
+#'
 unfold_tree <- function(graph, mode=c("all", "out", "in", "total"), roots) {
   # Argument checks
   if (!is_igraph(graph)) { stop("Not a graph object") }
@@ -2410,25 +2410,25 @@ unfold_tree <- function(graph, mode=c("all", "out", "in", "total"), roots) {
 
 
 #' Closeness centrality of vertices
-#' 
+#'
 #' Cloness centrality measures how many steps is required to access every other
 #' vertex from a given vertex.
-#' 
+#'
 #' The closeness centrality of a vertex is defined by the inverse of the
 #' average length of the shortest paths to/from all the other vertices in the
 #' graph:
-#' 
+#'
 #' \deqn{\frac{1}{\sum_{i\ne v} d_vi}}{1/sum( d(v,i), i != v)}
-#' 
+#'
 #' If there is no (directed) path between vertex \eqn{v}{\code{v}} and
 #' \eqn{i}{\code{i}} then the total number of vertices is used in the formula
 #' instead of the path length.
-#' 
+#'
 #' \code{estimate_closeness} only considers paths of length \code{cutoff} or
 #' smaller, this can be run for larger graphs, as the running time is not
 #' quadratic (if \code{cutoff} is small). If \code{cutoff} is zero or negative
 #' then the function calculates the exact closeness scores.
-#' 
+#'
 #' @aliases closeness closeness.estimate estimate_closeness
 #' @param graph The graph to analyze.
 #' @param vids The vertices for which closeness will be calculated.
@@ -2453,14 +2453,14 @@ unfold_tree <- function(graph, mode=c("all", "out", "in", "total"), roots) {
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- make_ring(10)
 #' g2 <- make_star(10)
 #' closeness(g)
 #' closeness(g2, mode="in")
 #' closeness(g2, mode="out")
 #' closeness(g2, mode="all")
-#' 
+#'
 closeness <- function(graph, vids=V(graph),
                       mode=c("out", "in", "all", "total"), weights=NULL,
                       normalized=FALSE) {
@@ -2468,13 +2468,13 @@ closeness <- function(graph, vids=V(graph),
   if (!is_igraph(graph)) { stop("Not a graph object") }
   vids <- as.igraph.vs(graph, vids)
   mode <- switch(igraph.match.arg(mode), "out"=1, "in"=2, "all"=3, "total"=3)
-  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) { 
-  weights <- E(graph)$weight 
-  } 
-  if (!is.null(weights) && any(!is.na(weights))) { 
-  weights <- as.numeric(weights) 
-  } else { 
-  weights <- NULL 
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+  weights <- E(graph)$weight
+  }
+  if (!is.null(weights) && !any(is.na(weights))) {
+  weights <- as.numeric(weights)
+  } else {
+  weights <- NULL
   }
   normalized <- as.logical(normalized)
 
@@ -2499,39 +2499,39 @@ estimate_closeness <- function(graph, vids=V(graph), mode=c("out", "in", "all", 
   vids <- as.igraph.vs(graph, vids)
   mode <- switch(igraph.match.arg(mode), "out"=1, "in"=2, "all"=3, "total"=3)
   cutoff <- as.numeric(cutoff)
-  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) { 
-  weights <- E(graph)$weight 
-  } 
-  if (!is.null(weights) && any(!is.na(weights))) { 
-  weights <- as.numeric(weights) 
-  } else { 
-  weights <- NULL 
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+  weights <- E(graph)$weight
+  }
+  if (!is.null(weights) && !any(is.na(weights))) {
+  weights <- as.numeric(weights)
+  } else {
+  weights <- NULL
   }
   normalized <- as.logical(normalized)
 
   on.exit( .Call(C_R_igraph_finalizer) )
   # Function call
   res <- .Call(C_R_igraph_closeness_estimate, graph, vids-1, mode, cutoff, weights, normalized)
-  if (igraph_opt("add.vertex.names") && is_named(graph)) { 
-  names(res) <- vertex_attr(graph, "name", vids) 
+  if (igraph_opt("add.vertex.names") && is_named(graph)) {
+  names(res) <- vertex_attr(graph, "name", vids)
   }
   res
 }
 
 
 #' Graph Laplacian
-#' 
+#'
 #' The Laplacian of a graph.
-#' 
+#'
 #' The Laplacian Matrix of a graph is a symmetric matrix having the same number
 #' of rows and columns as the number of vertices in the graph and element (i,j)
 #' is d[i], the degree of vertex i if if i==j, -1 if i!=j and there is an edge
 #' between vertices i and j and 0 otherwise.
-#' 
+#'
 #' A normalized version of the Laplacian Matrix is similar: element (i,j) is 1
 #' if i==j, -1/sqrt(d[i] d[j]) if i!=j and there is an edge between vertices i
 #' and j and 0 otherwise.
-#' 
+#'
 #' The weighted version of the Laplacian simply works with the weighted degree
 #' instead of the plain degree. I.e. (i,j) is d[i], the weighted degree of
 #' vertex i if if i==j, -w if i!=j and there is an edge between vertices i and
@@ -2554,24 +2554,24 @@ estimate_closeness <- function(graph, vids=V(graph), mode=c("out", "in", "all", 
 #' @export
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- make_ring(10)
 #' laplacian_matrix(g)
 #' laplacian_matrix(g, norm=TRUE)
 #' laplacian_matrix(g, norm=TRUE, sparse=FALSE)
-#' 
+#'
 laplacian_matrix <- function(graph, normalized=FALSE, weights=NULL,
                             sparse=igraph_opt("sparsematrices")) {
   # Argument checks
   if (!is_igraph(graph)) { stop("Not a graph object") }
   normalized <- as.logical(normalized)
-  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) { 
-    weights <- E(graph)$weight 
-  } 
-  if (!is.null(weights) && any(!is.na(weights))) { 
-    weights <- as.numeric(weights) 
-  } else { 
-    weights <- NULL 
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+    weights <- E(graph)$weight
+  }
+  if (!is.null(weights) && !any(is.na(weights))) {
+    weights <- as.numeric(weights)
+  } else {
+    weights <- NULL
   }
   sparse <- as.logical(sparse)
 
@@ -2588,22 +2588,22 @@ laplacian_matrix <- function(graph, normalized=FALSE, weights=NULL,
 }
 
 #' Graph matching
-#' 
+#'
 #' A matching in a graph means the selection of a set of edges that are
 #' pairwise non-adjacenct, i.e. they have no common incident vertices. A
 #' matching is maximal if it is not a proper subset of any other matching.
-#' 
+#'
 #' \code{is_matching} checks a matching vector and verifies whether its
 #' length matches the number of vertices in the given graph, its values are
 #' between zero (inclusive) and the number of vertices (inclusive), and
 #' whether there exists a corresponding edge in the graph for every matched
 #' vertex pair. For bipartite graphs, it also verifies whether the matched
 #' vertices are in different parts of the graph.
-#' 
+#'
 #' \code{is_max_matching} checks whether a matching is maximal.  A matching
 #' is maximal if and only if there exists no unmatched vertex in a graph
 #' such that one of its neighbors is also unmatched.
-#' 
+#'
 #' \code{max_bipartite_match} calculates a maximum matching in a bipartite
 #' graph. A matching in a bipartite graph is a partial assignment of
 #' vertices of the first kind to vertices of the second kind such that each
@@ -2614,7 +2614,7 @@ laplacian_matrix <- function(graph, normalized=FALSE, weights=NULL,
 #' matching with larger cardinality.  For weighted graphs, a maximum
 #' matching is a matching whose edges have the largest possible total
 #' weight among all possible matchings.
-#' 
+#'
 #' Maximum matchings in bipartite graphs are found by the push-relabel
 #' algorithm with greedy initialization and a global relabeling after every
 #' \eqn{n/2} steps where \eqn{n} is the number of vertices in the graph.
@@ -2643,7 +2643,7 @@ laplacian_matrix <- function(graph, normalized=FALSE, weights=NULL,
 #' is ignored.
 #' @return \code{is_matching} and \code{is_max_matching} return a logical
 #' scalar.
-#' 
+#'
 #' \code{max_bipartite_match} returns a list with components:
 #'   \item{matching_size}{The size of the matching, i.e. the number of edges
 #'     connecting the matched vertices.}
@@ -2652,7 +2652,7 @@ laplacian_matrix <- function(graph, normalized=FALSE, weights=NULL,
 #'     matching.}
 #'   \item{matching}{The matching itself. Numeric vertex id, or vertex
 #'     names if the graph was named. Non-matched vertices are denoted by
-#'     \code{NA}.} 
+#'     \code{NA}.}
 #' @author Tamas Nepusz \email{ntamas@@gmail.com}
 #' @examples
 #' g <- graph_from_literal( a-b-c-d-e-f )
@@ -2665,26 +2665,26 @@ laplacian_matrix <- function(graph, normalized=FALSE, weights=NULL,
 #' is_max_matching(g, m1)
 #' is_max_matching(g, m2)
 #' is_max_matching(g, m3)
-#' 
+#'
 #' V(g)$type <- c(FALSE,TRUE)
 #' print_all(g, v=TRUE)
 #' max_bipartite_match(g)
-#' 
+#'
 #' g2 <- graph_from_literal( a-b-c-d-e-f-g )
 #' V(g2)$type <- rep(c(FALSE,TRUE), length=vcount(g2))
 #' print_all(g2, v=TRUE)
 #' max_bipartite_match(g2)
 #' #' @keywords graphs
 #' @export
- 
+
 is_matching <- function(graph, matching, types=NULL) {
   # Argument checks
   if (!is_igraph(graph)) { stop("Not a graph object") }
-  if (is.null(types) && "type" %in% vertex_attr_names(graph)) { 
-    types <- V(graph)$type 
-  } 
-  if (!is.null(types)) { 
-    types <- as.logical(types) 
+  if (is.null(types) && "type" %in% vertex_attr_names(graph)) {
+    types <- V(graph)$type
+  }
+  if (!is.null(types)) {
+    types <- as.logical(types)
   }
   matching <- as.igraph.vs(graph, matching, na.ok=TRUE)-1
   matching[ is.na(matching) ] <- -1
@@ -2698,15 +2698,15 @@ is_matching <- function(graph, matching, types=NULL) {
 
 #' @export
 #' @rdname matching
- 
+
 is_max_matching <- function(graph, matching, types=NULL) {
   # Argument checks
   if (!is_igraph(graph)) { stop("Not a graph object") }
-  if (is.null(types) && "type" %in% vertex_attr_names(graph)) { 
-    types <- V(graph)$type 
-  } 
-  if (!is.null(types)) { 
-    types <- as.logical(types) 
+  if (is.null(types) && "type" %in% vertex_attr_names(graph)) {
+    types <- V(graph)$type
+  }
+  if (!is.null(types)) {
+    types <- as.logical(types)
   }
   matching <- as.igraph.vs(graph, matching, na.ok=TRUE)-1
   matching[ is.na(matching) ] <- -1
@@ -2720,24 +2720,24 @@ is_max_matching <- function(graph, matching, types=NULL) {
 
 #' @export
 #' @rdname matching
- 
+
 max_bipartite_match <- function(graph, types=NULL, weights=NULL,
                                        eps=.Machine$double.eps) {
   # Argument checks
   if (!is_igraph(graph)) { stop("Not a graph object") }
-  if (is.null(types) && "type" %in% vertex_attr_names(graph)) { 
-    types <- V(graph)$type 
-  } 
-  if (!is.null(types)) { 
-    types <- as.logical(types) 
+  if (is.null(types) && "type" %in% vertex_attr_names(graph)) {
+    types <- V(graph)$type
   }
-  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) { 
-    weights <- E(graph)$weight 
-  } 
-  if (!is.null(weights) && any(!is.na(weights))) { 
-    weights <- as.numeric(weights) 
-  } else { 
-    weights <- NULL 
+  if (!is.null(types)) {
+    types <- as.logical(types)
+  }
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+    weights <- E(graph)$weight
+  }
+  if (!is.null(weights) && !any(is.na(weights))) {
+    weights <- as.numeric(weights)
+  } else {
+    weights <- NULL
   }
   eps <- as.numeric(eps)
 
@@ -2756,18 +2756,18 @@ max_bipartite_match <- function(graph, types=NULL, weights=NULL,
 
 
 #' Find mutual edges in a directed graph
-#' 
+#'
 #' This function checks the reciproc pair of the supplied edges.
-#' 
+#'
 #' In a directed graph an (A,B) edge is mutual if the graph also includes a
 #' (B,A) directed edge.
-#' 
+#'
 #' Note that multi-graphs are not handled properly, i.e. if the graph contains
 #' two copies of (A,B) and one copy of (B,A), then these three edges are
 #' considered to be mutual.
-#' 
+#'
 #' Undirected graphs contain only mutual edges by definition.
-#' 
+#'
 #' @aliases is.mutual which_mutual
 #' @param graph The input graph.
 #' @param es Edge sequence, the edges that will be probed. By default is
@@ -2778,7 +2778,7 @@ max_bipartite_match <- function(graph, types=NULL, weights=NULL,
 #' want some statistics about mutual edges.
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' g <- sample_gnm(10, 50, directed=TRUE)
 #' reciprocity(g)
 #' dyad_census(g)
@@ -2790,14 +2790,14 @@ which_mutual <- which_mutual
 
 
 #' Average nearest neighbor degree
-#' 
+#'
 #' Calculate the average nearest neighbor degree of the given vertices and the
 #' same quantity in the function of vertex degree
-#' 
+#'
 #' Note that for zero degree vertices the answer in \sQuote{\code{knn}} is
 #' \code{NaN} (zero divided by zero), the same is true for \sQuote{\code{knnk}}
 #' if a given degree never appears in the network.
-#' 
+#'
 #' The weighted version computes a weighted average of the neighbor degrees as
 #'
 #' \code{k_nn_u = 1/s_u sum_v w_uv k_v},
@@ -2838,21 +2838,21 @@ which_mutual <- which_mutual
 #' Natl. Acad. Sci. USA 101, 3747 (2004)
 #' @keywords graphs
 #' @examples
-#' 
+#'
 #' # Some trivial ones
 #' g <- make_ring(10)
 #' knn(g)
 #' g2 <- make_star(10)
 #' knn(g2)
-#' 
+#'
 #' # A scale-free one, try to plot 'knnk'
 #' g3 <- sample_pa(1000, m=5)
 #' knn(g3)
-#' 
+#'
 #' # A random graph
 #' g4 <- sample_gnp(1000, p=5/1000)
 #' knn(g4)
-#' 
+#'
 #' # A weighted graph
 #' g5 <- make_star(10)
 #' E(g5)$weight <- seq(ecount(g5))

--- a/R/structural.properties.R
+++ b/R/structural.properties.R
@@ -85,10 +85,13 @@ diameter <- function(graph, directed=TRUE, unconnected=TRUE, weights=NULL) {
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -108,10 +111,13 @@ get_diameter <- function(graph, directed=TRUE, unconnected=TRUE,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -137,10 +143,13 @@ farthest_vertices <- function(graph, directed=TRUE, unconnected=TRUE,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -709,11 +718,15 @@ estimate_betweenness <- function(graph, vids=V(graph), directed=TRUE, cutoff, we
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
   weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-  weights <- as.numeric(weights)
-  } else {
-  weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
+
   nobigint <- as.logical(nobigint)
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -810,11 +823,15 @@ betweenness <- function(graph, v=V(graph), directed=TRUE, weights=NULL,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
+
   on.exit( .Call(C_R_igraph_finalizer) )
   res <- .Call(C_R_igraph_betweenness, graph, v-1,
                as.logical(directed), weights, as.logical(nobigint))
@@ -945,10 +962,13 @@ transitivity <- function(graph, type=c("undirected", "global", "globalundirected
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
 
   isolates <- igraph.match.arg(isolates)
@@ -1407,6 +1427,7 @@ alpha.centrality.dense <- function(graph, nodes=V(graph), alpha=1,
     attr <- "weight"
   } else {
     ## weights != NULL, but some weights are NA
+    warning("Weights contains NA elements, ignoring the weights.")
     attr <- NULL
   }
 
@@ -1450,6 +1471,7 @@ alpha.centrality.sparse <- function(graph, nodes=V(graph), alpha=1,
     attr <- "weight"
   } else {
     ## weights != NULL, but some weights are NA
+    warning("Weights contains NA elements, ignoring the weights.")
     attr <- NULL
   }
 
@@ -2255,10 +2277,13 @@ edge_betweenness <- function(graph, e=E(graph),
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
   weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-  weights <- as.numeric(weights)
-  } else {
-  weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -2279,10 +2304,13 @@ estimate_edge_betweenness <- function(graph, e=E(graph),
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
   weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-  weights <- as.numeric(weights)
-  } else {
-  weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -2471,11 +2499,15 @@ closeness <- function(graph, vids=V(graph),
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
   weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-  weights <- as.numeric(weights)
-  } else {
-  weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
+
   normalized <- as.logical(normalized)
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -2502,11 +2534,15 @@ estimate_closeness <- function(graph, vids=V(graph), mode=c("out", "in", "all", 
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
   weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-  weights <- as.numeric(weights)
-  } else {
-  weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+     weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
+
   normalized <- as.logical(normalized)
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -2568,11 +2604,15 @@ laplacian_matrix <- function(graph, normalized=FALSE, weights=NULL,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
+
   sparse <- as.logical(sparse)
 
   on.exit( .Call(C_R_igraph_finalizer) )
@@ -2734,11 +2774,15 @@ max_bipartite_match <- function(graph, types=NULL, weights=NULL,
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
-  if (!is.null(weights) && !any(is.na(weights))) {
-    weights <- as.numeric(weights)
-  } else {
-    weights <- NULL
+  if (!is.null(weights)) {
+    if (!any(is.na(weights))) {
+      weights <- as.numeric(weights)
+    } else {
+      warning("Weights vector contains NA elements, ignoring the weights vector.")
+      weights <- NULL
+    }
   }
+
   eps <- as.numeric(eps)
 
   on.exit( .Call(C_R_igraph_finalizer) )

--- a/tools/stimulus/types-R.def
+++ b/tools/stimulus/types-R.def
@@ -186,7 +186,7 @@ EDGEWEIGHTS:
     INCONV: if (is.null(%I%) && "weight" %in% edge_attr_names(%I1%)) { \
                %I% <- E(%I1%)$weight \
             } \
-            if (!is.null(%I%) && any(!is.na(%I%))) { \
+            if (!is.null(%I%) && !any(is.na(%I%))) { \
                %I% <- as.numeric(%I%) \
             } else { \
                %I% <- NULL \
@@ -196,7 +196,7 @@ VERTEXWEIGHTS:
     INCONV: if (is.null(%I%) && "weight" %in% vertex_attr_names(%I1%)) { \
                %I% <- V(%I1%)$weight \
             } \
-            if (!is.null(%I%) && any(!is.na(%I%))) { \
+            if (!is.null(%I%) && !any(is.na(%I%))) { \
                %I% <- as.numeric(%I%) \
             } else { \
                %I% <- NULL \
@@ -206,7 +206,7 @@ EDGECAPACITY:
     INCONV: if (is.null(%I%) && "capacity" %in% edge_attr_names(%I1%)) { \
                %I% <- E(%I1%)$capacity \
             } \
-            if (!is.null(%I%) && any(!is.na(%I%))) { \
+            if (!is.null(%I%) && !any(is.na(%I%))) { \
                %I% <- as.numeric(%I%) \
             } else { \
                %I% <- NULL \

--- a/tools/stimulus/types-R.def
+++ b/tools/stimulus/types-R.def
@@ -2,7 +2,7 @@
 GRAPH:
     INCONV: if (!is_igraph(%I%)) { stop("Not a graph object") }
 
-GRAPH_OR_0:    
+GRAPH_OR_0:
     INCONV: if (!is.null(graph) && !is_igraph(%I%)) { stop("Not a graph object") }
 
 INTEGER:
@@ -29,13 +29,13 @@ VECTOR:
        AsmDefaultCvec: graph.strength(%I1%, weights=weights)/(vcount(%I1%)-1)
 
 VERTEXINDEX:
-    OUTCONV: 
+    OUTCONV:
         OUT:  if (igraph_opt("add.vertex.names") && is_named(%I1%)) { \
                 names(%I%) <- vertex_attr(%I1%, "name", %I2%) \
               }
 
 VERTEXINDEX_OR_0:
-    OUTCONV: 
+    OUTCONV:
         OUT:  if (igraph_opt("add.vertex.names") && is_named(%I1%)) { \
                 names(%I%) <- vertex_attr(%I1%, "name", %I2%) \
               }
@@ -115,7 +115,7 @@ INTEGERPTR_OR_0:
 
 BOOLEANPTR:
 
-BOOLEANPTR_OR_0:    
+BOOLEANPTR_OR_0:
 
 REALPTR:
     INCONV:
@@ -186,30 +186,39 @@ EDGEWEIGHTS:
     INCONV: if (is.null(%I%) && "weight" %in% edge_attr_names(%I1%)) { \
                %I% <- E(%I1%)$weight \
             } \
-            if (!is.null(%I%) && !any(is.na(%I%))) { \
+            if (!is.null(%I%)) {
+              if (!any(is.na(%I%))) { \
                %I% <- as.numeric(%I%) \
-            } else { \
-               %I% <- NULL \
+              } else { \
+                warning("Edge weights contains NA elements, ignoring the edge weights.")
+                %I% <- NULL \
+              }
             }
 
 VERTEXWEIGHTS:
     INCONV: if (is.null(%I%) && "weight" %in% vertex_attr_names(%I1%)) { \
                %I% <- V(%I1%)$weight \
             } \
-            if (!is.null(%I%) && !any(is.na(%I%))) { \
-               %I% <- as.numeric(%I%) \
-            } else { \
-               %I% <- NULL \
+            if (!is.null(%I%)) {
+              if (!any(is.na(%I%))) { \
+                %I% <- as.numeric(%I%) \
+              } else { \
+                warning("Vertex weights contains NA elements, ignoring the vertex weights.")
+                %I% <- NULL \
+              }
             }
 
 EDGECAPACITY:
     INCONV: if (is.null(%I%) && "capacity" %in% edge_attr_names(%I1%)) { \
                %I% <- E(%I1%)$capacity \
             } \
-            if (!is.null(%I%) && !any(is.na(%I%))) { \
-               %I% <- as.numeric(%I%) \
-            } else { \
-               %I% <- NULL \
+            if (!is.null(%I%)) {
+              if (!any(is.na(%I%))) { \
+                %I% <- as.numeric(%I%) \
+              } else { \
+                warning("Edge capacities contains NA elements, ignoring the edge capacities.")
+                %I% <- NULL \
+              }
             }
 
 
@@ -351,12 +360,12 @@ SUBGRAPH_IMPL:
 
 EDGE_ATTRIBUTE_COMBINATION:
     INCONV: %I% <- igraph.i.attribute.combination(%I%)
-    DEFAULT: 
+    DEFAULT:
        Default: igraph_opt("edge.attr.comb")
 
 VERTEX_ATTRIBUTE_COMBINATION:
     INCONV: %I% <- igraph.i.attribute.combination(%I%)
-    DEFAULT: 
+    DEFAULT:
        Default: igraph_opt("vertex.attr.comb")
 
 ADD_WEIGHTS:
@@ -396,7 +405,7 @@ SCGNORM:
 
 SCGDIR:
     INCONV: %I% <- switch(igraph.match.arg(%I%), "default"=1, "left"=2, "right"=3)
-    DEFAULT: 
+    DEFAULT:
       Default: c("default", "left", "right")
 
 SPARSEMAT:
@@ -431,13 +440,13 @@ EIGENALGO:
     INCONV: %I% <- switch(igraph.match.arg(%I%), "auto"=0, "lapack"=1, \
                           "arpack"=2, "comp_auto"=3, "comp_lapack"=4, \
                           "comp_arpack"=5)
-    DEFAULT: 
+    DEFAULT:
       ARPACK: c("arpack", "auto", "lapack", "comp_auto", "comp_lapack", "comp_arpack")
 
 EIGENWHICH:
     INCONV: %I%.tmp <- eigen_defaults; \
             %I%.tmp[ names(%I%) ] <- %I% ; %I% <- %I%.tmp
-    DEFAULT: 
+    DEFAULT:
       Default: list()
 
 EIGENWHICHPOS:


### PR DESCRIPTION
This fixes #392. Vectors of weights or capacities are now only passed to the C core if there are no NA values at all in the vector.