### PR TITLE
Raise warning if membership is not numerical.

### DIFF
--- a/R/community.R
+++ b/R/community.R
@@ -424,6 +424,10 @@ modularity <- function(x, ...)
 modularity.igraph <- function(x, membership, weights=NULL, ...) {
   # Argument checks
   if (!is_igraph(x)) { stop("Not a graph object") }
+  if (is.null(membership) || !is.numeric(membership))
+  {
+    stop("Membership is not a numerical vector")
+  }
   membership <- as.numeric(membership)
   if (!is.null(weights)) weights <- as.numeric(weights)
 


### PR DESCRIPTION
This addresses the problem that was identified in PR #307. However, instead of interpreting any vector as a suitable membership vector, this PR simply raises a warning if the vector is not numerical.

It would be nice to have "named" communities, so that arbitrary vectors would also be suitable as membership, and that these names would also be consistently used throughout the code base. However, this is a much more extensive change. By allowing this in only a single function (`modularity`), but not elsewhere, this will presumably raise questions. This way, the input is expected to be consistent for all functions, namely a numerical vector.