### PR TITLE
feat: Support `index = NULL` when setting attributes

### DIFF
--- a/R/par.R
+++ b/R/par.R
@@ -195,7 +195,7 @@ igraph_i_options <- function(..., .in = parent.frame()) {
 }
 
 local_igraph_options <- function(..., .in = parent.frame()) {
-  old <- igraph_options(..., .in = .in)
+  old <- igraph_i_options(..., .in = .in)
   withr::defer(rlang::inject(igraph_options(!!!old)), envir = .in)
   invisible()
 }

--- a/man/edge_attr-set.Rd
+++ b/man/edge_attr-set.Rd
@@ -5,7 +5,7 @@
 \alias{edge.attributes<-}
 \title{Set one or more edge attributes}
 \usage{
-edge_attr(graph, name, index = E(graph)) <- value
+edge_attr(graph, name, index = NULL) <- value
 }
 \arguments{
 \item{graph}{The graph.}
@@ -15,7 +15,8 @@ then \code{value} must be a named list, and its entries are
 set as edge attributes.}
 
 \item{index}{An optional edge sequence to set the attributes
-of a subset of edges.}
+of a subset of edges.
+If `NULL`, the default, the attribute is set for all edges.}
 
 \item{value}{The new value of the attribute(s) for all
 (or \code{index}) edges.}

--- a/man/edge_attr.Rd
+++ b/man/edge_attr.Rd
@@ -6,7 +6,7 @@
 \alias{edge.attributes}
 \title{Query edge attributes of a graph}
 \usage{
-edge_attr(graph, name, index = E(graph))
+edge_attr(graph, name, index = NULL)
 }
 \arguments{
 \item{graph}{The graph}
@@ -14,8 +14,9 @@ edge_attr(graph, name, index = E(graph))
 \item{name}{The name of the attribute to query. If missing, then
 all edge attributes are returned in a list.}
 
-\item{index}{An optional edge sequence, to query edge attributes
-for a subset of edges.}
+\item{index}{An optional edge sequence to query edge attributes
+for a subset of edges.
+If `NULL`, the default, the attribute is queried for all edges.}
 }
 \value{
 The value of the edge attribute, or the list of all

--- a/man/set_edge_attr.Rd
+++ b/man/set_edge_attr.Rd
@@ -5,7 +5,7 @@
 \alias{set.edge.attribute}
 \title{Set edge attributes}
 \usage{
-set_edge_attr(graph, name, index = E(graph), value)
+set_edge_attr(graph, name, index = NULL, value)
 }
 \arguments{
 \item{graph}{The graph}
@@ -13,7 +13,8 @@ set_edge_attr(graph, name, index = E(graph), value)
 \item{name}{The name of the attribute to set.}
 
 \item{index}{An optional edge sequence to set the attributes of
-a subset of edges.}
+a subset of edges.
+If `NULL`, the default, the attribute is set for all edges.}
 
 \item{value}{The new value of the attribute for all (or \code{index})
 edges.}

--- a/man/set_vertex_attr.Rd
+++ b/man/set_vertex_attr.Rd
@@ -13,7 +13,8 @@ set_vertex_attr(graph, name, index = V(graph), value)
 \item{name}{The name of the attribute to set.}
 
 \item{index}{An optional vertex sequence to set the attributes
-of a subset of vertices.}
+of a subset of vertices.
+If `NULL`, the default, the attribute is set for all vertices.}
 
 \item{value}{The new value of the attribute for all (or \code{index})
 vertices.}

--- a/man/vertex_attr-set.Rd
+++ b/man/vertex_attr-set.Rd
@@ -5,14 +5,15 @@
 \alias{vertex.attributes<-}
 \title{Set one or more vertex attributes}
 \usage{
-vertex_attr(graph, name, index = V(graph)) <- value
+vertex_attr(graph, name, index = NULL) <- value
 }
 \arguments{
 \item{graph}{The graph.}
 
 \item{name}{The name of the vertex attribute to set. If missing,
 then \code{value} must be a named list, and its entries are
-set as vertex attributes.}
+set as vertex attributes.
+If `NULL`, the default, the attribute is set for all vertices.}
 
 \item{index}{An optional vertex sequence to set the attributes
 of a subset of vertices.}

--- a/man/vertex_attr.Rd
+++ b/man/vertex_attr.Rd
@@ -6,7 +6,7 @@
 \alias{vertex.attributes}
 \title{Query vertex attributes of a graph}
 \usage{
-vertex_attr(graph, name, index = V(graph))
+vertex_attr(graph, name, index = NULL)
 }
 \arguments{
 \item{graph}{The graph.}
@@ -14,8 +14,9 @@ vertex_attr(graph, name, index = V(graph))
 \item{name}{Name of the attribute to query. If missing, then
 all vertex attributes are returned in a list.}
 
-\item{index}{A vertex sequence, to query the attribute only
-for these vertices.}
+\item{index}{An optional vertex sequence to query the attribute only
+for these vertices.
+If `NULL`, the default, the attribute is queried for all vertices.}
 }
 \value{
 The value of the vertex attribute, or the list of


### PR DESCRIPTION
For #466. Two FIXMEs remain, to be addressed in a follow-up PR.

I'd like to propose to make attribute updates a bit stricter as part of this exercise: allow `value` only of length one or the same length as the index. While this is technically a breaking change, most uses of passing `value` of incompatible length are very likely a mistake. @ntamas: What do you think?