### PR TITLE
fix: Use longjmp by default in functions called from the top level

### DIFF
--- a/src/rinterface.h
+++ b/src/rinterface.h
@@ -28,12 +28,15 @@
 
 SEXP R_igraph_add_env(SEXP graph);
 
+void R_igraph_set_in_r_check(int set);
 void R_igraph_error();
 void R_igraph_warning();
 
 #define IGRAPH_R_CHECK(func) \
     do { \
+        R_igraph_set_in_r_check(1); \
         igraph_error_type_t __c = func; \
+        R_igraph_set_in_r_check(0); \
         R_igraph_warning(); \
         if (__c != IGRAPH_SUCCESS) { R_igraph_error(); } \
     } while (0)

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -2435,14 +2435,15 @@ void R_igraph_error_handler(const char *reason, const char *file,
    * IGRAPH_FINALLY_FREE() because 'reason' might be allocated on the heap and
    * IGRAPH_FINALLY_FREE() can then clean it up. */
 
-  if (R_igraph_errors_count == 0 || R_igraph_in_r_check != 0) {
+  if (R_igraph_errors_count == 0 || R_igraph_in_r_check == 0) {
     snprintf(R_igraph_error_reason, sizeof(R_igraph_error_reason),
       "At %s:%i : %s%s %s", file, line, reason,
       maybe_add_punctuation(reason, ","),
       igraph_strerror(igraph_errno));
     R_igraph_error_reason[sizeof(R_igraph_error_reason) - 1] = 0;
 
-    if (R_igraph_in_r_check != 0) {
+    if (R_igraph_in_r_check == 0) {
+      IGRAPH_FINALLY_FREE();
       R_igraph_error();
     }
   }

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -2380,6 +2380,12 @@ static int R_igraph_errors_count = 0;
 static char R_igraph_warning_reason[4096];
 static int R_igraph_warnings_count = 0;
 
+static int R_igraph_in_r_check = 0;
+
+void R_igraph_set_in_r_check(int set) {
+  R_igraph_in_r_check = set;
+}
+
 void R_igraph_error() {
   R_igraph_errors_count = 0;
   Rf_error("%s", R_igraph_error_reason);
@@ -2429,12 +2435,16 @@ void R_igraph_error_handler(const char *reason, const char *file,
    * IGRAPH_FINALLY_FREE() because 'reason' might be allocated on the heap and
    * IGRAPH_FINALLY_FREE() can then clean it up. */
 
-  if (R_igraph_errors_count == 0) {
+  if (R_igraph_errors_count == 0 || R_igraph_in_r_check != 0) {
     snprintf(R_igraph_error_reason, sizeof(R_igraph_error_reason),
       "At %s:%i : %s%s %s", file, line, reason,
       maybe_add_punctuation(reason, ","),
       igraph_strerror(igraph_errno));
     R_igraph_error_reason[sizeof(R_igraph_error_reason) - 1] = 0;
+
+    if (R_igraph_in_r_check != 0) {
+      R_igraph_error();
+    }
   }
   R_igraph_errors_count++;
 


### PR DESCRIPTION
This restores the behavior of the current CRAN version. It's also somewhat safe to longjmp if we're not very deep into the call stack.