### PR TITLE
fix: `NULL` means empty vertex or edge list again in all functions

### DIFF
--- a/R/attributes.R
+++ b/R/attributes.R
@@ -145,7 +145,7 @@ graph.attributes <- function(graph) {
 #' @param graph The graph.
 #' @param name Name of the attribute to query. If missing, then
 #'   all vertex attributes are returned in a list.
-#' @param index A vertex sequence, to query the attribute only
+#' @param index An optional vertex sequence to query the attribute only
 #'   for these vertices.
 #' @return The value of the vertex attribute, or the list of
 #'   all vertex attributes, if `name` is missing.
@@ -327,7 +327,7 @@ vertex.attributes <- function(graph, index = V(graph)) {
 #' @param graph The graph
 #' @param name The name of the attribute to query. If missing, then
 #'   all edge attributes are returned in a list.
-#' @param index An optional edge sequence, to query edge attributes
+#' @param index An optional edge sequence to query edge attributes
 #'   for a subset of edges.
 #' @return The value of the edge attribute, or the list of all
 #'   edge attributes if `name` is missing.

--- a/R/attributes.R
+++ b/R/attributes.R
@@ -174,7 +174,7 @@ vertex_attr <- function(graph, name, index = V(graph)) {
   } else {
     myattr <-
       .Call(C_R_igraph_mybracket2, graph, igraph_t_idx_attr, igraph_attr_idx_vertex)[[as.character(name)]]
-    if (! missing(index)) {
+    if (!missing(index)) {
       index <- as.igraph.vs(graph, index)
       myattr <- myattr[index]
     }
@@ -277,7 +277,7 @@ vertex.attributes <- function(graph, index = V(graph)) {
   res <- .Call(C_R_igraph_mybracket2_copy, graph, igraph_t_idx_attr, igraph_attr_idx_vertex)
 
   if (!missing(index) &&
-      (length(index) != vcount(graph) || any(index != V(graph)))) {
+    (length(index) != vcount(graph) || any(index != V(graph)))) {
     for (i in seq_along(res)) {
       res[[i]] <- res[[i]][index]
     }
@@ -307,7 +307,7 @@ vertex.attributes <- function(graph, index = V(graph)) {
   }
 
   if (!missing(index) &&
-      (length(index) != vcount(graph) || any(index != V(graph)))) {
+    (length(index) != vcount(graph) || any(index != V(graph)))) {
     vs <- V(graph)
     for (i in seq_along(value)) {
       tmp <- value[[i]]
@@ -454,7 +454,7 @@ edge.attributes <- function(graph, index = E(graph)) {
   res <- .Call(C_R_igraph_mybracket2_copy, graph, igraph_t_idx_attr, igraph_attr_idx_edge)
 
   if (!missing(index) &&
-      (length(index) != ecount(graph) || any(index != E(graph)))) {
+    (length(index) != ecount(graph) || any(index != E(graph)))) {
     for (i in seq_along(res)) {
       res[[i]] <- res[[i]][index]
     }
@@ -484,7 +484,7 @@ edge.attributes <- function(graph, index = E(graph)) {
   }
 
   if (!missing(index) &&
-      (length(index) != ecount(graph) || any(index != E(graph)))) {
+    (length(index) != ecount(graph) || any(index != E(graph)))) {
     es <- E(graph)
     for (i in seq_along(value)) {
       tmp <- value[[i]]

--- a/R/attributes.R
+++ b/R/attributes.R
@@ -145,9 +145,8 @@ graph.attributes <- function(graph) {
 #' @param graph The graph.
 #' @param name Name of the attribute to query. If missing, then
 #'   all vertex attributes are returned in a list.
-#' @param index An optional vertex sequence to query the attribute only
+#' @param index A vertex sequence, to query the attribute only
 #'   for these vertices.
-#'   If `NULL`, the default, the attribute is queried for all vertices.
 #' @return The value of the vertex attribute, or the list of
 #'   all vertex attributes, if \code{name} is missing.
 #'
@@ -162,16 +161,20 @@ graph.attributes <- function(graph) {
 #' vertex_attr(g, "label")
 #' vertex_attr(g)
 #' plot(g)
-vertex_attr <- function(graph, name, index = NULL) {
+vertex_attr <- function(graph, name, index = V(graph)) {
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
   if (missing(name)) {
-    vertex.attributes(graph, index = index)
+    if (missing(index)) {
+      vertex.attributes(graph)
+    } else {
+      vertex.attributes(graph, index = index)
+    }
   } else {
     myattr <-
       .Call(C_R_igraph_mybracket2, graph, igraph_t_idx_attr, igraph_attr_idx_vertex)[[as.character(name)]]
-    if (!is.null(index)) {
+    if (! missing(index)) {
       index <- as.igraph.vs(graph, index)
       myattr <- myattr[index]
     }
@@ -185,7 +188,6 @@ vertex_attr <- function(graph, name, index = NULL) {
 #' @param name The name of the vertex attribute to set. If missing,
 #'   then \code{value} must be a named list, and its entries are
 #'   set as vertex attributes.
-#'   If `NULL`, the default, the attribute is set for all vertices.
 #' @param index An optional vertex sequence to set the attributes
 #'   of a subset of vertices.
 #' @param value The new value of the attribute(s) for all
@@ -205,7 +207,7 @@ vertex_attr <- function(graph, name, index = NULL) {
 #' vertex_attr(g, "label") <- V(g)$name
 #' g
 #' plot(g)
-`vertex_attr<-` <- function(graph, name, index = NULL, value) {
+`vertex_attr<-` <- function(graph, name, index = V(graph), value) {
   if (missing(name)) {
     `vertex.attributes<-`(graph, index = index, value = value)
   } else {
@@ -219,7 +221,6 @@ vertex_attr <- function(graph, name, index = NULL) {
 #' @param name  The name of the attribute to set.
 #' @param index An optional vertex sequence to set the attributes
 #'   of a subset of vertices.
-#'   If `NULL`, the default, the attribute is set for all vertices.
 #' @param value The new value of the attribute for all (or \code{index})
 #'   vertices.
 #' @return The graph, with the vertex attribute added or set.
@@ -240,25 +241,19 @@ set_vertex_attr <- function(graph, name, index = V(graph), value) {
   )
 }
 
-i_set_vertex_attr <- function(graph, name, index = NULL, value,
+i_set_vertex_attr <- function(graph, name, index = V(graph), value,
                               check = TRUE) {
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
   single <- is_single_index(index)
-  if (!is.null(index) && check) {
+  if (!missing(index) && check) {
     index <- as.igraph.vs(graph, index)
   }
   name <- as.character(name)
   vc <- vcount(graph)
 
   vattrs <- .Call(C_R_igraph_mybracket2, graph, igraph_t_idx_attr, igraph_attr_idx_vertex)
-
-  # FIXME: optimize
-  if (is.null(index)) {
-    index <- V(graph)
-  }
-
   if (single) {
     vattrs[[name]][[index]] <- value
   } else {
@@ -270,26 +265,28 @@ i_set_vertex_attr <- function(graph, name, index = NULL, value,
 }
 
 #' @export
-vertex.attributes <- function(graph, index = NULL) {
+vertex.attributes <- function(graph, index = V(graph)) {
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
 
+  if (!missing(index)) {
+    index <- as.igraph.vs(graph, index)
+  }
+
   res <- .Call(C_R_igraph_mybracket2_copy, graph, igraph_t_idx_attr, igraph_attr_idx_vertex)
 
-  if (!is.null(index)) {
-    index <- as.igraph.vs(graph, index)
-    if (length(index) != vcount(graph) || any(index != V(graph))) {
-      for (i in seq_along(res)) {
-        res[[i]] <- res[[i]][index]
-      }
+  if (!missing(index) &&
+      (length(index) != vcount(graph) || any(index != V(graph)))) {
+    for (i in seq_along(res)) {
+      res[[i]] <- res[[i]][index]
     }
   }
   res
 }
 
 #' @export
-"vertex.attributes<-" <- function(graph, index = NULL, value) {
+"vertex.attributes<-" <- function(graph, index = V(graph), value) {
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
@@ -297,27 +294,27 @@ vertex.attributes <- function(graph, index = NULL) {
     any(names(value) == "") || any(duplicated(names(value)))) {
     stop("Value must be a named list with unique names")
   }
+  if (any(sapply(value, length) != length(index))) {
+    stop("Invalid attribute value length, must match number of vertices")
+  }
 
-  if (!is.null(index)) {
+  if (!missing(index)) {
     index <- as.igraph.vs(graph, index)
-
-    if (any(sapply(value, length) != length(index))) {
-      stop("Invalid attribute value length, must match number of vertices")
-    }
 
     if (any(duplicated(index)) || any(is.na(index))) {
       stop("Invalid vertices in index")
     }
+  }
 
-    if (length(index) != vcount(graph) || any(index != V(graph))) {
-      vs <- V(graph)
-      for (i in seq_along(value)) {
-        tmp <- value[[i]]
-        length(tmp) <- 0
-        length(tmp) <- length(vs)
-        tmp[index] <- value[[i]]
-        value[[i]] <- tmp
-      }
+  if (!missing(index) &&
+      (length(index) != vcount(graph) || any(index != V(graph)))) {
+    vs <- V(graph)
+    for (i in seq_along(value)) {
+      tmp <- value[[i]]
+      length(tmp) <- 0
+      length(tmp) <- length(vs)
+      tmp[index] <- value[[i]]
+      value[[i]] <- tmp
     }
   }
 
@@ -330,9 +327,8 @@ vertex.attributes <- function(graph, index = NULL) {
 #' @param graph The graph
 #' @param name The name of the attribute to query. If missing, then
 #'   all edge attributes are returned in a list.
-#' @param index An optional edge sequence to query edge attributes
+#' @param index An optional edge sequence, to query edge attributes
 #'   for a subset of edges.
-#'   If `NULL`, the default, the attribute is queried for all edges.
 #' @return The value of the edge attribute, or the list of all
 #'   edge attributes if \code{name} is missing.
 #'
@@ -346,12 +342,16 @@ vertex.attributes <- function(graph, index = NULL) {
 #'   set_edge_attr("color", value = "red")
 #' g
 #' plot(g, edge.width = E(g)$weight)
-edge_attr <- function(graph, name, index = NULL) {
+edge_attr <- function(graph, name, index = E(graph)) {
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
   if (missing(name)) {
-    edge.attributes(graph, index = index)
+    if (missing(index)) {
+      edge.attributes(graph)
+    } else {
+      edge.attributes(graph, index = index)
+    }
   } else {
     name <- as.character(name)
     myattr <- .Call(C_R_igraph_mybracket2, graph, igraph_t_idx_attr, igraph_attr_idx_edge)[[name]]
@@ -372,7 +372,6 @@ edge_attr <- function(graph, name, index = NULL) {
 #'   set as edge attributes.
 #' @param index An optional edge sequence to set the attributes
 #'   of a subset of edges.
-#'   If `NULL`, the default, the attribute is set for all edges.
 #' @param value The new value of the attribute(s) for all
 #'   (or \code{index}) edges.
 #' @return The graph, with the edge attribute(s) added or set.
@@ -390,7 +389,7 @@ edge_attr <- function(graph, name, index = NULL) {
 #' edge_attr(g, "label") <- E(g)$name
 #' g
 #' plot(g)
-`edge_attr<-` <- function(graph, name, index = NULL, value) {
+`edge_attr<-` <- function(graph, name, index = E(graph), value) {
   if (missing(name)) {
     `edge.attributes<-`(graph, index = index, value = value)
   } else {
@@ -404,7 +403,6 @@ edge_attr <- function(graph, name, index = NULL) {
 #' @param name  The name of the attribute to set.
 #' @param index An optional edge sequence to set the attributes of
 #'   a subset of edges.
-#'   If `NULL`, the default, the attribute is set for all edges.
 #' @param value The new value of the attribute for all (or \code{index})
 #'   edges.
 #' @return The graph, with the edge attribute added or set.
@@ -418,27 +416,21 @@ edge_attr <- function(graph, name, index = NULL) {
 #'   set_edge_attr("label", value = LETTERS[1:10])
 #' g
 #' plot(g)
-set_edge_attr <- function(graph, name, index = NULL, value) {
+set_edge_attr <- function(graph, name, index = E(graph), value) {
   i_set_edge_attr(graph = graph, name = name, index = index, value = value)
 }
 
-i_set_edge_attr <- function(graph, name, index = NULL, value,
+i_set_edge_attr <- function(graph, name, index = E(graph), value,
                             check = TRUE) {
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
   single <- is_single_index(index)
   name <- as.character(name)
-  if (!is.null(index) && check) index <- as.igraph.es(graph, index)
+  if (!missing(index) && check) index <- as.igraph.es(graph, index)
   ec <- ecount(graph)
 
   eattrs <- .Call(C_R_igraph_mybracket2, graph, igraph_t_idx_attr, igraph_attr_idx_edge)
-
-  # FIXME: optimize
-  if (is.null(index)) {
-    index <- E(graph)
-  }
-
   if (single) {
     eattrs[[name]][[index]] <- value
   } else {
@@ -450,28 +442,28 @@ i_set_edge_attr <- function(graph, name, index = NULL, value,
 }
 
 #' @export
-edge.attributes <- function(graph, index = NULL) {
+edge.attributes <- function(graph, index = E(graph)) {
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
 
-  res <- .Call(C_R_igraph_mybracket2_copy, graph, igraph_t_idx_attr, igraph_attr_idx_edge)
-
-  if (!is.null(index)) {
+  if (!missing(index)) {
     index <- as.igraph.es(graph, index)
-
-    if (length(index) != ecount(graph) || any(index != E(graph))) {
-      for (i in seq_along(res)) {
-        res[[i]] <- res[[i]][index]
-      }
-    }
   }
 
+  res <- .Call(C_R_igraph_mybracket2_copy, graph, igraph_t_idx_attr, igraph_attr_idx_edge)
+
+  if (!missing(index) &&
+      (length(index) != ecount(graph) || any(index != E(graph)))) {
+    for (i in seq_along(res)) {
+      res[[i]] <- res[[i]][index]
+    }
+  }
   res
 }
 
 #' @export
-"edge.attributes<-" <- function(graph, index = NULL, value) {
+"edge.attributes<-" <- function(graph, index = E(graph), value) {
   if (!is_igraph(graph)) {
     stop("Not a graph object")
   }
@@ -480,27 +472,26 @@ edge.attributes <- function(graph, index = NULL) {
     any(names(value) == "") || any(duplicated(names(value)))) {
     stop("Value must be a named list with unique names")
   }
+  if (any(sapply(value, length) != length(index))) {
+    stop("Invalid attribute value length, must match number of edges")
+  }
 
-  if (!is.null(index)) {
-    if (any(sapply(value, length) != length(index))) {
-      stop("Invalid attribute value length, must match number of edges")
-    }
-
+  if (!missing(index)) {
     index <- as.igraph.es(graph, index)
-
     if (any(duplicated(index)) || any(is.na(index))) {
       stop("Invalid edges in index")
     }
+  }
 
-    if (length(index) != ecount(graph) || any(index != E(graph))) {
-      es <- E(graph)
-      for (i in seq_along(value)) {
-        tmp <- value[[i]]
-        length(tmp) <- 0
-        length(tmp) <- length(es)
-        tmp[index] <- value[[i]]
-        value[[i]] <- tmp
-      }
+  if (!missing(index) &&
+      (length(index) != ecount(graph) || any(index != E(graph)))) {
+    es <- E(graph)
+    for (i in seq_along(value)) {
+      tmp <- value[[i]]
+      length(tmp) <- 0
+      length(tmp) <- length(es)
+      tmp[index] <- value[[i]]
+      value[[i]] <- tmp
     }
   }
 

--- a/R/attributes.R
+++ b/R/attributes.R
@@ -354,9 +354,13 @@ edge_attr <- function(graph, name, index = NULL) {
     edge.attributes(graph, index = index)
   } else {
     name <- as.character(name)
-    index <- as.igraph.es(graph, index)
     myattr <- .Call(C_R_igraph_mybracket2, graph, igraph_t_idx_attr, igraph_attr_idx_edge)[[name]]
-    myattr[index]
+    if (is.null(index)) {
+      myattr
+    } else {
+      index <- as.igraph.es(graph, index)
+      myattr[index]
+    }
   }
 }
 

--- a/R/iterators.R
+++ b/R/iterators.R
@@ -1369,9 +1369,7 @@ as.igraph.vs <- function(graph, v, na.ok = FALSE) {
       stop("Cannot use a vertex sequence from another graph.")
     }
   }
-  if (is.null(v)) {
-    V(graph)
-  } else if (is.character(v) && "name" %in% vertex_attr_names(graph)) {
+  if (is.character(v) && "name" %in% vertex_attr_names(graph)) {
     v <- as.numeric(match(v, V(graph)$name))
     if (!na.ok && any(is.na(v))) {
       stop("Invalid vertex names")
@@ -1399,9 +1397,7 @@ as.igraph.es <- function(graph, e) {
       stop("Cannot use an edge sequence from another graph.")
     }
   }
-  if (is.null(e)) {
-    res <- E(graph)
-  } else if (is.character(e)) {
+  if (is.character(e)) {
     Pairs <- grep("|", e, fixed = TRUE)
     Names <- if (length(Pairs) == 0) seq_along(e) else -Pairs
     res <- numeric(length(e))

--- a/R/par.R
+++ b/R/par.R
@@ -202,7 +202,7 @@ igraph_i_options <- function(..., .in = parent.frame()) {
 }
 
 local_igraph_options <- function(..., .in = parent.frame()) {
-  old <- igraph_i_options(..., .in = .in)
+  old <- igraph_options(..., .in = .in)
   withr::defer(rlang::inject(igraph_options(!!!old)), envir = .in)
   invisible()
 }

--- a/man/edge_attr-set.Rd
+++ b/man/edge_attr-set.Rd
@@ -5,7 +5,7 @@
 \alias{edge.attributes<-}
 \title{Set one or more edge attributes}
 \usage{
-edge_attr(graph, name, index = NULL) <- value
+edge_attr(graph, name, index = E(graph)) <- value
 }
 \arguments{
 \item{graph}{The graph.}
@@ -15,8 +15,7 @@ then \code{value} must be a named list, and its entries are
 set as edge attributes.}
 
 \item{index}{An optional edge sequence to set the attributes
-of a subset of edges.
-If `NULL`, the default, the attribute is set for all edges.}
+of a subset of edges.}
 
 \item{value}{The new value of the attribute(s) for all
 (or \code{index}) edges.}

--- a/man/edge_attr.Rd
+++ b/man/edge_attr.Rd
@@ -6,7 +6,7 @@
 \alias{edge.attributes}
 \title{Query edge attributes of a graph}
 \usage{
-edge_attr(graph, name, index = NULL)
+edge_attr(graph, name, index = E(graph))
 }
 \arguments{
 \item{graph}{The graph}
@@ -14,9 +14,8 @@ edge_attr(graph, name, index = NULL)
 \item{name}{The name of the attribute to query. If missing, then
 all edge attributes are returned in a list.}
 
-\item{index}{An optional edge sequence to query edge attributes
-for a subset of edges.
-If `NULL`, the default, the attribute is queried for all edges.}
+\item{index}{An optional edge sequence, to query edge attributes
+for a subset of edges.}
 }
 \value{
 The value of the edge attribute, or the list of all

--- a/man/set_edge_attr.Rd
+++ b/man/set_edge_attr.Rd
@@ -5,7 +5,7 @@
 \alias{set.edge.attribute}
 \title{Set edge attributes}
 \usage{
-set_edge_attr(graph, name, index = NULL, value)
+set_edge_attr(graph, name, index = E(graph), value)
 }
 \arguments{
 \item{graph}{The graph}
@@ -13,8 +13,7 @@ set_edge_attr(graph, name, index = NULL, value)
 \item{name}{The name of the attribute to set.}
 
 \item{index}{An optional edge sequence to set the attributes of
-a subset of edges.
-If `NULL`, the default, the attribute is set for all edges.}
+a subset of edges.}
 
 \item{value}{The new value of the attribute for all (or \code{index})
 edges.}

--- a/man/set_vertex_attr.Rd
+++ b/man/set_vertex_attr.Rd
@@ -13,8 +13,7 @@ set_vertex_attr(graph, name, index = V(graph), value)
 \item{name}{The name of the attribute to set.}
 
 \item{index}{An optional vertex sequence to set the attributes
-of a subset of vertices.
-If `NULL`, the default, the attribute is set for all vertices.}
+of a subset of vertices.}
 
 \item{value}{The new value of the attribute for all (or \code{index})
 vertices.}

--- a/man/vertex_attr-set.Rd
+++ b/man/vertex_attr-set.Rd
@@ -5,15 +5,14 @@
 \alias{vertex.attributes<-}
 \title{Set one or more vertex attributes}
 \usage{
-vertex_attr(graph, name, index = NULL) <- value
+vertex_attr(graph, name, index = V(graph)) <- value
 }
 \arguments{
 \item{graph}{The graph.}
 
 \item{name}{The name of the vertex attribute to set. If missing,
 then \code{value} must be a named list, and its entries are
-set as vertex attributes.
-If `NULL`, the default, the attribute is set for all vertices.}
+set as vertex attributes.}
 
 \item{index}{An optional vertex sequence to set the attributes
 of a subset of vertices.}

--- a/man/vertex_attr.Rd
+++ b/man/vertex_attr.Rd
@@ -6,7 +6,7 @@
 \alias{vertex.attributes}
 \title{Query vertex attributes of a graph}
 \usage{
-vertex_attr(graph, name, index = NULL)
+vertex_attr(graph, name, index = V(graph))
 }
 \arguments{
 \item{graph}{The graph.}
@@ -14,9 +14,8 @@ vertex_attr(graph, name, index = NULL)
 \item{name}{Name of the attribute to query. If missing, then
 all vertex attributes are returned in a list.}
 
-\item{index}{An optional vertex sequence to query the attribute only
-for these vertices.
-If `NULL`, the default, the attribute is queried for all vertices.}
+\item{index}{A vertex sequence, to query the attribute only
+for these vertices.}
 }
 \value{
 The value of the vertex attribute, or the list of


### PR DESCRIPTION
Closes #623.

Reverts #607 and #608.

Confirming that it fixes the causaleffect problem.