### PR TITLE
fix: Need less-than comparison for test

### DIFF
--- a/tests/testthat/test_leading.eigenvector.community.R
+++ b/tests/testthat/test_leading.eigenvector.community.R
@@ -57,7 +57,7 @@ test_that("cluster_leading_eigen works", {
 
   ## Stress-test. We skip this on R 3.4 and 3.5 because it seems like
   ## the results are not entirely deterministic there.
-  skip_if(getRversion() <= "3.5")
+  skip_if(getRversion() < "3.6")
 
   for (i in 1:100) {
     g <- sample_gnm(20, sample(5:40, 1))


### PR DESCRIPTION
to actually skip on R 3.5.