### PR TITLE
distances() with algorithm='johnson' now handles all mode parameter values correctly

### DIFF
--- a/R/structural.properties.R
+++ b/R/structural.properties.R
@@ -266,9 +266,12 @@ degree_distribution <- function(graph, cumulative = FALSE, ...) {
 #' unweighted graphs; the Dijkstra algorithm (\sQuote{`dijkstra`}), this
 #' works for graphs with non-negative edge weights; the Bellman-Ford algorithm
 #' (\sQuote{`bellman-ford`}), and Johnson's algorithm
-#' (\sQuote{`"johnson"`}). The latter two algorithms work with arbitrary
+#' (\sQuote{`johnson`}). The latter two algorithms work with arbitrary
 #' edge weights, but (naturally) only for graphs that don't have a negative
-#' cycle.
+#' cycle. Note that a negative-weight edge in an undirected graph implies
+#' such a cycle. Johnson's algorithm performs better than the Bellman-Ford
+#' one when many source (and target) vertices are given, with all-pairs
+#' shortest path length calculations being the typical use case.
 #'
 #' igraph can choose automatically between algorithms, and chooses the most
 #' efficient one that is appropriate for the supplied weights (if any). For

--- a/man/distances.Rd
+++ b/man/distances.Rd
@@ -182,9 +182,12 @@ are breadth-first search (\sQuote{\code{unweighted}}), this only works for
 unweighted graphs; the Dijkstra algorithm (\sQuote{\code{dijkstra}}), this
 works for graphs with non-negative edge weights; the Bellman-Ford algorithm
 (\sQuote{\code{bellman-ford}}), and Johnson's algorithm
-(\sQuote{\code{"johnson"}}). The latter two algorithms work with arbitrary
+(\sQuote{\code{johnson}}). The latter two algorithms work with arbitrary
 edge weights, but (naturally) only for graphs that don't have a negative
-cycle.
+cycle. Note that a negative-weight edge in an undirected graph implies
+such a cycle. Johnson's algorithm performs better than the Bellman-Ford
+one when many source (and target) vertices are given, with all-pairs
+shortest path length calculations being the typical use case.
 
 igraph can choose automatically between algorithms, and chooses the most
 efficient one that is appropriate for the supplied weights (if any). For


### PR DESCRIPTION
This PR fixes #571 properly by bringing support for all `mode` values instead of restricting the available modes when `algorithm='johnson'`.