### PR TITLE
Fix warning about partial matching

### DIFF
--- a/R/epi.R
+++ b/R/epi.R
@@ -192,7 +192,7 @@ plot.sir <- function(x, comp=c("NI", "NS", "NR"),
   # Plot the stochastic curves individually.
   plot(0, 0, type="n", xlim=xlim, ylim=ylim, xlab=xlab, ylab=ylab, ...)
   lapply(seq_along(sir), function(i) {
-    lines(sir[[i]]$time, sir[[i]][[comp]], col=color[1])
+    lines(sir[[i]]$times, sir[[i]][[comp]], col=color[1])
   })
 
   # Plot the median and quantiles.


### PR DESCRIPTION
Showed up when running examples.