### PR TITLE
Fix minor typo in documentation

### DIFF
--- a/R/data_frame.R
+++ b/R/data_frame.R
@@ -28,7 +28,7 @@
 #' the (symbolic) edge list and edge/vertex attributes.
 #'
 #' \code{graph_from_data_frame} creates igraph graphs from one or two data frames.
-#' It has two modes of operatation, depending whether the \code{vertices}
+#' It has two modes of operation, depending whether the \code{vertices}
 #' argument is \code{NULL} or not.
 #'
 #' If \code{vertices} is \code{NULL}, then the first two columns of \code{d}


### PR DESCRIPTION
operatation -> operation

Since this is a typo correction I don't think this patch is copyrightable. But just in case: I'm fine with GPL 2 or later and FDL.