### PR TITLE
chore: Use `R_NO_REMAP`

### DIFF
--- a/src/lazyeval.c
+++ b/src/lazyeval.c
@@ -16,7 +16,7 @@ SEXP promise_as_lazy(SEXP promise, SEXP env, int follow_symbols) {
     // get some symbols along the way. If the symbol is bound to a promise
     // keep going on up
     if (follow_symbols && TYPEOF(promise) == SYMSXP) {
-      SEXP obj = findVar(promise, env);
+      SEXP obj = Rf_findVar(promise, env);
       if (TYPEOF(obj) == PROMSXP) {
         promise = obj;
       }
@@ -24,16 +24,16 @@ SEXP promise_as_lazy(SEXP promise, SEXP env, int follow_symbols) {
   }
 
   // Make named list for output
-  SEXP lazy = PROTECT(allocVector(VECSXP, 2));
+  SEXP lazy = PROTECT(Rf_allocVector(VECSXP, 2));
   SET_VECTOR_ELT(lazy, 0, promise);
   SET_VECTOR_ELT(lazy, 1, env);
 
-  SEXP names = PROTECT(allocVector(STRSXP, 2));
-  SET_STRING_ELT(names, 0, mkChar("expr"));
-  SET_STRING_ELT(names, 1, mkChar("env"));
+  SEXP names = PROTECT(Rf_allocVector(STRSXP, 2));
+  SET_STRING_ELT(names, 0, Rf_mkChar("expr"));
+  SET_STRING_ELT(names, 1, Rf_mkChar("env"));
 
-  setAttrib(lazy, install("names"), names);
-  setAttrib(lazy, install("class"), PROTECT(mkString("lazy")));
+  Rf_setAttrib(lazy, Rf_install("names"), names);
+  Rf_setAttrib(lazy, Rf_install("class"), PROTECT(Rf_mkString("lazy")));
 
   UNPROTECT(3);
 
@@ -41,16 +41,16 @@ SEXP promise_as_lazy(SEXP promise, SEXP env, int follow_symbols) {
 }
 
 SEXP make_lazy(SEXP name, SEXP env, SEXP follow_symbols_) {
-  SEXP promise = PROTECT(findVar(name, env));
-  int follow_symbols = asLogical(follow_symbols_);
+  SEXP promise = PROTECT(Rf_findVar(name, env));
+  int follow_symbols = Rf_asLogical(follow_symbols_);
   SEXP ret = promise_as_lazy(promise, env, follow_symbols);
   UNPROTECT(1);
   return ret;
 }
 
 SEXP make_lazy_dots(SEXP env, SEXP follow_symbols_) {
-  SEXP dots = PROTECT(findVar(install("..."), env));
-  int follow_symbols = asLogical(follow_symbols_);
+  SEXP dots = PROTECT(Rf_findVar(Rf_install("..."), env));
+  int follow_symbols = Rf_asLogical(follow_symbols_);
 
   // Figure out how many elements in dots
   int n = 0;
@@ -59,8 +59,8 @@ SEXP make_lazy_dots(SEXP env, SEXP follow_symbols_) {
   }
 
   // Allocate list to store results
-  SEXP lazy_dots = PROTECT(allocVector(VECSXP, n));
-  SEXP names = PROTECT(allocVector(STRSXP, n));
+  SEXP lazy_dots = PROTECT(Rf_allocVector(VECSXP, n));
+  SEXP names = PROTECT(Rf_allocVector(STRSXP, n));
 
   // Iterate through all elements of dots, converting promises into lazy exprs
   int i = 0;
@@ -76,8 +76,8 @@ SEXP make_lazy_dots(SEXP env, SEXP follow_symbols_) {
     nxt = CDR(nxt);
     i++;
   }
-  setAttrib(lazy_dots, install("names"), names);
-  setAttrib(lazy_dots, install("class"), PROTECT(mkString("lazy_dots")));
+  Rf_setAttrib(lazy_dots, Rf_install("names"), names);
+  Rf_setAttrib(lazy_dots, Rf_install("class"), PROTECT(Rf_mkString("lazy_dots")));
 
   UNPROTECT(4);
 
@@ -159,7 +159,7 @@ SEXP promise_(SEXP expr, SEXP env) {
 
 SEXP promise_expr_(SEXP prom) {
   if (TYPEOF(prom) != PROMSXP) {
-    error("prom must be a promise");
+    Rf_error("prom must be a promise");
   }
 
   return PREXPR(prom);
@@ -167,7 +167,7 @@ SEXP promise_expr_(SEXP prom) {
 
 SEXP promise_env_(SEXP prom) {
   if (TYPEOF(prom) != PROMSXP) {
-    error("prom must be a promise");
+    Rf_error("prom must be a promise");
   }
 
   return PRENV(prom);

--- a/src/lazyeval.c
+++ b/src/lazyeval.c
@@ -1,3 +1,6 @@
+// Require R_ and Rf_ prefixes for R API
+#define R_NO_REMAP
+
 #include <R.h>
 #include <Rdefines.h>
 

--- a/src/rinterface.c
+++ b/src/rinterface.c
@@ -321,7 +321,7 @@ SEXP R_igraph_full_bipartite(SEXP n1, SEXP n2, SEXP directed, SEXP mode) {
   c_directed=LOGICAL(directed)[0];
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_full_bipartite(&c_graph, (isNull(types) ? 0 : &c_types), c_n1, c_n2, c_directed, c_mode));
+  IGRAPH_R_CHECK(igraph_full_bipartite(&c_graph, (Rf_isNull(types) ? 0 : &c_types), c_n1, c_n2, c_directed, c_mode));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -335,8 +335,8 @@ SEXP R_igraph_full_bipartite(SEXP n1, SEXP n2, SEXP directed, SEXP mode) {
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, graph);
   SET_VECTOR_ELT(r_result, 1, types);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("graph"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("types"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("graph"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("types"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -359,11 +359,11 @@ SEXP R_igraph_realize_degree_sequence(SEXP out_deg, SEXP in_deg, SEXP allowed_ed
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_vector(out_deg, &c_out_deg);
-  if (!isNull(in_deg)) { R_SEXP_to_vector(in_deg, &c_in_deg); }
+  if (!Rf_isNull(in_deg)) { R_SEXP_to_vector(in_deg, &c_in_deg); }
   c_allowed_edge_types = (igraph_edge_type_sw_t) Rf_asInteger(allowed_edge_types);
   c_method = (igraph_realize_degseq_t) Rf_asInteger(method);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_realize_degree_sequence(&c_graph, &c_out_deg, (isNull(in_deg) ? 0 : &c_in_deg), c_allowed_edge_types, c_method));
+  IGRAPH_R_CHECK(igraph_realize_degree_sequence(&c_graph, &c_out_deg, (Rf_isNull(in_deg) ? 0 : &c_in_deg), c_allowed_edge_types, c_method));
 
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
@@ -421,8 +421,8 @@ SEXP R_igraph_preference_game(SEXP nodes, SEXP types, SEXP type_dist, SEXP fixed
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, graph);
   SET_VECTOR_ELT(r_result, 1, node_type_vec);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("graph"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("node_type_vec"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("graph"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("node_type_vec"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -483,9 +483,9 @@ SEXP R_igraph_asymmetric_preference_game(SEXP nodes, SEXP out_types, SEXP in_typ
   SET_VECTOR_ELT(r_result, 0, graph);
   SET_VECTOR_ELT(r_result, 1, node_type_in_vec);
   SET_VECTOR_ELT(r_result, 2, node_type_out_vec);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("graph"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("node_type_in_vec"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("node_type_out_vec"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("graph"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("node_type_in_vec"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("node_type_out_vec"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -604,11 +604,11 @@ SEXP R_igraph_static_fitness_game(SEXP no_of_edges, SEXP fitness_out, SEXP fitne
                                         /* Convert input */
   c_no_of_edges=INTEGER(no_of_edges)[0];
   R_SEXP_to_vector(fitness_out, &c_fitness_out);
-  if (!isNull(fitness_in)) { R_SEXP_to_vector(fitness_in, &c_fitness_in); }
+  if (!Rf_isNull(fitness_in)) { R_SEXP_to_vector(fitness_in, &c_fitness_in); }
   c_loops=LOGICAL(loops)[0];
   c_multiple=LOGICAL(multiple)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_static_fitness_game(&c_graph, c_no_of_edges, &c_fitness_out, (isNull(fitness_in) ? 0 : &c_fitness_in), c_loops, c_multiple));
+  IGRAPH_R_CHECK(igraph_static_fitness_game(&c_graph, c_no_of_edges, &c_fitness_out, (Rf_isNull(fitness_in) ? 0 : &c_fitness_in), c_loops, c_multiple));
 
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
@@ -810,9 +810,9 @@ SEXP R_igraph_correlated_game(SEXP old_graph, SEXP corr, SEXP p, SEXP permutatio
   R_SEXP_to_igraph(old_graph, &c_old_graph);
   c_corr=REAL(corr)[0];
   c_p=REAL(p)[0];
-  if (!isNull(permutation)) { R_SEXP_to_vector(permutation, &c_permutation); }
+  if (!Rf_isNull(permutation)) { R_SEXP_to_vector(permutation, &c_permutation); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_correlated_game(&c_old_graph, &c_new_graph, c_corr, c_p, (isNull(permutation) ? 0 : &c_permutation)));
+  IGRAPH_R_CHECK(igraph_correlated_game(&c_old_graph, &c_new_graph, c_corr, c_p, (Rf_isNull(permutation) ? 0 : &c_permutation)));
 
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_new_graph);
@@ -846,9 +846,9 @@ SEXP R_igraph_correlated_pair_game(SEXP n, SEXP corr, SEXP p, SEXP directed, SEX
   c_corr=REAL(corr)[0];
   c_p=REAL(p)[0];
   c_directed=LOGICAL(directed)[0];
-  if (!isNull(permutation)) { R_SEXP_to_vector(permutation, &c_permutation); }
+  if (!Rf_isNull(permutation)) { R_SEXP_to_vector(permutation, &c_permutation); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_correlated_pair_game(&c_graph1, &c_graph2, c_n, c_corr, c_p, c_directed, (isNull(permutation) ? 0 : &c_permutation)));
+  IGRAPH_R_CHECK(igraph_correlated_pair_game(&c_graph1, &c_graph2, c_n, c_corr, c_p, c_directed, (Rf_isNull(permutation) ? 0 : &c_permutation)));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -863,8 +863,8 @@ SEXP R_igraph_correlated_pair_game(SEXP n, SEXP corr, SEXP p, SEXP directed, SEX
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, graph1);
   SET_VECTOR_ELT(r_result, 1, graph2);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("graph1"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("graph2"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("graph1"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("graph2"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -1032,10 +1032,10 @@ SEXP R_igraph_closeness(SEXP graph, SEXP vids, SEXP mode, SEXP weights, SEXP nor
   reachable_count=R_GlobalEnv; /* hack to have a non-NULL value */
   R_SEXP_to_igraph_vs(vids, &c_graph, &c_vids);
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_normalized=LOGICAL(normalized)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_closeness(&c_graph, &c_res, (isNull(reachable_count) ? 0 : &c_reachable_count), &c_all_reachable, c_vids, c_mode, (isNull(weights) ? 0 : &c_weights), c_normalized));
+  IGRAPH_R_CHECK(igraph_closeness(&c_graph, &c_res, (Rf_isNull(reachable_count) ? 0 : &c_reachable_count), &c_all_reachable, c_vids, c_mode, (Rf_isNull(weights) ? 0 : &c_weights), c_normalized));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -1052,9 +1052,9 @@ SEXP R_igraph_closeness(SEXP graph, SEXP vids, SEXP mode, SEXP weights, SEXP nor
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, reachable_count);
   SET_VECTOR_ELT(r_result, 2, all_reachable);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("reachable_count"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("all_reachable"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("reachable_count"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("all_reachable"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -1094,11 +1094,11 @@ SEXP R_igraph_closeness_cutoff(SEXP graph, SEXP vids, SEXP mode, SEXP weights, S
   reachable_count=R_GlobalEnv; /* hack to have a non-NULL value */
   R_SEXP_to_igraph_vs(vids, &c_graph, &c_vids);
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_normalized=LOGICAL(normalized)[0];
   c_cutoff=REAL(cutoff)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_closeness_cutoff(&c_graph, &c_res, (isNull(reachable_count) ? 0 : &c_reachable_count), &c_all_reachable, c_vids, c_mode, (isNull(weights) ? 0 : &c_weights), c_normalized, c_cutoff));
+  IGRAPH_R_CHECK(igraph_closeness_cutoff(&c_graph, &c_res, (Rf_isNull(reachable_count) ? 0 : &c_reachable_count), &c_all_reachable, c_vids, c_mode, (Rf_isNull(weights) ? 0 : &c_weights), c_normalized, c_cutoff));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -1115,9 +1115,9 @@ SEXP R_igraph_closeness_cutoff(SEXP graph, SEXP vids, SEXP mode, SEXP weights, S
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, reachable_count);
   SET_VECTOR_ELT(r_result, 2, all_reachable);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("reachable_count"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("all_reachable"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("reachable_count"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("all_reachable"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -1168,8 +1168,8 @@ SEXP R_igraph_get_all_shortest_paths(SEXP graph, SEXP from, SEXP to, SEXP mode) 
   igraph_vs_destroy(&c_to);
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, nrgeo);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("nrgeo"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("nrgeo"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -1205,10 +1205,10 @@ SEXP R_igraph_get_all_shortest_paths_dijkstra(SEXP graph, SEXP from, SEXP to, SE
   IGRAPH_FINALLY(igraph_vector_destroy, &c_nrgeo);
   c_from = (igraph_integer_t) REAL(from)[0];
   R_SEXP_to_igraph_vs(to, &c_graph, &c_to);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_get_all_shortest_paths_dijkstra(&c_graph, &c_res, &c_nrgeo, c_from, c_to, (isNull(weights) ? 0 : &c_weights), c_mode));
+  IGRAPH_R_CHECK(igraph_get_all_shortest_paths_dijkstra(&c_graph, &c_res, &c_nrgeo, c_from, c_to, (Rf_isNull(weights) ? 0 : &c_weights), c_mode));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -1222,8 +1222,8 @@ SEXP R_igraph_get_all_shortest_paths_dijkstra(SEXP graph, SEXP from, SEXP to, SE
   igraph_vs_destroy(&c_to);
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, nrgeo);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("nrgeo"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("nrgeo"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -1291,10 +1291,10 @@ SEXP R_igraph_betweenness_cutoff(SEXP graph, SEXP vids, SEXP directed, SEXP weig
   IGRAPH_FINALLY(igraph_vector_destroy, &c_res);
   R_SEXP_to_igraph_vs(vids, &c_graph, &c_vids);
   c_directed=LOGICAL(directed)[0];
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_cutoff=REAL(cutoff)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_betweenness_cutoff(&c_graph, &c_res, c_vids, c_directed, (isNull(weights) ? 0 : &c_weights), c_cutoff));
+  IGRAPH_R_CHECK(igraph_betweenness_cutoff(&c_graph, &c_res, c_vids, c_directed, (Rf_isNull(weights) ? 0 : &c_weights), c_cutoff));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -1326,9 +1326,9 @@ SEXP R_igraph_edge_betweenness(SEXP graph, SEXP directed, SEXP weights) {
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_res);
   c_directed=LOGICAL(directed)[0];
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_edge_betweenness(&c_graph, &c_res, c_directed, (isNull(weights) ? 0 : &c_weights)));
+  IGRAPH_R_CHECK(igraph_edge_betweenness(&c_graph, &c_res, c_directed, (Rf_isNull(weights) ? 0 : &c_weights)));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -1360,10 +1360,10 @@ SEXP R_igraph_edge_betweenness_cutoff(SEXP graph, SEXP directed, SEXP weights, S
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_res);
   c_directed=LOGICAL(directed)[0];
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_cutoff=REAL(cutoff)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_edge_betweenness_cutoff(&c_graph, &c_res, c_directed, (isNull(weights) ? 0 : &c_weights), c_cutoff));
+  IGRAPH_R_CHECK(igraph_edge_betweenness_cutoff(&c_graph, &c_res, c_directed, (Rf_isNull(weights) ? 0 : &c_weights), c_cutoff));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -1398,11 +1398,11 @@ SEXP R_igraph_harmonic_centrality_cutoff(SEXP graph, SEXP vids, SEXP mode, SEXP 
   IGRAPH_FINALLY(igraph_vector_destroy, &c_res);
   R_SEXP_to_igraph_vs(vids, &c_graph, &c_vids);
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_normalized=LOGICAL(normalized)[0];
   c_cutoff=REAL(cutoff)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_harmonic_centrality_cutoff(&c_graph, &c_res, c_vids, c_mode, (isNull(weights) ? 0 : &c_weights), c_normalized, c_cutoff));
+  IGRAPH_R_CHECK(igraph_harmonic_centrality_cutoff(&c_graph, &c_res, c_vids, c_mode, (Rf_isNull(weights) ? 0 : &c_weights), c_normalized, c_cutoff));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -1445,8 +1445,8 @@ SEXP R_igraph_personalized_pagerank(SEXP graph, SEXP algo, SEXP vids, SEXP direc
   R_SEXP_to_igraph_vs(vids, &c_graph, &c_vids);
   c_directed=LOGICAL(directed)[0];
   c_damping=REAL(damping)[0];
-  if (!isNull(personalized)) { R_SEXP_to_vector(personalized, &c_personalized); }
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(personalized)) { R_SEXP_to_vector(personalized, &c_personalized); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   if (c_algo == IGRAPH_PAGERANK_ALGO_ARPACK) {
     R_SEXP_to_igraph_arpack_options(options, &c_options1);
     c_options = &c_options1;
@@ -1454,7 +1454,7 @@ SEXP R_igraph_personalized_pagerank(SEXP graph, SEXP algo, SEXP vids, SEXP direc
     c_options = 0;
   }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_personalized_pagerank(&c_graph, c_algo, &c_vector, &c_value, c_vids, c_directed, c_damping, (isNull(personalized) ? 0 : &c_personalized), (isNull(weights) ? 0 : &c_weights), c_options));
+  IGRAPH_R_CHECK(igraph_personalized_pagerank(&c_graph, c_algo, &c_vector, &c_value, c_vids, c_directed, c_damping, (Rf_isNull(personalized) ? 0 : &c_personalized), (Rf_isNull(weights) ? 0 : &c_weights), c_options));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -1473,9 +1473,9 @@ SEXP R_igraph_personalized_pagerank(SEXP graph, SEXP algo, SEXP vids, SEXP direc
   SET_VECTOR_ELT(r_result, 0, vector);
   SET_VECTOR_ELT(r_result, 1, value);
   SET_VECTOR_ELT(r_result, 2, options);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("vector"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("value"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("options"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("vector"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("value"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("options"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -1589,11 +1589,11 @@ SEXP R_igraph_average_path_length_dijkstra(SEXP graph, SEXP weights, SEXP direct
   SEXP r_result, r_names;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_directed=LOGICAL(directed)[0];
   c_unconn=LOGICAL(unconn)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_average_path_length_dijkstra(&c_graph, &c_res, &c_unconn_pairs, (isNull(weights) ? 0 : &c_weights), c_directed, c_unconn));
+  IGRAPH_R_CHECK(igraph_average_path_length_dijkstra(&c_graph, &c_res, &c_unconn_pairs, (Rf_isNull(weights) ? 0 : &c_weights), c_directed, c_unconn));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -1604,8 +1604,8 @@ SEXP R_igraph_average_path_length_dijkstra(SEXP graph, SEXP weights, SEXP direct
   REAL(unconn_pairs)[0]=c_unconn_pairs;
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, unconn_pairs);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("unconnected"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("unconnected"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -1646,8 +1646,8 @@ SEXP R_igraph_path_length_hist(SEXP graph, SEXP directed) {
   REAL(unconnected)[0]=c_unconnected;
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, unconnected);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("unconnected"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("unconnected"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -1706,10 +1706,10 @@ SEXP R_igraph_feedback_arc_set(SEXP graph, SEXP weights, SEXP algo) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_result);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_algo = (igraph_fas_algorithm_t) Rf_asInteger(algo);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_feedback_arc_set(&c_graph, &c_result, (isNull(weights) ? 0 : &c_weights), c_algo));
+  IGRAPH_R_CHECK(igraph_feedback_arc_set(&c_graph, &c_result, (Rf_isNull(weights) ? 0 : &c_weights), c_algo));
 
                                         /* Convert output */
   PROTECT(result=R_igraph_vector_to_SEXPp1(&c_result));
@@ -1937,10 +1937,10 @@ SEXP R_igraph_eigenvector_centrality(SEXP graph, SEXP directed, SEXP scale, SEXP
   IGRAPH_FINALLY(igraph_vector_destroy, &c_vector);
   c_directed=LOGICAL(directed)[0];
   c_scale=LOGICAL(scale)[0];
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   R_SEXP_to_igraph_arpack_options(options, &c_options);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_eigenvector_centrality(&c_graph, &c_vector, &c_value, c_directed, c_scale, (isNull(weights) ? 0 : &c_weights), &c_options));
+  IGRAPH_R_CHECK(igraph_eigenvector_centrality(&c_graph, &c_vector, &c_value, c_directed, c_scale, (Rf_isNull(weights) ? 0 : &c_weights), &c_options));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -1954,9 +1954,9 @@ SEXP R_igraph_eigenvector_centrality(SEXP graph, SEXP directed, SEXP scale, SEXP
   SET_VECTOR_ELT(r_result, 0, vector);
   SET_VECTOR_ELT(r_result, 1, value);
   SET_VECTOR_ELT(r_result, 2, options);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("vector"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("value"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("options"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("vector"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("value"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("options"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -1986,10 +1986,10 @@ SEXP R_igraph_hub_score(SEXP graph, SEXP scale, SEXP weights, SEXP options) {
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_vector);
   c_scale=LOGICAL(scale)[0];
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   R_SEXP_to_igraph_arpack_options(options, &c_options);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_hub_score(&c_graph, &c_vector, &c_value, c_scale, (isNull(weights) ? 0 : &c_weights), &c_options));
+  IGRAPH_R_CHECK(igraph_hub_score(&c_graph, &c_vector, &c_value, c_scale, (Rf_isNull(weights) ? 0 : &c_weights), &c_options));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -2003,9 +2003,9 @@ SEXP R_igraph_hub_score(SEXP graph, SEXP scale, SEXP weights, SEXP options) {
   SET_VECTOR_ELT(r_result, 0, vector);
   SET_VECTOR_ELT(r_result, 1, value);
   SET_VECTOR_ELT(r_result, 2, options);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("vector"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("value"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("options"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("vector"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("value"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("options"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -2035,10 +2035,10 @@ SEXP R_igraph_authority_score(SEXP graph, SEXP scale, SEXP weights, SEXP options
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_vector);
   c_scale=LOGICAL(scale)[0];
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   R_SEXP_to_igraph_arpack_options(options, &c_options);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_authority_score(&c_graph, &c_vector, &c_value, c_scale, (isNull(weights) ? 0 : &c_weights), &c_options));
+  IGRAPH_R_CHECK(igraph_authority_score(&c_graph, &c_vector, &c_value, c_scale, (Rf_isNull(weights) ? 0 : &c_weights), &c_options));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -2052,9 +2052,9 @@ SEXP R_igraph_authority_score(SEXP graph, SEXP scale, SEXP weights, SEXP options
   SET_VECTOR_ELT(r_result, 0, vector);
   SET_VECTOR_ELT(r_result, 1, value);
   SET_VECTOR_ELT(r_result, 2, options);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("vector"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("value"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("options"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("vector"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("value"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("options"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -2096,8 +2096,8 @@ SEXP R_igraph_arpack_unpack_complex(SEXP vectors, SEXP values, SEXP nev) {
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, vectors);
   SET_VECTOR_ELT(r_result, 1, values);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("vectors"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("values"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("vectors"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("values"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -2129,7 +2129,7 @@ SEXP R_igraph_unfold_tree(SEXP graph, SEXP mode, SEXP roots) {
   IGRAPH_FINALLY(igraph_vector_destroy, &c_vertex_index);
   vertex_index=R_GlobalEnv; /* hack to have a non-NULL value */
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_unfold_tree(&c_graph, &c_tree, c_mode, &c_roots, (isNull(vertex_index) ? 0 : &c_vertex_index)));
+  IGRAPH_R_CHECK(igraph_unfold_tree(&c_graph, &c_tree, c_mode, &c_roots, (Rf_isNull(vertex_index) ? 0 : &c_vertex_index)));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -2143,8 +2143,8 @@ SEXP R_igraph_unfold_tree(SEXP graph, SEXP mode, SEXP roots) {
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, tree);
   SET_VECTOR_ELT(r_result, 1, vertex_index);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("tree"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("vertex_index"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("tree"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("vertex_index"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -2220,8 +2220,8 @@ SEXP R_igraph_maximum_cardinality_search(SEXP graph) {
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, alpha);
   SET_VECTOR_ELT(r_result, 1, alpham1);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("alpha"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("alpham1"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("alpha"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("alpham1"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -2259,9 +2259,9 @@ SEXP R_igraph_avg_nearest_neighbor_degree(SEXP graph, SEXP vids, SEXP mode, SEXP
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_knnk);
   knnk=R_GlobalEnv; /* hack to have a non-NULL value */
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_avg_nearest_neighbor_degree(&c_graph, c_vids, c_mode, c_neighbor_degree_mode, &c_knn, (isNull(knnk) ? 0 : &c_knnk), (isNull(weights) ? 0 : &c_weights)));
+  IGRAPH_R_CHECK(igraph_avg_nearest_neighbor_degree(&c_graph, c_vids, c_mode, c_neighbor_degree_mode, &c_knn, (Rf_isNull(knnk) ? 0 : &c_knnk), (Rf_isNull(weights) ? 0 : &c_weights)));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -2275,8 +2275,8 @@ SEXP R_igraph_avg_nearest_neighbor_degree(SEXP graph, SEXP vids, SEXP mode, SEXP
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, knn);
   SET_VECTOR_ELT(r_result, 1, knnk);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("knn"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("knnk"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("knn"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("knnk"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -2307,9 +2307,9 @@ SEXP R_igraph_strength(SEXP graph, SEXP vids, SEXP mode, SEXP loops, SEXP weight
   R_SEXP_to_igraph_vs(vids, &c_graph, &c_vids);
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
   c_loops=LOGICAL(loops)[0];
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_strength(&c_graph, &c_res, c_vids, c_mode, c_loops, (isNull(weights) ? 0 : &c_weights)));
+  IGRAPH_R_CHECK(igraph_strength(&c_graph, &c_res, c_vids, c_mode, c_loops, (Rf_isNull(weights) ? 0 : &c_weights)));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -2390,9 +2390,9 @@ SEXP R_igraph_centralization_degree(SEXP graph, SEXP mode, SEXP loops, SEXP norm
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, centralization);
   SET_VECTOR_ELT(r_result, 2, theoretical_max);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("centralization"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("theoretical_max"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("centralization"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("theoretical_max"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -2414,12 +2414,12 @@ SEXP R_igraph_centralization_degree_tmax(SEXP graph, SEXP nodes, SEXP mode, SEXP
 
   SEXP r_result;
                                         /* Convert input */
-  if (!isNull(graph)) { R_SEXP_to_igraph(graph, &c_graph); }
+  if (!Rf_isNull(graph)) { R_SEXP_to_igraph(graph, &c_graph); }
   c_nodes=INTEGER(nodes)[0];
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
   c_loops=LOGICAL(loops)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_centralization_degree_tmax((isNull(graph) ? 0 : &c_graph), c_nodes, c_mode, c_loops, &c_res));
+  IGRAPH_R_CHECK(igraph_centralization_degree_tmax((Rf_isNull(graph) ? 0 : &c_graph), c_nodes, c_mode, c_loops, &c_res));
 
                                         /* Convert output */
   PROTECT(res=NEW_NUMERIC(1));
@@ -2470,9 +2470,9 @@ SEXP R_igraph_centralization_betweenness(SEXP graph, SEXP directed, SEXP normali
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, centralization);
   SET_VECTOR_ELT(r_result, 2, theoretical_max);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("centralization"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("theoretical_max"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("centralization"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("theoretical_max"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -2493,11 +2493,11 @@ SEXP R_igraph_centralization_betweenness_tmax(SEXP graph, SEXP nodes, SEXP direc
 
   SEXP r_result;
                                         /* Convert input */
-  if (!isNull(graph)) { R_SEXP_to_igraph(graph, &c_graph); }
+  if (!Rf_isNull(graph)) { R_SEXP_to_igraph(graph, &c_graph); }
   c_nodes=INTEGER(nodes)[0];
   c_directed=LOGICAL(directed)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_centralization_betweenness_tmax((isNull(graph) ? 0 : &c_graph), c_nodes, c_directed, &c_res));
+  IGRAPH_R_CHECK(igraph_centralization_betweenness_tmax((Rf_isNull(graph) ? 0 : &c_graph), c_nodes, c_directed, &c_res));
 
                                         /* Convert output */
   PROTECT(res=NEW_NUMERIC(1));
@@ -2548,9 +2548,9 @@ SEXP R_igraph_centralization_closeness(SEXP graph, SEXP mode, SEXP normalized) {
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, centralization);
   SET_VECTOR_ELT(r_result, 2, theoretical_max);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("centralization"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("theoretical_max"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("centralization"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("theoretical_max"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -2571,11 +2571,11 @@ SEXP R_igraph_centralization_closeness_tmax(SEXP graph, SEXP nodes, SEXP mode) {
 
   SEXP r_result;
                                         /* Convert input */
-  if (!isNull(graph)) { R_SEXP_to_igraph(graph, &c_graph); }
+  if (!Rf_isNull(graph)) { R_SEXP_to_igraph(graph, &c_graph); }
   c_nodes=INTEGER(nodes)[0];
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_centralization_closeness_tmax((isNull(graph) ? 0 : &c_graph), c_nodes, c_mode, &c_res));
+  IGRAPH_R_CHECK(igraph_centralization_closeness_tmax((Rf_isNull(graph) ? 0 : &c_graph), c_nodes, c_mode, &c_res));
 
                                         /* Convert output */
   PROTECT(res=NEW_NUMERIC(1));
@@ -2637,11 +2637,11 @@ SEXP R_igraph_centralization_eigenvector_centrality(SEXP graph, SEXP directed, S
   SET_VECTOR_ELT(r_result, 2, options);
   SET_VECTOR_ELT(r_result, 3, centralization);
   SET_VECTOR_ELT(r_result, 4, theoretical_max);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("vector"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("value"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("options"));
-  SET_STRING_ELT(r_names, 3, CREATE_STRING_VECTOR("centralization"));
-  SET_STRING_ELT(r_names, 4, CREATE_STRING_VECTOR("theoretical_max"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("vector"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("value"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("options"));
+  SET_STRING_ELT(r_names, 3, Rf_mkChar("centralization"));
+  SET_STRING_ELT(r_names, 4, Rf_mkChar("theoretical_max"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(6);
 
@@ -2663,12 +2663,12 @@ SEXP R_igraph_centralization_eigenvector_centrality_tmax(SEXP graph, SEXP nodes,
 
   SEXP r_result;
                                         /* Convert input */
-  if (!isNull(graph)) { R_SEXP_to_igraph(graph, &c_graph); }
+  if (!Rf_isNull(graph)) { R_SEXP_to_igraph(graph, &c_graph); }
   c_nodes=INTEGER(nodes)[0];
   c_directed=LOGICAL(directed)[0];
   c_scale=LOGICAL(scale)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_centralization_eigenvector_centrality_tmax((isNull(graph) ? 0 : &c_graph), c_nodes, c_directed, c_scale, &c_res));
+  IGRAPH_R_CHECK(igraph_centralization_eigenvector_centrality_tmax((Rf_isNull(graph) ? 0 : &c_graph), c_nodes, c_directed, c_scale, &c_res));
 
                                         /* Convert output */
   PROTECT(res=NEW_NUMERIC(1));
@@ -2723,10 +2723,10 @@ SEXP R_igraph_assortativity(SEXP graph, SEXP types1, SEXP types2, SEXP directed)
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
   R_SEXP_to_vector(types1, &c_types1);
-  if (!isNull(types2)) { R_SEXP_to_vector(types2, &c_types2); }
+  if (!Rf_isNull(types2)) { R_SEXP_to_vector(types2, &c_types2); }
   c_directed=LOGICAL(directed)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_assortativity(&c_graph, &c_types1, (isNull(types2) ? 0 : &c_types2), &c_res, c_directed));
+  IGRAPH_R_CHECK(igraph_assortativity(&c_graph, &c_types1, (Rf_isNull(types2) ? 0 : &c_types2), &c_res, c_directed));
 
                                         /* Convert output */
   PROTECT(res=NEW_NUMERIC(1));
@@ -2868,14 +2868,14 @@ SEXP R_igraph_diversity(SEXP graph, SEXP weights, SEXP vids) {
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   if (0 != igraph_vector_init(&c_res, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_res);
   R_SEXP_to_igraph_vs(vids, &c_graph, &c_vids);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_diversity(&c_graph, (isNull(weights) ? 0 : &c_weights), &c_res, c_vids));
+  IGRAPH_R_CHECK(igraph_diversity(&c_graph, (Rf_isNull(weights) ? 0 : &c_weights), &c_res, c_vids));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -2942,7 +2942,7 @@ SEXP R_igraph_random_edge_walk(SEXP graph, SEXP weights, SEXP start, SEXP mode, 
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   if (0 != igraph_vector_init(&c_edgewalk, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -2952,7 +2952,7 @@ SEXP R_igraph_random_edge_walk(SEXP graph, SEXP weights, SEXP start, SEXP mode, 
   c_steps=INTEGER(steps)[0];
   c_stuck = (igraph_random_walk_stuck_t) Rf_asInteger(stuck);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_random_edge_walk(&c_graph, (isNull(weights) ? 0 : &c_weights), &c_edgewalk, c_start, c_mode, c_steps, c_stuck));
+  IGRAPH_R_CHECK(igraph_random_edge_walk(&c_graph, (Rf_isNull(weights) ? 0 : &c_weights), &c_edgewalk, c_start, c_mode, c_steps, c_stuck));
 
                                         /* Convert output */
   PROTECT(edgewalk=R_igraph_vector_to_SEXPp1(&c_edgewalk));
@@ -2978,10 +2978,10 @@ SEXP R_igraph_global_efficiency(SEXP graph, SEXP weights, SEXP directed) {
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_directed=LOGICAL(directed)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_global_efficiency(&c_graph, &c_res, (isNull(weights) ? 0 : &c_weights), c_directed));
+  IGRAPH_R_CHECK(igraph_global_efficiency(&c_graph, &c_res, (Rf_isNull(weights) ? 0 : &c_weights), c_directed));
 
                                         /* Convert output */
   PROTECT(res=NEW_NUMERIC(1));
@@ -3013,11 +3013,11 @@ SEXP R_igraph_local_efficiency(SEXP graph, SEXP vids, SEXP weights, SEXP directe
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_res);
   R_SEXP_to_igraph_vs(vids, &c_graph, &c_vids);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_directed=LOGICAL(directed)[0];
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_local_efficiency(&c_graph, &c_res, c_vids, (isNull(weights) ? 0 : &c_weights), c_directed, c_mode));
+  IGRAPH_R_CHECK(igraph_local_efficiency(&c_graph, &c_res, c_vids, (Rf_isNull(weights) ? 0 : &c_weights), c_directed, c_mode));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -3045,11 +3045,11 @@ SEXP R_igraph_average_local_efficiency(SEXP graph, SEXP weights, SEXP directed, 
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_directed=LOGICAL(directed)[0];
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_average_local_efficiency(&c_graph, &c_res, (isNull(weights) ? 0 : &c_weights), c_directed, c_mode));
+  IGRAPH_R_CHECK(igraph_average_local_efficiency(&c_graph, &c_res, (Rf_isNull(weights) ? 0 : &c_weights), c_directed, c_mode));
 
                                         /* Convert output */
   PROTECT(res=NEW_NUMERIC(1));
@@ -3074,10 +3074,10 @@ SEXP R_igraph_is_graphical(SEXP out_deg, SEXP in_deg, SEXP allowed_edge_types) {
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_vector(out_deg, &c_out_deg);
-  if (!isNull(in_deg)) { R_SEXP_to_vector(in_deg, &c_in_deg); }
+  if (!Rf_isNull(in_deg)) { R_SEXP_to_vector(in_deg, &c_in_deg); }
   c_allowed_edge_types = (igraph_edge_type_sw_t) Rf_asInteger(allowed_edge_types);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_is_graphical(&c_out_deg, (isNull(in_deg) ? 0 : &c_in_deg), c_allowed_edge_types, &c_res));
+  IGRAPH_R_CHECK(igraph_is_graphical(&c_out_deg, (Rf_isNull(in_deg) ? 0 : &c_in_deg), c_allowed_edge_types, &c_res));
 
                                         /* Convert output */
   PROTECT(res=NEW_LOGICAL(1));
@@ -3107,13 +3107,13 @@ SEXP R_igraph_bipartite_projection_size(SEXP graph, SEXP types) {
   SEXP r_result, r_names;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(types)) { R_SEXP_to_vector_bool(types, &c_types); }
+  if (!Rf_isNull(types)) { R_SEXP_to_vector_bool(types, &c_types); }
   c_vcount1=0;
   c_ecount1=0;
   c_vcount2=0;
   c_ecount2=0;
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_bipartite_projection_size(&c_graph, (isNull(types) ? 0 : &c_types), &c_vcount1, &c_ecount1, &c_vcount2, &c_ecount2));
+  IGRAPH_R_CHECK(igraph_bipartite_projection_size(&c_graph, (Rf_isNull(types) ? 0 : &c_types), &c_vcount1, &c_ecount1, &c_vcount2, &c_ecount2));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(4));
@@ -3130,10 +3130,10 @@ SEXP R_igraph_bipartite_projection_size(SEXP graph, SEXP types) {
   SET_VECTOR_ELT(r_result, 1, ecount1);
   SET_VECTOR_ELT(r_result, 2, vcount2);
   SET_VECTOR_ELT(r_result, 3, ecount2);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("vcount1"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("ecount1"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("vcount2"));
-  SET_STRING_ELT(r_names, 3, CREATE_STRING_VECTOR("ecount2"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("vcount1"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("ecount1"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("vcount2"));
+  SET_STRING_ELT(r_names, 3, Rf_mkChar("ecount2"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(5);
 
@@ -3210,8 +3210,8 @@ SEXP R_igraph_incidence(SEXP incidence, SEXP directed, SEXP mode, SEXP multiple)
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, graph);
   SET_VECTOR_ELT(r_result, 1, types);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("graph"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("types"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("graph"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("types"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -3236,7 +3236,7 @@ SEXP R_igraph_get_incidence(SEXP graph, SEXP types) {
   SEXP r_result, r_names;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(types)) { R_SEXP_to_vector_bool(types, &c_types); }
+  if (!Rf_isNull(types)) { R_SEXP_to_vector_bool(types, &c_types); }
   if (0 != igraph_matrix_init(&c_res, 0, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -3252,7 +3252,7 @@ SEXP R_igraph_get_incidence(SEXP graph, SEXP types) {
   IGRAPH_FINALLY(igraph_vector_destroy, &c_col_ids);
   col_ids=R_GlobalEnv; /* hack to have a non-NULL value */
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_get_incidence(&c_graph, (isNull(types) ? 0 : &c_types), &c_res, (isNull(row_ids) ? 0 : &c_row_ids), (isNull(col_ids) ? 0 : &c_col_ids)));
+  IGRAPH_R_CHECK(igraph_get_incidence(&c_graph, (Rf_isNull(types) ? 0 : &c_types), &c_res, (Rf_isNull(row_ids) ? 0 : &c_row_ids), (Rf_isNull(col_ids) ? 0 : &c_col_ids)));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -3269,9 +3269,9 @@ SEXP R_igraph_get_incidence(SEXP graph, SEXP types) {
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, row_ids);
   SET_VECTOR_ELT(r_result, 2, col_ids);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("row_ids"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("col_ids"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("row_ids"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("col_ids"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -3299,7 +3299,7 @@ SEXP R_igraph_is_bipartite(SEXP graph) {
   IGRAPH_FINALLY(igraph_vector_bool_destroy, &c_type);
   type=R_GlobalEnv; /* hack to have a non-NULL value */
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_is_bipartite(&c_graph, &c_res, (isNull(type) ? 0 : &c_type)));
+  IGRAPH_R_CHECK(igraph_is_bipartite(&c_graph, &c_res, (Rf_isNull(type) ? 0 : &c_type)));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -3311,8 +3311,8 @@ SEXP R_igraph_is_bipartite(SEXP graph) {
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, type);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("type"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("type"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -3348,7 +3348,7 @@ SEXP R_igraph_bipartite_game_gnp(SEXP n1, SEXP n2, SEXP p, SEXP directed, SEXP m
   c_directed=LOGICAL(directed)[0];
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_bipartite_game_gnp(&c_graph, (isNull(types) ? 0 : &c_types), c_n1, c_n2, c_p, c_directed, c_mode));
+  IGRAPH_R_CHECK(igraph_bipartite_game_gnp(&c_graph, (Rf_isNull(types) ? 0 : &c_types), c_n1, c_n2, c_p, c_directed, c_mode));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -3362,8 +3362,8 @@ SEXP R_igraph_bipartite_game_gnp(SEXP n1, SEXP n2, SEXP p, SEXP directed, SEXP m
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, graph);
   SET_VECTOR_ELT(r_result, 1, types);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("graph"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("types"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("graph"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("types"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -3399,7 +3399,7 @@ SEXP R_igraph_bipartite_game_gnm(SEXP n1, SEXP n2, SEXP m, SEXP directed, SEXP m
   c_directed=LOGICAL(directed)[0];
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_bipartite_game_gnm(&c_graph, (isNull(types) ? 0 : &c_types), c_n1, c_n2, c_m, c_directed, c_mode));
+  IGRAPH_R_CHECK(igraph_bipartite_game_gnm(&c_graph, (Rf_isNull(types) ? 0 : &c_types), c_n1, c_n2, c_m, c_directed, c_mode));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -3413,8 +3413,8 @@ SEXP R_igraph_bipartite_game_gnm(SEXP n1, SEXP n2, SEXP m, SEXP directed, SEXP m
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, graph);
   SET_VECTOR_ELT(r_result, 1, types);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("graph"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("types"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("graph"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("types"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -3466,9 +3466,9 @@ SEXP R_igraph_clusters(SEXP graph, SEXP mode) {
   SET_VECTOR_ELT(r_result, 0, membership);
   SET_VECTOR_ELT(r_result, 1, csize);
   SET_VECTOR_ELT(r_result, 2, no);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("membership"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("csize"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("no"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("membership"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("csize"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("no"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -3593,11 +3593,11 @@ SEXP R_igraph_biconnected_components(SEXP graph) {
   SET_VECTOR_ELT(r_result, 2, component_edges);
   SET_VECTOR_ELT(r_result, 3, components);
   SET_VECTOR_ELT(r_result, 4, articulation_points);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("no"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("tree_edges"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("component_edges"));
-  SET_STRING_ELT(r_names, 3, CREATE_STRING_VECTOR("components"));
-  SET_STRING_ELT(r_names, 4, CREATE_STRING_VECTOR("articulation_points"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("no"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("tree_edges"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("component_edges"));
+  SET_STRING_ELT(r_names, 3, Rf_mkChar("components"));
+  SET_STRING_ELT(r_names, 4, Rf_mkChar("articulation_points"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(6);
 
@@ -3803,7 +3803,7 @@ SEXP R_igraph_weighted_cliques(SEXP graph, SEXP vertex_weights, SEXP min_weight,
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(vertex_weights)) { R_SEXP_to_vector(vertex_weights, &c_vertex_weights); }
+  if (!Rf_isNull(vertex_weights)) { R_SEXP_to_vector(vertex_weights, &c_vertex_weights); }
   if (0 != igraph_vector_ptr_init(&c_res, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -3812,7 +3812,7 @@ SEXP R_igraph_weighted_cliques(SEXP graph, SEXP vertex_weights, SEXP min_weight,
   c_max_weight=REAL(max_weight)[0];
   c_maximal=LOGICAL(maximal)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_weighted_cliques(&c_graph, (isNull(vertex_weights) ? 0 : &c_vertex_weights), &c_res, c_min_weight, c_max_weight, c_maximal));
+  IGRAPH_R_CHECK(igraph_weighted_cliques(&c_graph, (Rf_isNull(vertex_weights) ? 0 : &c_vertex_weights), &c_res, c_min_weight, c_max_weight, c_maximal));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vectorlist_to_SEXP_p1(&c_res));
@@ -3837,13 +3837,13 @@ SEXP R_igraph_largest_weighted_cliques(SEXP graph, SEXP vertex_weights) {
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(vertex_weights)) { R_SEXP_to_vector(vertex_weights, &c_vertex_weights); }
+  if (!Rf_isNull(vertex_weights)) { R_SEXP_to_vector(vertex_weights, &c_vertex_weights); }
   if (0 != igraph_vector_ptr_init(&c_res, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(R_igraph_vectorlist_destroy, &c_res);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_largest_weighted_cliques(&c_graph, (isNull(vertex_weights) ? 0 : &c_vertex_weights), &c_res));
+  IGRAPH_R_CHECK(igraph_largest_weighted_cliques(&c_graph, (Rf_isNull(vertex_weights) ? 0 : &c_vertex_weights), &c_res));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vectorlist_to_SEXP_p1(&c_res));
@@ -3868,9 +3868,9 @@ SEXP R_igraph_weighted_clique_number(SEXP graph, SEXP vertex_weights) {
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(vertex_weights)) { R_SEXP_to_vector(vertex_weights, &c_vertex_weights); }
+  if (!Rf_isNull(vertex_weights)) { R_SEXP_to_vector(vertex_weights, &c_vertex_weights); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_weighted_clique_number(&c_graph, (isNull(vertex_weights) ? 0 : &c_vertex_weights), &c_res));
+  IGRAPH_R_CHECK(igraph_weighted_clique_number(&c_graph, (Rf_isNull(vertex_weights) ? 0 : &c_vertex_weights), &c_res));
 
                                         /* Convert output */
   PROTECT(res=NEW_NUMERIC(1));
@@ -3900,9 +3900,9 @@ SEXP R_igraph_layout_star(SEXP graph, SEXP center, SEXP order) {
   }
   IGRAPH_FINALLY(igraph_matrix_destroy, &c_res);
   c_center = (igraph_integer_t) REAL(center)[0];
-  if (!isNull(order)) { R_SEXP_to_vector(order, &c_order); }
+  if (!Rf_isNull(order)) { R_SEXP_to_vector(order, &c_order); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_layout_star(&c_graph, &c_res, c_center, (isNull(order) ? 0 : &c_order)));
+  IGRAPH_R_CHECK(igraph_layout_star(&c_graph, &c_res, c_center, (Rf_isNull(order) ? 0 : &c_order)));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_matrix_to_SEXP(&c_res));
@@ -3999,10 +3999,10 @@ SEXP R_igraph_layout_drl(SEXP graph, SEXP res, SEXP use_seed, SEXP options, SEXP
   IGRAPH_FINALLY(igraph_matrix_destroy, &c_res);
   c_use_seed=LOGICAL(use_seed)[0];
   R_SEXP_to_igraph_layout_drl_options(options, &c_options);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
-  if (!isNull(fixed)) { R_SEXP_to_vector_bool(fixed, &c_fixed); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(fixed)) { R_SEXP_to_vector_bool(fixed, &c_fixed); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_layout_drl(&c_graph, &c_res, c_use_seed, &c_options, (isNull(weights) ? 0 : &c_weights), (isNull(fixed) ? 0 : &c_fixed)));
+  IGRAPH_R_CHECK(igraph_layout_drl(&c_graph, &c_res, c_use_seed, &c_options, (Rf_isNull(weights) ? 0 : &c_weights), (Rf_isNull(fixed) ? 0 : &c_fixed)));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_matrix_to_SEXP(&c_res));
@@ -4035,10 +4035,10 @@ SEXP R_igraph_layout_drl_3d(SEXP graph, SEXP res, SEXP use_seed, SEXP options, S
   IGRAPH_FINALLY(igraph_matrix_destroy, &c_res);
   c_use_seed=LOGICAL(use_seed)[0];
   R_SEXP_to_igraph_layout_drl_options(options, &c_options);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
-  if (!isNull(fixed)) { R_SEXP_to_vector_bool(fixed, &c_fixed); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(fixed)) { R_SEXP_to_vector_bool(fixed, &c_fixed); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_layout_drl_3d(&c_graph, &c_res, c_use_seed, &c_options, (isNull(weights) ? 0 : &c_weights), (isNull(fixed) ? 0 : &c_fixed)));
+  IGRAPH_R_CHECK(igraph_layout_drl_3d(&c_graph, &c_res, c_use_seed, &c_options, (Rf_isNull(weights) ? 0 : &c_weights), (Rf_isNull(fixed) ? 0 : &c_fixed)));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_matrix_to_SEXP(&c_res));
@@ -4081,13 +4081,13 @@ SEXP R_igraph_layout_sugiyama(SEXP graph, SEXP layers, SEXP hgap, SEXP vgap, SEX
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_extd_to_orig_eids);
   extd_to_orig_eids=R_GlobalEnv; /* hack to have a non-NULL value */
-  if (!isNull(layers)) { R_SEXP_to_vector(layers, &c_layers); }
+  if (!Rf_isNull(layers)) { R_SEXP_to_vector(layers, &c_layers); }
   c_hgap=REAL(hgap)[0];
   c_vgap=REAL(vgap)[0];
   c_maxiter=INTEGER(maxiter)[0];
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_layout_sugiyama(&c_graph, &c_res, (isNull(extd_graph) ? 0 : &c_extd_graph), (isNull(extd_to_orig_eids) ? 0 : &c_extd_to_orig_eids), (isNull(layers) ? 0 : &c_layers), c_hgap, c_vgap, c_maxiter, (isNull(weights) ? 0 : &c_weights)));
+  IGRAPH_R_CHECK(igraph_layout_sugiyama(&c_graph, &c_res, (Rf_isNull(extd_graph) ? 0 : &c_extd_graph), (Rf_isNull(extd_to_orig_eids) ? 0 : &c_extd_to_orig_eids), (Rf_isNull(layers) ? 0 : &c_layers), c_hgap, c_vgap, c_maxiter, (Rf_isNull(weights) ? 0 : &c_weights)));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -4105,9 +4105,9 @@ SEXP R_igraph_layout_sugiyama(SEXP graph, SEXP layers, SEXP hgap, SEXP vgap, SEX
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, extd_graph);
   SET_VECTOR_ELT(r_result, 2, extd_to_orig_eids);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("extd_graph"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("extd_to_orig_eids"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("extd_graph"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("extd_to_orig_eids"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -4133,10 +4133,10 @@ SEXP R_igraph_layout_mds(SEXP graph, SEXP dist, SEXP dim) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_matrix_destroy, &c_res);
-  if (!isNull(dist)) { R_SEXP_to_matrix(dist, &c_dist); }
+  if (!Rf_isNull(dist)) { R_SEXP_to_matrix(dist, &c_dist); }
   c_dim=INTEGER(dim)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_layout_mds(&c_graph, &c_res, (isNull(dist) ? 0 : &c_dist), c_dim));
+  IGRAPH_R_CHECK(igraph_layout_mds(&c_graph, &c_res, (Rf_isNull(dist) ? 0 : &c_dist), c_dim));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_matrix_to_SEXP(&c_res));
@@ -4164,7 +4164,7 @@ SEXP R_igraph_layout_bipartite(SEXP graph, SEXP types, SEXP hgap, SEXP vgap, SEX
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(types)) { R_SEXP_to_vector_bool(types, &c_types); }
+  if (!Rf_isNull(types)) { R_SEXP_to_vector_bool(types, &c_types); }
   if (0 != igraph_matrix_init(&c_res, 0, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -4173,7 +4173,7 @@ SEXP R_igraph_layout_bipartite(SEXP graph, SEXP types, SEXP hgap, SEXP vgap, SEX
   c_vgap=REAL(vgap)[0];
   c_maxiter=INTEGER(maxiter)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_layout_bipartite(&c_graph, (isNull(types) ? 0 : &c_types), &c_res, c_hgap, c_vgap, c_maxiter));
+  IGRAPH_R_CHECK(igraph_layout_bipartite(&c_graph, (Rf_isNull(types) ? 0 : &c_types), &c_res, c_hgap, c_vgap, c_maxiter));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_matrix_to_SEXP(&c_res));
@@ -4420,11 +4420,11 @@ SEXP R_igraph_modularity(SEXP graph, SEXP membership, SEXP weights, SEXP resolut
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
   R_SEXP_to_vector(membership, &c_membership);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_resolution=REAL(resolution)[0];
   c_directed=LOGICAL(directed)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_modularity(&c_graph, &c_membership, (isNull(weights) ? 0 : &c_weights), c_resolution, c_directed, &c_modularity));
+  IGRAPH_R_CHECK(igraph_modularity(&c_graph, &c_membership, (Rf_isNull(weights) ? 0 : &c_weights), c_resolution, c_directed, &c_modularity));
 
                                         /* Convert output */
   PROTECT(modularity=NEW_NUMERIC(1));
@@ -4450,7 +4450,7 @@ SEXP R_igraph_modularity_matrix(SEXP graph, SEXP weights, SEXP resolution, SEXP 
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_resolution=REAL(resolution)[0];
   if (0 != igraph_matrix_init(&c_modmat, 0, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
@@ -4458,7 +4458,7 @@ SEXP R_igraph_modularity_matrix(SEXP graph, SEXP weights, SEXP resolution, SEXP 
   IGRAPH_FINALLY(igraph_matrix_destroy, &c_modmat);
   c_directed=LOGICAL(directed)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_modularity_matrix(&c_graph, (isNull(weights) ? 0 : &c_weights), c_resolution, &c_modmat, c_directed));
+  IGRAPH_R_CHECK(igraph_modularity_matrix(&c_graph, (Rf_isNull(weights) ? 0 : &c_weights), c_resolution, &c_modmat, c_directed));
 
                                         /* Convert output */
   PROTECT(modmat=R_igraph_matrix_to_SEXP(&c_modmat));
@@ -4503,8 +4503,8 @@ SEXP R_igraph_community_fluid_communities(SEXP graph, SEXP no_of_communities) {
   REAL(modularity)[0]=c_modularity;
   SET_VECTOR_ELT(r_result, 0, membership);
   SET_VECTOR_ELT(r_result, 1, modularity);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("membership"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("modularity"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("membership"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("modularity"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -4533,11 +4533,11 @@ SEXP R_igraph_community_label_propagation(SEXP graph, SEXP weights, SEXP initial
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_membership);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
-  if (!isNull(initial)) { R_SEXP_to_vector(initial, &c_initial); }
-  if (!isNull(fixed)) { R_SEXP_to_vector_bool(fixed, &c_fixed); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(initial)) { R_SEXP_to_vector(initial, &c_initial); }
+  if (!Rf_isNull(fixed)) { R_SEXP_to_vector_bool(fixed, &c_fixed); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_community_label_propagation(&c_graph, &c_membership, (isNull(weights) ? 0 : &c_weights), (isNull(initial) ? 0 : &c_initial), (isNull(fixed) ? 0 : &c_fixed), &c_modularity));
+  IGRAPH_R_CHECK(igraph_community_label_propagation(&c_graph, &c_membership, (Rf_isNull(weights) ? 0 : &c_weights), (Rf_isNull(initial) ? 0 : &c_initial), (Rf_isNull(fixed) ? 0 : &c_fixed), &c_modularity));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -4549,8 +4549,8 @@ SEXP R_igraph_community_label_propagation(SEXP graph, SEXP weights, SEXP initial
   REAL(modularity)[0]=c_modularity;
   SET_VECTOR_ELT(r_result, 0, membership);
   SET_VECTOR_ELT(r_result, 1, modularity);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("membership"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("modularity"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("membership"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("modularity"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -4576,7 +4576,7 @@ SEXP R_igraph_community_multilevel(SEXP graph, SEXP weights, SEXP resolution) {
   SEXP r_result, r_names;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_resolution=REAL(resolution)[0];
   if (0 != igraph_vector_init(&c_membership, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
@@ -4593,7 +4593,7 @@ SEXP R_igraph_community_multilevel(SEXP graph, SEXP weights, SEXP resolution) {
   IGRAPH_FINALLY(igraph_vector_destroy, &c_modularity);
   modularity=R_GlobalEnv; /* hack to have a non-NULL value */
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_community_multilevel(&c_graph, (isNull(weights) ? 0 : &c_weights), c_resolution, &c_membership, (isNull(memberships) ? 0 : &c_memberships), (isNull(modularity) ? 0 : &c_modularity)));
+  IGRAPH_R_CHECK(igraph_community_multilevel(&c_graph, (Rf_isNull(weights) ? 0 : &c_weights), c_resolution, &c_membership, (Rf_isNull(memberships) ? 0 : &c_memberships), (Rf_isNull(modularity) ? 0 : &c_modularity)));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -4610,9 +4610,9 @@ SEXP R_igraph_community_multilevel(SEXP graph, SEXP weights, SEXP resolution) {
   SET_VECTOR_ELT(r_result, 0, membership);
   SET_VECTOR_ELT(r_result, 1, memberships);
   SET_VECTOR_ELT(r_result, 2, modularity);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("membership"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("memberships"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("modularity"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("membership"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("memberships"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("modularity"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -4640,9 +4640,9 @@ SEXP R_igraph_community_optimal_modularity(SEXP graph, SEXP weights) {
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_membership);
   membership=R_GlobalEnv; /* hack to have a non-NULL value */
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_community_optimal_modularity(&c_graph, &c_modularity, (isNull(membership) ? 0 : &c_membership), (isNull(weights) ? 0 : &c_weights)));
+  IGRAPH_R_CHECK(igraph_community_optimal_modularity(&c_graph, &c_modularity, (Rf_isNull(membership) ? 0 : &c_membership), (Rf_isNull(weights) ? 0 : &c_weights)));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -4654,8 +4654,8 @@ SEXP R_igraph_community_optimal_modularity(SEXP graph, SEXP weights) {
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, modularity);
   SET_VECTOR_ELT(r_result, 1, membership);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("modularity"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("membership"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("modularity"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("membership"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -4683,12 +4683,12 @@ SEXP R_igraph_community_leiden(SEXP graph, SEXP weights, SEXP vertex_weights, SE
   SEXP r_result, r_names;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
-  if (!isNull(vertex_weights)) { R_SEXP_to_vector(vertex_weights, &c_vertex_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(vertex_weights)) { R_SEXP_to_vector(vertex_weights, &c_vertex_weights); }
   c_resolution_parameter=REAL(resolution_parameter)[0];
   c_beta=REAL(beta)[0];
   c_start=LOGICAL(start)[0];
-  if (!isNull(membership)) {
+  if (!Rf_isNull(membership)) {
     if (0 != R_SEXP_to_vector_copy(membership, &c_membership)) {
       igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
     }
@@ -4701,7 +4701,7 @@ SEXP R_igraph_community_leiden(SEXP graph, SEXP weights, SEXP vertex_weights, SE
   membership=NEW_NUMERIC(0);
   c_nb_clusters=0;
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_community_leiden(&c_graph, (isNull(weights) ? 0 : &c_weights), (isNull(vertex_weights) ? 0 : &c_vertex_weights), c_resolution_parameter, c_beta, c_start, (isNull(membership) ? 0 : &c_membership), &c_nb_clusters, &c_quality));
+  IGRAPH_R_CHECK(igraph_community_leiden(&c_graph, (Rf_isNull(weights) ? 0 : &c_weights), (Rf_isNull(vertex_weights) ? 0 : &c_vertex_weights), c_resolution_parameter, c_beta, c_start, (Rf_isNull(membership) ? 0 : &c_membership), &c_nb_clusters, &c_quality));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -4716,9 +4716,9 @@ SEXP R_igraph_community_leiden(SEXP graph, SEXP weights, SEXP vertex_weights, SE
   SET_VECTOR_ELT(r_result, 0, membership);
   SET_VECTOR_ELT(r_result, 1, nb_clusters);
   SET_VECTOR_ELT(r_result, 2, quality);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("membership"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("nb_clusters"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("quality"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("membership"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("nb_clusters"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("quality"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -4756,8 +4756,8 @@ SEXP R_igraph_split_join_distance(SEXP comm1, SEXP comm2) {
   INTEGER(distance21)[0]=c_distance21;
   SET_VECTOR_ELT(r_result, 0, distance12);
   SET_VECTOR_ELT(r_result, 1, distance21);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("distance12"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("distance21"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("distance12"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("distance21"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -4898,9 +4898,9 @@ SEXP R_igraph_hrg_consensus(SEXP graph, SEXP hrg, SEXP start, SEXP num_samples) 
   SET_VECTOR_ELT(r_result, 0, parents);
   SET_VECTOR_ELT(r_result, 1, weights);
   SET_VECTOR_ELT(r_result, 2, hrg);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("parents"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("weights"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("hrg"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("parents"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("weights"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("hrg"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -4959,9 +4959,9 @@ SEXP R_igraph_hrg_predict(SEXP graph, SEXP hrg, SEXP start, SEXP num_samples, SE
   SET_VECTOR_ELT(r_result, 0, edges);
   SET_VECTOR_ELT(r_result, 1, prob);
   SET_VECTOR_ELT(r_result, 2, hrg);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("edges"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("prob"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("hrg"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("edges"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("prob"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("hrg"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -5017,15 +5017,15 @@ SEXP R_igraph_community_infomap(SEXP graph, SEXP e_weights, SEXP v_weights, SEXP
   SEXP r_result, r_names;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(e_weights)) { R_SEXP_to_vector(e_weights, &c_e_weights); }
-  if (!isNull(v_weights)) { R_SEXP_to_vector(v_weights, &c_v_weights); }
+  if (!Rf_isNull(e_weights)) { R_SEXP_to_vector(e_weights, &c_e_weights); }
+  if (!Rf_isNull(v_weights)) { R_SEXP_to_vector(v_weights, &c_v_weights); }
   c_nb_trials=INTEGER(nb_trials)[0];
   if (0 != igraph_vector_init(&c_membership, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_membership);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_community_infomap(&c_graph, (isNull(e_weights) ? 0 : &c_e_weights), (isNull(v_weights) ? 0 : &c_v_weights), c_nb_trials, &c_membership, &c_codelength));
+  IGRAPH_R_CHECK(igraph_community_infomap(&c_graph, (Rf_isNull(e_weights) ? 0 : &c_e_weights), (Rf_isNull(v_weights) ? 0 : &c_v_weights), c_nb_trials, &c_membership, &c_codelength));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -5037,8 +5037,8 @@ SEXP R_igraph_community_infomap(SEXP graph, SEXP e_weights, SEXP v_weights, SEXP
   REAL(codelength)[0]=c_codelength;
   SET_VECTOR_ELT(r_result, 0, membership);
   SET_VECTOR_ELT(r_result, 1, codelength);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("membership"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("codelength"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("membership"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("codelength"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -5195,9 +5195,9 @@ SEXP R_igraph_dyad_census(SEXP graph) {
   SET_VECTOR_ELT(r_result, 0, mut);
   SET_VECTOR_ELT(r_result, 1, asym);
   SET_VECTOR_ELT(r_result, 2, null);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("mut"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("asym"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("null"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("mut"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("asym"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("null"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -5284,10 +5284,10 @@ SEXP R_igraph_local_scan_0(SEXP graph, SEXP weights, SEXP mode) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_res);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_local_scan_0(&c_graph, &c_res, (isNull(weights) ? 0 : &c_weights), c_mode));
+  IGRAPH_R_CHECK(igraph_local_scan_0(&c_graph, &c_res, (Rf_isNull(weights) ? 0 : &c_weights), c_mode));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -5319,10 +5319,10 @@ SEXP R_igraph_local_scan_0_them(SEXP us, SEXP them, SEXP weights_them, SEXP mode
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_res);
-  if (!isNull(weights_them)) { R_SEXP_to_vector(weights_them, &c_weights_them); }
+  if (!Rf_isNull(weights_them)) { R_SEXP_to_vector(weights_them, &c_weights_them); }
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_local_scan_0_them(&c_us, &c_them, &c_res, (isNull(weights_them) ? 0 : &c_weights_them), c_mode));
+  IGRAPH_R_CHECK(igraph_local_scan_0_them(&c_us, &c_them, &c_res, (Rf_isNull(weights_them) ? 0 : &c_weights_them), c_mode));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -5352,10 +5352,10 @@ SEXP R_igraph_local_scan_1_ecount(SEXP graph, SEXP weights, SEXP mode) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_res);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_local_scan_1_ecount(&c_graph, &c_res, (isNull(weights) ? 0 : &c_weights), c_mode));
+  IGRAPH_R_CHECK(igraph_local_scan_1_ecount(&c_graph, &c_res, (Rf_isNull(weights) ? 0 : &c_weights), c_mode));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -5387,10 +5387,10 @@ SEXP R_igraph_local_scan_1_ecount_them(SEXP us, SEXP them, SEXP weights_them, SE
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_res);
-  if (!isNull(weights_them)) { R_SEXP_to_vector(weights_them, &c_weights_them); }
+  if (!Rf_isNull(weights_them)) { R_SEXP_to_vector(weights_them, &c_weights_them); }
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_local_scan_1_ecount_them(&c_us, &c_them, &c_res, (isNull(weights_them) ? 0 : &c_weights_them), c_mode));
+  IGRAPH_R_CHECK(igraph_local_scan_1_ecount_them(&c_us, &c_them, &c_res, (Rf_isNull(weights_them) ? 0 : &c_weights_them), c_mode));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -5422,10 +5422,10 @@ SEXP R_igraph_local_scan_k_ecount(SEXP graph, SEXP k, SEXP weights, SEXP mode) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_res);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_local_scan_k_ecount(&c_graph, c_k, &c_res, (isNull(weights) ? 0 : &c_weights), c_mode));
+  IGRAPH_R_CHECK(igraph_local_scan_k_ecount(&c_graph, c_k, &c_res, (Rf_isNull(weights) ? 0 : &c_weights), c_mode));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -5459,10 +5459,10 @@ SEXP R_igraph_local_scan_k_ecount_them(SEXP us, SEXP them, SEXP k, SEXP weights_
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_res);
-  if (!isNull(weights_them)) { R_SEXP_to_vector(weights_them, &c_weights_them); }
+  if (!Rf_isNull(weights_them)) { R_SEXP_to_vector(weights_them, &c_weights_them); }
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_local_scan_k_ecount_them(&c_us, &c_them, c_k, &c_res, (isNull(weights_them) ? 0 : &c_weights_them), c_mode));
+  IGRAPH_R_CHECK(igraph_local_scan_k_ecount_them(&c_us, &c_them, c_k, &c_res, (Rf_isNull(weights_them) ? 0 : &c_weights_them), c_mode));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -5492,10 +5492,10 @@ SEXP R_igraph_local_scan_neighborhood_ecount(SEXP graph, SEXP weights, SEXP neig
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_res);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
-  if (!isNull(neighborhoods)) { R_igraph_SEXP_to_vectorlist_int(neighborhoods, &c_neighborhoods); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(neighborhoods)) { R_igraph_SEXP_to_vectorlist_int(neighborhoods, &c_neighborhoods); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_local_scan_neighborhood_ecount(&c_graph, &c_res, (isNull(weights) ? 0 : &c_weights), &c_neighborhoods));
+  IGRAPH_R_CHECK(igraph_local_scan_neighborhood_ecount(&c_graph, &c_res, (Rf_isNull(weights) ? 0 : &c_weights), &c_neighborhoods));
 
                                         /* Convert output */
   PROTECT(res=R_igraph_vector_to_SEXP(&c_res));
@@ -5581,9 +5581,9 @@ SEXP R_igraph_maxflow(SEXP graph, SEXP source, SEXP target, SEXP capacity) {
   IGRAPH_FINALLY(igraph_vector_destroy, &c_partition2);
   c_source = (igraph_integer_t) REAL(source)[0];
   c_target = (igraph_integer_t) REAL(target)[0];
-  if (!isNull(capacity)) { R_SEXP_to_vector(capacity, &c_capacity); }
+  if (!Rf_isNull(capacity)) { R_SEXP_to_vector(capacity, &c_capacity); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_maxflow(&c_graph, &c_value, (isNull(flow) ? 0 : &c_flow), (isNull(cut) ? 0 : &c_cut), &c_partition1, &c_partition2, c_source, c_target, (isNull(capacity) ? 0 : &c_capacity), &c_stats));
+  IGRAPH_R_CHECK(igraph_maxflow(&c_graph, &c_value, (Rf_isNull(flow) ? 0 : &c_flow), (Rf_isNull(cut) ? 0 : &c_cut), &c_partition1, &c_partition2, c_source, c_target, (Rf_isNull(capacity) ? 0 : &c_capacity), &c_stats));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(6));
@@ -5609,12 +5609,12 @@ SEXP R_igraph_maxflow(SEXP graph, SEXP source, SEXP target, SEXP capacity) {
   SET_VECTOR_ELT(r_result, 3, partition1);
   SET_VECTOR_ELT(r_result, 4, partition2);
   SET_VECTOR_ELT(r_result, 5, stats);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("value"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("flow"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("cut"));
-  SET_STRING_ELT(r_names, 3, CREATE_STRING_VECTOR("partition1"));
-  SET_STRING_ELT(r_names, 4, CREATE_STRING_VECTOR("partition2"));
-  SET_STRING_ELT(r_names, 5, CREATE_STRING_VECTOR("stats"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("value"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("flow"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("cut"));
+  SET_STRING_ELT(r_names, 3, Rf_mkChar("partition1"));
+  SET_STRING_ELT(r_names, 4, Rf_mkChar("partition2"));
+  SET_STRING_ELT(r_names, 5, Rf_mkChar("stats"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(7);
 
@@ -5658,9 +5658,9 @@ SEXP R_igraph_st_mincut(SEXP graph, SEXP source, SEXP target, SEXP capacity) {
   IGRAPH_FINALLY(igraph_vector_destroy, &c_partition2);
   c_source = (igraph_integer_t) REAL(source)[0];
   c_target = (igraph_integer_t) REAL(target)[0];
-  if (!isNull(capacity)) { R_SEXP_to_vector(capacity, &c_capacity); }
+  if (!Rf_isNull(capacity)) { R_SEXP_to_vector(capacity, &c_capacity); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_st_mincut(&c_graph, &c_value, (isNull(cut) ? 0 : &c_cut), &c_partition1, &c_partition2, c_source, c_target, (isNull(capacity) ? 0 : &c_capacity)));
+  IGRAPH_R_CHECK(igraph_st_mincut(&c_graph, &c_value, (Rf_isNull(cut) ? 0 : &c_cut), &c_partition1, &c_partition2, c_source, c_target, (Rf_isNull(capacity) ? 0 : &c_capacity)));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(4));
@@ -5680,10 +5680,10 @@ SEXP R_igraph_st_mincut(SEXP graph, SEXP source, SEXP target, SEXP capacity) {
   SET_VECTOR_ELT(r_result, 1, cut);
   SET_VECTOR_ELT(r_result, 2, partition1);
   SET_VECTOR_ELT(r_result, 3, partition2);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("value"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("cut"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("partition1"));
-  SET_STRING_ELT(r_names, 3, CREATE_STRING_VECTOR("partition2"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("value"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("cut"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("partition1"));
+  SET_STRING_ELT(r_names, 3, Rf_mkChar("partition2"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(5);
 
@@ -5721,7 +5721,7 @@ SEXP R_igraph_dominator_tree(SEXP graph, SEXP root, SEXP mode) {
   IGRAPH_FINALLY(igraph_vector_destroy, &c_leftout);
   c_mode = (igraph_neimode_t) Rf_asInteger(mode);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_dominator_tree(&c_graph, c_root, &c_dom, (isNull(domtree) ? 0 : &c_domtree), &c_leftout, c_mode));
+  IGRAPH_R_CHECK(igraph_dominator_tree(&c_graph, c_root, &c_dom, (Rf_isNull(domtree) ? 0 : &c_domtree), &c_leftout, c_mode));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -5739,9 +5739,9 @@ SEXP R_igraph_dominator_tree(SEXP graph, SEXP root, SEXP mode) {
   SET_VECTOR_ELT(r_result, 0, dom);
   SET_VECTOR_ELT(r_result, 1, domtree);
   SET_VECTOR_ELT(r_result, 2, leftout);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("dom"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("domtree"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("leftout"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("dom"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("domtree"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("leftout"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -5789,8 +5789,8 @@ SEXP R_igraph_all_st_cuts(SEXP graph, SEXP source, SEXP target) {
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, cuts);
   SET_VECTOR_ELT(r_result, 1, partition1s);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("cuts"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("partition1s"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("cuts"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("partition1s"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -5827,9 +5827,9 @@ SEXP R_igraph_all_st_mincuts(SEXP graph, SEXP source, SEXP target, SEXP capacity
   IGRAPH_FINALLY(R_igraph_vectorlist_destroy, &c_partition1s);
   c_source = (igraph_integer_t) REAL(source)[0];
   c_target = (igraph_integer_t) REAL(target)[0];
-  if (!isNull(capacity)) { R_SEXP_to_vector(capacity, &c_capacity); }
+  if (!Rf_isNull(capacity)) { R_SEXP_to_vector(capacity, &c_capacity); }
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_all_st_mincuts(&c_graph, &c_value, &c_cuts, &c_partition1s, c_source, c_target, (isNull(capacity) ? 0 : &c_capacity)));
+  IGRAPH_R_CHECK(igraph_all_st_mincuts(&c_graph, &c_value, &c_cuts, &c_partition1s, c_source, c_target, (Rf_isNull(capacity) ? 0 : &c_capacity)));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -5845,9 +5845,9 @@ SEXP R_igraph_all_st_mincuts(SEXP graph, SEXP source, SEXP target, SEXP capacity
   SET_VECTOR_ELT(r_result, 0, value);
   SET_VECTOR_ELT(r_result, 1, cuts);
   SET_VECTOR_ELT(r_result, 2, partition1s);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("value"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("cuts"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("partition1s"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("value"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("cuts"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("partition1s"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -6100,10 +6100,10 @@ SEXP R_igraph_isomorphic_vf2(SEXP graph1, SEXP graph2, SEXP vertex_color1, SEXP 
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
-  if (!isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
-  if (!isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
-  if (!isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
+  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
+  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
+  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
+  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
   if (0 != igraph_vector_init(&c_map12, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -6115,7 +6115,7 @@ SEXP R_igraph_isomorphic_vf2(SEXP graph1, SEXP graph2, SEXP vertex_color1, SEXP 
   IGRAPH_FINALLY(igraph_vector_destroy, &c_map21);
   map21=R_GlobalEnv; /* hack to have a non-NULL value */
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_isomorphic_vf2(&c_graph1, &c_graph2, (isNull(vertex_color1) ? 0 : &c_vertex_color1), (isNull(vertex_color2) ? 0 : &c_vertex_color2), (isNull(edge_color1) ? 0 : &c_edge_color1), (isNull(edge_color2) ? 0 : &c_edge_color2), &c_iso, (isNull(map12) ? 0 : &c_map12), (isNull(map21) ? 0 : &c_map21), 0, 0, 0));
+  IGRAPH_R_CHECK(igraph_isomorphic_vf2(&c_graph1, &c_graph2, (Rf_isNull(vertex_color1) ? 0 : &c_vertex_color1), (Rf_isNull(vertex_color2) ? 0 : &c_vertex_color2), (Rf_isNull(edge_color1) ? 0 : &c_edge_color1), (Rf_isNull(edge_color2) ? 0 : &c_edge_color2), &c_iso, (Rf_isNull(map12) ? 0 : &c_map12), (Rf_isNull(map21) ? 0 : &c_map21), 0, 0, 0));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -6131,9 +6131,9 @@ SEXP R_igraph_isomorphic_vf2(SEXP graph1, SEXP graph2, SEXP vertex_color1, SEXP 
   SET_VECTOR_ELT(r_result, 0, iso);
   SET_VECTOR_ELT(r_result, 1, map12);
   SET_VECTOR_ELT(r_result, 2, map21);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("iso"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("map12"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("map21"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("iso"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("map12"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("map21"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -6162,13 +6162,13 @@ SEXP R_igraph_count_isomorphisms_vf2(SEXP graph1, SEXP graph2, SEXP vertex_color
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
-  if (!isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
-  if (!isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
-  if (!isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
+  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
+  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
+  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
+  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
   c_count=0;
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_count_isomorphisms_vf2(&c_graph1, &c_graph2, (isNull(vertex_color1) ? 0 : &c_vertex_color1), (isNull(vertex_color2) ? 0 : &c_vertex_color2), (isNull(edge_color1) ? 0 : &c_edge_color1), (isNull(edge_color2) ? 0 : &c_edge_color2), &c_count, 0, 0, 0));
+  IGRAPH_R_CHECK(igraph_count_isomorphisms_vf2(&c_graph1, &c_graph2, (Rf_isNull(vertex_color1) ? 0 : &c_vertex_color1), (Rf_isNull(vertex_color2) ? 0 : &c_vertex_color2), (Rf_isNull(edge_color1) ? 0 : &c_edge_color1), (Rf_isNull(edge_color2) ? 0 : &c_edge_color2), &c_count, 0, 0, 0));
 
                                         /* Convert output */
   PROTECT(count=NEW_INTEGER(1));
@@ -6200,16 +6200,16 @@ SEXP R_igraph_get_isomorphisms_vf2(SEXP graph1, SEXP graph2, SEXP vertex_color1,
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
-  if (!isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
-  if (!isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
-  if (!isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
+  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
+  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
+  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
+  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
   if (0 != igraph_vector_ptr_init(&c_maps, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(R_igraph_vectorlist_destroy, &c_maps);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_get_isomorphisms_vf2(&c_graph1, &c_graph2, (isNull(vertex_color1) ? 0 : &c_vertex_color1), (isNull(vertex_color2) ? 0 : &c_vertex_color2), (isNull(edge_color1) ? 0 : &c_edge_color1), (isNull(edge_color2) ? 0 : &c_edge_color2), &c_maps, 0, 0, 0));
+  IGRAPH_R_CHECK(igraph_get_isomorphisms_vf2(&c_graph1, &c_graph2, (Rf_isNull(vertex_color1) ? 0 : &c_vertex_color1), (Rf_isNull(vertex_color2) ? 0 : &c_vertex_color2), (Rf_isNull(edge_color1) ? 0 : &c_edge_color1), (Rf_isNull(edge_color2) ? 0 : &c_edge_color2), &c_maps, 0, 0, 0));
 
                                         /* Convert output */
   PROTECT(maps=R_igraph_vectorlist_to_SEXP(&c_maps));
@@ -6246,10 +6246,10 @@ SEXP R_igraph_subisomorphic_vf2(SEXP graph1, SEXP graph2, SEXP vertex_color1, SE
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
-  if (!isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
-  if (!isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
-  if (!isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
+  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
+  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
+  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
+  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
   if (0 != igraph_vector_init(&c_map12, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -6261,7 +6261,7 @@ SEXP R_igraph_subisomorphic_vf2(SEXP graph1, SEXP graph2, SEXP vertex_color1, SE
   IGRAPH_FINALLY(igraph_vector_destroy, &c_map21);
   map21=R_GlobalEnv; /* hack to have a non-NULL value */
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_subisomorphic_vf2(&c_graph1, &c_graph2, (isNull(vertex_color1) ? 0 : &c_vertex_color1), (isNull(vertex_color2) ? 0 : &c_vertex_color2), (isNull(edge_color1) ? 0 : &c_edge_color1), (isNull(edge_color2) ? 0 : &c_edge_color2), &c_iso, (isNull(map12) ? 0 : &c_map12), (isNull(map21) ? 0 : &c_map21), 0, 0, 0));
+  IGRAPH_R_CHECK(igraph_subisomorphic_vf2(&c_graph1, &c_graph2, (Rf_isNull(vertex_color1) ? 0 : &c_vertex_color1), (Rf_isNull(vertex_color2) ? 0 : &c_vertex_color2), (Rf_isNull(edge_color1) ? 0 : &c_edge_color1), (Rf_isNull(edge_color2) ? 0 : &c_edge_color2), &c_iso, (Rf_isNull(map12) ? 0 : &c_map12), (Rf_isNull(map21) ? 0 : &c_map21), 0, 0, 0));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -6277,9 +6277,9 @@ SEXP R_igraph_subisomorphic_vf2(SEXP graph1, SEXP graph2, SEXP vertex_color1, SE
   SET_VECTOR_ELT(r_result, 0, iso);
   SET_VECTOR_ELT(r_result, 1, map12);
   SET_VECTOR_ELT(r_result, 2, map21);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("iso"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("map12"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("map21"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("iso"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("map12"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("map21"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -6308,13 +6308,13 @@ SEXP R_igraph_count_subisomorphisms_vf2(SEXP graph1, SEXP graph2, SEXP vertex_co
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
-  if (!isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
-  if (!isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
-  if (!isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
+  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
+  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
+  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
+  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
   c_count=0;
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_count_subisomorphisms_vf2(&c_graph1, &c_graph2, (isNull(vertex_color1) ? 0 : &c_vertex_color1), (isNull(vertex_color2) ? 0 : &c_vertex_color2), (isNull(edge_color1) ? 0 : &c_edge_color1), (isNull(edge_color2) ? 0 : &c_edge_color2), &c_count, 0, 0, 0));
+  IGRAPH_R_CHECK(igraph_count_subisomorphisms_vf2(&c_graph1, &c_graph2, (Rf_isNull(vertex_color1) ? 0 : &c_vertex_color1), (Rf_isNull(vertex_color2) ? 0 : &c_vertex_color2), (Rf_isNull(edge_color1) ? 0 : &c_edge_color1), (Rf_isNull(edge_color2) ? 0 : &c_edge_color2), &c_count, 0, 0, 0));
 
                                         /* Convert output */
   PROTECT(count=NEW_INTEGER(1));
@@ -6346,16 +6346,16 @@ SEXP R_igraph_get_subisomorphisms_vf2(SEXP graph1, SEXP graph2, SEXP vertex_colo
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
-  if (!isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
-  if (!isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
-  if (!isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
+  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
+  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
+  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
+  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
   if (0 != igraph_vector_ptr_init(&c_maps, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(R_igraph_vectorlist_destroy, &c_maps);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_get_subisomorphisms_vf2(&c_graph1, &c_graph2, (isNull(vertex_color1) ? 0 : &c_vertex_color1), (isNull(vertex_color2) ? 0 : &c_vertex_color2), (isNull(edge_color1) ? 0 : &c_edge_color1), (isNull(edge_color2) ? 0 : &c_edge_color2), &c_maps, 0, 0, 0));
+  IGRAPH_R_CHECK(igraph_get_subisomorphisms_vf2(&c_graph1, &c_graph2, (Rf_isNull(vertex_color1) ? 0 : &c_vertex_color1), (Rf_isNull(vertex_color2) ? 0 : &c_vertex_color2), (Rf_isNull(edge_color1) ? 0 : &c_edge_color1), (Rf_isNull(edge_color2) ? 0 : &c_edge_color2), &c_maps, 0, 0, 0));
 
                                         /* Convert output */
   PROTECT(maps=R_igraph_vectorlist_to_SEXP(&c_maps));
@@ -6409,14 +6409,14 @@ SEXP R_igraph_canonical_permutation(SEXP graph, SEXP colors, SEXP sh) {
   SEXP r_result, r_names;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(colors)) { R_SEXP_to_vector_int(colors, &c_colors); }
+  if (!Rf_isNull(colors)) { R_SEXP_to_vector_int(colors, &c_colors); }
   if (0 != igraph_vector_init(&c_labeling, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_labeling);
   c_sh = (igraph_bliss_sh_t) Rf_asInteger(sh);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_canonical_permutation(&c_graph, (isNull(colors) ? 0 : &c_colors), &c_labeling, c_sh, &c_info));
+  IGRAPH_R_CHECK(igraph_canonical_permutation(&c_graph, (Rf_isNull(colors) ? 0 : &c_colors), &c_labeling, c_sh, &c_info));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -6428,8 +6428,8 @@ SEXP R_igraph_canonical_permutation(SEXP graph, SEXP colors, SEXP sh) {
   if (c_info.group_size) { free(c_info.group_size); }
   SET_VECTOR_ELT(r_result, 0, labeling);
   SET_VECTOR_ELT(r_result, 1, info);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("labeling"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("info"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("labeling"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("info"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -6490,8 +6490,8 @@ SEXP R_igraph_isomorphic_bliss(SEXP graph1, SEXP graph2, SEXP colors1, SEXP colo
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!isNull(colors1)) { R_SEXP_to_vector_int(colors1, &c_colors1); }
-  if (!isNull(colors2)) { R_SEXP_to_vector_int(colors2, &c_colors2); }
+  if (!Rf_isNull(colors1)) { R_SEXP_to_vector_int(colors1, &c_colors1); }
+  if (!Rf_isNull(colors2)) { R_SEXP_to_vector_int(colors2, &c_colors2); }
   if (0 != igraph_vector_init(&c_map12, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -6504,7 +6504,7 @@ SEXP R_igraph_isomorphic_bliss(SEXP graph1, SEXP graph2, SEXP colors1, SEXP colo
   map21=R_GlobalEnv; /* hack to have a non-NULL value */
   c_sh = (igraph_bliss_sh_t) Rf_asInteger(sh);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_isomorphic_bliss(&c_graph1, &c_graph2, (isNull(colors1) ? 0 : &c_colors1), (isNull(colors2) ? 0 : &c_colors2), &c_iso, (isNull(map12) ? 0 : &c_map12), (isNull(map21) ? 0 : &c_map21), c_sh, &c_info1, &c_info2));
+  IGRAPH_R_CHECK(igraph_isomorphic_bliss(&c_graph1, &c_graph2, (Rf_isNull(colors1) ? 0 : &c_colors1), (Rf_isNull(colors2) ? 0 : &c_colors2), &c_iso, (Rf_isNull(map12) ? 0 : &c_map12), (Rf_isNull(map21) ? 0 : &c_map21), c_sh, &c_info1, &c_info2));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(5));
@@ -6526,11 +6526,11 @@ SEXP R_igraph_isomorphic_bliss(SEXP graph1, SEXP graph2, SEXP colors1, SEXP colo
   SET_VECTOR_ELT(r_result, 2, map21);
   SET_VECTOR_ELT(r_result, 3, info1);
   SET_VECTOR_ELT(r_result, 4, info2);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("iso"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("map12"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("map21"));
-  SET_STRING_ELT(r_names, 3, CREATE_STRING_VECTOR("info1"));
-  SET_STRING_ELT(r_names, 4, CREATE_STRING_VECTOR("info2"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("iso"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("map12"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("map21"));
+  SET_STRING_ELT(r_names, 3, Rf_mkChar("info1"));
+  SET_STRING_ELT(r_names, 4, Rf_mkChar("info2"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(6);
 
@@ -6552,10 +6552,10 @@ SEXP R_igraph_automorphisms(SEXP graph, SEXP colors, SEXP sh) {
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(colors)) { R_SEXP_to_vector_int(colors, &c_colors); }
+  if (!Rf_isNull(colors)) { R_SEXP_to_vector_int(colors, &c_colors); }
   c_sh = (igraph_bliss_sh_t) Rf_asInteger(sh);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_automorphisms(&c_graph, (isNull(colors) ? 0 : &c_colors), c_sh, &c_info));
+  IGRAPH_R_CHECK(igraph_automorphisms(&c_graph, (Rf_isNull(colors) ? 0 : &c_colors), c_sh, &c_info));
 
                                         /* Convert output */
   PROTECT(info=R_igraph_bliss_info_to_SEXP(&c_info));
@@ -6582,14 +6582,14 @@ SEXP R_igraph_automorphism_group(SEXP graph, SEXP colors, SEXP sh) {
   SEXP r_result, r_names;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(colors)) { R_SEXP_to_vector_int(colors, &c_colors); }
+  if (!Rf_isNull(colors)) { R_SEXP_to_vector_int(colors, &c_colors); }
   if (0 != igraph_vector_ptr_init(&c_generators, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(R_igraph_vectorlist_destroy, &c_generators);
   c_sh = (igraph_bliss_sh_t) Rf_asInteger(sh);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_automorphism_group(&c_graph, (isNull(colors) ? 0 : &c_colors), &c_generators, c_sh, &c_info));
+  IGRAPH_R_CHECK(igraph_automorphism_group(&c_graph, (Rf_isNull(colors) ? 0 : &c_colors), &c_generators, c_sh, &c_info));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(2));
@@ -6601,8 +6601,8 @@ SEXP R_igraph_automorphism_group(SEXP graph, SEXP colors, SEXP sh) {
   if (c_info.group_size) { free(c_info.group_size); }
   SET_VECTOR_ELT(r_result, 0, generators);
   SET_VECTOR_ELT(r_result, 1, info);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("generators"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("info"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("generators"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("info"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -6653,9 +6653,9 @@ SEXP R_igraph_simplify_and_colorize(SEXP graph) {
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, vertex_color);
   SET_VECTOR_ELT(r_result, 2, edge_color);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("vertex_color"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("edge_color"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("vertex_color"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("edge_color"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -6686,13 +6686,13 @@ SEXP R_igraph_scg_grouping(SEXP V, SEXP nt, SEXP nt_vec, SEXP mtype, SEXP algo, 
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_groups);
   c_nt=INTEGER(nt)[0];
-  if (!isNull(nt_vec)) { R_SEXP_to_vector(nt_vec, &c_nt_vec); }
+  if (!Rf_isNull(nt_vec)) { R_SEXP_to_vector(nt_vec, &c_nt_vec); }
   c_mtype = (igraph_scg_matrix_t) Rf_asInteger(mtype);
   c_algo = (igraph_scg_algorithm_t) Rf_asInteger(algo);
-  if (!isNull(p)) { R_SEXP_to_vector(p, &c_p); }
+  if (!Rf_isNull(p)) { R_SEXP_to_vector(p, &c_p); }
   c_maxiter=INTEGER(maxiter)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_scg_grouping(&c_V, &c_groups, c_nt, (isNull(nt_vec) ? 0 : &c_nt_vec), c_mtype, c_algo, (isNull(p) ? 0 : &c_p), c_maxiter));
+  IGRAPH_R_CHECK(igraph_scg_grouping(&c_V, &c_groups, c_nt, (Rf_isNull(nt_vec) ? 0 : &c_nt_vec), c_mtype, c_algo, (Rf_isNull(p) ? 0 : &c_p), c_maxiter));
 
                                         /* Convert output */
   PROTECT(groups=R_igraph_vector_to_SEXPp1(&c_groups));
@@ -6726,10 +6726,10 @@ SEXP R_igraph_scg_norm_eps(SEXP V, SEXP groups, SEXP mtype, SEXP p, SEXP norm) {
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_eps);
   c_mtype = (igraph_scg_matrix_t) Rf_asInteger(mtype);
-  if (!isNull(p)) { R_SEXP_to_vector(p, &c_p); }
+  if (!Rf_isNull(p)) { R_SEXP_to_vector(p, &c_p); }
   c_norm = (igraph_scg_norm_t) Rf_asInteger(norm);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_scg_norm_eps(&c_V, &c_groups, &c_eps, c_mtype, (isNull(p) ? 0 : &c_p), c_norm));
+  IGRAPH_R_CHECK(igraph_scg_norm_eps(&c_V, &c_groups, &c_eps, c_mtype, (Rf_isNull(p) ? 0 : &c_p), c_norm));
 
                                         /* Convert output */
   PROTECT(eps=R_igraph_vector_to_SEXP(&c_eps));
@@ -6755,10 +6755,10 @@ SEXP R_igraph_is_matching(SEXP graph, SEXP types, SEXP matching) {
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(types)) { R_SEXP_to_vector_bool(types, &c_types); }
+  if (!Rf_isNull(types)) { R_SEXP_to_vector_bool(types, &c_types); }
   R_SEXP_to_vector_long_copy(matching, &c_matching);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_is_matching(&c_graph, (isNull(types) ? 0 : &c_types), &c_matching, &c_res));
+  IGRAPH_R_CHECK(igraph_is_matching(&c_graph, (Rf_isNull(types) ? 0 : &c_types), &c_matching, &c_res));
 
                                         /* Convert output */
   igraph_vector_long_destroy(&c_matching);
@@ -6784,10 +6784,10 @@ SEXP R_igraph_is_maximal_matching(SEXP graph, SEXP types, SEXP matching) {
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(types)) { R_SEXP_to_vector_bool(types, &c_types); }
+  if (!Rf_isNull(types)) { R_SEXP_to_vector_bool(types, &c_types); }
   R_SEXP_to_vector_long_copy(matching, &c_matching);
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_is_maximal_matching(&c_graph, (isNull(types) ? 0 : &c_types), &c_matching, &c_res));
+  IGRAPH_R_CHECK(igraph_is_maximal_matching(&c_graph, (Rf_isNull(types) ? 0 : &c_types), &c_matching, &c_res));
 
                                         /* Convert output */
   igraph_vector_long_destroy(&c_matching);
@@ -6818,16 +6818,16 @@ SEXP R_igraph_maximum_bipartite_matching(SEXP graph, SEXP types, SEXP weights, S
   SEXP r_result, r_names;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!isNull(types)) { R_SEXP_to_vector_bool(types, &c_types); }
+  if (!Rf_isNull(types)) { R_SEXP_to_vector_bool(types, &c_types); }
   c_matching_size=0;
   if (0 != igraph_vector_long_init(&c_matching, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_vector_long_destroy, &c_matching);
-  if (!isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
+  if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
   c_eps=REAL(eps)[0];
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_maximum_bipartite_matching(&c_graph, (isNull(types) ? 0 : &c_types), &c_matching_size, &c_matching_weight, &c_matching, (isNull(weights) ? 0 : &c_weights), c_eps));
+  IGRAPH_R_CHECK(igraph_maximum_bipartite_matching(&c_graph, (Rf_isNull(types) ? 0 : &c_types), &c_matching_size, &c_matching_weight, &c_matching, (Rf_isNull(weights) ? 0 : &c_weights), c_eps));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(3));
@@ -6842,9 +6842,9 @@ SEXP R_igraph_maximum_bipartite_matching(SEXP graph, SEXP types, SEXP weights, S
   SET_VECTOR_ELT(r_result, 0, matching_size);
   SET_VECTOR_ELT(r_result, 1, matching_weight);
   SET_VECTOR_ELT(r_result, 2, matching);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("matching_size"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("matching_weight"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("matching"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("matching_size"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("matching_weight"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("matching"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(4);
 
@@ -6896,7 +6896,7 @@ SEXP R_igraph_eigen_adjacency(SEXP graph, SEXP algorithm, SEXP which, SEXP optio
   IGRAPH_FINALLY(igraph_matrix_complex_destroy, &c_cmplxvectors);
   cmplxvectors=R_GlobalEnv; /* hack to have a non-NULL value */
                                         /* Call igraph */
-  IGRAPH_R_CHECK(igraph_eigen_adjacency(&c_graph, c_algorithm, &c_which, &c_options, 0, &c_values, &c_vectors, (isNull(cmplxvalues) ? 0 : &c_cmplxvalues), (isNull(cmplxvectors) ? 0 : &c_cmplxvectors)));
+  IGRAPH_R_CHECK(igraph_eigen_adjacency(&c_graph, c_algorithm, &c_which, &c_options, 0, &c_values, &c_vectors, (Rf_isNull(cmplxvalues) ? 0 : &c_cmplxvalues), (Rf_isNull(cmplxvectors) ? 0 : &c_cmplxvectors)));
 
                                         /* Convert output */
   PROTECT(r_result=NEW_LIST(5));
@@ -6919,11 +6919,11 @@ SEXP R_igraph_eigen_adjacency(SEXP graph, SEXP algorithm, SEXP which, SEXP optio
   SET_VECTOR_ELT(r_result, 2, vectors);
   SET_VECTOR_ELT(r_result, 3, cmplxvalues);
   SET_VECTOR_ELT(r_result, 4, cmplxvectors);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("options"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("values"));
-  SET_STRING_ELT(r_names, 2, CREATE_STRING_VECTOR("vectors"));
-  SET_STRING_ELT(r_names, 3, CREATE_STRING_VECTOR("cmplxvalues"));
-  SET_STRING_ELT(r_names, 4, CREATE_STRING_VECTOR("cmplxvectors"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("options"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("values"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("vectors"));
+  SET_STRING_ELT(r_names, 3, Rf_mkChar("cmplxvalues"));
+  SET_STRING_ELT(r_names, 4, Rf_mkChar("cmplxvectors"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(6);
 
@@ -7029,8 +7029,8 @@ SEXP R_igraph_convex_hull(SEXP data) {
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, resverts);
   SET_VECTOR_ELT(r_result, 1, rescoords);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("resverts"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("rescoords"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("resverts"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("rescoords"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -7089,8 +7089,8 @@ SEXP R_igraph_is_eulerian(SEXP graph) {
   LOGICAL(has_cycle)[0]=c_has_cycle;
   SET_VECTOR_ELT(r_result, 0, has_path);
   SET_VECTOR_ELT(r_result, 1, has_cycle);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("has_path"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("has_cycle"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("has_path"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("has_cycle"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -7134,8 +7134,8 @@ SEXP R_igraph_eulerian_path(SEXP graph) {
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, edge_res);
   SET_VECTOR_ELT(r_result, 1, vertex_res);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("epath"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("vpath"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("epath"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("vpath"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -7179,8 +7179,8 @@ SEXP R_igraph_eulerian_cycle(SEXP graph) {
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, edge_res);
   SET_VECTOR_ELT(r_result, 1, vertex_res);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("epath"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("vpath"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("epath"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("vpath"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 
@@ -7217,8 +7217,8 @@ SEXP R_igraph_is_tree(SEXP graph, SEXP mode) {
   INTEGER(root)[0] = c_root + 1;
   SET_VECTOR_ELT(r_result, 0, res);
   SET_VECTOR_ELT(r_result, 1, root);
-  SET_STRING_ELT(r_names, 0, CREATE_STRING_VECTOR("res"));
-  SET_STRING_ELT(r_names, 1, CREATE_STRING_VECTOR("root"));
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("root"));
   SET_NAMES(r_result, r_names);
   UNPROTECT(3);
 

--- a/src/rinterface.c
+++ b/src/rinterface.c
@@ -26,6 +26,9 @@
 
 #include "config.h"
 
+// Require R_ and Rf_ prefixes for R API
+#define R_NO_REMAP
+
 #include <R.h>
 #include <Rinternals.h>
 #include <Rdefines.h>

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -26,6 +26,9 @@
 
 #include "config.h"
 
+// Require R_ and Rf_ prefixes for R API
+#define R_NO_REMAP
+
 #include <R.h>
 #include <Rinternals.h>
 #include <Rdefines.h>

--- a/src/rrandom.c
+++ b/src/rrandom.c
@@ -20,6 +20,9 @@
 
 */
 
+// Require R_ and Rf_ prefixes for R API
+#define R_NO_REMAP
+
 #include <Rmath.h>
 
 #include "igraph_random.h"


### PR DESCRIPTION
to have clean `Rf_` and `R_` prefixes for R API calls.