### PR TITLE
fix: Iterators created with `E(P = ...)` or `E(path = ...)` are incomplete

### DIFF
--- a/R/iterators.R
+++ b/R/iterators.R
@@ -317,6 +317,7 @@ E <- function(graph, P = NULL, path = NULL, directed = TRUE) {
   if (is.null(P) && is.null(path)) {
     ec <- ecount(graph)
     res <- seq_len(ec)
+    res <- set_complete_iterator(res)
   } else if (!is.null(P)) {
     on.exit(.Call(C_R_igraph_finalizer))
     res <- .Call(
@@ -340,7 +341,6 @@ E <- function(graph, P = NULL, path = NULL, directed = TRUE) {
   }
 
   class(res) <- "igraph.es"
-  res <- set_complete_iterator(res)
   add_vses_graph_ref(res, graph)
 }
 

--- a/tests/testthat/test-iterators.R
+++ b/tests/testthat/test-iterators.R
@@ -93,9 +93,11 @@ test_that("V(g) returns complete iterator, completeness is lost with next subset
 })
 
 test_that("E(g) returns complete iterator, completeness is lost with next subsetting", {
-  g <- make_star(4)
+  g <- make_full_graph(4)
   iter <- E(g)
   expect_true(is_complete_iterator(iter))
   expect_false(is_complete_iterator(iter[1]))
   expect_false(is_complete_iterator(iter[1:3]))
+  expect_false(is_complete_iterator(E(g, P = 1:4)))
+  expect_false(is_complete_iterator(E(g, path = 1:4)))
 })


### PR DESCRIPTION
For https://github.com/igraph/rigraph/pull/633#issuecomment-1404175110.