### PR TITLE
skip fledge job if the repo is a fork

### DIFF
--- a/.github/workflows/fledge.yaml
+++ b/.github/workflows/fledge.yaml
@@ -16,9 +16,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  fledge:
-    if: ${{ github.repository_owner == 'igraph' }}
+  check_fork:
     runs-on: ubuntu-latest
+    outputs:
+      is_forked: ${{ steps.check.outputs.is_forked }}
+    steps:
+      - name: Check if the repo is forked
+        id: check
+        run: |
+          echo "is_forked=$(curl -s -H "Accept: application/vnd.github+json" -H 'Authorization: Bearer ${{ github.token }}' -H "X-GitHub-Api-Version: 2022-11-28" ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY} | jq .fork)" >> $GITHUB_OUTPUT
+
+  fledge:
+    runs-on: ubuntu-latest
+    needs: check_fork
+    if: needs.check_fork.outputs.is_forked == 'false'
     permissions:
       contents: write
     env:


### PR DESCRIPTION
Checks whether the repo is a fork or not. If it's a fork the fledge job will not run.