### PR TITLE
Remove igraph version from GML header

### DIFF
--- a/patches/002-workaround-gml-creator.patch
+++ b/patches/002-workaround-gml-creator.patch
@@ -1,0 +1,15 @@
+diff --git a/src/core/io/gml.c b/src/core/io/gml.c
+index 77c7f0541..375523ee6 100644
+--- a/src/core/io/gml.c
++++ b/src/core/io/gml.c
+@@ -611,8 +611,8 @@ int igraph_write_graph_gml(const igraph_t *graph, FILE *outstream,
+     timestr[strlen(timestr) - 1] = '\0'; /* nicely remove \n */
+ 
+     CHECK(fprintf(outstream,
+-                  "Creator \"igraph version %s %s\"\nVersion 1\ngraph\n[\n",
+-                  IGRAPH_VERSION, creator ? creator : timestr));
++                  "Creator \"igraph %s\"\nVersion 1\ngraph\n[\n",
++                  creator ? creator : timestr));
+ 
+     IGRAPH_STRVECTOR_INIT_FINALLY(&gnames, 0);
+     IGRAPH_STRVECTOR_INIT_FINALLY(&vnames, 0);


### PR DESCRIPTION
We no longer have `IGRAPH_VERSION` available at compile time, and this is the only instance where it is used.

Patching the C core for now. Moving forward, perhaps `igraph_write_graph_gml()` could accept a version argument that can be provided externally?