### PR TITLE
Fix warning due to factors in graph_from_data_frame

### DIFF
--- a/R/data_frame.R
+++ b/R/data_frame.R
@@ -156,7 +156,7 @@ graph_from_data_frame <- function(d, directed=TRUE, vertices=NULL) {
     if (ncol(vertices) > 1) {
       for (i in 2:ncol(vertices)) {
         newval <- vertices[,i]
-        if (class(newval) == "factor") {
+        if ("factor" %in% class(newval)){
           newval <- as.character(newval)
         }
         attrs[[ names(vertices)[i] ]] <- newval
@@ -176,10 +176,12 @@ graph_from_data_frame <- function(d, directed=TRUE, vertices=NULL) {
   attrs <- list()
   if (ncol(d) > 2) {
     for (i in 3:ncol(d)) {
-      newval <- d[,i]
-      if (class(newval) == "factor") {
+      newval <- d[,i] 
+      
+      if ("factor" %in% class(newval)) {
         newval <- as.character(newval)
       }
+      
       attrs[[ names(d)[i] ]] <- newval
     }
   }


### PR DESCRIPTION
When converting a data.frame with an POSIXct column to an igraph object
using the function 'graph_from_data_frame', a warning is issued due to
ineffective checking of classes:
> Warning message:
> In if (class(newval) == "factor") { :
>   the condition has length > 1 and only the first element will be used

Th warning is true as a POSIXct object has actually two classes:
"POSIXct" and "POSIXt".

To remove the warning, the class of edge and vertex attributes is now
checked using the infix notation "%in%".

Signed-off-by: Claus Hunsen <hunsen@fim.uni-passau.de> copied here by Ignatius Pang <ignatius.pang@gmail.com?