### PR TITLE
test: rm leftover magrittr pipe definition

### DIFF
--- a/tests/testthat/test-new-layout-api.R
+++ b/tests/testthat/test-new-layout-api.R
@@ -1,6 +1,4 @@
 
-`%>%` <- magrittr::`%>%`
-
 test_that("two step layouting works", {
   g <- make_ring(10)
   l1 <- layout_as_star(g)


### PR DESCRIPTION
useless now since the package imports it.