### PR TITLE
remove @importFrom graphics plot

### DIFF
--- a/R/cohesive.blocks.R
+++ b/R/cohesive.blocks.R
@@ -365,7 +365,6 @@ summary.cohesiveBlocks <- function(object, ...) {
 #' @method plot cohesiveBlocks
 #' @export
 #' @importFrom grDevices rainbow
-#' @importFrom graphics plot
  
 plot.cohesiveBlocks <- function(x, y,
                                 colbar=rainbow(max(cohesion(x))+1),
@@ -378,7 +377,6 @@ plot.cohesiveBlocks <- function(x, y,
 
 #' @rdname cohesive_blocks
 #' @export
-#' @importFrom graphics plot
 
 plot_hierarchy <- function(blocks,
                           layout=layout_as_tree(hierarchy(blocks),

--- a/R/community.R
+++ b/R/community.R
@@ -1953,7 +1953,6 @@ cluster_infomap <- function(graph, e.weights=NULL, v.weights=NULL,
 #' @rdname communities
 #' @method plot communities
 #' @export
-#' @importFrom graphics plot
 
 plot.communities <- function(x, y,
                              col=membership(x),
@@ -2080,7 +2079,6 @@ plot_dendrogram.communities <- function(x,
 }
 
 #' @importFrom grDevices palette
-#' @importFrom graphics plot
 #' @importFrom stats rect.hclust
 
 dendPlotHclust <- function(communities, rect=length(communities),
@@ -2096,8 +2094,6 @@ dendPlotHclust <- function(communities, rect=length(communities),
   invisible(ret)
 }
 
-#' @importFrom graphics plot
-
 dendPlotDendrogram <- function(communities, hang=-1, ...,
                                use.modularity=FALSE) {
   plot(as.dendrogram(communities, hang=hang, use.modularity=use.modularity),
@@ -2105,7 +2101,6 @@ dendPlotDendrogram <- function(communities, hang=-1, ...,
 }
 
 #' @importFrom grDevices palette
-#' @importFrom graphics plot
 
 dendPlotPhylo <- function(communities, colbar=palette(),
                           col=colbar[membership(communities)],

--- a/R/epi.R
+++ b/R/epi.R
@@ -137,7 +137,7 @@ quantile.sir <- function(x, comp=c("NI", "NS", "NR"), prob, ...) {
 #' infectious diseases and its applications (2nd ed.). London: Griffin.
 #' @method plot sir
 #' @export
-#' @importFrom graphics plot lines
+#' @importFrom graphics lines
 #' @keywords graphs
 #' @examples
 #' 

--- a/R/hrg.R
+++ b/R/hrg.R
@@ -602,7 +602,6 @@ plot_dendrogram.igraphHRG <- function(x, mode=igraph_opt("dend.plot.type"), ...)
   }
 }
 
-#' @importFrom graphics plot
 #' @importFrom grDevices rainbow
 #' @importFrom stats rect.hclust
 
@@ -618,13 +617,10 @@ hrgPlotHclust <- function(x, rect=0, colbar=rainbow(rect), hang=.01,
   invisible(ret)
 }
 
-#' @importFrom graphics plot
-
 hrgPlotDendrogram <- function(x, ...) {
   plot(as.dendrogram(x), ...)
 }
 
-#' @importFrom graphics plot
 #' @importFrom grDevices rainbow
 
 hrgPlotPhylo <- function(x, colbar=rainbow(11, start=.7, end=.1),

--- a/R/plot.R
+++ b/R/plot.R
@@ -71,7 +71,7 @@
 #' @export
 #' @export plot.igraph
 #' @importFrom grDevices rainbow
-#' @importFrom graphics plot polygon text par
+#' @importFrom graphics polygon text par
 #' @keywords graphs
 #' @examples
 #' 

--- a/R/socnet.R
+++ b/R/socnet.R
@@ -1203,7 +1203,7 @@ tkigraph <- function() {
 }
 
 #' @importFrom grDevices dev.new
-#' @importFrom graphics plot hist lines legend
+#' @importFrom graphics hist lines legend
 #' @importFrom stats coef vcov
 
 .tkigraph.degree.dist <- function(power=FALSE) {
@@ -1468,7 +1468,7 @@ tkigraph <- function() {
   .tkigraph.showData(value, title=paste("Components of graph #", gnos))
 }
 
-#' @importFrom graphics hist plot
+#' @importFrom graphics hist
 #' @importFrom grDevices dev.new
 
 .tkigraph.calculate.clusters <- function() {
@@ -1582,7 +1582,7 @@ tkigraph <- function() {
 }
 
 #' @importFrom grDevices dev.new
-#' @importFrom graphics layout layout.show par plot text
+#' @importFrom graphics layout layout.show par text
 
 .tkigraph.motifs.draw <- function() {
   read <- .tkigraph.dialogbox(TITLE="Draw all motifs",
@@ -1632,7 +1632,7 @@ tkigraph <- function() {
 }
 
 #' @importFrom grDevices dev.new
-#' @importFrom graphics barplot layout layout.show par plot text
+#' @importFrom graphics barplot layout layout.show par text
 
 .tkigraph.motifs.find <- function() {
 


### PR DESCRIPTION
`graphics::plot` is now a re-export of `base::plot`; this may be removed in the future.