### PR TITLE
Add examples to get.edge.ids (multiple edges)

### DIFF
--- a/R/interface.R
+++ b/R/interface.R
@@ -434,7 +434,22 @@ get.edges <- function(graph, es) {
 #' 
 #' ## non-existant edge
 #' get.edge.ids(g, c(2,1, 1,4, 5,4))
+#'
+#' ## multiple edges
+#' ## multi = FALSE, a single edge id is returned,
+#' ## as many times as corresponding pairs in the vertex series.
+#' g <-  make_graph(rep(c(1,2), 5))
+#' eis <- get.edge.ids(g, c(1,2, 1,2), multi=FALSE)
+#' eis
+#' E(g)[eis]
 #' 
+#' ## multi = TRUE, as many different edges, if any,
+#' ## are returned as pairs in the vertex series.
+#' eim <- get.edge.ids(g, c(1,2, 1,2, 1,2), multi=TRUE)
+#' eim
+#' E(g)[eim]
+#' 
+
 get.edge.ids <- function(graph, vp, directed=TRUE, error=FALSE, multi=FALSE) {
   if (!is_igraph(graph)) {
     stop("Not a graph object")


### PR DESCRIPTION
Add examples to get.edge.ids to demonstrate its behaviour on multiple edges.