### PR TITLE
Separate objects by newline in Makevars.win

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ src/Makevars.win src/Makevars.ucrt src/Makevars.in: src/%: tools/stimulus/% \
 		object_files
 	sed 's/@VERSION@/'$(VERSION)'/g' $< >$@
 	printf "%s" "OBJECTS=" >> $@
-	cat object_files >> $@
+	sed 's/ / \\\n/g' object_files >> $@
 
 pre_build: venv patches $(CSRC) $(CINC2) $(PARSER2) $(RSRC) $(RGEN) \
 	$(CGEN) $(RAY2) $(ARPACK2) $(UUID2)


### PR DESCRIPTION
This is for avoiding too long lines in `Makevars.win`, for easy review. The assumption is that there is a quoting error, but I don't see it yet.