### PR TITLE
ci: Fix oldrel runs by adding a dependency on the development version of the ape package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
     stats,
     utils
 Suggests:
-    ape,
+    ape (>= 5.7-0.1),
     digest,
     graph,
     igraphdata,
@@ -46,3 +46,5 @@ Config/testthat/start-first: vs-es, scan, vs-operators, weakref, watts.strogatz.
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
+Remotes:
+    emmanuelparadis/ape


### PR DESCRIPTION
Related to #681

@krlmlr 

I don't think this PR should _close_ the issue since the Remotes field can only be removed after a CRAN release of ape. https://github.com/emmanuelparadis/ape/pull/68#issuecomment-1441266986