### PR TITLE
chore: Add new docs target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ build: pre_build
 	R CMD INSTALL -l "/tmp" --no-configure --no-byte-compile .
 
 docs: pre_build
-		tools/builddocs.sh
+	tools/builddocs.sh
 
 igraph: igraph_$(VERSION).tar.gz
 

--- a/Makefile
+++ b/Makefile
@@ -229,14 +229,15 @@ build: pre_build
 	if ! [ -f src/Makevars ]; then ./configure; fi
 	R CMD INSTALL -l "/tmp" --no-configure --no-byte-compile .
 
+docs: pre_build
+		tools/builddocs.sh
+
 igraph: igraph_$(VERSION).tar.gz
 
-igraph_$(VERSION).tar.gz: pre_build
+igraph_$(VERSION).tar.gz: docs
 	rm -f src/config.h
 	rm -f src/Makevars
 	touch src/config.h
-	mkdir -p man
-	tools/builddocs.sh
 	Rscript -e 'devtools::build(path = ".")'
 
 #############

--- a/man/as_adj_list.Rd
+++ b/man/as_adj_list.Rd
@@ -34,7 +34,7 @@ of neighbor vertices (according to the \code{mode} argument) of all
 vertices.
 
 \code{as_adj_edge_list} returns a list of numeric vectors, which include the
-ids of adjacent edgs (according to the \code{mode} argument) of all
+ids of adjacent edges (according to the \code{mode} argument) of all
 vertices.
 
 If \code{igraph_opt("return.vs.es")} is true (default), the numeric


### PR DESCRIPTION
so that we can run `make docs` before committing, e.g., in a pre-commit hook.