### PR TITLE
fix: `as_long_data_frame()` now correctly processes vertex attributes and works with graphs without vertex attributes

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -1021,7 +1021,6 @@ as_long_data_frame <- function(graph) {
 
   ver2 <- ver
   if (length(ver) > 0) {
-    # https://github.com/igraph/rigraph/issues/297
     names(ver) <- paste0("from_", names(ver))
     names(ver2) <- paste0("to_", names(ver2))
     edg <- cbind(edg, ver[el[, 1], , drop = FALSE], ver2[el[, 2], , drop = FALSE])

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -1020,10 +1020,12 @@ as_long_data_frame <- function(graph) {
   rownames(edg) <- seq_len(ecount(graph))
 
   ver2 <- ver
-  names(ver) <- paste0("from_", names(ver))
-  names(ver2) <- paste0("to_", names(ver2))
-
-  edg <- cbind(edg, ver[el[, 1], ], ver2[el[, 2], ])
+  if (length(ver) > 0) {
+    # https://github.com/igraph/rigraph/issues/297
+    names(ver) <- paste0("from_", names(ver))
+    names(ver2) <- paste0("to_", names(ver2))
+    edg <- cbind(edg, ver[el[, 1], , drop = FALSE], ver2[el[, 2], , drop = FALSE])
+  }
 
   edg
 }

--- a/tests/testthat/_snaps/graph.data.frame.md
+++ b/tests/testthat/_snaps/graph.data.frame.md
@@ -24,4 +24,12 @@
       1    1  2         a          A       b        B
       2    2  3         b          B       c        C
       3    1  3         a          A       c        C
+    Code
+      E(ring)$info <- 3:1
+      as_long_data_frame(ring)
+    Output
+        from to info from_name from_score to_name to_score
+      1    1  2    3         a          A       b        B
+      2    2  3    2         b          B       c        C
+      3    1  3    1         a          A       c        C
 

--- a/tests/testthat/_snaps/graph.data.frame.md
+++ b/tests/testthat/_snaps/graph.data.frame.md
@@ -1,0 +1,27 @@
+# as_long_data_frame() works correctly with and without names
+
+    Code
+      ring <- make_ring(3)
+      as_long_data_frame(ring)
+    Output
+        from to
+      1    1  2
+      2    2  3
+      3    1  3
+    Code
+      V(ring)$name <- letters[1:3]
+      as_long_data_frame(ring)
+    Output
+        from to from_name to_name
+      1    1  2         a       b
+      2    2  3         b       c
+      3    1  3         a       c
+    Code
+      V(ring)$score <- LETTERS[1:3]
+      as_long_data_frame(ring)
+    Output
+        from to from_name from_score to_name to_score
+      1    1  2         a          A       b        B
+      2    2  3         b          B       c        C
+      3    1  3         a          A       c        C
+

--- a/tests/testthat/test-graph.data.frame.R
+++ b/tests/testthat/test-graph.data.frame.R
@@ -56,5 +56,8 @@ test_that("as_long_data_frame() works correctly with and without names", {
 
     V(ring)$score <- LETTERS[1:3]
     as_long_data_frame(ring)
+
+    E(ring)$info <- 3:1
+    as_long_data_frame(ring)
   })
 })

--- a/tests/testthat/test-graph.data.frame.R
+++ b/tests/testthat/test-graph.data.frame.R
@@ -45,3 +45,16 @@ test_that("graph_from_data_frame works on matrices", {
   el2 <- as_data_frame(g)
   expect_that(as.data.frame(el), is_equivalent_to(el2))
 })
+
+test_that("as_long_data_frame() works correctly with and without names", {
+  expect_snapshot({
+    ring <- make_ring(3)
+    as_long_data_frame(ring)
+
+    V(ring)$name <- letters[1:3]
+    as_long_data_frame(ring)
+
+    V(ring)$score <- LETTERS[1:3]
+    as_long_data_frame(ring)
+  })
+})


### PR DESCRIPTION
Closes #297.