### PR TITLE
fix: fix warning about yyget_leng returning wrong type when using LTO

### DIFF
--- a/src/core/io/dl-lexer.c
+++ b/src/core/io/dl-lexer.c
@@ -1,6 +1,6 @@
-#line 2 "src/core/io/dl-lexer.c"
+#line 1 "src/core/io/dl-lexer.c"
 
-#line 4 "src/core/io/dl-lexer.c"
+#line 3 "src/core/io/dl-lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -823,10 +823,10 @@ static const flex_int16_t yy_chk[318] =
 #endif
 #define stdout 0
 #endif
-#line 827 "src/core/io/dl-lexer.c"
+#line 826 "src/core/io/dl-lexer.c"
 #define YY_NO_INPUT 1
 
-#line 830 "src/core/io/dl-lexer.c"
+#line 829 "src/core/io/dl-lexer.c"
 
 #define INITIAL 0
 #define LABELM 1
@@ -917,7 +917,7 @@ FILE *yyget_out ( yyscan_t yyscanner );
 
 void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			yy_size_t yyget_leng ( yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
 char *yyget_text ( yyscan_t yyscanner );
 
@@ -1115,7 +1115,7 @@ YY_DECL
 #line 80 "src/core/io/dl-lexer.l"
 
 
-#line 1119 "src/core/io/dl-lexer.c"
+#line 1118 "src/core/io/dl-lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1323,7 +1323,7 @@ YY_RULE_SETUP
 #line 138 "src/core/io/dl-lexer.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1327 "src/core/io/dl-lexer.c"
+#line 1326 "src/core/io/dl-lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -2182,7 +2182,7 @@ FILE *yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-yy_size_t yyget_leng  (yyscan_t yyscanner)
+int yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;

--- a/src/core/io/dl-lexer.h
+++ b/src/core/io/dl-lexer.h
@@ -2,9 +2,9 @@
 #define igraph_dl_yyHEADER_H 1
 #define igraph_dl_yyIN_HEADER 1
 
-#line 6 "src/core/io/dl-lexer.h"
+#line 5 "src/core/io/dl-lexer.h"
 
-#line 8 "src/core/io/dl-lexer.h"
+#line 7 "src/core/io/dl-lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -732,6 +732,6 @@ extern int yylex \
 
 #line 138 "src/core/io/dl-lexer.l"
 
-#line 736 "src/core/io/dl-lexer.h"
+#line 735 "src/core/io/dl-lexer.h"
 #undef igraph_dl_yyIN_HEADER
 #endif /* igraph_dl_yyHEADER_H */

--- a/src/core/io/gml-lexer.c
+++ b/src/core/io/gml-lexer.c
@@ -1,6 +1,6 @@
-#line 2 "src/core/io/gml-lexer.c"
+#line 1 "src/core/io/gml-lexer.c"
 
-#line 4 "src/core/io/gml-lexer.c"
+#line 3 "src/core/io/gml-lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -732,9 +732,9 @@ static const flex_int16_t yy_chk[61] =
 #endif
 #define stdout 0
 #endif
-#line 736 "src/core/io/gml-lexer.c"
+#line 735 "src/core/io/gml-lexer.c"
 #define YY_NO_INPUT 1
-#line 738 "src/core/io/gml-lexer.c"
+#line 737 "src/core/io/gml-lexer.c"
 
 #define INITIAL 0
 
@@ -821,7 +821,7 @@ FILE *yyget_out ( yyscan_t yyscanner );
 
 void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			yy_size_t yyget_leng ( yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
 char *yyget_text ( yyscan_t yyscanner );
 
@@ -1022,7 +1022,7 @@ YY_DECL
 #line 77 "src/core/io/gml-lexer.l"
 
 
-#line 1026 "src/core/io/gml-lexer.c"
+#line 1025 "src/core/io/gml-lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1159,7 +1159,7 @@ YY_RULE_SETUP
 #line 112 "src/core/io/gml-lexer.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1163 "src/core/io/gml-lexer.c"
+#line 1162 "src/core/io/gml-lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -2021,7 +2021,7 @@ FILE *yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-yy_size_t yyget_leng  (yyscan_t yyscanner)
+int yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;

--- a/src/core/io/gml-lexer.h
+++ b/src/core/io/gml-lexer.h
@@ -2,9 +2,9 @@
 #define igraph_gml_yyHEADER_H 1
 #define igraph_gml_yyIN_HEADER 1
 
-#line 6 "src/core/io/gml-lexer.h"
+#line 5 "src/core/io/gml-lexer.h"
 
-#line 8 "src/core/io/gml-lexer.h"
+#line 7 "src/core/io/gml-lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -731,6 +731,6 @@ extern int yylex \
 #line 112 "src/core/io/gml-lexer.l"
 
 
-#line 735 "src/core/io/gml-lexer.h"
+#line 734 "src/core/io/gml-lexer.h"
 #undef igraph_gml_yyIN_HEADER
 #endif /* igraph_gml_yyHEADER_H */

--- a/src/core/io/lgl-lexer.c
+++ b/src/core/io/lgl-lexer.c
@@ -1,6 +1,6 @@
-#line 2 "src/core/io/lgl-lexer.c"
+#line 1 "src/core/io/lgl-lexer.c"
 
-#line 4 "src/core/io/lgl-lexer.c"
+#line 3 "src/core/io/lgl-lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -718,9 +718,9 @@ static const flex_int16_t yy_chk[19] =
 #endif
 #define stdout 0
 #endif
-#line 722 "src/core/io/lgl-lexer.c"
+#line 721 "src/core/io/lgl-lexer.c"
 #define YY_NO_INPUT 1
-#line 724 "src/core/io/lgl-lexer.c"
+#line 723 "src/core/io/lgl-lexer.c"
 
 #define INITIAL 0
 
@@ -807,7 +807,7 @@ FILE *yyget_out ( yyscan_t yyscanner );
 
 void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			yy_size_t yyget_leng ( yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
 char *yyget_text ( yyscan_t yyscanner );
 
@@ -1007,7 +1007,7 @@ YY_DECL
 
 #line 79 "src/core/io/lgl-lexer.l"
  /* --------------------------------------------------hashmark------*/
-#line 1011 "src/core/io/lgl-lexer.c"
+#line 1010 "src/core/io/lgl-lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1108,7 +1108,7 @@ YY_RULE_SETUP
 #line 101 "src/core/io/lgl-lexer.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1112 "src/core/io/lgl-lexer.c"
+#line 1111 "src/core/io/lgl-lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -1967,7 +1967,7 @@ FILE *yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-yy_size_t yyget_leng  (yyscan_t yyscanner)
+int yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;

--- a/src/core/io/lgl-lexer.h
+++ b/src/core/io/lgl-lexer.h
@@ -2,9 +2,9 @@
 #define igraph_lgl_yyHEADER_H 1
 #define igraph_lgl_yyIN_HEADER 1
 
-#line 6 "src/core/io/lgl-lexer.h"
+#line 5 "src/core/io/lgl-lexer.h"
 
-#line 8 "src/core/io/lgl-lexer.h"
+#line 7 "src/core/io/lgl-lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -731,6 +731,6 @@ extern int yylex \
 #line 101 "src/core/io/lgl-lexer.l"
 
 
-#line 735 "src/core/io/lgl-lexer.h"
+#line 734 "src/core/io/lgl-lexer.h"
 #undef igraph_lgl_yyIN_HEADER
 #endif /* igraph_lgl_yyHEADER_H */

--- a/src/core/io/ncol-lexer.c
+++ b/src/core/io/ncol-lexer.c
@@ -1,6 +1,6 @@
-#line 2 "src/core/io/ncol-lexer.c"
+#line 1 "src/core/io/ncol-lexer.c"
 
-#line 4 "src/core/io/ncol-lexer.c"
+#line 3 "src/core/io/ncol-lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -718,9 +718,9 @@ static const flex_int16_t yy_chk[17] =
 #endif
 #define stdout 0
 #endif
-#line 722 "src/core/io/ncol-lexer.c"
+#line 721 "src/core/io/ncol-lexer.c"
 #define YY_NO_INPUT 1
-#line 724 "src/core/io/ncol-lexer.c"
+#line 723 "src/core/io/ncol-lexer.c"
 
 #define INITIAL 0
 
@@ -807,7 +807,7 @@ FILE *yyget_out ( yyscan_t yyscanner );
 
 void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			yy_size_t yyget_leng ( yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
 char *yyget_text ( yyscan_t yyscanner );
 
@@ -1007,7 +1007,7 @@ YY_DECL
 
 #line 79 "src/core/io/ncol-lexer.l"
  /* ------------------------------------------------whitespace------*/
-#line 1011 "src/core/io/ncol-lexer.c"
+#line 1010 "src/core/io/ncol-lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1103,7 +1103,7 @@ YY_RULE_SETUP
 #line 99 "src/core/io/ncol-lexer.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1107 "src/core/io/ncol-lexer.c"
+#line 1106 "src/core/io/ncol-lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -1962,7 +1962,7 @@ FILE *yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-yy_size_t yyget_leng  (yyscan_t yyscanner)
+int yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;

--- a/src/core/io/ncol-lexer.h
+++ b/src/core/io/ncol-lexer.h
@@ -2,9 +2,9 @@
 #define igraph_ncol_yyHEADER_H 1
 #define igraph_ncol_yyIN_HEADER 1
 
-#line 6 "src/core/io/ncol-lexer.h"
+#line 5 "src/core/io/ncol-lexer.h"
 
-#line 8 "src/core/io/ncol-lexer.h"
+#line 7 "src/core/io/ncol-lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -731,6 +731,6 @@ extern int yylex \
 #line 99 "src/core/io/ncol-lexer.l"
 
 
-#line 735 "src/core/io/ncol-lexer.h"
+#line 734 "src/core/io/ncol-lexer.h"
 #undef igraph_ncol_yyIN_HEADER
 #endif /* igraph_ncol_yyHEADER_H */

--- a/src/core/io/pajek-lexer.c
+++ b/src/core/io/pajek-lexer.c
@@ -1,6 +1,6 @@
-#line 2 "src/core/io/pajek-lexer.c"
+#line 1 "src/core/io/pajek-lexer.c"
 
-#line 4 "src/core/io/pajek-lexer.c"
+#line 3 "src/core/io/pajek-lexer.c"
 
 #define  YY_INT_ALIGNED short int
 
@@ -839,9 +839,9 @@ static const flex_int16_t yy_chk[339] =
 #endif
 #define stdout 0
 #endif
-#line 843 "src/core/io/pajek-lexer.c"
+#line 842 "src/core/io/pajek-lexer.c"
 #define YY_NO_INPUT 1
-#line 845 "src/core/io/pajek-lexer.c"
+#line 844 "src/core/io/pajek-lexer.c"
 
 #define INITIAL 0
 
@@ -928,7 +928,7 @@ FILE *yyget_out ( yyscan_t yyscanner );
 
 void yyset_out  ( FILE * _out_str , yyscan_t yyscanner );
 
-			yy_size_t yyget_leng ( yyscan_t yyscanner );
+			int yyget_leng ( yyscan_t yyscanner );
 
 char *yyget_text ( yyscan_t yyscanner );
 
@@ -1126,7 +1126,7 @@ YY_DECL
 #line 77 "src/core/io/pajek-lexer.l"
 
 
-#line 1130 "src/core/io/pajek-lexer.c"
+#line 1129 "src/core/io/pajek-lexer.c"
 
 	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
@@ -1595,7 +1595,7 @@ YY_RULE_SETUP
 #line 147 "src/core/io/pajek-lexer.l"
 YY_FATAL_ERROR( "flex scanner jammed" );
 	YY_BREAK
-#line 1599 "src/core/io/pajek-lexer.c"
+#line 1598 "src/core/io/pajek-lexer.c"
 
 	case YY_END_OF_BUFFER:
 		{
@@ -2454,7 +2454,7 @@ FILE *yyget_out  (yyscan_t yyscanner)
 /** Get the length of the current token.
  * @param yyscanner The scanner object.
  */
-yy_size_t yyget_leng  (yyscan_t yyscanner)
+int yyget_leng  (yyscan_t yyscanner)
 {
     struct yyguts_t * yyg = (struct yyguts_t*)yyscanner;
     return yyleng;

--- a/src/core/io/pajek-lexer.h
+++ b/src/core/io/pajek-lexer.h
@@ -2,9 +2,9 @@
 #define igraph_pajek_yyHEADER_H 1
 #define igraph_pajek_yyIN_HEADER 1
 
-#line 6 "src/core/io/pajek-lexer.h"
+#line 5 "src/core/io/pajek-lexer.h"
 
-#line 8 "src/core/io/pajek-lexer.h"
+#line 7 "src/core/io/pajek-lexer.h"
 
 #define  YY_INT_ALIGNED short int
 
@@ -731,6 +731,6 @@ extern int yylex \
 #line 147 "src/core/io/pajek-lexer.l"
 
 
-#line 735 "src/core/io/pajek-lexer.h"
+#line 734 "src/core/io/pajek-lexer.h"
 #undef igraph_pajek_yyIN_HEADER
 #endif /* igraph_pajek_yyHEADER_H */

--- a/tools/fix-lexers.sh
+++ b/tools/fix-lexers.sh
@@ -11,13 +11,7 @@ for fname in src/core/io/*-lexer.c; do
     mv ${fname}.new ${fname}
 
     # Remove 'noreturn' declaration from exit points
-	sed -e 's/^\([^#]*\)yynoreturn /\1__attribute__((unused)) /g' ${fname} >${fname}.new
-    mv ${fname}.new ${fname}
-
-    # flex on Ubuntu 20.04 generates 'int yyget_leng'; flex on macOS generates
-    # 'yy_size_t yyget_leng'. We need to be consistent as we also declare
-    # yyget_leng ourselves in the parser and we use yy_size_t there
-    cat ${fname} | sed -e 's/int yyget_leng/yy_size_t yyget_leng/g' >${fname}.new
+    sed -e 's/^\([^#]*\)yynoreturn /\1__attribute__((unused)) /g' ${fname} >${fname}.new
     mv ${fname}.new ${fname}
 done
 
@@ -29,8 +23,8 @@ for fname in src/core/io/*-lexer.c src/core/io/*-parser.c; do
 done
 
 for fname in src/core/io/*-parser.c; do
-	# Bison 3.8.2 (and maybe other versions) refer to #include yy.tab.h in the
-	# generated file; we need to replace this with the real header name
+    # Bison 3.8.2 (and maybe other versions) refer to #include yy.tab.h in the
+    # generated file; we need to replace this with the real header name
     header=`basename ${fname} .c`.h
     cat ${fname} | sed -e 's,^#include.*yy.tab.h.*$,#include "io/'"${header}"'",g' >${fname}.new
     mv ${fname}.new ${fname}


### PR DESCRIPTION
This attempt to fix the following errors found by CRAN:

https://www.stats.ox.ac.uk/pub/bdr/LTO/igraph.out

```
src/core/io/pajek-lexer.h:500:8: warning: type of ‘igraph_pajek_yyget_leng’ does not match original declaration [-Wlto-type-mismatch]
src/core/io/pajek-lexer.c:2457:11: note: return value type mismatch
src/core/io/pajek-lexer.c:2457:11: note: type ‘yy_size_t’ should match type ‘int’
src/core/io/pajek-lexer.c:2457:11: note: ‘igraph_pajek_yyget_leng’ was previously declared here
src/core/io/pajek-lexer.c:2457:11: note: code may be misoptimized unless ‘-fno-strict-aliasing’ is used
```

I noticed that this problem does not occur when compiling the C core separately. In fact, it seems that `yyget_leng` _should_ return `int` instead fo `yy_size_t`.

This PR removes the string replacement that was meant to maintain compatibility with the ancient flex version that comes with macOS. Since we now generate parser sources with the latest flex on CI, I think there is no need for this fix anymore.

An alternative would be to avoid doing the replacement for `yyget_leng`.

----

Note: I used the latest flex 2.6.4. for this. Not sure why it generated slightly different line numbers.