### PR TITLE
Graph imported from data.frame is not simplified

### DIFF
--- a/R/data_frame.R
+++ b/R/data_frame.R
@@ -49,7 +49,7 @@
 #'
 #' Regardless of the \code{directed} status of the graph, the graph is not
 #' simplified. To remove the loops and/or multiple edges from a graph, use
-#' \code{simplify}. Simplifying the graph can speed up some calculations.
+#' \code{simplify}.
 #'
 #' \code{as_data_frame} converts the igraph graph into one or more data
 #' frames, depending on the \code{what} argument.

--- a/R/data_frame.R
+++ b/R/data_frame.R
@@ -47,6 +47,10 @@
 #' Excel and are imported into R via \code{\link{read.table}},
 #' \code{\link{read.delim}} or \code{\link{read.csv}}.
 #'
+#' Regardless of the \code{directed} status of the graph, the graph is not
+#' simplified. To remove the loops and/or multiple edges from a graph, use
+#' \code{simplify}. Simplifying the graph can speed up some calculations.
+#'
 #' \code{as_data_frame} converts the igraph graph into one or more data
 #' frames, depending on the \code{what} argument.
 #'


### PR DESCRIPTION
As discussed in #394, I would like to document that stating the graph as undirected does not imply that reversed links are aggregated automagically. I think that simplication could speed up some calculations. Let me know if you feel this addition informative.
Best.