### PR TITLE
docs: Add installation instructions from R-universe

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,22 @@ You can install the stable version of R/igraph from CRAN:
 install.packages("igraph")
 ```
 
-For the development version, you can use Github, with the `remotes`
-package:
+For the development version, you can use R-universe
 
 ```r
-remotes::install_github("igraph/rigraph")
+options(
+  repos = c(
+    igraph = 'https://igraph.r-universe.dev',
+    CRAN = 'https://cloud.r-project.org'
+  )
+)
+install.packages('igraph')
+```
+
+or Github, with the `devtools` package:
+
+```r
+devtools::install_github("igraph/rigraph")
 ```
 
 For installation from source on Windows, you need to have


### PR DESCRIPTION
Since rigraph is on CRAN its universe was automatically created https://igraph.r-universe.dev

For context on R-universe https://ropensci.org/r-universe/

Related issue #658 (the instructions are less useful now for Windows users who wouldn't get a binary from R-universe until that error is fixed).

Note I switched remotes for devtools since devtools is meant to remain the interface for users.