### PR TITLE
Avoid crash in cluster_label_prop

### DIFF
--- a/R/community.R
+++ b/R/community.R
@@ -1586,6 +1586,7 @@ cluster_label_prop <- function(graph, weights=NULL, initial=NULL,
                                         fixed=NULL) {
   # Argument checks
   if (!is_igraph(graph)) { stop("Not a graph object") }
+  stopifnot("Graph must be fully connected to use an initial state" = is_connected(graph) | is.null(initial))
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
   weights <- E(graph)$weight
   }


### PR DESCRIPTION
If cluster_label_prop is ran with an initial state and the graph is not fully connected, R crashes (#312) . Added code to throw an error in that case to avoid crashing R (a fix in the C code would be nicer but I'm unable to do that and the issue has been open for 2 years).