### PR TITLE
Fix test order

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,5 +41,6 @@ Config/Needs/build: roxygen2, devtools, irlba, pkgconfig
 Config/Needs/coverage: covr
 Config/testthat/edition: 3
 Config/testthat/parallel: true
+Config/testthat/start-first: vs-es, scan, vs-operators, weakref, watts.strogatz.game
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)

--- a/tests/testthat/test-vs-es.R
+++ b/tests/testthat/test-vs-es.R
@@ -141,8 +141,6 @@ test_that("printing connected vs/es works", {
     vs[numeric()]
   })
 
-  skip_on_os("mac")
-  skip_if(identical(Sys.getenv("R_COVR"), "true"))
   expect_snapshot({
     es[numeric()]
   })
@@ -164,7 +162,6 @@ test_that("printing named connected vs/es works", {
     vs[numeric()]
   })
 
-  skip_if(identical(Sys.getenv("R_COVR"), "true"))
   expect_snapshot({
     es[numeric()]
   })

--- a/tests/testthat/test_graph.edgelist.R
+++ b/tests/testthat/test_graph.edgelist.R
@@ -1,4 +1,6 @@
 test_that("graph_from_edgelist works", {
+  set.seed(20230115)
+
   g <- sample_gnp(50, 5 / 50)
   el <- as_edgelist(g)
   g2 <- graph_from_edgelist(el, directed = FALSE)


### PR DESCRIPTION
for faster parallel testing and to avoid having to skip tests.

The vs-es failures occur sporadically with parallel testing, I hope that they disappear if these tests always run first.