### PR TITLE
Use testthat edition 3

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -27,3 +27,5 @@
 ^cran-comments\.template.md$
 ^CRAN-RELEASE$
 ^CRAN-SUBMISSION$
+^igraph\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 igraph.Rcheck/
 .venv/
 .vscode/
+.Rproj.user

--- a/igraph.Rproj
+++ b/igraph.Rproj
@@ -1,0 +1,22 @@
+Version: 1.0
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+LineEndingConversion: Posix
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/tests/testthat/dyad.census.R
+++ b/tests/testthat/dyad.census.R
@@ -1,6 +1,3 @@
-
-context("dyad_census")
-
 test_that("dyad_census works", {
 
   library(igraph)

--- a/tests/testthat/dyad.census.R
+++ b/tests/testthat/dyad.census.R
@@ -1,7 +1,5 @@
 test_that("dyad_census works", {
 
-  library(igraph)
-
   g1 <- make_ring(10)
   expect_that(dc1 <- dyad_census(g1), gives_warning("undirected"))
   expect_that(dc1, equals(list(mut=10, asym=0, null=35)))

--- a/tests/testthat/test-constructor-modifiers.R
+++ b/tests/testthat/test-constructor-modifiers.R
@@ -1,7 +1,3 @@
-
-context("Constructor modifiers")
-
-
 test_that("without_attr", {
 
   set.seed(42)

--- a/tests/testthat/test-graph-ids.R
+++ b/tests/testthat/test-graph-ids.R
@@ -1,6 +1,3 @@
-
-context("Graph ids")
-
 test_that("ids change when updating the graph", {
 
   g <- make_ring(10)

--- a/tests/testthat/test-index-es.R
+++ b/tests/testthat/test-index-es.R
@@ -1,6 +1,3 @@
-
-context("VS/ES indexing")
-
 test_that("I can index a vs twice", {
 
   edges <- data.frame(

--- a/tests/testthat/test-index-es.R
+++ b/tests/testthat/test-index-es.R
@@ -17,7 +17,7 @@ test_that("I can index a vs twice", {
 
   x <- V(g)[ 3:4 ] [ state == 'NM' ]
 
-  expect_equal(x, V(g)['ABQ'])
+  expect_equal(ignore_attr = TRUE, x, V(g)['ABQ'])
 })
 
 test_that("I can index an es twice", {
@@ -33,5 +33,5 @@ test_that("I can index an es twice", {
 
   x <- E(g)['BOS' %->% 'JFK'][carrier == 'foo']
 
-  expect_equal(x, E(g)[ carrier == 'foo' & .from('BOS') & .to('JFK')])
+  expect_equal(ignore_attr = TRUE, x, E(g)[ carrier == 'foo' & .from('BOS') & .to('JFK')])
 })

--- a/tests/testthat/test-isomorphism.R
+++ b/tests/testthat/test-isomorphism.R
@@ -68,7 +68,7 @@ test_that("isomorphisms", {
               V(g2)[4,1,2,3],
               V(g2)[4,3,2,1])
 
-  expect_equivalent(isomorphisms(g, g2), res)
+  expect_equal(ignore_attr = TRUE, isomorphisms(g, g2), res)
 
   g3 <- graph_(from_literal(X - Y - Z - X))
   expect_equal(isomorphisms(g, g3), list())
@@ -89,7 +89,7 @@ test_that("subgraph_isomorphisms, lad", {
               V(g)[4,3,2],
               V(g)[4,1,2])
 
-  expect_equivalent(subgraph_isomorphisms(g2, g, method = "lad"), res)
+  expect_equal(ignore_attr = TRUE, subgraph_isomorphisms(g2, g, method = "lad"), res)
 
   g3 <- graph_(from_literal(X - Y - Z - X))
   expect_equal(subgraph_isomorphisms(g3, g, method = "lad"), list())
@@ -110,7 +110,7 @@ test_that("subgraph_isomorphisms, vf2", {
               V(g)[4,1,2],
               V(g)[4,3,2])
 
-  expect_equivalent(subgraph_isomorphisms(g2, g, method = "vf2"), res)
+  expect_equal(ignore_attr = TRUE, subgraph_isomorphisms(g2, g, method = "vf2"), res)
 
   g3 <- graph_(from_literal(X - Y - Z - X))
   expect_equal(subgraph_isomorphisms(g3, g, method = "vf2"), list())

--- a/tests/testthat/test-isomorphism.R
+++ b/tests/testthat/test-isomorphism.R
@@ -1,6 +1,3 @@
-
-context("New isomorphism API")
-
 test_that("isomorphic", {
 
   g <- graph_(from_literal(A - B - C - A))

--- a/tests/testthat/test-make.R
+++ b/tests/testthat/test-make.R
@@ -1,6 +1,3 @@
-
-context("Make API")
-
 test_that("make_ works, order of arguments does not matter", {
 
   g0 <- make_undirected_graph(1:10)

--- a/tests/testthat/test-make_graph.R
+++ b/tests/testthat/test-make_graph.R
@@ -1,6 +1,3 @@
-
-context("make_graph")
-
 test_that("make_graph works", {
 
   g <- make_graph(1:10)

--- a/tests/testthat/test-make_lattice.R
+++ b/tests/testthat/test-make_lattice.R
@@ -1,6 +1,3 @@
-
-context("make_lattice")
-
 test_that("make_lattice works", {
 
   g <- make_lattice(dim = 2, length = 3, circular=F)

--- a/tests/testthat/test-new-layout-api.R
+++ b/tests/testthat/test-new-layout-api.R
@@ -1,8 +1,6 @@
 
 `%>%` <- magrittr::`%>%`
 
-context("New layout API")
-
 test_that("two step layouting works", {
 
   g <- make_ring(10)

--- a/tests/testthat/test-notable.R
+++ b/tests/testthat/test-notable.R
@@ -1,6 +1,3 @@
-
-context("Notable graphs")
-
 test_that("notable graphs work with make_graph", {
 
   g <- make_graph("Levi")

--- a/tests/testthat/test-old-data-type.R
+++ b/tests/testthat/test-old-data-type.R
@@ -1,6 +1,3 @@
-
-context("Old data type and VS/ES")
-
 test_that("VS/ES work with old data type", {
 
   karate <-

--- a/tests/testthat/test-random_walk.R
+++ b/tests/testthat/test-random_walk.R
@@ -1,5 +1,3 @@
-context("Random walks")
-
 test_that("undirected random_walk works", {
 
   set.seed(42)

--- a/tests/testthat/test-random_walk.R
+++ b/tests/testthat/test-random_walk.R
@@ -3,7 +3,7 @@ test_that("undirected random_walk works", {
   set.seed(42)
   g <- make_ring(10)
   w <- random_walk(g, start = 1, steps = 10)
-  expect_equivalent(w, structure(c(1L, 10L, 9L, 8L, 9L, 10L, 9L, 10L,
+  expect_equal(ignore_attr = TRUE, w, structure(c(1L, 10L, 9L, 8L, 9L, 10L, 9L, 10L,
                                    1L, 10L), class = "igraph.vs"))
 
 })
@@ -34,13 +34,13 @@ test_that("undirected random_edge_walk works", {
   set.seed(42)
   g <- make_star(11, mode="undirected")
   w <- random_edge_walk(g, start = 1, steps = 10)
-  expect_equivalent(w, structure(c(10L, 10L, 3L, 3L, 7L, 7L, 8L, 8L,
+  expect_equal(ignore_attr = TRUE, w, structure(c(10L, 10L, 3L, 3L, 7L, 7L, 8L, 8L,
                                    7L, 7L), class = "igraph.es"))
 
   set.seed(42)
   g <- make_ring(10)
   w <- random_edge_walk(g, start = 1, steps = 10)
-  expect_equivalent(w, structure(c(10L, 9L, 8L, 8L, 9L, 9L, 9L, 10L, 10L, 9L), class = "igraph.es"))
+  expect_equal(ignore_attr = TRUE, w, structure(c(10L, 9L, 8L, 8L, 9L, 9L, 9L, 10L, 10L, 9L), class = "igraph.es"))
 })
 
 test_that("directed random_edge_walk works", {
@@ -48,25 +48,25 @@ test_that("directed random_edge_walk works", {
 
   set.seed(42)
   w <- random_edge_walk(g, start = 1, steps = 10)
-  expect_equivalent(w, structure(c(10L), class = "igraph.es"))
+  expect_equal(ignore_attr = TRUE, w, structure(c(10L), class = "igraph.es"))
 
   set.seed(42)
   w <- random_edge_walk(g, start = 7, steps = 10)
-  expect_equivalent(w, structure(integer(), class = "igraph.es"))
+  expect_equal(ignore_attr = TRUE, w, structure(integer(), class = "igraph.es"))
 
   g <- make_ring(10, directed = TRUE)
 
   set.seed(42)
   w <- random_edge_walk(g, start = 1, steps = 5)
-  expect_equivalent(w, structure(c(1L, 2L, 3L, 4L, 5L), class = "igraph.es"))
+  expect_equal(ignore_attr = TRUE, w, structure(c(1L, 2L, 3L, 4L, 5L), class = "igraph.es"))
 
   set.seed(42)
   w <- random_edge_walk(g, start = 1, steps = 5, mode = "in")
-  expect_equivalent(w, structure(c(10L, 9L, 8L, 7L, 6L), class = "igraph.es"))
+  expect_equal(ignore_attr = TRUE, w, structure(c(10L, 9L, 8L, 7L, 6L), class = "igraph.es"))
 
   set.seed(42)
   w <- random_edge_walk(g, start = 1, steps = 10, mode = "all")
-  expect_equivalent(w, structure(c(10L, 9L, 8L, 8L, 9L, 9L, 9L, 10L, 10L, 9L), class = "igraph.es"))
+  expect_equal(ignore_attr = TRUE, w, structure(c(10L, 9L, 8L, 8L, 9L, 9L, 9L, 10L, 10L, 9L), class = "igraph.es"))
 })
 
 test_that("directed random_edge_walk can return wtih an error when stuck", {

--- a/tests/testthat/test-random_walk.R
+++ b/tests/testthat/test-random_walk.R
@@ -54,7 +54,7 @@ test_that("directed random_edge_walk works", {
 
   set.seed(42)
   w <- random_edge_walk(g, start = 7, steps = 10)
-  expect_equivalent(w, structure(list(), class = "igraph.es"))
+  expect_equivalent(w, structure(integer(), class = "igraph.es"))
 
   g <- make_ring(10, directed = TRUE)
 

--- a/tests/testthat/test-version.R
+++ b/tests/testthat/test-version.R
@@ -1,6 +1,3 @@
-
-context("igraph_version")
-
 test_that("igraph_version returns a version string", {
 
   ## This is essentially a semver regex, we do not allow a

--- a/tests/testthat/test-versions.R
+++ b/tests/testthat/test-versions.R
@@ -1,6 +1,3 @@
-
-context("Data version and conversion")
-
 test_that("we create graphs of the current version", {
 
   g <- make_ring(10)

--- a/tests/testthat/test-vs-es-printing.R
+++ b/tests/testthat/test-vs-es-printing.R
@@ -1,6 +1,3 @@
-
-context("Detailed printing of vs and es")
-
 test_that("vs printing", {
 
   local_rng_version("3.5.0")

--- a/tests/testthat/test-vs-es-quirks.R
+++ b/tests/testthat/test-vs-es-quirks.R
@@ -1,6 +1,3 @@
-
-context("Vertex and edge sequence quirks")
-
 test_that("graph is not updated if not in LHS", {
 
   g <- make_(ring(10),

--- a/tests/testthat/test-vs-es.R
+++ b/tests/testthat/test-vs-es.R
@@ -1,6 +1,3 @@
-
-context("Vertex and edge sequences")
-
 test_that("we can create vertex/edge seqs", {
 
   g <- make_ring(10)

--- a/tests/testthat/test-vs-es.R
+++ b/tests/testthat/test-vs-es.R
@@ -282,11 +282,11 @@ test_that("indexing without arguments", {
   g <- make_ring(10)
 
   x <- V(g)[]
-  expect_equal(V(g), x)
+  expect_equal(ignore_attr = TRUE, V(g), x)
 
   x2 <- V(g)[[]]
   v <- V(g)
   attr(v, "single") <- TRUE
 
-  expect_equal(v, x2)
+  expect_equal(ignore_attr = TRUE, v, x2)
 })

--- a/tests/testthat/test-vs-operators.R
+++ b/tests/testthat/test-vs-operators.R
@@ -1,6 +1,3 @@
-
-context("VS/ES operators")
-
 test_that("c on attached vs", {
   g <- make_ring(10)
 

--- a/tests/testthat/test-vs-operators.R
+++ b/tests/testthat/test-vs-operators.R
@@ -3,16 +3,16 @@ test_that("c on attached vs", {
 
   vg <- V(g)[1:5]
   vg2 <- V(g)[6:10]
-  expect_equivalent(c(vg, vg2), V(g))
+  expect_equal(ignore_attr = TRUE, c(vg, vg2), V(g))
   expect_equal(get_vs_graph_id(c(vg, vg2)), get_graph_id(g))
 
   vg <- V(g)
   vg2 <- V(g)[FALSE]
-  expect_equivalent(c(vg, vg2), V(g))
-  expect_equivalent(c(vg2, vg), V(g))
+  expect_equal(ignore_attr = TRUE, c(vg, vg2), V(g))
+  expect_equal(ignore_attr = TRUE, c(vg2, vg), V(g))
 
   vg <- V(g)[c(2,5,6,8)]
-  expect_equivalent(c(vg, vg), V(g)[c(2,5,6,8,2,5,6,8)])
+  expect_equal(ignore_attr = TRUE, c(vg, vg), V(g)[c(2,5,6,8,2,5,6,8)])
 })
 
 test_that("c on detached vs", {
@@ -30,10 +30,10 @@ test_that("c on detached vs", {
   rm(g)
   gc()
 
-  expect_equivalent(c(vg, vg2), vg3)
-  expect_equivalent(c(vg3, vg4), vg3)
-  expect_equivalent(c(vg4, vg3), vg3)
-  expect_equivalent(c(vg5, vg5), vg6)
+  expect_equal(ignore_attr = TRUE, c(vg, vg2), vg3)
+  expect_equal(ignore_attr = TRUE, c(vg3, vg4), vg3)
+  expect_equal(ignore_attr = TRUE, c(vg4, vg3), vg3)
+  expect_equal(ignore_attr = TRUE, c(vg5, vg5), vg6)
 })
 
 test_that("c on attached vs, names", {
@@ -42,18 +42,18 @@ test_that("c on attached vs, names", {
 
   vg <- V(g)[1:5]
   vg2 <- V(g)[6:10]
-  expect_equivalent(c(vg, vg2), V(g))
+  expect_equal(ignore_attr = TRUE, c(vg, vg2), V(g))
   expect_equal(names(c(vg, vg2)), names(V(g)))
 
   vg <- V(g)
   vg2 <- V(g)[FALSE]
-  expect_equivalent(c(vg, vg2), V(g))
+  expect_equal(ignore_attr = TRUE, c(vg, vg2), V(g))
   expect_equal(names(c(vg, vg2)), names(V(g)))
-  expect_equivalent(c(vg2, vg), V(g))
+  expect_equal(ignore_attr = TRUE, c(vg2, vg), V(g))
   expect_equal(names(c(vg2, vg)), names(V(g)))
 
   vg <- V(g)[c(2,5,6,8)]
-  expect_equivalent(c(vg, vg), V(g)[c(2,5,6,8,2,5,6,8)])
+  expect_equal(ignore_attr = TRUE, c(vg, vg), V(g)[c(2,5,6,8,2,5,6,8)])
   expect_equal(names(c(vg, vg)), names(V(g)[c(2,5,6,8,2,5,6,8)]))
 })
 
@@ -72,13 +72,13 @@ test_that("c on detached vs, names", {
   rm(g)
   gc()
 
-  expect_equivalent(c(vg, vg2), vg3)
+  expect_equal(ignore_attr = TRUE, c(vg, vg2), vg3)
   expect_equal(names(c(vg, vg2)), names(vg3))
-  expect_equivalent(c(vg3, vg4), vg3)
+  expect_equal(ignore_attr = TRUE, c(vg3, vg4), vg3)
   expect_equal(names(c(vg3, vg4)), names(vg3))
-  expect_equivalent(c(vg4, vg3), vg3)
+  expect_equal(ignore_attr = TRUE, c(vg4, vg3), vg3)
   expect_equal(names(c(vg3, vg4)), names(vg3))
-  expect_equivalent(c(vg5, vg5), vg6)
+  expect_equal(ignore_attr = TRUE, c(vg5, vg5), vg6)
   expect_equal(names(c(vg5, vg5)), names(vg6))
 })
 
@@ -91,16 +91,16 @@ test_that("union on attached vs", {
   v1 <- V(g)[1:7]
   v2 <- V(g)[6:10]
   vu <- union(v1, v2)
-  expect_equivalent(vu, V(g))
+  expect_equal(ignore_attr = TRUE, vu, V(g))
 
-  expect_equivalent(union(V(g)), V(g))
+  expect_equal(ignore_attr = TRUE, union(V(g)), V(g))
 
   v3 <- V(g)[FALSE]
-  expect_equivalent(union(V(g), v3), V(g))
-  expect_equivalent(union(v3, V(g), v3), V(g))
-  expect_equivalent(union(v3), v3)
-  expect_equivalent(union(v3, v3, v3), v3)
-  expect_equivalent(union(v3, v3), v3)
+  expect_equal(ignore_attr = TRUE, union(V(g), v3), V(g))
+  expect_equal(ignore_attr = TRUE, union(v3, V(g), v3), V(g))
+  expect_equal(ignore_attr = TRUE, union(v3), v3)
+  expect_equal(ignore_attr = TRUE, union(v3, v3, v3), v3)
+  expect_equal(ignore_attr = TRUE, union(v3, v3), v3)
 })
 
 test_that("union on detached vs", {
@@ -116,15 +116,15 @@ test_that("union on detached vs", {
   rm(g)
   gc()
 
-  expect_equivalent(vu, vg)
+  expect_equal(ignore_attr = TRUE, vu, vg)
 
-  expect_equivalent(union(vg), vg)
+  expect_equal(ignore_attr = TRUE, union(vg), vg)
 
-  expect_equivalent(union(vg, v3), vg)
-  expect_equivalent(union(v3, vg, v3), vg)
-  expect_equivalent(union(v3), v3)
-  expect_equivalent(union(v3, v3, v3), v3)
-  expect_equivalent(union(v3, v3), v3)
+  expect_equal(ignore_attr = TRUE, union(vg, v3), vg)
+  expect_equal(ignore_attr = TRUE, union(v3, vg, v3), vg)
+  expect_equal(ignore_attr = TRUE, union(v3), v3)
+  expect_equal(ignore_attr = TRUE, union(v3, v3, v3), v3)
+  expect_equal(ignore_attr = TRUE, union(v3, v3), v3)
 
 })
 
@@ -136,26 +136,26 @@ test_that("union on attached vs, names", {
   v1 <- V(g)[1:7]
   v2 <- V(g)[6:10]
   vu <- union(v1, v2)
-  expect_equivalent(vu, V(g))
+  expect_equal(ignore_attr = TRUE, vu, V(g))
   expect_equal(names(vu), names(V(g)))
 
-  expect_equivalent(union(V(g)), V(g))
+  expect_equal(ignore_attr = TRUE, union(V(g)), V(g))
   expect_equal(names(union(V(g))), names(V(g)))
 
   v3 <- V(g)[FALSE]
-  expect_equivalent(union(V(g), v3), V(g))
+  expect_equal(ignore_attr = TRUE, union(V(g), v3), V(g))
   expect_equal(names(union(V(g), v3)), names(V(g)))
 
-  expect_equivalent(union(v3, V(g), v3), V(g))
+  expect_equal(ignore_attr = TRUE, union(v3, V(g), v3), V(g))
   expect_equal(names(union(v3, V(g), v3)), names(V(g)))
 
-  expect_equivalent(union(v3), v3)
+  expect_equal(ignore_attr = TRUE, union(v3), v3)
   expect_equal(names(union(v3)), names(v3))
 
-  expect_equivalent(union(v3, v3, v3), v3)
+  expect_equal(ignore_attr = TRUE, union(v3, v3, v3), v3)
   expect_equal(names(union(v3, v3, v3)), names(v3))
 
-  expect_equivalent(union(v3, v3), v3)
+  expect_equal(ignore_attr = TRUE, union(v3, v3), v3)
   expect_equal(names(union(v3, v3)), names(v3))
 
 })
@@ -174,25 +174,25 @@ test_that("union on detached vs, names", {
   gc()
 
   vu <- union(v1, v2)
-  expect_equivalent(vu, vg)
+  expect_equal(ignore_attr = TRUE, vu, vg)
   expect_equal(names(vu), names(vg))
 
-  expect_equivalent(union(vg), vg)
+  expect_equal(ignore_attr = TRUE, union(vg), vg)
   expect_equal(names(union(vg)), names(vg))
 
-  expect_equivalent(union(vg, v3), vg)
+  expect_equal(ignore_attr = TRUE, union(vg, v3), vg)
   expect_equal(names(union(vg, v3)), names(vg))
 
-  expect_equivalent(union(v3, vg, v3), vg)
+  expect_equal(ignore_attr = TRUE, union(v3, vg, v3), vg)
   expect_equal(names(union(v3, vg, v3)), names(vg))
 
-  expect_equivalent(union(v3), v3)
+  expect_equal(ignore_attr = TRUE, union(v3), v3)
   expect_equal(names(union(v3)), names(v3))
 
-  expect_equivalent(union(v3, v3, v3), v3)
+  expect_equal(ignore_attr = TRUE, union(v3, v3, v3), v3)
   expect_equal(names(union(v3, v3, v3)), names(v3))
 
-  expect_equivalent(union(v3, v3), v3)
+  expect_equal(ignore_attr = TRUE, union(v3, v3), v3)
   expect_equal(names(union(v3, v3)), names(v3))
 
 })
@@ -215,22 +215,22 @@ test_that("intersection on attached vs", {
   v24 <- V(g)[FALSE]
 
   vi1 <- intersection(v1, v2)
-  expect_equivalent(vi1, v12)
+  expect_equal(ignore_attr = TRUE, vi1, v12)
 
   vi2 <- intersection(v1, v3)
-  expect_equivalent(vi2, v13)
+  expect_equal(ignore_attr = TRUE, vi2, v13)
 
   vi3 <- intersection(v1, v4)
-  expect_equivalent(vi3, v14)
+  expect_equal(ignore_attr = TRUE, vi3, v14)
 
   vi4 <- intersection(v1, vg)
-  expect_equivalent(vi4, v1)
+  expect_equal(ignore_attr = TRUE, vi4, v1)
 
   vi5 <- intersection(v2, v4)
-  expect_equivalent(vi5, v24)
+  expect_equal(ignore_attr = TRUE, vi5, v24)
 
   vi6 <- intersection(v3, vg)
-  expect_equivalent(vi6, v3)
+  expect_equal(ignore_attr = TRUE, vi6, v3)
 
 })
 
@@ -253,22 +253,22 @@ test_that("intersection on detached vs", {
   gc()
 
   vi1 <- intersection(v1, v2)
-  expect_equivalent(vi1, v12)
+  expect_equal(ignore_attr = TRUE, vi1, v12)
 
   vi2 <- intersection(v1, v3)
-  expect_equivalent(vi2, v13)
+  expect_equal(ignore_attr = TRUE, vi2, v13)
 
   vi3 <- intersection(v1, v4)
-  expect_equivalent(vi3, v14)
+  expect_equal(ignore_attr = TRUE, vi3, v14)
 
   vi4 <- intersection(v1, vg)
-  expect_equivalent(vi4, v1)
+  expect_equal(ignore_attr = TRUE, vi4, v1)
 
   vi5 <- intersection(v2, v4)
-  expect_equivalent(vi5, v24)
+  expect_equal(ignore_attr = TRUE, vi5, v24)
 
   vi6 <- intersection(v3, vg)
-  expect_equivalent(vi6, v3)
+  expect_equal(ignore_attr = TRUE, vi6, v3)
 
 })
 
@@ -289,27 +289,27 @@ test_that("intersection on attached vs, names", {
   v24 <- V(g)[FALSE]
 
   vi1 <- intersection(v1, v2)
-  expect_equivalent(vi1, v12)
+  expect_equal(ignore_attr = TRUE, vi1, v12)
   expect_equal(names(vi1), names(v12))
 
   vi2 <- intersection(v1, v3)
-  expect_equivalent(vi2, v13)
+  expect_equal(ignore_attr = TRUE, vi2, v13)
   expect_equal(names(vi2), names(v13))
 
   vi3 <- intersection(v1, v4)
-  expect_equivalent(vi3, v14)
+  expect_equal(ignore_attr = TRUE, vi3, v14)
   expect_equal(names(vi3), names(v14))
 
   vi4 <- intersection(v1, vg)
-  expect_equivalent(vi4, v1)
+  expect_equal(ignore_attr = TRUE, vi4, v1)
   expect_equal(names(vi4), names(v1))
 
   vi5 <- intersection(v2, v4)
-  expect_equivalent(vi5, v24)
+  expect_equal(ignore_attr = TRUE, vi5, v24)
   expect_equal(names(vi5), names(v24))
 
   vi6 <- intersection(v3, vg)
-  expect_equivalent(vi6, v3)
+  expect_equal(ignore_attr = TRUE, vi6, v3)
   expect_equal(names(vi6), names(v3))
 
 })
@@ -334,27 +334,27 @@ test_that("intersection on detached vs, names", {
   gc()
 
   vi1 <- intersection(v1, v2)
-  expect_equivalent(vi1, v12)
+  expect_equal(ignore_attr = TRUE, vi1, v12)
   expect_equal(names(vi1), names(v12))
 
   vi2 <- intersection(v1, v3)
-  expect_equivalent(vi2, v13)
+  expect_equal(ignore_attr = TRUE, vi2, v13)
   expect_equal(names(vi2), names(v13))
 
   vi3 <- intersection(v1, v4)
-  expect_equivalent(vi3, v14)
+  expect_equal(ignore_attr = TRUE, vi3, v14)
   expect_equal(names(vi3), names(v14))
 
   vi4 <- intersection(v1, vg)
-  expect_equivalent(vi4, v1)
+  expect_equal(ignore_attr = TRUE, vi4, v1)
   expect_equal(names(vi4), names(v1))
 
   vi5 <- intersection(v2, v4)
-  expect_equivalent(vi5, v24)
+  expect_equal(ignore_attr = TRUE, vi5, v24)
   expect_equal(names(vi5), names(v24))
 
   vi6 <- intersection(v3, vg)
-  expect_equivalent(vi6, v3)
+  expect_equal(ignore_attr = TRUE, vi6, v3)
   expect_equal(names(vi6), names(v3))
 
 })
@@ -385,12 +385,12 @@ test_that("difference on attached vs", {
   vd5 <- difference(v3, v3)
   vd6 <- difference(v3, v4)
 
-  expect_equivalent(vd1, vr1)
-  expect_equivalent(vd2, vr2)
-  expect_equivalent(vd3, vr3)
-  expect_equivalent(vd4, vr4)
-  expect_equivalent(vd5, vr5)
-  expect_equivalent(vd6, vr6)
+  expect_equal(ignore_attr = TRUE, vd1, vr1)
+  expect_equal(ignore_attr = TRUE, vd2, vr2)
+  expect_equal(ignore_attr = TRUE, vd3, vr3)
+  expect_equal(ignore_attr = TRUE, vd4, vr4)
+  expect_equal(ignore_attr = TRUE, vd5, vr5)
+  expect_equal(ignore_attr = TRUE, vd6, vr6)
 
 })
 
@@ -421,12 +421,12 @@ test_that("difference on detached vs", {
   vd5 <- difference(v3, v3)
   vd6 <- difference(v3, v4)
 
-  expect_equivalent(vd1, vr1)
-  expect_equivalent(vd2, vr2)
-  expect_equivalent(vd3, vr3)
-  expect_equivalent(vd4, vr4)
-  expect_equivalent(vd5, vr5)
-  expect_equivalent(vd6, vr6)
+  expect_equal(ignore_attr = TRUE, vd1, vr1)
+  expect_equal(ignore_attr = TRUE, vd2, vr2)
+  expect_equal(ignore_attr = TRUE, vd3, vr3)
+  expect_equal(ignore_attr = TRUE, vd4, vr4)
+  expect_equal(ignore_attr = TRUE, vd5, vr5)
+  expect_equal(ignore_attr = TRUE, vd6, vr6)
 
 })
 
@@ -455,22 +455,22 @@ test_that("difference on attached vs, names", {
   vd5 <- difference(v3, v3)
   vd6 <- difference(v3, v4)
 
-  expect_equivalent(vd1, vr1)
+  expect_equal(ignore_attr = TRUE, vd1, vr1)
   expect_equal(names(vd1), names(vr1))
 
-  expect_equivalent(vd2, vr2)
+  expect_equal(ignore_attr = TRUE, vd2, vr2)
   expect_equal(names(vd2), names(vr2))
 
-  expect_equivalent(vd3, vr3)
+  expect_equal(ignore_attr = TRUE, vd3, vr3)
   expect_equal(names(vd3), names(vr3))
 
-  expect_equivalent(vd4, vr4)
+  expect_equal(ignore_attr = TRUE, vd4, vr4)
   expect_equal(names(vd4), names(vr4))
 
-  expect_equivalent(vd5, vr5)
+  expect_equal(ignore_attr = TRUE, vd5, vr5)
   expect_equal(names(vd5), names(vr5))
 
-  expect_equivalent(vd6, vr6)
+  expect_equal(ignore_attr = TRUE, vd6, vr6)
   expect_equal(names(vd6), names(vr6))
 
 })
@@ -503,22 +503,22 @@ test_that("difference on detached vs, names", {
   vd5 <- difference(v3, v3)
   vd6 <- difference(v3, v4)
 
-  expect_equivalent(vd1, vr1)
+  expect_equal(ignore_attr = TRUE, vd1, vr1)
   expect_equal(names(vd1), names(vr1))
 
-  expect_equivalent(vd2, vr2)
+  expect_equal(ignore_attr = TRUE, vd2, vr2)
   expect_equal(names(vd2), names(vr2))
 
-  expect_equivalent(vd3, vr3)
+  expect_equal(ignore_attr = TRUE, vd3, vr3)
   expect_equal(names(vd3), names(vr3))
 
-  expect_equivalent(vd4, vr4)
+  expect_equal(ignore_attr = TRUE, vd4, vr4)
   expect_equal(names(vd4), names(vr4))
 
-  expect_equivalent(vd5, vr5)
+  expect_equal(ignore_attr = TRUE, vd5, vr5)
   expect_equal(names(vd5), names(vr5))
 
-  expect_equivalent(vd6, vr6)
+  expect_equal(ignore_attr = TRUE, vd6, vr6)
   expect_equal(names(vd6), names(vr6))
 
 })
@@ -533,7 +533,7 @@ test_that("rev on attached vs", {
     vg <- V(g)[idx]
     vgr <- V(g)[rev(idx)]
     vg2 <- rev(vg)
-    expect_equivalent(vg2, vgr)
+    expect_equal(ignore_attr = TRUE, vg2, vgr)
   }
 
 })
@@ -548,7 +548,7 @@ test_that("rev on detached vs", {
     rm(g)
     gc()
     vg2 <- rev(vg)
-    expect_equivalent(vg2, vgr)
+    expect_equal(ignore_attr = TRUE, vg2, vgr)
   }
 
 })
@@ -562,7 +562,7 @@ test_that("rev on attached vs, names", {
     vg <- V(g)[idx]
     vgr <- V(g)[rev(idx)]
     vg2 <- rev(vg)
-    expect_equivalent(vg2, vgr)
+    expect_equal(ignore_attr = TRUE, vg2, vgr)
     expect_equal(names(vg2), names(vgr))
   }
 
@@ -579,7 +579,7 @@ test_that("rev on detached vs, names", {
     rm(g)
     gc()
     vg2 <- rev(vg)
-    expect_equivalent(vg2, vgr)
+    expect_equal(ignore_attr = TRUE, vg2, vgr)
     expect_equal(names(vg2), names(vgr))
   }
 
@@ -601,7 +601,7 @@ test_that("unique on attached vs", {
     g <- make_ring(10)
     vg <- unique(V(g)[ d[[1]] ])
     vr <- V(g)[ d[[2]] ]
-    expect_equivalent(vg, vr)
+    expect_equal(ignore_attr = TRUE, vg, vr)
   })
 
 })
@@ -615,7 +615,7 @@ test_that("unique on detached vs", {
     rm(g)
     gc()
     vg <- unique(vg)
-    expect_equivalent(vg, vr)
+    expect_equal(ignore_attr = TRUE, vg, vr)
   })
 
 })
@@ -627,7 +627,7 @@ test_that("unique on attached vs, names", {
     V(g)$name <- letters[1:10]
     vg <- unique(V(g)[ d[[1]] ])
     vr <- V(g)[ d[[2]] ]
-    expect_equivalent(vg, vr)
+    expect_equal(ignore_attr = TRUE, vg, vr)
   })
 
 })
@@ -642,7 +642,7 @@ test_that("unique on detached vs, names", {
     rm(g)
     gc()
     vg <- unique(vg)
-    expect_equivalent(vg, vr)
+    expect_equal(ignore_attr = TRUE, vg, vr)
   })
 
 })

--- a/tests/testthat/test-weakref.R
+++ b/tests/testthat/test-weakref.R
@@ -1,6 +1,3 @@
-
-context("Weak references")
-
 test_that("we can create weak references", {
 
   g <- new.env()

--- a/tests/testthat/test_add.edges.R
+++ b/tests/testthat/test_add.edges.R
@@ -1,6 +1,3 @@
-
-context("add_edges")
-
 test_that("add_edges keeps edge id order", {
   library(igraph)
   g <- make_empty_graph(10)

--- a/tests/testthat/test_add.edges.R
+++ b/tests/testthat/test_add.edges.R
@@ -1,5 +1,4 @@
 test_that("add_edges keeps edge id order", {
-  library(igraph)
   g <- make_empty_graph(10)
   edges <- c(1,2, 2,3, 3,4, 1,6, 1,7, 9,10)
   g2 <- add_edges(g, edges)
@@ -10,7 +9,6 @@ test_that("add_edges keeps edge id order", {
 })
 
 test_that("add_edges adds attributes", {
-  library(igraph)
   g <- make_empty_graph(10)
   g3 <- add_edges(g, (edges <- c(1,5, 2,6, 3,10, 4,5)),
                   attr=list(weight=(weights <- c(1,2,1,-1))) )
@@ -20,7 +18,6 @@ test_that("add_edges adds attributes", {
 })
 
 test_that("add_edges unknown attributes to NA", {
-  library(igraph)
   g <- make_empty_graph(10)
   g2 <- add_edges(g, (edges <- c(1,2, 2,3, 3,4, 1,6, 1,7, 9,10)) )
   g4 <- add_edges(g2, c(1,4, 4,6, 7,1), attr=list(weight=c(-1,1,-2.5)))
@@ -28,7 +25,6 @@ test_that("add_edges unknown attributes to NA", {
 })
 
 test_that("add_edges appends attributes properly", {
-  library(igraph)
   g <- make_empty_graph(10)
   g3 <- add_edges(g, (edges1 <- c(1,5, 2,6, 3,10, 4,5)),
                   attr=list(weight=(weights1 <- c(1,2,1,-1))) )
@@ -38,7 +34,6 @@ test_that("add_edges appends attributes properly", {
 })
 
 test_that("add_edges signals error for zero vertex ids", {
-  library(igraph)
   g <- make_full_graph(5) %du% make_full_graph(5) %du% make_full_graph(5)
   expect_that(add_edges(g, c(0,5, 0,10, 5,10)),
               throws_error("Invalid vertex id"))

--- a/tests/testthat/test_add.vertices.R
+++ b/tests/testthat/test_add.vertices.R
@@ -1,6 +1,3 @@
-
-context("add_vertices")
-
 test_that("add_vertices works", {
   library(igraph)
   g <- graph_from_literal(A-B-C-D-E)

--- a/tests/testthat/test_add.vertices.R
+++ b/tests/testthat/test_add.vertices.R
@@ -1,5 +1,4 @@
 test_that("add_vertices works", {
-  library(igraph)
   g <- graph_from_literal(A-B-C-D-E)
   g2 <- add_vertices(g, (nv <- 4))
   expect_that(vcount(g2), equals(vcount(g) + nv))
@@ -8,7 +7,6 @@ test_that("add_vertices works", {
 })
 
 test_that("add_vertices handles attributes properly", {
-  library(igraph)
   g <- graph_from_literal(A-B-C-D-E)
   g3 <- add_vertices(g, (nv <- 3),
                      attr=list(name=(names <- c("F","G","H")),

--- a/tests/testthat/test_adjacency.spectral.embedding.R
+++ b/tests/testthat/test_adjacency.spectral.embedding.R
@@ -14,14 +14,12 @@ mag_sort <- function(x) {
 }
 
 test_that("Undirected, unweighted case works", {
-  library(Matrix)
-
   set.seed(42)
   g <- random.graph.game(10, 15, type="gnm", directed=FALSE)
 
   no <- 7
   A <- g[]
-  A <- A + 1/2 * as(Matrix(diag(degree(g)), doDiag=FALSE), "generalMatrix")
+  A <- A + 1/2 * as(Matrix::Matrix(diag(degree(g)), doDiag=FALSE), "generalMatrix")
   ss <- eigen(A)
 
   U <- std(ss$vectors)
@@ -59,15 +57,13 @@ test_that("Undirected, unweighted case works", {
 })
 
 test_that("Undirected, weighted case works", {
-  library(Matrix)
-
   set.seed(42)
   g <- random.graph.game(10, 20, type="gnm", directed=FALSE)
   E(g)$weight <- sample(1:5, ecount(g), replace=TRUE)
 
   no <- 3
   A <- g[]
-  A <- A + 1/2 * as(Matrix(diag(degree(g)), doDiag=FALSE), "generalMatrix")
+  A <- A + 1/2 * as(Matrix::Matrix(diag(degree(g)), doDiag=FALSE), "generalMatrix")
   ss <- eigen(A)
 
   U <- std(ss$vectors)
@@ -103,14 +99,12 @@ test_that("Undirected, weighted case works", {
 })
 
 test_that("Directed, unweighted case works", {
-  library(Matrix)
-
   set.seed(42)
   g <- random.graph.game(10, 20, type="gnm", directed=TRUE)
 
   no <- 3
   A <- g[]
-  A <- A + 1/2 * as(Matrix(diag(degree(g)), doDiag=FALSE), "generalMatrix")
+  A <- A + 1/2 * as(Matrix::Matrix(diag(degree(g)), doDiag=FALSE), "generalMatrix")
   ss <- svd(A)
 
   U <- std(ss$u)
@@ -156,15 +150,13 @@ test_that("Directed, unweighted case works", {
 })
 
 test_that("Directed, weighted case works", {
-  library(Matrix)
-
   set.seed(42)
   g <- random.graph.game(10, 20, type="gnm", directed=TRUE)
   E(g)$weight <- sample(1:5, ecount(g), replace=TRUE)
 
   no <- 3
   A <- g[]
-  A <- A + 1/2 * as(Matrix(diag(degree(g)), doDiag=FALSE), "generalMatrix")
+  A <- A + 1/2 * as(Matrix::Matrix(diag(degree(g)), doDiag=FALSE), "generalMatrix")
   ss <- svd(A)
 
   U <- std(ss$u)

--- a/tests/testthat/test_adjacency.spectral.embedding.R
+++ b/tests/testthat/test_adjacency.spectral.embedding.R
@@ -1,6 +1,3 @@
-
-context("adjacency spectral embedding")
-
 std <- function(x) {
   x <- zapsmall(x)
   apply(x, 2, function(col) {

--- a/tests/testthat/test_adjacency.spectral.embedding.R
+++ b/tests/testthat/test_adjacency.spectral.embedding.R
@@ -14,7 +14,6 @@ mag_sort <- function(x) {
 }
 
 test_that("Undirected, unweighted case works", {
-  library(igraph)
   library(Matrix)
 
   set.seed(42)
@@ -60,7 +59,6 @@ test_that("Undirected, unweighted case works", {
 })
 
 test_that("Undirected, weighted case works", {
-  library(igraph)
   library(Matrix)
 
   set.seed(42)
@@ -105,7 +103,6 @@ test_that("Undirected, weighted case works", {
 })
 
 test_that("Directed, unweighted case works", {
-  library(igraph)
   library(Matrix)
 
   set.seed(42)
@@ -159,7 +156,6 @@ test_that("Directed, unweighted case works", {
 })
 
 test_that("Directed, weighted case works", {
-  library(igraph)
   library(Matrix)
 
   set.seed(42)
@@ -208,7 +204,6 @@ test_that("Directed, weighted case works", {
 })
 
 test_that("Issue #50 is resolved", {
-  library(igraph)
   set.seed(12345)
 
   g <- erdos.renyi.game(15, .4)
@@ -223,7 +218,6 @@ test_that("Issue #50 is resolved", {
 })
 
 test_that("Issue #51 is resolved", {
-  library(igraph)
   set.seed(12345)
 
   pref.matrix <- diag(0.2, 2) + 0.2

--- a/tests/testthat/test_all.st.cuts.R
+++ b/tests/testthat/test_all.st.cuts.R
@@ -1,7 +1,5 @@
 test_that("all.st.cuts works", {
 
-  library(igraph)
-
   unvs <- function(x) lapply(x, as.vector)
 
   g <- graph_from_literal( a -+ b -+ c -+ d -+ e )

--- a/tests/testthat/test_all.st.cuts.R
+++ b/tests/testthat/test_all.st.cuts.R
@@ -1,6 +1,3 @@
-
-context("all.st.cuts")
-
 test_that("all.st.cuts works", {
 
   library(igraph)

--- a/tests/testthat/test_alpha.centrality.R
+++ b/tests/testthat/test_alpha.centrality.R
@@ -1,6 +1,3 @@
-
-context("alpha_centrality")
-
 test_that("dense alpha_centrality works", {
   library(igraph)
   g.1 <- graph( c(1,3,2,3,3,4,4,5) )

--- a/tests/testthat/test_alpha.centrality.R
+++ b/tests/testthat/test_alpha.centrality.R
@@ -1,5 +1,4 @@
 test_that("dense alpha_centrality works", {
-  library(igraph)
   g.1 <- graph( c(1,3,2,3,3,4,4,5) )
   ac1 <- alpha_centrality(g.1, sparse=FALSE)
   expect_that(ac1, equals(c(1, 1, 3, 4, 5)))
@@ -15,7 +14,6 @@ test_that("dense alpha_centrality works", {
 
 test_that("sparse alpha_centrality works", {
   if (require(Matrix, quietly=TRUE)) {
-    library(igraph)
     g.1 <- graph( c(1,3,2,3,3,4,4,5) )
     ac1 <- alpha_centrality(g.1, sparse=TRUE)
     expect_that(ac1, equals(c(1, 1, 3, 4, 5)))
@@ -34,7 +32,6 @@ test_that("sparse alpha_centrality works", {
 ## weighted version
 
 test_that("weighted dense alpha_centrality works", {
-  library(igraph)
   star <- make_star(10)
   E(star)$weight <- sample(ecount(star))
 
@@ -50,7 +47,6 @@ test_that("weighted dense alpha_centrality works", {
 
 test_that("weighted sparse alpha_centrality works", {
   if (require("Matrix", quietly=TRUE)) {
-    library(igraph)
     star <- make_star(10)
     E(star)$weight <- sample(ecount(star))
 
@@ -67,7 +63,6 @@ test_that("weighted sparse alpha_centrality works", {
 
 test_that("undirected, alpha centrality works, #653", {
   if (require("Matrix", quietly = TRUE)) {
-    library(igraph)
     g <- make_ring(10)
 
     ac1 <- alpha_centrality(g, sparse = TRUE)

--- a/tests/testthat/test_are.connected.R
+++ b/tests/testthat/test_are.connected.R
@@ -1,6 +1,3 @@
-
-context("are_adjacent")
-
 test_that("are_adjacent works", {
   library(igraph)
 

--- a/tests/testthat/test_are.connected.R
+++ b/tests/testthat/test_are.connected.R
@@ -1,6 +1,4 @@
 test_that("are_adjacent works", {
-  library(igraph)
-
   g <- graph_from_literal( A-B-C, B-D )
   expect_true(are_adjacent(g, "A", "B"))
   expect_true(are_adjacent(g, "B", "A"))

--- a/tests/testthat/test_arpack.R
+++ b/tests/testthat/test_arpack.R
@@ -1,12 +1,10 @@
 test_that("arpack works for identity matrix", {
-  library(igraph)
   f <- function(x, extra=NULL) x
   res <- arpack(f, options=list(n=10, nev=2, ncv=4), sym=TRUE)
   expect_that(res$values, equals(c(1,1)))
 })
 
 test_that("arpack works on the Laplacian of a star", {
-  library(igraph)
   f <- function(x, extra=NULL) {
     y <- x
     y[1] <- (length(x)-1)*x[1] - sum(x[-1])
@@ -28,7 +26,6 @@ test_that("arpack works on the Laplacian of a star", {
 # Complex case
 
 test_that("arpack works for non-symmetric matrices", {
-  library(igraph)
   A <- structure(c(-6, -6, 7, 6, 1, -9, -3, 2, -9, -7, 0, 1, -7, 8,
                    -7, 10, 0, 0, 1, 1, 10, 0, 8, -4, -4, -5, 8, 9, -6, 9, 3, 8,
                    6, -1, 9, -9, -6, -3, -1, -7, 8, -4, -4, 10, 0, 5, -2, 0, 7,

--- a/tests/testthat/test_arpack.R
+++ b/tests/testthat/test_arpack.R
@@ -1,6 +1,3 @@
-
-context("arpack")
-
 test_that("arpack works for identity matrix", {
   library(igraph)
   f <- function(x, extra=NULL) x

--- a/tests/testthat/test_articulation.points.R
+++ b/tests/testthat/test_articulation.points.R
@@ -1,6 +1,3 @@
-
-context("articulation_points")
-
 test_that("articulation_points works", {
   library(igraph)
 

--- a/tests/testthat/test_articulation.points.R
+++ b/tests/testthat/test_articulation.points.R
@@ -1,6 +1,4 @@
 test_that("articulation_points works", {
-  library(igraph)
-
   g <- make_full_graph(5) + make_full_graph(5)
   clu <- components(g)$membership
   g <- add_edges(g, c(match(1,clu), match(2,clu)) )

--- a/tests/testthat/test_as.directed.R
+++ b/tests/testthat/test_as.directed.R
@@ -1,6 +1,4 @@
 test_that("as.directed works", {
-  library(igraph)
-
   g <- sample_gnp(100, 2/100)
   g2 <- as.directed(g, mode="mutual")
   g3 <- as.directed(g, mode="arbitrary")
@@ -19,7 +17,6 @@ test_that("as.directed works", {
 })
 
 test_that("as.directed keeps attributes", {
-  library(igraph)
   g <- graph_from_literal( A-B-C, D-A, E )
   g$name <- "Small graph"
   g2 <- as.directed(g, mode="mutual")

--- a/tests/testthat/test_as.directed.R
+++ b/tests/testthat/test_as.directed.R
@@ -1,6 +1,3 @@
-
-context("as.directed")
-
 test_that("as.directed works", {
   library(igraph)
 

--- a/tests/testthat/test_as.undirected.R
+++ b/tests/testthat/test_as.undirected.R
@@ -1,6 +1,3 @@
-
-context("as.undirected")
-
 test_that("as.undirected keeps attributes", {
   library(igraph)
   g <- graph_from_literal(A+-+B, A--+C, C+-+D)

--- a/tests/testthat/test_as.undirected.R
+++ b/tests/testthat/test_as.undirected.R
@@ -1,5 +1,4 @@
 test_that("as.undirected keeps attributes", {
-  library(igraph)
   g <- graph_from_literal(A+-+B, A--+C, C+-+D)
   g$name <- "Tiny graph"
   E(g)$weight <- seq_len(ecount(g))

--- a/tests/testthat/test_assortativity.R
+++ b/tests/testthat/test_assortativity.R
@@ -1,6 +1,3 @@
-
-context("assortativity")
-
 test_that("assortativity works", {
   library(igraph)
 

--- a/tests/testthat/test_assortativity.R
+++ b/tests/testthat/test_assortativity.R
@@ -1,6 +1,4 @@
 test_that("assortativity works", {
-  library(igraph)
-
   g <- read_graph(f <- gzfile("celegansneural.gml.gz"), format="gml")
 
   assR <- function(graph) {
@@ -35,8 +33,6 @@ test_that("assortativity works", {
 })
 
 test_that("nominal assortativity works", {
-  library(igraph)
-
   o <- read_graph(f <- gzfile("football.gml.gz"), format="gml")
   o <- simplify(o)
   an <- assortativity_nominal(o, V(o)$value+1)

--- a/tests/testthat/test_attributes.R
+++ b/tests/testthat/test_attributes.R
@@ -1,6 +1,4 @@
 test_that("assigning and querying attributes work", {
-  library(igraph)
-
   ## Create a small ring graph, assign attributes
   ring <- graph_from_literal( A-B-C-D-E-F-G-A )
   E(ring)$weight <- seq_len(ecount(ring))
@@ -11,8 +9,6 @@ test_that("assigning and querying attributes work", {
 })
 
 test_that("brackering works", {
-  library(igraph)
-
   g <- graph(c(1,2, 1,3, 3,4))
   g <- set_vertex_attr(g, name="weight", value=1:vcount(g))
   g <- set_edge_attr(g, name="weight", value=1:ecount(g))
@@ -32,7 +28,6 @@ test_that("brackering works", {
 })
 
 test_that("brackering works with a function", {
-  library(igraph)
   library(testthat)
 
   g <- graph(c(1,2, 1,3, 3,4))
@@ -57,8 +52,6 @@ test_that("brackering works with a function", {
 })
 
 test_that("brackering works with shortcuts", {
-  library(igraph)
-
   g <- graph(c(1,2, 1,3, 3,4))
   g <- set_vertex_attr(g, name="weight", value=1:vcount(g))
   g <- set_edge_attr(g, name="weight", value=1:ecount(g))

--- a/tests/testthat/test_attributes.R
+++ b/tests/testthat/test_attributes.R
@@ -1,6 +1,3 @@
-
-context("attributes")
-
 test_that("assigning and querying attributes work", {
   library(igraph)
 

--- a/tests/testthat/test_authority.score.R
+++ b/tests/testthat/test_authority.score.R
@@ -1,6 +1,4 @@
 test_that("authority score works", {
-  library(igraph)
-
   ashs <- function(graph, as=TRUE) {
     mscale <- function(x) {
       if (sd(x)!=0) { x <- scale(x) }
@@ -28,7 +26,6 @@ test_that("authority score works", {
 })
 
 test_that("authority scores of a ring are all one", {
-  library(igraph)
   g3 <- make_ring(100)
   expect_that(authority_score(g3)$vector, equals(rep(1, vcount(g3))))
   expect_that(hub_score(g3)$vector, equals(rep(1, vcount(g3))))

--- a/tests/testthat/test_authority.score.R
+++ b/tests/testthat/test_authority.score.R
@@ -1,6 +1,3 @@
-
-context("authority_score")
-
 test_that("authority score works", {
   library(igraph)
 

--- a/tests/testthat/test_average.path.length.R
+++ b/tests/testthat/test_average.path.length.R
@@ -1,6 +1,3 @@
-
-context("mean_distance")
-
 test_that("mean_distance works", {
   apl <- function(graph) {
     sp <- distances(graph, mode="out")

--- a/tests/testthat/test_ba.game.R
+++ b/tests/testthat/test_ba.game.R
@@ -1,6 +1,4 @@
 test_that("sample_pa works", {
-  library(igraph)
-
   g <- sample_pa(100, m=2)
   expect_that(ecount(g), equals(197))
   expect_that(vcount(g), equals(100))
@@ -18,7 +16,6 @@ test_that("sample_pa works", {
 })
 
 test_that("sample_pa can start from a graph", {
-  library(igraph)
   set.seed(1234)
 
   g4 <- sample_pa(10, m=1, algorithm="bag", start.graph=make_empty_graph(5))

--- a/tests/testthat/test_ba.game.R
+++ b/tests/testthat/test_ba.game.R
@@ -1,6 +1,3 @@
-
-context("sample_pa")
-
 test_that("sample_pa works", {
   library(igraph)
 

--- a/tests/testthat/test_betweenness.R
+++ b/tests/testthat/test_betweenness.R
@@ -1,5 +1,4 @@
 test_that("betweenness works for kite graph", {
-  library(igraph)
   kite <- graph_from_literal(Andre    - Beverly:Carol:Diane:Fernando,
                         Beverly  - Andre:Diane:Ed:Garth,
                         Carol    - Andre:Diane:Fernando,
@@ -25,7 +24,6 @@ test_that("betweenness works for kite graph", {
 })
 
 test_that("weighted betweenness works", {
-  library(igraph)
   nontriv <- graph( c(0,19,0,16,0,20,1,19,2,5,3,7,3,8,
                       4,15,4,11,5,8,5,19,6,7,6,10,6,8,
                       6,9,7,20,9,10,9,20,10,19,
@@ -47,8 +45,6 @@ test_that("weighted betweenness works", {
 })
 
 test_that("normalization works well", {
-  library(igraph)
-
   g1 <- graph_from_literal( 0 +-+ 1 +-+ 2 )
 
   b11 <- betweenness(g1, normalized=TRUE, directed=FALSE)

--- a/tests/testthat/test_betweenness.R
+++ b/tests/testthat/test_betweenness.R
@@ -1,6 +1,3 @@
-
-context("betweenness")
-
 test_that("betweenness works for kite graph", {
   library(igraph)
   kite <- graph_from_literal(Andre    - Beverly:Carol:Diane:Fernando,

--- a/tests/testthat/test_biconnected.components.R
+++ b/tests/testthat/test_biconnected.components.R
@@ -1,6 +1,4 @@
 test_that("biconnected_components works", {
-  library(igraph)
-
   g <- make_full_graph(5) + make_full_graph(5)
   clu <- components(g)$membership
   g <- add_edges(g, c(match(1,clu), match(2,clu)) )

--- a/tests/testthat/test_biconnected.components.R
+++ b/tests/testthat/test_biconnected.components.R
@@ -1,6 +1,3 @@
-
-context("biconnected_components")
-
 test_that("biconnected_components works", {
   library(igraph)
 

--- a/tests/testthat/test_bipartite.projection.R
+++ b/tests/testthat/test_bipartite.projection.R
@@ -1,6 +1,3 @@
-
-context("bipartite_projection")
-
 test_that("bipartite_projection works", {
   library(igraph)
   local_rng_version("3.5.0")

--- a/tests/testthat/test_bipartite.projection.R
+++ b/tests/testthat/test_bipartite.projection.R
@@ -1,5 +1,4 @@
 test_that("bipartite_projection works", {
-  library(igraph)
   local_rng_version("3.5.0")
   set.seed(42)
 
@@ -35,7 +34,6 @@ test_that("bipartite_projection works", {
 })
 
 test_that("bipartite_projection can calculate only one projection", {
-  library(igraph)
   set.seed(42)
 
   g <- sample_bipartite(5, 10, p=.3)
@@ -54,7 +52,6 @@ test_that("bipartite_projection can calculate only one projection", {
 
 test_that("bipartite_projection removes 'type' attribute if requested", {
 
-  library(igraph)
   g <- make_full_bipartite_graph(10,5)
   proj <- bipartite_projection(g)
   proj1 <- bipartite_projection(g, which="true")
@@ -77,7 +74,6 @@ test_that("bipartite_projection removes 'type' attribute if requested", {
 
 test_that("bipartite_projection breaks for non-bipartite graphs (#543)", {
 
-  library(igraph)
   g <- graph_from_literal(A-0, B-1, A-1, 0-1)
   V(g)$type <- V(g)$name %in% LETTERS
 
@@ -89,7 +85,6 @@ test_that("bipartite_projection breaks for non-bipartite graphs (#543)", {
 
 test_that("bipartite_projection prints a warning if the type attribute is non-logical (#476)", {
 
-  library(igraph)
   g <- make_full_bipartite_graph(10, 5)
   V(g)$type <- as.numeric(V(g)$type)
   expect_warning(bipartite_projection(g), "logical")

--- a/tests/testthat/test_bipartite.random.game.R
+++ b/tests/testthat/test_bipartite.random.game.R
@@ -1,6 +1,3 @@
-
-context("sample_bipartite")
-
 test_that("sample_bipartite works", {
 
   library(igraph)

--- a/tests/testthat/test_bipartite.random.game.R
+++ b/tests/testthat/test_bipartite.random.game.R
@@ -1,7 +1,5 @@
 test_that("sample_bipartite works", {
 
-  library(igraph)
-
   set.seed(42)
   g1 <- sample_bipartite(10, 5, type="gnp", p=.1)
   expect_that(g1$name, equals("Bipartite Gnp random graph"))

--- a/tests/testthat/test_bonpow.R
+++ b/tests/testthat/test_bonpow.R
@@ -1,5 +1,4 @@
 test_that("Power centrality works", {
-  library(igraph)
   library(Matrix)
 
   ## Generate some test data from Bonacich, 1987:

--- a/tests/testthat/test_bonpow.R
+++ b/tests/testthat/test_bonpow.R
@@ -1,6 +1,3 @@
-
-context("Bonacich's power centrality")
-
 test_that("Power centrality works", {
   library(igraph)
   library(Matrix)

--- a/tests/testthat/test_bonpow.R
+++ b/tests/testthat/test_bonpow.R
@@ -1,6 +1,4 @@
 test_that("Power centrality works", {
-  library(Matrix)
-
   ## Generate some test data from Bonacich, 1987:
   fig1 <- graph_from_literal( A -+ B -+ C:D )
   fig1.bp <- lapply(seq(0, 0.8, by=0.2), function(x)

--- a/tests/testthat/test_bridges.R
+++ b/tests/testthat/test_bridges.R
@@ -1,6 +1,3 @@
-
-context("bridges")
-
 test_that("bridges works", {
   g <- make_graph("krackhardt_kite")
   expect_that(sort(as.vector(bridges(g))), equals((ecount(g)-1):(ecount(g))))

--- a/tests/testthat/test_bug-1019624.R
+++ b/tests/testthat/test_bug-1019624.R
@@ -1,6 +1,3 @@
-
-context("Bug 1019624 from Launchpad")
-
 test_that("weighted graph_from_adjacency_matrix works on integer matrices", {
   library(igraph)
   data <- matrix(c(0,0,0,2, 0,0,0,0, 0,0,0,2, 0,1,0,0), 4)

--- a/tests/testthat/test_bug-1019624.R
+++ b/tests/testthat/test_bug-1019624.R
@@ -1,5 +1,4 @@
 test_that("weighted graph_from_adjacency_matrix works on integer matrices", {
-  library(igraph)
   data <- matrix(c(0,0,0,2, 0,0,0,0, 0,0,0,2, 0,1,0,0), 4)
   g <- graph_from_adjacency_matrix(data, weighted=TRUE)
   expect_that(as.matrix(g[]), is_equivalent_to(data))

--- a/tests/testthat/test_bug-1032819.R
+++ b/tests/testthat/test_bug-1032819.R
@@ -1,6 +1,3 @@
-
-context("Bug 1032819 from Launchpad")
-
 test_that("VF2 isomorphism considers colors", {
   library(igraph)
   g <- make_full_graph(3)

--- a/tests/testthat/test_bug-1032819.R
+++ b/tests/testthat/test_bug-1032819.R
@@ -1,5 +1,4 @@
 test_that("VF2 isomorphism considers colors", {
-  library(igraph)
   g <- make_full_graph(3)
   path <- make_ring(3, circular=F)
   V(g)$color <- c(1,1,2)

--- a/tests/testthat/test_bug-1033045.R
+++ b/tests/testthat/test_bug-1033045.R
@@ -1,5 +1,4 @@
 test_that("Minimal s-t separators work", {
-  library(igraph)
   g <- graph_from_literal(a -- 1:3 -- 5 -- 2:4 -- b, 1 -- 2, 3 -- 4)
   stsep <- min_st_separators(g)
   ims <- sapply(stsep, is_min_separator, graph=g)

--- a/tests/testthat/test_bug-1033045.R
+++ b/tests/testthat/test_bug-1033045.R
@@ -1,6 +1,3 @@
-
-context("Bug 1033045 from Launchpad")
-
 test_that("Minimal s-t separators work", {
   library(igraph)
   g <- graph_from_literal(a -- 1:3 -- 5 -- 2:4 -- b, 1 -- 2, 3 -- 4)

--- a/tests/testthat/test_bug-1073705-indexing.R
+++ b/tests/testthat/test_bug-1073705-indexing.R
@@ -1,6 +1,4 @@
 test_that("Weighted indexing does not remove edges", {
-  library(igraph)
-
   g <- make_ring(10)
   g[1, 2, attr="weight"] <- 0
   expect_true("weight" %in% edge_attr_names(g))

--- a/tests/testthat/test_bug-1073705-indexing.R
+++ b/tests/testthat/test_bug-1073705-indexing.R
@@ -1,6 +1,3 @@
-
-context("Bug 1073705 from Launchpad")
-
 test_that("Weighted indexing does not remove edges", {
   library(igraph)
 

--- a/tests/testthat/test_bug-1073800-clique.R
+++ b/tests/testthat/test_bug-1073800-clique.R
@@ -1,5 +1,4 @@
 test_that("Largest cliques is correct", {
-  library(igraph)
   unvs <- function(x) lapply(x, . %>% as.vector %>% sort)
   adj <- matrix(1, nrow=11, ncol=11) - diag(11)
   g <- graph_from_adjacency_matrix(adj)

--- a/tests/testthat/test_bug-1073800-clique.R
+++ b/tests/testthat/test_bug-1073800-clique.R
@@ -1,6 +1,3 @@
-
-context("Bug 1073800 from Launchpad")
-
 test_that("Largest cliques is correct", {
   library(igraph)
   unvs <- function(x) lapply(x, . %>% as.vector %>% sort)

--- a/tests/testthat/test_bug-154.R
+++ b/tests/testthat/test_bug-154.R
@@ -1,6 +1,3 @@
-
-context("Bug 154 from Github")
-
 test_that("graph.get.subisomorphisms.vf2() works even if the graph has a vertex attribute named x", {
     g <- graph.full(4)
     V(g)$x <- 1:4

--- a/tests/testthat/test_canonical.permutation.R
+++ b/tests/testthat/test_canonical.permutation.R
@@ -1,6 +1,3 @@
-
-context("canonical_permutation")
-
 test_that("canonical_permutation works", {
   library(igraph)
 

--- a/tests/testthat/test_canonical.permutation.R
+++ b/tests/testthat/test_canonical.permutation.R
@@ -1,6 +1,4 @@
 test_that("canonical_permutation works", {
-  library(igraph)
-
   g1 <- sample_gnm(10, 20)
   cp1 <- canonical_permutation(g1)
   cf1 <- permute(g1, cp1$labeling)

--- a/tests/testthat/test_cliques.R
+++ b/tests/testthat/test_cliques.R
@@ -1,5 +1,4 @@
 test_that("cliques works", {
-  library(igraph)
   set.seed(42)
 
   check.clique <- function(graph, vids) {

--- a/tests/testthat/test_cliques.R
+++ b/tests/testthat/test_cliques.R
@@ -1,6 +1,3 @@
-
-context("cliques")
-
 test_that("cliques works", {
   library(igraph)
   set.seed(42)

--- a/tests/testthat/test_closeness.R
+++ b/tests/testthat/test_closeness.R
@@ -1,6 +1,3 @@
-
-context("closeness")
-
 test_that("closeness works", {
   library(igraph)
 

--- a/tests/testthat/test_closeness.R
+++ b/tests/testthat/test_closeness.R
@@ -1,6 +1,4 @@
 test_that("closeness works", {
-  library(igraph)
-
   kite <- graph_from_literal(Andre    - Beverly:Carol:Diane:Fernando,
                     Beverly  - Andre:Diane:Ed:Garth,
                     Carol    - Andre:Diane:Fernando,
@@ -26,7 +24,6 @@ test_that("closeness works", {
 
 test_that("closeness centralization works", {
 
-  library(igraph)
   kite <- graph_from_literal(Andre    - Beverly:Carol:Diane:Fernando,
                     Beverly  - Andre:Diane:Ed:Garth,
                     Carol    - Andre:Diane:Fernando,

--- a/tests/testthat/test_clusters.R
+++ b/tests/testthat/test_clusters.R
@@ -1,6 +1,3 @@
-
-context("components")
-
 test_that("components works", {
   library(igraph)
   set.seed(42)
@@ -51,8 +48,6 @@ test_that("groups works", {
                                         `2` = letters[11:15]), .Dim = 2L,
                                         .Dimnames = list(c("1", "2")))))
 })
-
-context("is_connected")
 
 test_that("is_connected works", {
   library(igraph)

--- a/tests/testthat/test_coloring.R
+++ b/tests/testthat/test_coloring.R
@@ -1,5 +1,3 @@
-context("greedy vertex coloring")
-
 test_that("greedy_vertex_coloring works", {
     g <- make_star(10, mode="undirected")
     expect_that(
@@ -19,8 +17,6 @@ test_that("greedy_vertex_coloring works on named graphs", {
     expect_that(as.vector(vc), equals(c(1, rep(2, vcount(g)-1))))
     expect_that(names(vc), equals(V(g)$name))
 })
-
-context("simplify_and_colorize")
 
 test_that("simplify_and_colorize works", {
     g <- make_graph(~ A-B-C-D-E, B-C, B-C, B-C, D-E-E, simplify=FALSE)

--- a/tests/testthat/test_communities.R
+++ b/tests/testthat/test_communities.R
@@ -1,6 +1,3 @@
-
-context("communities")
-
 test_that("community detection functions work", {
   library(igraph)
   set.seed(42)

--- a/tests/testthat/test_communities.R
+++ b/tests/testthat/test_communities.R
@@ -1,5 +1,4 @@
 test_that("community detection functions work", {
-  library(igraph)
   set.seed(42)
 
   F <- list("cluster_edge_betweenness", "cluster_fast_greedy",
@@ -49,7 +48,6 @@ test_that("community detection functions work", {
 })
 
 test_that("creating communities objects works", {
-  library(igraph)
   set.seed(42)
 
   karate <- make_graph("Zachary")
@@ -67,7 +65,6 @@ test_that("creating communities objects works", {
 
 test_that("communities function works", {
   skip_if_no_glpk()
-  library(igraph)
   g <- make_graph("Zachary")
   oc <- cluster_optimal(g)
   gr <- communities(oc)

--- a/tests/testthat/test_constraint.R
+++ b/tests/testthat/test_constraint.R
@@ -1,6 +1,3 @@
-
-context("constraint")
-
 test_that("constraint works", {
   library(igraph)
 

--- a/tests/testthat/test_constraint.R
+++ b/tests/testthat/test_constraint.R
@@ -1,6 +1,4 @@
 test_that("constraint works", {
-  library(igraph)
-
   constraint.orig <- function(graph, nodes=V(graph), attr=NULL) {
     if (!is_igraph(graph)) {
       stop("Not a graph object")

--- a/tests/testthat/test_contract.vertices.R
+++ b/tests/testthat/test_contract.vertices.R
@@ -1,6 +1,3 @@
-
-context("contract")
-
 test_that("contract works", {
   library(igraph)
   local_rng_version("3.5.0")

--- a/tests/testthat/test_contract.vertices.R
+++ b/tests/testthat/test_contract.vertices.R
@@ -1,5 +1,4 @@
 test_that("contract works", {
-  library(igraph)
   local_rng_version("3.5.0")
   set.seed(42)
 

--- a/tests/testthat/test_correlated.R
+++ b/tests/testthat/test_correlated.R
@@ -3,7 +3,6 @@
 
 test_that("sample_correlated_gnp works", {
 
-  library(igraph)
   set.seed(42)
 
   g <- erdos.renyi.game(10, .1)
@@ -18,7 +17,6 @@ test_that("sample_correlated_gnp works", {
 
 test_that("sample_correlated_gnp works when p is not given", {
 
-  library(igraph)
   set.seed(42)
 
   g <- erdos.renyi.game(10, .1)
@@ -33,7 +31,6 @@ test_that("sample_correlated_gnp works when p is not given", {
 
 test_that("sample_correlated_gnp works even for non-ER graphs", {
 
-  library(igraph)
   set.seed(42)
 
   g <- grg.game(100, 0.2)
@@ -48,7 +45,6 @@ test_that("sample_correlated_gnp works even for non-ER graphs", {
 
 test_that("sample_correlated_gnp_pair works", {
 
-  library(igraph)
   set.seed(42)
 
   gp <- sample_correlated_gnp_pair(10, corr=.95, p=.1, permutation=NULL)
@@ -60,7 +56,6 @@ test_that("sample_correlated_gnp_pair works", {
 
 test_that("sample_correlated_gnp corner cases work", {
 
-  library(igraph)
   set.seed(42)
 
   is.full <- function(g) {
@@ -88,7 +83,6 @@ test_that("sample_correlated_gnp corner cases work", {
 
 test_that("permutation works for sample_correlated_gnp", {
 
-  library(igraph)
   set.seed(42)
 
   g <- erdos.renyi.game(10, .3)

--- a/tests/testthat/test_correlated.R
+++ b/tests/testthat/test_correlated.R
@@ -1,6 +1,3 @@
-
-context("Correlated E-R random graphs")
-
 ## Not very meaningful tests. They good for testing that the
 ## functions run, but not much more
 

--- a/tests/testthat/test_count.multiple.R
+++ b/tests/testthat/test_count.multiple.R
@@ -1,6 +1,3 @@
-
-context("multiple edges")
-
 test_that("any_multiple, count_multiple, which_multiple works", {
   library(igraph)
   set.seed(42)

--- a/tests/testthat/test_count.multiple.R
+++ b/tests/testthat/test_count.multiple.R
@@ -1,5 +1,4 @@
 test_that("any_multiple, count_multiple, which_multiple works", {
-  library(igraph)
   set.seed(42)
 
   g <- barabasi.game(10, m=3, algorithm="bag")

--- a/tests/testthat/test_decompose.graph.R
+++ b/tests/testthat/test_decompose.graph.R
@@ -1,6 +1,3 @@
-
-context("decompose")
-
 test_that("decompose works", {
   library(igraph)
   g <- sample_gnp(1000, 1/1500)

--- a/tests/testthat/test_decompose.graph.R
+++ b/tests/testthat/test_decompose.graph.R
@@ -1,5 +1,4 @@
 test_that("decompose works", {
-  library(igraph)
   g <- sample_gnp(1000, 1/1500)
   G <- decompose(g)
   clu <- components(g)
@@ -8,14 +7,12 @@ test_that("decompose works", {
 })
 
 test_that("decompose works for many components", {
-  library(igraph)
   g <- make_empty_graph(50001)
   tmp <- decompose(g)
   expect_that(1, equals(1))
 })
 
 test_that("decompose works for many components and attributes", {
-  library(igraph)
   g <- make_empty_graph(50001)
   V(g)$name <- 1:vcount(g)
   tmp <- decompose(g)
@@ -23,7 +20,6 @@ test_that("decompose works for many components and attributes", {
 })
 
 test_that("decompose keeps attributes", {
-  library(igraph)
   g <- make_ring(10) + make_ring(5)
   V(g)$name <- letters[1:(10+5)]
   E(g)$name <- apply(as_edgelist(g), 1, paste, collapse="-")

--- a/tests/testthat/test_degree.R
+++ b/tests/testthat/test_degree.R
@@ -1,6 +1,3 @@
-
-context("degree")
-
 test_that("degree works", {
   library(igraph)
 

--- a/tests/testthat/test_degree.R
+++ b/tests/testthat/test_degree.R
@@ -1,6 +1,4 @@
 test_that("degree works", {
-  library(igraph)
-
   g <- sample_gnp(100, 1/100)
   d <- degree(g)
   el <- as_edgelist(g)

--- a/tests/testthat/test_degseq.R
+++ b/tests/testthat/test_degseq.R
@@ -1,6 +1,3 @@
-
-context("realize_degseq, sample_degseq")
-
 test_that("realize_degseq works", {
   gc <- function(graph) {
     clu <- components(graph)

--- a/tests/testthat/test_delete.edges.R
+++ b/tests/testthat/test_delete.edges.R
@@ -1,5 +1,4 @@
 test_that("delete_edges works", {
-  library(igraph)
   g <- graph_from_literal(A:B:C - D:E:F, D-E-F)
   g2 <- delete_edges(g, E(g, P=c("D", "E")))
   expect_that(as.matrix(g2[]),

--- a/tests/testthat/test_delete.edges.R
+++ b/tests/testthat/test_delete.edges.R
@@ -1,6 +1,3 @@
-
-context("delete_edges")
-
 test_that("delete_edges works", {
   library(igraph)
   g <- graph_from_literal(A:B:C - D:E:F, D-E-F)

--- a/tests/testthat/test_delete.vertices.R
+++ b/tests/testthat/test_delete.vertices.R
@@ -1,5 +1,4 @@
 test_that("delete_vertices works", {
-  library(igraph)
   g <- graph_from_literal(A:B:C - D:E:F, D-E-F)
 
   g2 <- delete_vertices(g, "A")

--- a/tests/testthat/test_delete.vertices.R
+++ b/tests/testthat/test_delete.vertices.R
@@ -1,6 +1,3 @@
-
-context("delete_vertices")
-
 test_that("delete_vertices works", {
   library(igraph)
   g <- graph_from_literal(A:B:C - D:E:F, D-E-F)

--- a/tests/testthat/test_deprecated_indexing_functions.R
+++ b/tests/testthat/test_deprecated_indexing_functions.R
@@ -1,6 +1,3 @@
-
-context("Deprecated indexing functions")
-
 test_that("deprecated indexing functions are indeed deprecated", {
 
   g <- make_ring(10)

--- a/tests/testthat/test_diameter.R
+++ b/tests/testthat/test_diameter.R
@@ -1,7 +1,5 @@
 test_that("diameter works", {
 
-  library(igraph)
-
   gc <- function(graph) {
     clu <- components(graph)
     induced_subgraph(graph, which(clu$membership==which.max(clu$csize)))

--- a/tests/testthat/test_diameter.R
+++ b/tests/testthat/test_diameter.R
@@ -1,6 +1,3 @@
-
-context("diameter")
-
 test_that("diameter works", {
 
   library(igraph)

--- a/tests/testthat/test_dimSelect.R
+++ b/tests/testthat/test_dimSelect.R
@@ -1,5 +1,4 @@
 test_that("dimensionality selection works", {
-  library(igraph)
   set.seed(42)
 
   k <- graph.famous("zachary")

--- a/tests/testthat/test_dimSelect.R
+++ b/tests/testthat/test_dimSelect.R
@@ -1,6 +1,3 @@
-
-context("Dimensionality selection")
-
 test_that("dimensionality selection works", {
   library(igraph)
   set.seed(42)

--- a/tests/testthat/test_dominator.tree.R
+++ b/tests/testthat/test_dominator.tree.R
@@ -1,5 +1,4 @@
 test_that("dominator_tree works", {
-  library(igraph)
   g <- graph_from_literal(R-+A:B:C, A-+D, B-+A:D:E, C-+F:G, D-+L,
                  E-+H, F-+I, G-+I:J, H-+E:K, I-+K, J-+I,
                  K-+I:R, L-+H)

--- a/tests/testthat/test_dominator.tree.R
+++ b/tests/testthat/test_dominator.tree.R
@@ -1,6 +1,3 @@
-
-context("dominator_tree")
-
 test_that("dominator_tree works", {
   library(igraph)
   g <- graph_from_literal(R-+A:B:C, A-+D, B-+A:D:E, C-+F:G, D-+L,

--- a/tests/testthat/test_dot.product.game.R
+++ b/tests/testthat/test_dot.product.game.R
@@ -1,6 +1,3 @@
-
-context("Dot-product random graphs")
-
 test_that("Dot product rng works", {
 
   library(igraph)

--- a/tests/testthat/test_dot.product.game.R
+++ b/tests/testthat/test_dot.product.game.R
@@ -1,6 +1,5 @@
 test_that("Dot product rng works", {
 
-  library(igraph)
   set.seed(42)
   vecs <- cbind(c(0,1,1,1,0)/3, c(0,1,1,0,1)/3, c(1,1,1,1,0)/4,
                 c(0,1,1,1,0))
@@ -31,7 +30,6 @@ test_that("Dot product rng works", {
 
 test_that("Dot product rng gives warnings", {
 
-  library(igraph)
   vecs <- cbind(c(1,1,1)/3, -c(1,1,1)/3)
   expect_that(g <- sample_dot_product(vecs),
       gives_warning("Negative connection probability in dot-product graph"))

--- a/tests/testthat/test_dyad.census.R
+++ b/tests/testthat/test_dyad.census.R
@@ -1,5 +1,4 @@
 test_that("dyad_census works", {
-  library(igraph)
   ce <- simplify(read_graph(gzfile("celegansneural.gml.gz"), format="gml"))
   dc <- dyad_census(ce)
 

--- a/tests/testthat/test_dyad.census.R
+++ b/tests/testthat/test_dyad.census.R
@@ -1,6 +1,3 @@
-
-context("dyad_census")
-
 test_that("dyad_census works", {
   library(igraph)
   ce <- simplify(read_graph(gzfile("celegansneural.gml.gz"), format="gml"))

--- a/tests/testthat/test_edge.betweenness.R
+++ b/tests/testthat/test_edge.betweenness.R
@@ -1,6 +1,4 @@
 test_that("edge_betweenness works", {
-  library(igraph)
-
   kite <- graph_from_literal(Andre    - Beverly:Carol:Diane:Fernando,
                     Beverly  - Andre:Diane:Ed:Garth,
                     Carol    - Andre:Diane:Fernando,

--- a/tests/testthat/test_edge.betweenness.R
+++ b/tests/testthat/test_edge.betweenness.R
@@ -1,6 +1,3 @@
-
-context("edge_betweenness")
-
 test_that("edge_betweenness works", {
   library(igraph)
 

--- a/tests/testthat/test_edge.betweenness.community.R
+++ b/tests/testthat/test_edge.betweenness.community.R
@@ -1,6 +1,3 @@
-
-context("cluster_edge_betweenness")
-
 test_that("cluster_edge_betweenness works", {
   library(igraph)
 

--- a/tests/testthat/test_edge.betweenness.community.R
+++ b/tests/testthat/test_edge.betweenness.community.R
@@ -1,6 +1,4 @@
 test_that("cluster_edge_betweenness works", {
-  library(igraph)
-
   g <- make_graph("Zachary")
   ebc <- cluster_edge_betweenness(g)
 

--- a/tests/testthat/test_edge.connectivity.R
+++ b/tests/testthat/test_edge.connectivity.R
@@ -1,6 +1,3 @@
-
-context("edge_connectivity")
-
 test_that("edge_connectivity works", {
 
   library(igraph)

--- a/tests/testthat/test_edge.connectivity.R
+++ b/tests/testthat/test_edge.connectivity.R
@@ -1,7 +1,5 @@
 test_that("edge_connectivity works", {
 
-  library(igraph)
-
   gc <- function(graph) {
     clu <- components(graph)
     induced_subgraph(graph, which(clu$membership==which.max(clu$csize)))

--- a/tests/testthat/test_edgenames.R
+++ b/tests/testthat/test_edgenames.R
@@ -1,6 +1,3 @@
-
-context("edge names")
-
 test_that("edge names work", {
 
   library(igraph)

--- a/tests/testthat/test_edgenames.R
+++ b/tests/testthat/test_edgenames.R
@@ -1,7 +1,5 @@
 test_that("edge names work", {
 
-  library(igraph)
-
   ## named edges
   igraph_options(print.edge.attributes = TRUE)
   g <- make_ring(10)

--- a/tests/testthat/test_efficiency.R
+++ b/tests/testthat/test_efficiency.R
@@ -1,5 +1,3 @@
-context("efficiency")
-
 test_that("global_efficiency works", {
     g <- graph_from_literal(A-B-C-D-A)
     expect_that(global_efficiency(g), equals(5/6))

--- a/tests/testthat/test_eulerian.R
+++ b/tests/testthat/test_eulerian.R
@@ -1,6 +1,3 @@
-
-context("eulerian_path")
-
 test_that("has_eulerian_path works", {
     g <- graph_from_literal(A-B-C-D-A)
     expect_true(has_eulerian_path(g))
@@ -40,8 +37,6 @@ test_that("eulerian_path works", {
     g <- graph_from_literal(A-B-C-D-A-D-C, B-D, simplify=FALSE)
     expect_error(eulerian_path(g), "The graph does not have an Eulerian path")
 })
-
-context("eulerian_cycle")
 
 test_that("has_eulerian_cycle works", {
     g <- graph_from_literal(A-B-C-D-A)

--- a/tests/testthat/test_evcent.R
+++ b/tests/testthat/test_evcent.R
@@ -1,7 +1,5 @@
 test_that("eigen_centrality works", {
 
-  library(igraph)
-
   kite <- graph_from_literal(Andre    - Beverly:Carol:Diane:Fernando,
                     Beverly  - Andre:Diane:Ed:Garth,
                     Carol    - Andre:Diane:Fernando,

--- a/tests/testthat/test_evcent.R
+++ b/tests/testthat/test_evcent.R
@@ -1,6 +1,3 @@
-
-context("eigen_centrality")
-
 test_that("eigen_centrality works", {
 
   library(igraph)

--- a/tests/testthat/test_farthest_vertices.R
+++ b/tests/testthat/test_farthest_vertices.R
@@ -1,6 +1,3 @@
-
-context("farthest_vertices")
-
 test_that("farthest_vertices works", {
 
   library(igraph)

--- a/tests/testthat/test_farthest_vertices.R
+++ b/tests/testthat/test_farthest_vertices.R
@@ -1,7 +1,5 @@
 test_that("farthest_vertices works", {
 
-  library(igraph)
-
   kite <- graph_from_literal(Andre    - Beverly:Carol:Diane:Fernando,
                     Beverly  - Andre:Diane:Ed:Garth,
                     Carol    - Andre:Diane:Fernando,

--- a/tests/testthat/test_fastgreedy.community.R
+++ b/tests/testthat/test_fastgreedy.community.R
@@ -1,6 +1,5 @@
 test_that("cluster_fast_greedy works", {
 
-  library(igraph)
   set.seed(42)
 
   g <- make_graph("Zachary")

--- a/tests/testthat/test_fastgreedy.community.R
+++ b/tests/testthat/test_fastgreedy.community.R
@@ -1,6 +1,3 @@
-
-context("cluster_fast_greedy")
-
 test_that("cluster_fast_greedy works", {
 
   library(igraph)

--- a/tests/testthat/test_forestfire.R
+++ b/tests/testthat/test_forestfire.R
@@ -1,6 +1,5 @@
 test_that("sample_forestfire works", {
 
-  library(igraph)
   set.seed(42)
 
   pars <- list(sparse=c(0.35, 0.2/0.35),

--- a/tests/testthat/test_forestfire.R
+++ b/tests/testthat/test_forestfire.R
@@ -1,6 +1,3 @@
-
-context("sample_forestfire")
-
 test_that("sample_forestfire works", {
 
   library(igraph)

--- a/tests/testthat/test_get.adjacency.R
+++ b/tests/testthat/test_get.adjacency.R
@@ -1,7 +1,5 @@
 test_that("as_adj works", {
 
-  library(igraph)
-
   g <- sample_gnp(50, 1/50)
   A <- as_adj(g, sparse=FALSE)
   g2 <- graph_from_adjacency_matrix(A, mode="undirected")

--- a/tests/testthat/test_get.adjacency.R
+++ b/tests/testthat/test_get.adjacency.R
@@ -1,6 +1,3 @@
-
-context("as_adj")
-
 test_that("as_adj works", {
 
   library(igraph)

--- a/tests/testthat/test_get.adjlist.R
+++ b/tests/testthat/test_get.adjlist.R
@@ -1,6 +1,3 @@
-
-context("as_adj_list")
-
 test_that("as_adj_list works", {
 
   library(igraph)

--- a/tests/testthat/test_get.adjlist.R
+++ b/tests/testthat/test_get.adjlist.R
@@ -1,7 +1,5 @@
 test_that("as_adj_list works", {
 
-  library(igraph)
-
   g <- sample_gnp(50, 2/50)
   al <- as_adj_list(g)
   g2 <- graph_from_adj_list(al, mode="all")

--- a/tests/testthat/test_get.all.shortest.paths.R
+++ b/tests/testthat/test_get.all.shortest.paths.R
@@ -1,6 +1,3 @@
-
-context("all_shortest_paths")
-
 test_that("all_shortest_paths works", {
 
   library(igraph)

--- a/tests/testthat/test_get.all.shortest.paths.R
+++ b/tests/testthat/test_get.all.shortest.paths.R
@@ -1,7 +1,5 @@
 test_that("all_shortest_paths works", {
 
-  library(igraph)
-
   edges <- matrix(c("s", "a", 2,
                     "s", "b", 4,
                     "a", "t", 4,

--- a/tests/testthat/test_get.diameter.R
+++ b/tests/testthat/test_get.diameter.R
@@ -1,7 +1,5 @@
 test_that("get_diameter works", {
 
-  library(igraph)
-
   g <- make_ring(10)
   E(g)$weight <- sample(seq_len(ecount(g)))
   d <- diameter(g)

--- a/tests/testthat/test_get.diameter.R
+++ b/tests/testthat/test_get.diameter.R
@@ -1,6 +1,3 @@
-
-context("get_diameter")
-
 test_that("get_diameter works", {
 
   library(igraph)

--- a/tests/testthat/test_get.edge.R
+++ b/tests/testthat/test_get.edge.R
@@ -1,5 +1,4 @@
 test_that("ends works", {
-  library(igraph)
   g <- sample_gnp(100, 3/100)
   edges <- unlist(lapply(seq_len(ecount(g)), ends, graph=g))
   g2 <- graph(edges, dir=FALSE, n=vcount(g))

--- a/tests/testthat/test_get.edge.R
+++ b/tests/testthat/test_get.edge.R
@@ -1,6 +1,3 @@
-
-context("ends")
-
 test_that("ends works", {
   library(igraph)
   g <- sample_gnp(100, 3/100)

--- a/tests/testthat/test_get.edgelist.R
+++ b/tests/testthat/test_get.edgelist.R
@@ -1,5 +1,4 @@
 test_that("as_edgelist works", {
-  library(igraph)
   g <- sample_gnp(100, 3/100)
   e <- as_edgelist(g)
   g2 <- graph(t(e), n=vcount(g), dir=FALSE)

--- a/tests/testthat/test_get.edgelist.R
+++ b/tests/testthat/test_get.edgelist.R
@@ -1,6 +1,3 @@
-
-context("edgelist")
-
 test_that("as_edgelist works", {
   library(igraph)
   g <- sample_gnp(100, 3/100)

--- a/tests/testthat/test_get.incidence.R
+++ b/tests/testthat/test_get.incidence.R
@@ -1,6 +1,3 @@
-
-context("as_incidence_matrix")
-
 test_that("as_incidence_matrix works", {
 
   library(igraph)

--- a/tests/testthat/test_get.incidence.R
+++ b/tests/testthat/test_get.incidence.R
@@ -1,7 +1,5 @@
 test_that("as_incidence_matrix works", {
 
-  library(igraph)
-
   ## Dense
   I <- matrix(sample(0:1, 35, replace=TRUE, prob=c(3,1)), ncol=5)
   g <- graph_from_incidence_matrix(I)

--- a/tests/testthat/test_get.shortest.paths.R
+++ b/tests/testthat/test_get.shortest.paths.R
@@ -1,7 +1,5 @@
 test_that("shortest_paths works", {
 
-  library(igraph)
-
   edges <- matrix(c("s", "a", 2,
                     "s", "b", 4,
                     "a", "t", 4,

--- a/tests/testthat/test_get.shortest.paths.R
+++ b/tests/testthat/test_get.shortest.paths.R
@@ -36,11 +36,11 @@ test_that("shortest_paths can handle negative weights", {
   sps <- shortest_paths(g, 2)$vpath
 
   expect_true(length(sps) == 7)
-  expect_equivalent(as.vector(sps[[1]]), integer(0))
-  expect_equivalent(as.vector(sps[[2]]), c(2))
-  expect_equivalent(as.vector(sps[[3]]), integer(0))
-  expect_equivalent(as.vector(sps[[4]]), c(2, 4))
-  expect_equivalent(as.vector(sps[[5]]), c(2, 5))
-  expect_equivalent(as.vector(sps[[6]]), integer(0))
-  expect_equivalent(as.vector(sps[[7]]), integer(0))
+  expect_equal(ignore_attr = TRUE, as.vector(sps[[1]]), integer(0))
+  expect_equal(ignore_attr = TRUE, as.vector(sps[[2]]), c(2))
+  expect_equal(ignore_attr = TRUE, as.vector(sps[[3]]), integer(0))
+  expect_equal(ignore_attr = TRUE, as.vector(sps[[4]]), c(2, 4))
+  expect_equal(ignore_attr = TRUE, as.vector(sps[[5]]), c(2, 5))
+  expect_equal(ignore_attr = TRUE, as.vector(sps[[6]]), integer(0))
+  expect_equal(ignore_attr = TRUE, as.vector(sps[[7]]), integer(0))
 })

--- a/tests/testthat/test_get.shortest.paths.R
+++ b/tests/testthat/test_get.shortest.paths.R
@@ -1,6 +1,3 @@
-
-context("shortest_paths")
-
 test_that("shortest_paths works", {
 
   library(igraph)

--- a/tests/testthat/test_girth.R
+++ b/tests/testthat/test_girth.R
@@ -1,6 +1,3 @@
-
-context("girth")
-
 test_that("girth works", {
 
   library(igraph)

--- a/tests/testthat/test_girth.R
+++ b/tests/testthat/test_girth.R
@@ -1,7 +1,5 @@
 test_that("girth works", {
 
-  library(igraph)
-
   ## No circle in a tree
   g <- make_tree(1000, 3)
   gi <- girth(g)

--- a/tests/testthat/test_graph.adhesion.R
+++ b/tests/testthat/test_graph.adhesion.R
@@ -1,6 +1,3 @@
-
-context("adhesion")
-
 test_that("adhesion works", {
 
   library(igraph)

--- a/tests/testthat/test_graph.adhesion.R
+++ b/tests/testthat/test_graph.adhesion.R
@@ -1,7 +1,5 @@
 test_that("adhesion works", {
 
-  library(igraph)
-
   g <- make_graph("Zachary")
   expect_that(adhesion(g), equals(1))
   expect_that(cohesion(g), equals(1))

--- a/tests/testthat/test_graph.adjacency.R
+++ b/tests/testthat/test_graph.adjacency.R
@@ -1,6 +1,3 @@
-
-context("graph.adjacency")
-
 test_that("graph_from_adjacency_matrix works", {
 
   library(igraph)

--- a/tests/testthat/test_graph.adjacency.R
+++ b/tests/testthat/test_graph.adjacency.R
@@ -159,7 +159,7 @@ test_that("graph_from_adjacency_matrix empty graph bug is fixed", {
   library(igraph)
   A <- Matrix(0, 10, 10, sparse=TRUE, doDiag=FALSE)
   g <- graph_from_adjacency_matrix(A, mode="undirected")
-  expect_equal(as.matrix(g[]), as.matrix(A), check.attributes=FALSE)
+  expect_equal(ignore_attr = TRUE, as.matrix(g[]), as.matrix(A))
 
 })
 

--- a/tests/testthat/test_graph.adjacency.R
+++ b/tests/testthat/test_graph.adjacency.R
@@ -1,7 +1,5 @@
 test_that("graph_from_adjacency_matrix works", {
 
-  library(igraph)
-
   M1 <- rbind(c(0,0,1,1),
               c(1,0,0,0),
               c(0,1,0,1),
@@ -145,7 +143,6 @@ test_that("graph_from_adjacency_matrix works", {
 test_that("graph_from_adjacency_matrix 2 edge bug is fixed", {
 
   library(Matrix)
-  library(igraph)
   A <- Matrix(0, 10, 10, sparse=TRUE, doDiag=FALSE)
   A[3,5] <- A[5,3] <- 1
   g <- graph_from_adjacency_matrix(A, mode="undirected")
@@ -156,7 +153,6 @@ test_that("graph_from_adjacency_matrix 2 edge bug is fixed", {
 test_that("graph_from_adjacency_matrix empty graph bug is fixed", {
 
   library(Matrix)
-  library(igraph)
   A <- Matrix(0, 10, 10, sparse=TRUE, doDiag=FALSE)
   g <- graph_from_adjacency_matrix(A, mode="undirected")
   expect_equal(ignore_attr = TRUE, as.matrix(g[]), as.matrix(A))
@@ -165,7 +161,6 @@ test_that("graph_from_adjacency_matrix empty graph bug is fixed", {
 
 test_that("bug #554 is fixed", {
 
-  library(igraph)
   library(Matrix)
 
   M <- Matrix(0, 5, 5, doDiag=FALSE)
@@ -176,8 +171,6 @@ test_that("bug #554 is fixed", {
 })
 
 test_that("graph_from_adjacency_matrix works for sparse matrices without values", {
-
-  library(igraph)
 
   # https://github.com/igraph/rigraph/issues/269
   M <- Matrix::sparseMatrix(i=c(1,3),j=c(3,4),dims=c(5,5))

--- a/tests/testthat/test_graph.adjacency.R
+++ b/tests/testthat/test_graph.adjacency.R
@@ -142,8 +142,7 @@ test_that("graph_from_adjacency_matrix works", {
 
 test_that("graph_from_adjacency_matrix 2 edge bug is fixed", {
 
-  library(Matrix)
-  A <- Matrix(0, 10, 10, sparse=TRUE, doDiag=FALSE)
+  A <- Matrix::Matrix(0, 10, 10, sparse=TRUE, doDiag=FALSE)
   A[3,5] <- A[5,3] <- 1
   g <- graph_from_adjacency_matrix(A, mode="undirected")
   expect_that(g[], equals(A))
@@ -152,8 +151,7 @@ test_that("graph_from_adjacency_matrix 2 edge bug is fixed", {
 
 test_that("graph_from_adjacency_matrix empty graph bug is fixed", {
 
-  library(Matrix)
-  A <- Matrix(0, 10, 10, sparse=TRUE, doDiag=FALSE)
+  A <- Matrix::Matrix(0, 10, 10, sparse=TRUE, doDiag=FALSE)
   g <- graph_from_adjacency_matrix(A, mode="undirected")
   expect_equal(ignore_attr = TRUE, as.matrix(g[]), as.matrix(A))
 
@@ -161,9 +159,7 @@ test_that("graph_from_adjacency_matrix empty graph bug is fixed", {
 
 test_that("bug #554 is fixed", {
 
-  library(Matrix)
-
-  M <- Matrix(0, 5, 5, doDiag=FALSE)
+  M <- Matrix::Matrix(0, 5, 5, doDiag=FALSE)
   M[1,2] <- M[2,1] <- M[3,4] <- M[4,3] <- 1
   g <- graph_from_adjacency_matrix(M, mode="undirected", weighted=TRUE)
   expect_that(g[], equals(M))

--- a/tests/testthat/test_graph.adjlist.R
+++ b/tests/testthat/test_graph.adjlist.R
@@ -1,7 +1,5 @@
 test_that("graph_from_adj_list works", {
 
-  library(igraph)
-
   g <- sample_gnp(100, 3/100)
   al <- as_adj_list(g)
   g2 <- graph_from_adj_list(al, mode="all")

--- a/tests/testthat/test_graph.adjlist.R
+++ b/tests/testthat/test_graph.adjlist.R
@@ -1,6 +1,3 @@
-
-context("graph_from_adj_list")
-
 test_that("graph_from_adj_list works", {
 
   library(igraph)

--- a/tests/testthat/test_graph.atlas.R
+++ b/tests/testthat/test_graph.atlas.R
@@ -1,5 +1,4 @@
 test_that("graph.atlas works", {
-  library(igraph)
   g124 <- graph.atlas(124)
   expect_true(graph.isomorphic(g124, graph(c(1,2,2,3,3,4,4,5,1,5,1,3,2,6),
                                            directed=FALSE)))

--- a/tests/testthat/test_graph.atlas.R
+++ b/tests/testthat/test_graph.atlas.R
@@ -1,6 +1,3 @@
-
-context("graph.atlas")
-
 test_that("graph.atlas works", {
   library(igraph)
   g124 <- graph.atlas(124)

--- a/tests/testthat/test_graph.bfs.R
+++ b/tests/testthat/test_graph.bfs.R
@@ -1,6 +1,5 @@
 test_that("BFS works from multiple root vertices", {
 
-  library(igraph)
   g <- make_ring(10) %du% make_ring(10)
 
   expect_that(as.vector(bfs(g, 1)$order),

--- a/tests/testthat/test_graph.bfs.R
+++ b/tests/testthat/test_graph.bfs.R
@@ -21,7 +21,7 @@ test_that("issue 133", {
 
   g <- graph_from_edgelist(matrix(c(1,2,2,3), ncol = 2, byrow = TRUE))
 
-  expect_equal(
+  expect_equal(ignore_attr = TRUE,
     bfs(g, 1, restricted = c(1, 2), unreachable = FALSE)$order,
     V(g)[c(1, 2, NA_real_), na_ok = TRUE]
   )

--- a/tests/testthat/test_graph.bfs.R
+++ b/tests/testthat/test_graph.bfs.R
@@ -1,6 +1,3 @@
-
-context("BFS")
-
 test_that("BFS works from multiple root vertices", {
 
   library(igraph)

--- a/tests/testthat/test_graph.bipartite.R
+++ b/tests/testthat/test_graph.bipartite.R
@@ -1,6 +1,4 @@
 test_that("make_bipartite_graph works", {
-  library(igraph)
-
   I <- matrix(sample(0:1, 35, replace=TRUE, prob=c(3,1)), ncol=5)
   g <- graph_from_incidence_matrix(I)
 

--- a/tests/testthat/test_graph.bipartite.R
+++ b/tests/testthat/test_graph.bipartite.R
@@ -1,6 +1,3 @@
-
-context("make_bipartite_graph")
-
 test_that("make_bipartite_graph works", {
   library(igraph)
 

--- a/tests/testthat/test_graph.complementer.R
+++ b/tests/testthat/test_graph.complementer.R
@@ -1,7 +1,5 @@
 test_that("complementer works", {
 
-  library(igraph)
-
   g <- sample_gnp(50, 3/50)
   g2 <- complementer(g)
   g3 <- complementer(g2)

--- a/tests/testthat/test_graph.complementer.R
+++ b/tests/testthat/test_graph.complementer.R
@@ -1,6 +1,3 @@
-
-context("complementer")
-
 test_that("complementer works", {
 
   library(igraph)

--- a/tests/testthat/test_graph.compose.R
+++ b/tests/testthat/test_graph.compose.R
@@ -1,6 +1,3 @@
-
-context("compose")
-
 test_that("compose works", {
 
   library(igraph)

--- a/tests/testthat/test_graph.compose.R
+++ b/tests/testthat/test_graph.compose.R
@@ -1,7 +1,5 @@
 test_that("compose works", {
 
-  library(igraph)
-
   g1 <- sample_gnp(50, 3/50, directed=TRUE)
   gi <- graph( rep(1:vcount(g1), each=2), directed=TRUE )
 

--- a/tests/testthat/test_graph.coreness.R
+++ b/tests/testthat/test_graph.coreness.R
@@ -1,5 +1,4 @@
 test_that("coreness works", {
-  library(igraph)
   g <- make_ring(10)
   g <- add_edges(g, c(1,2, 2,3, 1,3))
   gc <- coreness(g)

--- a/tests/testthat/test_graph.coreness.R
+++ b/tests/testthat/test_graph.coreness.R
@@ -1,6 +1,3 @@
-
-context("coreness")
-
 test_that("coreness works", {
   library(igraph)
   g <- make_ring(10)

--- a/tests/testthat/test_graph.data.frame.R
+++ b/tests/testthat/test_graph.data.frame.R
@@ -1,6 +1,3 @@
-
-context("graph_from_data_frame")
-
 test_that("graph_from_data_frame works", {
 
   library(igraph) ; igraph_options(print.full=TRUE)

--- a/tests/testthat/test_graph.data.frame.R
+++ b/tests/testthat/test_graph.data.frame.R
@@ -24,8 +24,6 @@ test_that("graph_from_data_frame works", {
 
 test_that("graph_from_data_frame works on matrices", {
 
-  library(igraph)
-
   el <- cbind(1:5,5:1,weight=1:5)
   g <- graph_from_data_frame(el)
   g <- delete_vertex_attr(g, "name")

--- a/tests/testthat/test_graph.de.bruijn.R
+++ b/tests/testthat/test_graph.de.bruijn.R
@@ -1,6 +1,5 @@
 test_that("make_de_bruijn_graph works", {
 
-  library(igraph)
   g <- make_de_bruijn_graph(2,1)
   g2 <- make_de_bruijn_graph(2,2)
   g3 <- make_line_graph(g)

--- a/tests/testthat/test_graph.de.bruijn.R
+++ b/tests/testthat/test_graph.de.bruijn.R
@@ -1,6 +1,3 @@
-
-context("make_de_bruijn_graph")
-
 test_that("make_de_bruijn_graph works", {
 
   library(igraph)

--- a/tests/testthat/test_graph.density.R
+++ b/tests/testthat/test_graph.density.R
@@ -1,7 +1,5 @@
 test_that("edge_density works", {
 
-  library(igraph)
-
   g <- sample_gnp(50, 4/50)
   gd <- edge_density(g)
   gd2 <- ecount(g) / vcount(g) / (vcount(g)-1) * 2

--- a/tests/testthat/test_graph.density.R
+++ b/tests/testthat/test_graph.density.R
@@ -1,6 +1,3 @@
-
-context("edge_density")
-
 test_that("edge_density works", {
 
   library(igraph)

--- a/tests/testthat/test_graph.edgelist.R
+++ b/tests/testthat/test_graph.edgelist.R
@@ -1,6 +1,3 @@
-
-context("graph_from_edgelist")
-
 test_that("graph_from_edgelist works", {
 
   library(igraph)

--- a/tests/testthat/test_graph.edgelist.R
+++ b/tests/testthat/test_graph.edgelist.R
@@ -1,7 +1,5 @@
 test_that("graph_from_edgelist works", {
 
-  library(igraph)
-
   g <- sample_gnp(50, 5/50)
   el <- as_edgelist(g)
   g2 <- graph_from_edgelist(el, directed=FALSE)

--- a/tests/testthat/test_graph.eigen.R
+++ b/tests/testthat/test_graph.eigen.R
@@ -1,6 +1,3 @@
-
-context("Eigenproblems")
-
 test_that("spectrum works for symmetric matrices", {
   library(igraph)
   set.seed(42)

--- a/tests/testthat/test_graph.eigen.R
+++ b/tests/testthat/test_graph.eigen.R
@@ -1,5 +1,4 @@
 test_that("spectrum works for symmetric matrices", {
-  library(igraph)
   set.seed(42)
 
   std <- function(x) {

--- a/tests/testthat/test_graph.formula.R
+++ b/tests/testthat/test_graph.formula.R
@@ -1,6 +1,3 @@
-
-context("graph_from_literal")
-
 test_that("simplify argument works", {
 
   library(igraph)

--- a/tests/testthat/test_graph.formula.R
+++ b/tests/testthat/test_graph.formula.R
@@ -1,6 +1,5 @@
 test_that("simplify argument works", {
 
-  library(igraph)
   g1 <- graph_from_literal(1-1, 1-2, 1-2)
   g2 <- graph_from_literal(1-1, 1-2, 1-2, simplify=FALSE)
 

--- a/tests/testthat/test_graph.isoclass.R
+++ b/tests/testthat/test_graph.isoclass.R
@@ -1,6 +1,3 @@
-
-context("isomorphism_class")
-
 test_that("isomorphism_class works", {
 
   library(igraph)

--- a/tests/testthat/test_graph.isoclass.R
+++ b/tests/testthat/test_graph.isoclass.R
@@ -1,7 +1,5 @@
 test_that("isomorphism_class works", {
 
-  library(igraph)
-
   g1 <- graph_from_isomorphism_class(3, 10)
   g2 <- graph_from_isomorphism_class(3, 11)
   expect_that(isomorphism_class(g1), equals(10))

--- a/tests/testthat/test_graph.kautz.R
+++ b/tests/testthat/test_graph.kautz.R
@@ -1,5 +1,4 @@
 test_that("make_kautz_graph works", {
-  library(igraph)
   g <- make_kautz_graph(2,3)
   expect_that(g$name, equals("Kautz graph 2-3"))
   expect_that(g$m, equals(2))

--- a/tests/testthat/test_graph.kautz.R
+++ b/tests/testthat/test_graph.kautz.R
@@ -1,6 +1,3 @@
-
-context("make_kautz_graph")
-
 test_that("make_kautz_graph works", {
   library(igraph)
   g <- make_kautz_graph(2,3)

--- a/tests/testthat/test_graph.knn.R
+++ b/tests/testthat/test_graph.knn.R
@@ -1,6 +1,3 @@
-
-context("knn")
-
 test_that("knn works", {
   library(igraph)
   set.seed(42)

--- a/tests/testthat/test_graph.knn.R
+++ b/tests/testthat/test_graph.knn.R
@@ -1,5 +1,4 @@
 test_that("knn works", {
-  library(igraph)
   set.seed(42)
 
   ## Some trivial ones

--- a/tests/testthat/test_graph.maxflow.R
+++ b/tests/testthat/test_graph.maxflow.R
@@ -1,6 +1,3 @@
-
-context("max_flow")
-
 test_that("max_flow works", {
   library(igraph)
   E <- rbind( c(1,3,3), c(3,4,1), c(4,2,2), c(1,5,1), c(5,6,2), c(6,2,10))

--- a/tests/testthat/test_graph.maxflow.R
+++ b/tests/testthat/test_graph.maxflow.R
@@ -1,5 +1,4 @@
 test_that("max_flow works", {
-  library(igraph)
   E <- rbind( c(1,3,3), c(3,4,1), c(4,2,2), c(1,5,1), c(5,6,2), c(6,2,10))
   colnames(E) <- c("from", "to", "capacity")
   g1 <- graph_from_data_frame(as.data.frame(E))

--- a/tests/testthat/test_graph.mincut.R
+++ b/tests/testthat/test_graph.mincut.R
@@ -1,7 +1,5 @@
 test_that("min_cut works", {
 
-  library(igraph)
-
   g2 <- graph( c(1,2,2,3,3,4, 1,6,6,5,5,4, 4,1) )
   E(g2)$capacity <- c(3,1,2, 10,1,3, 2)
   mc <- min_cut(g2, value.only=FALSE)
@@ -14,8 +12,6 @@ test_that("min_cut works", {
 })
 
 test_that("s-t min_cut works", {
-
-  library(igraph)
 
   g2 <- graph( c(1,2,2,3,3,4, 1,6,6,5,5,4, 4,1) )
   E(g2)$capacity <- c(3,1,2, 10,1,3, 2)

--- a/tests/testthat/test_graph.mincut.R
+++ b/tests/testthat/test_graph.mincut.R
@@ -1,6 +1,3 @@
-
-context("min_cut")
-
 test_that("min_cut works", {
 
   library(igraph)

--- a/tests/testthat/test_graph.subisomorphic.lad.R
+++ b/tests/testthat/test_graph.subisomorphic.lad.R
@@ -1,7 +1,5 @@
 test_that("graph.subisomorphic, method = 'lad' works", {
 
-  library(igraph)
-
   pattern <- graph_from_literal(1:2:3:4:5,
                        1 - 2:5, 2 - 1:5:3, 3 - 2:4, 4 - 3:5, 5 - 4:2:1)
   target <- graph_from_literal(1:2:3:4:5:6:7:8:9,
@@ -23,7 +21,6 @@ test_that("graph.subisomorphic, method = 'lad' works", {
 
 test_that("LAD stress test", {
 
-  library(igraph)
   local_rng_version("3.5.0")
   set.seed(42)
   N <- 100

--- a/tests/testthat/test_graph.subisomorphic.lad.R
+++ b/tests/testthat/test_graph.subisomorphic.lad.R
@@ -1,6 +1,3 @@
-
-context("graph.subisomorphic, lad")
-
 test_that("graph.subisomorphic, method = 'lad' works", {
 
   library(igraph)

--- a/tests/testthat/test_graph.subisomorphic.vf2.R
+++ b/tests/testthat/test_graph.subisomorphic.vf2.R
@@ -1,6 +1,5 @@
 test_that("graph.subisomorphic.vf2 works", {
 
-  library(igraph)
   set.seed(42)
 
   g1 <- sample_gnp(20,6/20)

--- a/tests/testthat/test_graph.subisomorphic.vf2.R
+++ b/tests/testthat/test_graph.subisomorphic.vf2.R
@@ -1,6 +1,3 @@
-
-context("graph.subisomorphic.vf2")
-
 test_that("graph.subisomorphic.vf2 works", {
 
   library(igraph)

--- a/tests/testthat/test_graphNEL.R
+++ b/tests/testthat/test_graphNEL.R
@@ -1,6 +1,3 @@
-
-context("graphNEL conversion")
-
 test_that("graphNEL conversion works", {
 
   if (!requireNamespace("graph", quietly = TRUE)) skip("No graph package")

--- a/tests/testthat/test_graphlets.R
+++ b/tests/testthat/test_graphlets.R
@@ -1,6 +1,3 @@
-
-context("Graphlets")
-
 sortgl <- function(x) {
   cl <- lapply(x$cliques, sort)
   n <- sapply(cl, length)

--- a/tests/testthat/test_graphlets.R
+++ b/tests/testthat/test_graphlets.R
@@ -5,8 +5,6 @@ sortgl <- function(x) {
 }
 
 test_that("Graphlets work for some simple graphs", {
-  library(igraph)
-
   g <- make_full_graph(5)
   E(g)$weight <- 1
   gl <- graphlet_basis(g)
@@ -25,7 +23,6 @@ test_that("Graphlets work for some simple graphs", {
 })
 
 test_that("Graphlets filtering works", {
-  library(igraph)
   gt <- data.frame(from  =c("A", "A", "B", "B", "B", "C", "C", "D"),
                    to    =c("B", "C", "C", "D", "E", "D", "E", "E"),
                    weight=c( 8 ,  8 ,  8 ,  5 ,  5 ,  5 ,  5 ,  5 ))
@@ -78,7 +75,6 @@ graphlets.old <- function(graph) {
 }
 
 test_that("Graphlets work for a bigger graph", {
-  library(igraph)
   set.seed(42)
   g <- make_graph("zachary")
   E(g)$weight <- sample(1:5, ecount(g), replace=TRUE)
@@ -152,8 +148,6 @@ graphlets.project.old <- function(graph, cliques, iter, Mu=NULL) {
 }
 
 test_that("Graphlet projection works", {
-  library(igraph)
-
   D1 <- matrix(0, 5, 5)
   D2 <- matrix(0, 5, 5)
   D3 <- matrix(0, 5, 5)

--- a/tests/testthat/test_hrg.R
+++ b/tests/testthat/test_hrg.R
@@ -1,5 +1,4 @@
 test_that("Starting from state works (#225)", {
-  library(igraph)
   set.seed(42)
 
   g <- sample_gnp(10, p=1/2) + sample_gnp(10, p=1/2)

--- a/tests/testthat/test_hrg.R
+++ b/tests/testthat/test_hrg.R
@@ -1,6 +1,3 @@
-
-context("Hierarchical random graphs")
-
 test_that("Starting from state works (#225)", {
   library(igraph)
   set.seed(42)

--- a/tests/testthat/test_hsbm.R
+++ b/tests/testthat/test_hsbm.R
@@ -1,6 +1,3 @@
-
-context("Hierarchical stochastic block models")
-
 test_that("HSBM works", {
   library(igraph)
   set.seed(42)

--- a/tests/testthat/test_hsbm.R
+++ b/tests/testthat/test_hsbm.R
@@ -34,7 +34,7 @@ test_that("HSBM works", {
 })
 
 test_that("HSBM with 1 cluster per block works", {
-  res <- Matrix(0, nrow=10, ncol=10, doDiag=FALSE)
+  res <- Matrix::Matrix(0, nrow=10, ncol=10, doDiag=FALSE)
   res[6:10, 1:5] <- res[1:5, 6:10] <- 1
   g <- sample_hierarchical_sbm(10, 5, rho=1, C=matrix(0), p=1)
   expect_that(g[], equals(res))

--- a/tests/testthat/test_hsbm.R
+++ b/tests/testthat/test_hsbm.R
@@ -1,5 +1,4 @@
 test_that("HSBM works", {
-  library(igraph)
   set.seed(42)
 
   C <- matrix(c(1  , 1/2,   0,
@@ -35,7 +34,6 @@ test_that("HSBM works", {
 })
 
 test_that("HSBM with 1 cluster per block works", {
-  library(igraph)
   res <- Matrix(0, nrow=10, ncol=10, doDiag=FALSE)
   res[6:10, 1:5] <- res[1:5, 6:10] <- 1
   g <- sample_hierarchical_sbm(10, 5, rho=1, C=matrix(0), p=1)
@@ -43,8 +41,6 @@ test_that("HSBM with 1 cluster per block works", {
 })
 
 test_that("HSBM with list arguments works", {
-  library(igraph)
-
   b <- 5
   C <- matrix(c(1  , 1/2,   0,
                 1/2,   0, 1/2,

--- a/tests/testthat/test_identical_graphs.R
+++ b/tests/testthat/test_identical_graphs.R
@@ -1,5 +1,3 @@
-context("identical_graphs")
-
 test_that("identical_graphs works", {
     g <- make_ring(5)
     g2 <- make_ring(5)

--- a/tests/testthat/test_igraph.options.R
+++ b/tests/testthat/test_igraph.options.R
@@ -1,7 +1,5 @@
 test_that("igraph_options works", {
 
-  library(igraph)
-
   igraph_options(verbose=TRUE)
   expect_true(igraph_opt("verbose"))
 

--- a/tests/testthat/test_igraph.options.R
+++ b/tests/testthat/test_igraph.options.R
@@ -1,6 +1,3 @@
-
-context("igraph_options")
-
 test_that("igraph_options works", {
 
   library(igraph)

--- a/tests/testthat/test_independent.vertex.sets.R
+++ b/tests/testthat/test_independent.vertex.sets.R
@@ -1,6 +1,3 @@
-
-context("ivs")
-
 test_that("ivs works", {
 
   library(igraph)

--- a/tests/testthat/test_independent.vertex.sets.R
+++ b/tests/testthat/test_independent.vertex.sets.R
@@ -1,7 +1,5 @@
 test_that("ivs works", {
 
-  library(igraph)
-
   g <- sample_gnp(50, 0.8)
   ivs <- ivs(g, min=ivs_size(g))
   ec <- sapply(seq_along(ivs), function(x)

--- a/tests/testthat/test_indexing.R
+++ b/tests/testthat/test_indexing.R
@@ -1,6 +1,3 @@
-
-context("Indexing")
-
 mm <- function(...) {
   v <- as.numeric(as.vector(list(...)))
   matrix(v, nrow=sqrt(length(v)))

--- a/tests/testthat/test_indexing.R
+++ b/tests/testthat/test_indexing.R
@@ -245,9 +245,9 @@ test_that("[[ works with from and to", {
 
   g <- make_tree(20)
 
-  expect_equivalent(g[[1, ]], g[[from = 1]])
-  expect_equivalent(g[[, 1]], g[[to = 1]])
-  expect_equivalent(g[[1:5, 4:10]], g[[from = 1:5, to = 4:10]])
+  expect_equal(ignore_attr = TRUE, g[[1, ]], g[[from = 1]])
+  expect_equal(ignore_attr = TRUE, g[[, 1]], g[[to = 1]])
+  expect_equal(ignore_attr = TRUE, g[[1:5, 4:10]], g[[from = 1:5, to = 4:10]])
 
   expect_error(g[[1, from = 1]], "Cannot give both")
   expect_error(g[[, 2, to = 10]], "Cannot give both")

--- a/tests/testthat/test_indexing2.R
+++ b/tests/testthat/test_indexing2.R
@@ -1,6 +1,3 @@
-
-context("Assignments via indexing")
-
 library(igraph)
 
 am <- function(x) {

--- a/tests/testthat/test_indexing3.R
+++ b/tests/testthat/test_indexing3.R
@@ -3,5 +3,5 @@ test_that("Indexing multi-graphs as adjacency list", {
   g <- make_graph(~ A -+ B:C, A -+ B:C:D, simplify = FALSE)
   e <- g[['A', 'B', edges = TRUE]]
 
-  expect_equal(sort(e[[1]]), E(g)[1,3])
+  expect_equal(ignore_attr = TRUE, sort(e[[1]]), E(g)[1,3])
 })

--- a/tests/testthat/test_indexing3.R
+++ b/tests/testthat/test_indexing3.R
@@ -1,6 +1,3 @@
-
-context("Indexing")
-
 test_that("Indexing multi-graphs as adjacency list", {
 
   g <- make_graph(~ A -+ B:C, A -+ B:C:D, simplify = FALSE)

--- a/tests/testthat/test_is.bipartite.R
+++ b/tests/testthat/test_is.bipartite.R
@@ -1,6 +1,3 @@
-
-context("is_bipartite")
-
 test_that("is_bipartite works", {
 
   library(igraph)

--- a/tests/testthat/test_is.bipartite.R
+++ b/tests/testthat/test_is.bipartite.R
@@ -1,7 +1,5 @@
 test_that("is_bipartite works", {
 
-  library(igraph)
-
   I <- matrix(sample(0:1, 35, replace=TRUE, prob=c(3,1)), ncol=5)
   g <- graph_from_incidence_matrix(I)
   expect_true(bipartite_mapping(g)$res)

--- a/tests/testthat/test_is.chordal.R
+++ b/tests/testthat/test_is.chordal.R
@@ -1,7 +1,5 @@
 test_that("is_chordal works", {
 
-  library(igraph)
-
   ## The examples from the Tarjan-Yannakakis paper
   g1 <- graph_from_literal(A-B:C:I, B-A:C:D, C-A:B:E:H, D-B:E:F,
                   E-C:D:F:H, F-D:E:G, G-F:H, H-C:E:G:I,

--- a/tests/testthat/test_is.chordal.R
+++ b/tests/testthat/test_is.chordal.R
@@ -1,6 +1,3 @@
-
-context("is_chordal")
-
 test_that("is_chordal works", {
 
   library(igraph)

--- a/tests/testthat/test_iterators.R
+++ b/tests/testthat/test_iterators.R
@@ -1,7 +1,5 @@
 test_that("iterators work", {
 
-  library(igraph)
-
   ## Create a small ring graph, assign attributes
   ring <- graph_from_literal( A-B-C-D-E-F-G-A )
   E(ring)$weight <- seq_len(ecount(ring))
@@ -15,8 +13,6 @@ test_that("iterators work", {
 })
 
 test_that("complex attributes work", {
-  library(igraph)
-
   g <- make_ring(10)
   foo <- lapply(1:vcount(g), seq, from=1)
   V(g)$foo <- foo

--- a/tests/testthat/test_iterators.R
+++ b/tests/testthat/test_iterators.R
@@ -1,6 +1,3 @@
-
-context("iterators")
-
 test_that("iterators work", {
 
   library(igraph)

--- a/tests/testthat/test_label.propagation.community.R
+++ b/tests/testthat/test_label.propagation.community.R
@@ -1,6 +1,3 @@
-
-context("cluster_label_prop")
-
 test_that("label.probagation.community works", {
 
   library(igraph)

--- a/tests/testthat/test_label.propagation.community.R
+++ b/tests/testthat/test_label.propagation.community.R
@@ -1,7 +1,5 @@
 test_that("label.probagation.community works", {
 
-  library(igraph)
-
   g <- make_graph("Zachary")
   set.seed(42)
   lpc <- cluster_label_prop(g)

--- a/tests/testthat/test_laplacian.spectral.embedding.R
+++ b/tests/testthat/test_laplacian.spectral.embedding.R
@@ -1,6 +1,3 @@
-
-context("Spectral embedding of the Laplacian")
-
 std <- function(x) {
   x <- zapsmall(x)
   apply(x, 2, function(col) {

--- a/tests/testthat/test_laplacian.spectral.embedding.R
+++ b/tests/testthat/test_laplacian.spectral.embedding.R
@@ -14,7 +14,6 @@ mag_sort <- function(x) {
 }
 
 test_that("Undirected, unweighted, D-A case works", {
-  library(igraph)
   library(Matrix)
 
   set.seed(42)
@@ -68,7 +67,6 @@ test_that("Undirected, unweighted, D-A case works", {
 })
 
 test_that("Undirected, unweighted, DAD case works", {
-  library(igraph)
   set.seed(42)
   g <- random.graph.game(10, 20, type="gnm", directed=FALSE)
 
@@ -171,7 +169,6 @@ test_that("Undirected, unweighted, I-DAD case works", {
 })
 
 test_that("Undirected, weighted, D-A case works", {
-  library(igraph)
   library(Matrix)
 
   set.seed(42*42)
@@ -227,7 +224,6 @@ test_that("Undirected, weighted, D-A case works", {
 })
 
 test_that("Undirected, unweighted, DAD case works", {
-  library(igraph)
   set.seed(42)
 
   g <- random.graph.game(10, 20, type="gnm", directed=FALSE)
@@ -280,7 +276,6 @@ test_that("Undirected, unweighted, DAD case works", {
 })
 
 test_that("Undirected, unweighted, I-DAD case works", {
-  library(igraph)
   set.seed(42)
 
   g <- random.graph.game(10, 20, type="gnm", directed=FALSE)
@@ -333,7 +328,6 @@ test_that("Undirected, unweighted, I-DAD case works", {
 })
 
 test_that("Directed, unweighted, OAP case works", {
-  library(igraph)
   set.seed(42*42)
 
   g <- random.graph.game(10, 30, type="gnm", directed=TRUE)
@@ -389,7 +383,6 @@ test_that("Directed, unweighted, OAP case works", {
 })
 
 test_that("Directed, weighted case works", {
-  library(igraph)
   set.seed(42*42)
 
   g <- random.graph.game(10, 30, type="gnm", directed=TRUE)

--- a/tests/testthat/test_laplacian.spectral.embedding.R
+++ b/tests/testthat/test_laplacian.spectral.embedding.R
@@ -14,13 +14,11 @@ mag_sort <- function(x) {
 }
 
 test_that("Undirected, unweighted, D-A case works", {
-  library(Matrix)
-
   set.seed(42)
   g <- random.graph.game(10, 20, type="gnm", directed=FALSE)
 
   no <- 3
-  A <- as(Matrix(diag(degree(g)), doDiag=FALSE), "generalMatrix") - g[]
+  A <- as(Matrix::Matrix(diag(degree(g)), doDiag=FALSE), "generalMatrix") - g[]
   ss <- eigen(A)
 
   D <- ss$values
@@ -169,14 +167,12 @@ test_that("Undirected, unweighted, I-DAD case works", {
 })
 
 test_that("Undirected, weighted, D-A case works", {
-  library(Matrix)
-
   set.seed(42*42)
   g <- random.graph.game(10, 20, type="gnm", directed=FALSE)
   E(g)$weight <- sample(1:5, ecount(g), replace=TRUE)
 
   no <- 3
-  A <- as(Matrix(diag(graph.strength(g)), doDiag=FALSE), "generalMatrix") - g[]
+  A <- as(Matrix::Matrix(diag(graph.strength(g)), doDiag=FALSE), "generalMatrix") - g[]
   ss <- eigen(A)
 
   D <- ss$values

--- a/tests/testthat/test_largest.cliques.R
+++ b/tests/testthat/test_largest.cliques.R
@@ -1,7 +1,5 @@
 test_that("largest_cliques works", {
 
-  library(igraph)
-
   g <- sample_gnp(50,20/50)
   lc <- largest_cliques(g)
 

--- a/tests/testthat/test_largest.cliques.R
+++ b/tests/testthat/test_largest.cliques.R
@@ -1,6 +1,3 @@
-
-context("largest_cliques")
-
 test_that("largest_cliques works", {
 
   library(igraph)

--- a/tests/testthat/test_largest.independent.vertex.sets.R
+++ b/tests/testthat/test_largest.independent.vertex.sets.R
@@ -1,6 +1,3 @@
-
-context("largest_ivs")
-
 test_that("largest_ivs works", {
 
   library(igraph)

--- a/tests/testthat/test_largest.independent.vertex.sets.R
+++ b/tests/testthat/test_largest.independent.vertex.sets.R
@@ -1,7 +1,5 @@
 test_that("largest_ivs works", {
 
-  library(igraph)
-
   g <- sample_gnp(50, 0.8)
   livs <- largest_ivs(g)
   expect_that(unique(sapply(livs, length)),

--- a/tests/testthat/test_layout.fr.R
+++ b/tests/testthat/test_layout.fr.R
@@ -1,6 +1,3 @@
-
-context("Fruchterman-Reingold layout")
-
 test_that("", {
 
   skip_on_os("solaris")

--- a/tests/testthat/test_layout.fr.R
+++ b/tests/testthat/test_layout.fr.R
@@ -2,7 +2,6 @@ test_that("", {
 
   skip_on_os("solaris")
 
-  library(igraph)
   set.seed(42)
   g <- make_ring(10)
   l <- layout_with_fr(g, niter=50, start.temp=sqrt(10)/10)

--- a/tests/testthat/test_layout.kk.R
+++ b/tests/testthat/test_layout.kk.R
@@ -20,7 +20,6 @@ test_that("Kamada-Kawai layout generator works", {
     all(abs(norm_radii) < eps) && all(abs(norm_dists) < eps)
   }
 
-  library(igraph)
   g <- make_ring(10)
   l <- layout_with_kk(g, maxiter=50, coords=layout_in_circle(g))
   expect_true(looks_circular(l))
@@ -55,8 +54,6 @@ test_that("3D Kamada-Kawai layout generator works", {
 
   skip_on_cran()
   skip_on_ci()
-
-  library(igraph)
 
   set.seed(42)
 

--- a/tests/testthat/test_layout.kk.R
+++ b/tests/testthat/test_layout.kk.R
@@ -1,6 +1,3 @@
-
-context("Kamada-Kawai layouts")
-
 test_that("Kamada-Kawai layout generator works", {
 
   set.seed(42)

--- a/tests/testthat/test_layout.mds.R
+++ b/tests/testthat/test_layout.mds.R
@@ -1,6 +1,3 @@
-
-context("layout_with_mds")
-
 test_that("layout_with_mds works", {
 
   library(igraph)

--- a/tests/testthat/test_layout.mds.R
+++ b/tests/testthat/test_layout.mds.R
@@ -1,7 +1,5 @@
 test_that("layout_with_mds works", {
 
-  library(igraph)
-
   ## A tree
 
   g <- make_tree(10, 2, "undirected")

--- a/tests/testthat/test_layout.merge.R
+++ b/tests/testthat/test_layout.merge.R
@@ -1,6 +1,3 @@
-
-context("merge_coords")
-
 test_that("merge_coords works", {
 
   library(igraph)

--- a/tests/testthat/test_layout.merge.R
+++ b/tests/testthat/test_layout.merge.R
@@ -1,6 +1,5 @@
 test_that("merge_coords works", {
 
-  library(igraph)
   set.seed(42)
 
   g <- list(make_ring(10), make_ring(5))

--- a/tests/testthat/test_layout.sugiyama.R
+++ b/tests/testthat/test_layout.sugiyama.R
@@ -1,5 +1,3 @@
-context("layout_with_sugiyama")
-
 test_that("layout_with_sugiyama does not demote matrices to vectors in res$layout.dummy", {
     ex <- graph.formula( A -+ B:C, B -+ C:D)
     layex <- layout.sugiyama(ex, layers=NULL)

--- a/tests/testthat/test_layout_nicely.R
+++ b/tests/testthat/test_layout_nicely.R
@@ -1,5 +1,3 @@
-context("Automatic layout")
-
 test_that("layout_nicely() works with negative weights", {
     g <- make_graph("petersen")
     E(g)$weight <- -5:9

--- a/tests/testthat/test_layout_null_singleton.R
+++ b/tests/testthat/test_layout_null_singleton.R
@@ -1,5 +1,3 @@
-context("layouts for null and singleton graphs")
-
 test_that("layout algorithms work for null graphs", {
     g <- make_empty_graph()
     mat <- matrix(as.numeric(c()), ncol=2)

--- a/tests/testthat/test_leading.eigenvector.community.R
+++ b/tests/testthat/test_leading.eigenvector.community.R
@@ -1,6 +1,3 @@
-
-context("cluster_leading_eigen")
-
 test_that("cluster_leading_eigen works", {
 
   library(igraph)

--- a/tests/testthat/test_leiden.R
+++ b/tests/testthat/test_leiden.R
@@ -1,6 +1,3 @@
-
-context("cluster_leiden")
-
 test_that("cluster_leiden works", {
 
   library(igraph)

--- a/tests/testthat/test_leiden.R
+++ b/tests/testthat/test_leiden.R
@@ -1,6 +1,5 @@
 test_that("cluster_leiden works", {
 
-  library(igraph)
   set.seed(42)
 
   g <- make_graph("Zachary")

--- a/tests/testthat/test_matching.R
+++ b/tests/testthat/test_matching.R
@@ -1,5 +1,3 @@
-context("is_matching")
-
 test_that("is_matching works", {
   library(igraph)
 
@@ -29,8 +27,6 @@ test_that("is_matching works with names", {
   expect_false(is_matching(g, c("a", "b")))
 })
 
-context("is_max_matching")
-
 test_that("is_max_matching works", {
   library(igraph)
 
@@ -59,8 +55,6 @@ test_that("is_max_matching works with names", {
   expect_false(is_max_matching(g, c("a", "b", "c", "d", "e", "5", "4", "3", "2", "1")))
   expect_false(is_max_matching(g, c("a", "b")))
 })
-
-context("max_bipartite_match")
 
 test_that("max_bipartite_match works", {
   library(igraph)

--- a/tests/testthat/test_matching.R
+++ b/tests/testthat/test_matching.R
@@ -1,6 +1,4 @@
 test_that("is_matching works", {
-  library(igraph)
-
   df <- data.frame(x = 1:5, y = letters[1:5])
   g <- graph_from_data_frame(df)
 
@@ -14,8 +12,6 @@ test_that("is_matching works", {
 })
 
 test_that("is_matching works with names", {
-  library(igraph)
-
   df <- data.frame(x = 1:5, y = letters[1:5])
   g <- graph_from_data_frame(df)
 
@@ -28,8 +24,6 @@ test_that("is_matching works with names", {
 })
 
 test_that("is_max_matching works", {
-  library(igraph)
-
   df <- data.frame(x = 1:5, y = letters[1:5])
   g <- graph_from_data_frame(df)
 
@@ -43,8 +37,6 @@ test_that("is_max_matching works", {
 })
 
 test_that("is_max_matching works with names", {
-  library(igraph)
-
   df <- data.frame(x = 1:5, y = letters[1:5])
   g <- graph_from_data_frame(df)
 
@@ -57,8 +49,6 @@ test_that("is_max_matching works with names", {
 })
 
 test_that("max_bipartite_match works", {
-  library(igraph)
-
   df <- data.frame(x = 1:5, y = letters[1:5])
   g <- graph_from_data_frame(df)
   V(g)$type <- 1:vcount(g) > 5
@@ -70,8 +60,6 @@ test_that("max_bipartite_match works", {
 })
 
 test_that("max_bipartite_match handles missing types gracefully", {
-  library(igraph)
-
   df <- data.frame(x = 1:5, y = letters[1:5])
   g <- graph_from_data_frame(df)
   expect_error(max_bipartite_match(g), "supply .*types.* argument")

--- a/tests/testthat/test_maximal_cliques.R
+++ b/tests/testthat/test_maximal_cliques.R
@@ -80,7 +80,6 @@ bk4 <- function(graph, min=0, max=Inf) {
 #################################################################
 
 test_that("Maximal cliques work", {
-  library(igraph)
   set.seed(42)
   G <- sample_gnm(1000, 1000)
   cli <- make_full_graph(10)
@@ -97,7 +96,6 @@ test_that("Maximal cliques work", {
 })
 
 test_that("Maximal cliques work for subsets", {
-  library(igraph)
   set.seed(42)
   G <- sample_gnp(100, .5)
 
@@ -111,7 +109,6 @@ test_that("Maximal cliques work for subsets", {
 })
 
 test_that("Counting maximal cliques works", {
-  library(igraph)
   set.seed(42)
   G <- sample_gnp(100, .5)
 

--- a/tests/testthat/test_maximal_cliques.R
+++ b/tests/testthat/test_maximal_cliques.R
@@ -1,6 +1,3 @@
-
-context("Maximal cliques")
-
 mysort <- function(x) {
   xl <- sapply(x, length)
   x <- lapply(x, sort)

--- a/tests/testthat/test_minimal.st.separators.R
+++ b/tests/testthat/test_minimal.st.separators.R
@@ -1,6 +1,5 @@
 test_that("min_st_separators works", {
 
-  library(igraph)
   g <- make_graph("Zachary")
   msts <- min_st_separators(g)
   is <- sapply(msts, is_separator, graph=g)

--- a/tests/testthat/test_minimal.st.separators.R
+++ b/tests/testthat/test_minimal.st.separators.R
@@ -1,6 +1,3 @@
-
-context("min_st_separators")
-
 test_that("min_st_separators works", {
 
   library(igraph)

--- a/tests/testthat/test_minimum.size.separators.R
+++ b/tests/testthat/test_minimum.size.separators.R
@@ -1,6 +1,3 @@
-
-context("min_separators")
-
 test_that("min_separators works", {
 
   library(igraph)

--- a/tests/testthat/test_minimum.size.separators.R
+++ b/tests/testthat/test_minimum.size.separators.R
@@ -1,7 +1,5 @@
 test_that("min_separators works", {
 
-  library(igraph)
-
   camp <- graph_from_literal(Harry:Steve:Don:Bert - Harry:Steve:Don:Bert,
                     Pam:Brazey:Carol:Pat - Pam:Brazey:Carol:Pat,
                     Holly   - Carol:Pat:Pam:Jennie:Bill,

--- a/tests/testthat/test_modularity_matrix.R
+++ b/tests/testthat/test_modularity_matrix.R
@@ -1,7 +1,5 @@
 test_that("modularity_matrix works", {
 
-  library(igraph)
-
   kar <- make_graph("zachary")
 
   fc <- cluster_fast_greedy(kar)
@@ -18,8 +16,6 @@ test_that("modularity_matrix works", {
 })
 
 test_that("modularity_matrix still accepts a membership argument for compatibility", {
-
-  library(igraph)
 
   kar <- make_graph("zachary")
   expect_warning(

--- a/tests/testthat/test_modularity_matrix.R
+++ b/tests/testthat/test_modularity_matrix.R
@@ -1,6 +1,3 @@
-
-context("modularity_matrix")
-
 test_that("modularity_matrix works", {
 
   library(igraph)

--- a/tests/testthat/test_motifs.R
+++ b/tests/testthat/test_motifs.R
@@ -1,6 +1,5 @@
 test_that("motif finding works", {
 
-  library(igraph)
   set.seed(123)
 
   b <- sample_gnp(10000, 4/10000, directed=TRUE)

--- a/tests/testthat/test_motifs.R
+++ b/tests/testthat/test_motifs.R
@@ -1,6 +1,3 @@
-
-context("motifs")
-
 test_that("motif finding works", {
 
   library(igraph)

--- a/tests/testthat/test_multilevel.community.R
+++ b/tests/testthat/test_multilevel.community.R
@@ -1,6 +1,5 @@
 test_that("cluster_louvain works", {
 
-  library(igraph)
   set.seed(42)
 
   g <- make_graph("Zachary")

--- a/tests/testthat/test_multilevel.community.R
+++ b/tests/testthat/test_multilevel.community.R
@@ -1,6 +1,3 @@
-
-context("cluster_louvain")
-
 test_that("cluster_louvain works", {
 
   library(igraph)

--- a/tests/testthat/test_neighborhood.R
+++ b/tests/testthat/test_neighborhood.R
@@ -1,7 +1,5 @@
 test_that("ego works", {
 
-  library(igraph)
-
   neig <- function(graph, order, vertices) {
     sp <- distances(graph)
     v <- unique(unlist(lapply(vertices, function(x) {
@@ -40,7 +38,6 @@ test_that("ego works", {
 
 test_that("mindist works", {
 
-  library(igraph)
   g <- make_ring(10)
   expect_that(ego_size(g, order=2, mindist=0), equals(rep(5, 10)))
   expect_that(ego_size(g, order=2, mindist=1), equals(rep(4, 10)))

--- a/tests/testthat/test_neighborhood.R
+++ b/tests/testthat/test_neighborhood.R
@@ -1,6 +1,3 @@
-
-context("ego")
-
 test_that("ego works", {
 
   library(igraph)

--- a/tests/testthat/test_neighbors.R
+++ b/tests/testthat/test_neighbors.R
@@ -1,6 +1,3 @@
-
-context("neighbors")
-
 test_that("neighbors works", {
 
   library(igraph)

--- a/tests/testthat/test_neighbors.R
+++ b/tests/testthat/test_neighbors.R
@@ -1,7 +1,5 @@
 test_that("neighbors works", {
 
-  library(igraph)
-
   g <- sample_gnp(100, 20/100)
   al <- as_adj_list(g, mode="all")
   for (i in 1:length(al)) {
@@ -12,8 +10,6 @@ test_that("neighbors works", {
 })
 
 test_that("neighbors prints an error for an empty input vector", {
-  library(igraph)
-
   g <- make_tree(10)
   expect_error(neighbors(g, numeric()), "No vertex was specified")
 

--- a/tests/testthat/test_operators.R
+++ b/tests/testthat/test_operators.R
@@ -1,7 +1,5 @@
 test_that("operators work", {
 
-  library(igraph)
-
   o <- function(x) x[order(x[,1], x[,2]),]
 
   g1 <- make_ring(10)

--- a/tests/testthat/test_operators.R
+++ b/tests/testthat/test_operators.R
@@ -1,6 +1,3 @@
-
-context("operators")
-
 test_that("operators work", {
 
   library(igraph)

--- a/tests/testthat/test_operators3.R
+++ b/tests/testthat/test_operators3.R
@@ -1,7 +1,5 @@
 test_that("infix operators work", {
 
-  library(igraph)
-
   g <- make_ring(10)
   V(g)$name <- letters[1:10]
   E(g)$name <- LETTERS[1:10]

--- a/tests/testthat/test_operators3.R
+++ b/tests/testthat/test_operators3.R
@@ -1,6 +1,3 @@
-
-context("infix operators")
-
 test_that("infix operators work", {
 
   library(igraph)

--- a/tests/testthat/test_operators4.R
+++ b/tests/testthat/test_operators4.R
@@ -1,7 +1,3 @@
-
-context("operators on named graphs")
-
-
 test_that("disjoint union works for named graphs", {
 
   library(igraph)

--- a/tests/testthat/test_operators4.R
+++ b/tests/testthat/test_operators4.R
@@ -1,7 +1,5 @@
 test_that("disjoint union works for named graphs", {
 
-  library(igraph)
-
   g1 <- g2 <- make_ring(10)
   g1$foo <- "bar"
   V(g1)$name <- letters[ 1:10]
@@ -37,8 +35,6 @@ test_that("disjoint union works for named graphs", {
 
 test_that("disjoint union gives warning for non-unique vertex names", {
 
-  library(igraph)
-
   g1 <- make_ring(5); V(g1)$name <- letters[1:5]
   g2 <- make_ring(5); V(g2)$name <- letters[5:9]
 
@@ -48,8 +44,6 @@ test_that("disjoint union gives warning for non-unique vertex names", {
 
 
 test_that("union of unnamed graphs works", {
-
-  library(igraph)
 
   g1 <- make_ring(10)
   g2 <- make_ring(13)
@@ -84,8 +78,6 @@ test_that("union of unnamed graphs works", {
 })
 
 test_that("union of named graphs works", {
-
-  library(igraph)
 
   g1 <- make_ring(10)
   g2 <- make_ring(13)
@@ -155,8 +147,6 @@ m NA 23    m
 })
 
 test_that("intersection of named graphs works", {
-
-  library(igraph)
 
   g1 <- make_ring(10)
   g2 <- make_ring(13)
@@ -243,8 +233,6 @@ m NA 23    m
 
 test_that("difference of named graphs works", {
 
-  library(igraph)
-
   g1 <- make_ring(10)
   g2 <- make_star(11, center=11, mode="undirected")
   V(g1)$name <- letters[1:10]
@@ -290,8 +278,6 @@ test_that("difference of named graphs works", {
 })
 
 test_that("compose works for named graphs", {
-
-  library(igraph)
 
   g1 <- graph_from_literal( A-B:D:E, B-C:D, C-D, D-E )
   g2 <- graph_from_literal( A-B-E-A )
@@ -344,7 +330,6 @@ C    5     e    NA   NA    C
 })
 
 test_that("intersection of non-named graphs keeps attributes properly", {
-  library(igraph)
   set.seed(42)
 
   g <- sample_gnp(10, 1/2)
@@ -369,7 +354,6 @@ test_that("intersection of non-named graphs keeps attributes properly", {
 })
 
 test_that("union of non-named graphs keeps attributes properly", {
-  library(igraph)
   set.seed(42)
 
   g <- sample_gnp(10, 1/2)

--- a/tests/testthat/test_optimal.community.R
+++ b/tests/testthat/test_optimal.community.R
@@ -1,6 +1,3 @@
-
-context("cluster_optimal")
-
 test_that("cluster_optimal works", {
 
   skip_if_no_glpk()

--- a/tests/testthat/test_optimal.community.R
+++ b/tests/testthat/test_optimal.community.R
@@ -2,7 +2,6 @@ test_that("cluster_optimal works", {
 
   skip_if_no_glpk()
 
-  library(igraph)
   g <- make_graph("Zachary")
   oc <- cluster_optimal(g)
 
@@ -23,7 +22,6 @@ test_that("weighted cluster_optimal works", {
 
   skip_if_no_glpk()
 
-  library(igraph)
   local_rng_version("3.5.0")
   set.seed(42)
   g <- make_full_graph(5) + make_ring(5)

--- a/tests/testthat/test_pajek.R
+++ b/tests/testthat/test_pajek.R
@@ -1,6 +1,3 @@
-
-context("Pajek file format")
-
 test_that("writing Pajek files works", {
 
   library(igraph)

--- a/tests/testthat/test_pajek.R
+++ b/tests/testthat/test_pajek.R
@@ -1,7 +1,5 @@
 test_that("writing Pajek files works", {
 
-  library(igraph)
-
   g <- make_ring(9)
   V(g)$color <- c("red", "green", "yellow")
 

--- a/tests/testthat/test_print.R
+++ b/tests/testthat/test_print.R
@@ -1,6 +1,3 @@
-
-context("print.igraph")
-
 test_that("print.igraph works", {
 
   library(igraph)

--- a/tests/testthat/test_print.R
+++ b/tests/testthat/test_print.R
@@ -1,6 +1,5 @@
 test_that("print.igraph works", {
 
-  library(igraph)
   igraph_options(print.full=TRUE)
   options(width=76)
 

--- a/tests/testthat/test_psumtree.R
+++ b/tests/testthat/test_psumtree.R
@@ -1,6 +1,3 @@
-
-context("Prefix sum tree")
-
 test_that("Prefix sum tree works", {
 
   library(igraph)

--- a/tests/testthat/test_psumtree.R
+++ b/tests/testthat/test_psumtree.R
@@ -1,6 +1,5 @@
 test_that("Prefix sum tree works", {
 
-  library(igraph)
   set.seed(42)
   mysample <- function(x, size, prob=NULL) {
     if (!is.null(prob)) { prob <- as.numeric(prob) }

--- a/tests/testthat/test_read_graph.R
+++ b/tests/testthat/test_read_graph.R
@@ -1,5 +1,3 @@
-context("Graph file formats")
-
 test_that("reading GraphML file works", {
     skip_if_no_graphml()
 

--- a/tests/testthat/test_rewire.R
+++ b/tests/testthat/test_rewire.R
@@ -1,5 +1,3 @@
-context("rewire")
-
 test_that("rewire(each_edge(mode='in')) keeps the in-degree distribution", {
     g <- barabasi.game(1000)
 

--- a/tests/testthat/test_sample.R
+++ b/tests/testthat/test_sample.R
@@ -1,6 +1,3 @@
-
-context("Various samplers")
-
 test_that("Sampling from a Dirichlet works", {
 
   library(igraph)

--- a/tests/testthat/test_sample.R
+++ b/tests/testthat/test_sample.R
@@ -1,6 +1,5 @@
 test_that("Sampling from a Dirichlet works", {
 
-  library(igraph)
   set.seed(42)
   sd <- sample_dirichlet(100, alpha=c(1, 1, 1))
   expect_that(dim(sd), equals(c(3, 100)))

--- a/tests/testthat/test_sbm.game.R
+++ b/tests/testthat/test_sbm.game.R
@@ -1,6 +1,3 @@
-
-context("Stochastic block models")
-
 test_that("Generating stochastic block models works", {
 
   library(igraph)

--- a/tests/testthat/test_sbm.game.R
+++ b/tests/testthat/test_sbm.game.R
@@ -1,6 +1,5 @@
 test_that("Generating stochastic block models works", {
 
-  library(igraph)
   pm <- matrix(1, nrow=2, ncol=2)
   bs <- c(4,6)
   g1 <- sample_sbm(10, pref.matrix=pm, block.sizes=bs,

--- a/tests/testthat/test_scan.R
+++ b/tests/testthat/test_scan.R
@@ -1,6 +1,3 @@
-
-context("Local scan statistics")
-
 library(igraph)
 require(digest)
 

--- a/tests/testthat/test_scan.R
+++ b/tests/testthat/test_scan.R
@@ -138,7 +138,6 @@ test_that("General scan-stat works, US, scan-1, weighted, directed", {
 
 test_that("Issue 18 is resolved", {
 
-  library(igraph)
   g <- graph(c(1,2,2,1, 1,3,3,1, 2,4, 3,4, 3,5,5,3, 4,5,5,4))
   expect_that(local_scan(g, mode="all"), equals(c(4, 3, 7, 6, 5)))
   expect_that(local_scan(g, mode="out"), equals(c(4, 3, 7, 2, 5)))
@@ -146,7 +145,6 @@ test_that("Issue 18 is resolved", {
 })
 
 test_that("Issue 18 is really resolved", {
-  library(igraph)
   el <- c(1, 5, 1, 7, 2, 5, 2, 7, 2, 10, 2, 13, 2, 18, 3, 5, 3, 10, 3,
           13, 4, 5, 4, 10, 5, 7, 5, 10, 5, 13, 5, 18, 6, 3, 6, 5, 6, 7,
           6, 13, 7, 5, 8, 5, 8, 10, 8, 18, 9, 3, 9, 5, 9, 7, 9, 10, 11,
@@ -167,7 +165,6 @@ test_that("Issue 18 is really resolved", {
 
 test_that("Issue 20 is resolved", {
 
-  library(igraph)
   set.seed(12345)
   g1 <- erdos.renyi.game(n=20, p.or.m=0.1, directed=TRUE)
   g2 <- erdos.renyi.game(n=20, p.or.m=0.1, directed=TRUE)
@@ -177,7 +174,6 @@ test_that("Issue 20 is resolved", {
 })
 
 test_that("FUN argument works, #32", {
-  library(igraph)
   r1 <- local_scan(graph.ring(10), k=1, FUN="ecount")
   r2 <- local_scan(graph.ring(10), k=1, FUN=ecount)
   expect_that(r1, equals(rep(2, 10)))

--- a/tests/testthat/test_sdf.R
+++ b/tests/testthat/test_sdf.R
@@ -1,7 +1,5 @@
 test_that("sdf works", {
 
-  library(igraph)
-
   sdf <- igraph:::sdf
   `[.igraphSDF` <- igraph:::`[.igraphSDF`
   `[<-.igraphSDF` <- igraph:::`[<-.igraphSDF`

--- a/tests/testthat/test_sdf.R
+++ b/tests/testthat/test_sdf.R
@@ -1,6 +1,3 @@
-
-context("sdf")
-
 test_that("sdf works", {
 
   library(igraph)

--- a/tests/testthat/test_sgm.R
+++ b/tests/testthat/test_sgm.R
@@ -1,6 +1,3 @@
-
-context("Seeded graph matching")
-
 test_that("SGM works", {
   library(igraph)
   local_rng_version("3.5.0")

--- a/tests/testthat/test_sgm.R
+++ b/tests/testthat/test_sgm.R
@@ -1,5 +1,4 @@
 test_that("SGM works", {
-  library(igraph)
   local_rng_version("3.5.0")
   set.seed(42)
 

--- a/tests/testthat/test_sir.R
+++ b/tests/testthat/test_sir.R
@@ -1,6 +1,3 @@
-
-context("SIR epidemics model on a network")
-
 test_that("SIR works", {
 
   skip_on_os("solaris")

--- a/tests/testthat/test_sir.R
+++ b/tests/testthat/test_sir.R
@@ -4,8 +4,6 @@ test_that("SIR works", {
 
   set.seed(42)
   library(digest)
-  library(igraph)
-
   g <- sample_gnm(50, 50)
   res <- sir(g, beta=5, gamma=1, no.sim=10)
   exps <- c(

--- a/tests/testthat/test_sphere.R
+++ b/tests/testthat/test_sphere.R
@@ -1,6 +1,3 @@
-
-context("Sampling points from a sphere")
-
 test_that("Sampling sphere surface works", {
 
   library(igraph)

--- a/tests/testthat/test_sphere.R
+++ b/tests/testthat/test_sphere.R
@@ -1,6 +1,5 @@
 test_that("Sampling sphere surface works", {
 
-  library(igraph)
   library(digest)
 
   set.seed(42)
@@ -18,7 +17,6 @@ test_that("Sampling sphere surface works", {
 
 test_that("Sampling sphere volume works", {
 
-  library(igraph)
   library(digest)
 
   set.seed(42)

--- a/tests/testthat/test_topology.R
+++ b/tests/testthat/test_topology.R
@@ -1,5 +1,3 @@
-context("automorphisms")
-
 test_that("automorphisms works", {
   library(igraph)
 

--- a/tests/testthat/test_topology.R
+++ b/tests/testthat/test_topology.R
@@ -1,6 +1,4 @@
 test_that("automorphisms works", {
-  library(igraph)
-
   g <- make_ring(10)
   expect_that(automorphisms(g)$group_size, equals("20"))
 
@@ -10,8 +8,6 @@ test_that("automorphisms works", {
 
 
 test_that("automorphisms works with colored graphs", {
-  library(igraph)
-
   g <- make_full_graph(4)
   expect_that(automorphisms(g, colors=c(1,2,1,2))$group_size, equals("4"))
 

--- a/tests/testthat/test_transitivity.R
+++ b/tests/testthat/test_transitivity.R
@@ -1,5 +1,4 @@
 test_that("transitivity works", {
-  library(igraph)
   set.seed(42)
   g <- sample_gnp(100, p=10/100)
 
@@ -21,7 +20,6 @@ test_that("transitivity works", {
 
 test_that("no integer overflow", {
 
-  library(igraph)
   set.seed(42)
   g <- graph.star(80000, mode="undirected") + edges(sample(2:1000), 100)
   mtr <- min(transitivity(g, type="local"), na.rm=TRUE)

--- a/tests/testthat/test_transitivity.R
+++ b/tests/testthat/test_transitivity.R
@@ -1,6 +1,3 @@
-
-context("transitivity")
-
 test_that("transitivity works", {
   library(igraph)
   set.seed(42)

--- a/tests/testthat/test_trees.R
+++ b/tests/testthat/test_trees.R
@@ -1,7 +1,7 @@
 test_that("is_tree works for non-trees", {
     g <- make_graph("zachary")
     expect_false(is_tree(g))
-    expect_equal(is_tree(g, details=TRUE), list(res=FALSE, root=V(g)[numeric(0)]))
+    expect_equal(ignore_attr = TRUE, is_tree(g, details=TRUE), list(res=FALSE, root=V(g)[numeric(0)]))
 
     g <- sample_pa(15, m=3)
     expect_false(is_tree(g))
@@ -12,17 +12,17 @@ test_that("is_tree works for undirected trees", {
     # g <- permute(make_tree(7, 2), c(5, 2, 3, 4, 1, 6, 7))
     g <- make_tree(7, 2)
     expect_true(is_tree(g))
-    expect_equal(is_tree(g, details=TRUE), list(res=TRUE, root=V(g)[1]))
+    expect_equal(ignore_attr = TRUE, is_tree(g, details=TRUE), list(res=TRUE, root=V(g)[1]))
 })
 
 test_that("is_tree works for directed in-trees", {
     g <- permute(make_tree(7, 2, mode="in"), c(5, 2, 3, 4, 1, 6, 7))
 
     expect_true(is_tree(g, mode="in"))
-    expect_equal(is_tree(g, mode="in", details=TRUE), list(res=TRUE, root=V(g)[5]))
+    expect_equal(ignore_attr = TRUE, is_tree(g, mode="in", details=TRUE), list(res=TRUE, root=V(g)[5]))
 
     expect_true(is_tree(g, mode="all"))
-    expect_equal(is_tree(g, mode="all", details=TRUE), list(res=TRUE, root=V(g)[1]))
+    expect_equal(ignore_attr = TRUE, is_tree(g, mode="all", details=TRUE), list(res=TRUE, root=V(g)[1]))
 
     expect_false(is_tree(g, mode="out"))
     expect_false(is_tree(g, mode="out", details=TRUE)$res)
@@ -32,10 +32,10 @@ test_that("is_tree works for directed out-trees", {
     g <- permute(make_tree(7, 2, mode="out"), c(3, 2, 1, 4, 5, 6, 7))
 
     expect_true(is_tree(g, mode="out"))
-    expect_equal(is_tree(g, mode="out", details=TRUE), list(res=TRUE, root=V(g)[3]))
+    expect_equal(ignore_attr = TRUE, is_tree(g, mode="out", details=TRUE), list(res=TRUE, root=V(g)[3]))
 
     expect_true(is_tree(g, mode="all"))
-    expect_equal(is_tree(g, mode="all", details=TRUE), list(res=TRUE, root=V(g)[1]))
+    expect_equal(ignore_attr = TRUE, is_tree(g, mode="all", details=TRUE), list(res=TRUE, root=V(g)[1]))
 
     expect_false(is_tree(g, mode="in"))
     expect_false(is_tree(g, mode="in", details=TRUE)$res)

--- a/tests/testthat/test_trees.R
+++ b/tests/testthat/test_trees.R
@@ -1,5 +1,3 @@
-context("is_tree")
-
 test_that("is_tree works for non-trees", {
     g <- make_graph("zachary")
     expect_false(is_tree(g))
@@ -51,8 +49,6 @@ test_that("a graph with a single vertex and no edges is tree", {
     expect_true(is_tree(make_empty_graph(1)))
 })
 
-context("to_prufer, make_from_prufer")
-
 test_that("to_prufer and make_from_prufer works for trees", {
     g <- make_tree(13, 3, mode="undirected")
     seq <- to_prufer(g)
@@ -82,8 +78,6 @@ test_that("make_(from_prufer(...)) works", {
 test_that("to_prufer prints an error for non-trees", {
     expect_error(to_prufer(make_graph("zachary")), "must be a tree")
 })
-
-context("sample_tree")
 
 test_that("sample_tree works", {
     g <- sample_tree(100)
@@ -145,8 +139,6 @@ test_that("sample_tree yields a null graph for n=0", {
 test_that("sample_tree throws an error for the Prufer method with directed graphs", {
     expect_error(sample_tree(10, method="prufer", directed=T), "nvalid value")
 })
-
-context("sample_spanning_tree")
 
 test_that("sample_spanning_tree works for connected graphs", {
     g <- make_full_graph(8)

--- a/tests/testthat/test_triangles.R
+++ b/tests/testthat/test_triangles.R
@@ -1,6 +1,3 @@
-
-context("Triangles")
-
 test_that("Listing triangles works", {
 
   triangles <- function(...) as.vector(igraph::triangles(...))

--- a/tests/testthat/test_unfold.tree.R
+++ b/tests/testthat/test_unfold.tree.R
@@ -1,7 +1,5 @@
 test_that("unfold_tree works", {
 
-  library(igraph)
-
   g <- make_tree(7, 2)
   g <- add_edges(g, c(2,7, 1,4))
   g2 <- unfold_tree(g, roots=1)

--- a/tests/testthat/test_unfold.tree.R
+++ b/tests/testthat/test_unfold.tree.R
@@ -1,6 +1,3 @@
-
-context("unfold_tree")
-
 test_that("unfold_tree works", {
 
   library(igraph)

--- a/tests/testthat/test_walktrap.community.R
+++ b/tests/testthat/test_walktrap.community.R
@@ -1,6 +1,3 @@
-
-context("cluster_walktrap")
-
 test_that("cluster_walktrap works", {
 
   library(igraph)

--- a/tests/testthat/test_walktrap.community.R
+++ b/tests/testthat/test_walktrap.community.R
@@ -1,7 +1,5 @@
 test_that("cluster_walktrap works", {
 
-  library(igraph)
-
   g <- make_graph("Zachary")
   set.seed(42)
   wc <- cluster_walktrap(g)

--- a/tests/testthat/test_watts.strogatz.game.R
+++ b/tests/testthat/test_watts.strogatz.game.R
@@ -1,7 +1,5 @@
 test_that("sample_smallworld works", {
 
-  library(igraph)
-
   for (i in 1:50) {
     p <- runif(1)
     d <- sample(1:3, 1)

--- a/tests/testthat/test_watts.strogatz.game.R
+++ b/tests/testthat/test_watts.strogatz.game.R
@@ -1,6 +1,3 @@
-
-context("sample_smallworld")
-
 test_that("sample_smallworld works", {
 
   library(igraph)

--- a/tests/testthat/test_weighted_cliques.R
+++ b/tests/testthat/test_weighted_cliques.R
@@ -1,6 +1,3 @@
-
-context("weighted_cliques")
-
 test_that("weighted_cliques works", {
   g <- make_graph( ~ A-B-C-A-D-E-F-G-H-D-F-H-E-G-D )
   weights <- c(5,5,5,3,3,3,3,2)

--- a/tools/stimulus/DESCRIPTION
+++ b/tools/stimulus/DESCRIPTION
@@ -36,3 +36,5 @@ SystemRequirements:
     C++11
 BugReports: https://github.com/igraph/rigraph/issues
 Encoding: UTF-8
+Config/testthat/edition: 3
+Config/testthat/parallel: true


### PR DESCRIPTION
for parallel testing.

Starts with consistent code formatting (removal of spaces at EOF and lines at EOL), a prerequisite for the following bulk search+replace operations.

Adapts the test code to be compatible with testthat edition 3, which is required for parallel testing. This reduces the time to test the entire package to a half (4 cores, 32s -> ~16s).

Finally, `library()` shouldn't be used in test code, and is not necessary.

A lot of files are touched, each commit addresses a particular issue and can be reviewed individually. I can submit smaller PRs if needed.