### PR TITLE
docs: link to installation troubleshooting info

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ For installation from source on Windows, you need to have
 Additionally, the three system requirements of `glpk`, `libxml2` and `gmp` are
 not optional, but hard requirements. For versions R >= 4.0 you can install these
 using
+
 ```
 pacman -Sy mingw-w64-{i686,x86_64}-glpk mingw-w64-{i686,x86_64}-libxml2 mingw-w64-{i686,x86_64}-gmp
 ```
+
+See the package wiki for more information on [installation troubleshooting](https://github.com/igraph/rigraph/wiki/Installation-Troubleshooting).
 
 ## Documentation
 


### PR DESCRIPTION
@szhorvat would it make sense to retire the wiki page and transfer the content a vignette/article instead so that it'd end up on the pkgdown website (and in the pkgdown search index)?

cc @krlmlr 