### PR TITLE
Added Travis build status to README.

### DIFF
--- a/inst/README.md
+++ b/inst/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/igraph/rigraph.svg?branch=dev)](https://travis-ci.org/igraph/rigraph)
 
 # R/igraph
 


### PR DESCRIPTION
This PR add the current Travis build status to the `README.md`. This not only makes the build status clear, it also makes clear to people that there actually is a CI in the background.