### PR TITLE
chore: Use true vertex names for printing vertex sets. If a vertex set captures a relationship between vertices (e.g., the `father` component of `bfs()`), the vertex set is printed as a named vector

### DIFF
--- a/R/iterators.R
+++ b/R/iterators.R
@@ -1262,13 +1262,18 @@ print.igraph.vs <- function(x,
                             id = igraph_opt("print.id"),
                             ...) {
   graph <- get_vs_graph(x)
+  if (!is.null(graph)) {
+    vertices <- V(graph)
+  } else {
+    vertices <- NULL
+  }
   len <- length(x)
   gid <- graph_id(x)
 
   title <- "+ " %+% chr(len) %+% "/" %+%
-    (if (is.null(graph)) "?" else chr(vcount(graph))) %+%
+    (if (is.null(vertices)) "?" else chr(length(vertices))) %+%
     (if (len == 1) " vertex" else " vertices") %+%
-    (if (!is.null(names(x))) ", named" else "") %+%
+    (if (!is.null(names(vertices))) ", named" else "") %+%
     (if (isTRUE(id) && !is.na(gid)) paste(", from", substr(gid, 1, 7)) else "") %+%
     (if (is.null(graph)) " (deleted)" else "") %+%
     ":\n"
@@ -1288,7 +1293,14 @@ print.igraph.vs <- function(x,
   } else {
     ## Single bracket
 
-    x2 <- if (!is.null(names(x))) names(x) else as.vector(x)
+    if (!is.null(names(vertices))) {
+      x2 <- names(vertices)[as.vector(x)]
+      if (!is.null(names(x)) && !identical(names(x), x2)) {
+        names(x2) <- names(x)
+      }
+    } else {
+      x2 <- as.vector(x)
+    }
     if (length(x2)) {
       if (is.logical(full) && full) {
         print(x2, quote = FALSE)

--- a/tests/testthat/_snaps/graph.bfs.md
+++ b/tests/testthat/_snaps/graph.bfs.md
@@ -21,15 +21,18 @@
       
       $father
       + 3/3 vertices, named:
-      [1] a b c
+         a    b    c 
+      <NA> <NA>    b 
       
       $pred
       + 3/3 vertices, named:
-      [1] a b c
+         a    b    c 
+      <NA> <NA>    b 
       
       $succ
       + 3/3 vertices, named:
-      [1] a b c
+         a    b    c 
+      <NA>    c <NA> 
       
       $dist
         a   b   c 

--- a/tests/testthat/_snaps/vs-es.md
+++ b/tests/testthat/_snaps/vs-es.md
@@ -84,8 +84,8 @@
     Code
       vs
     Output
-      + 10/? vertices, named (deleted):
-       [1] a b c d e f g h i j
+      + 10/? vertices (deleted):
+       [1]  1  2  3  4  5  6  7  8  9 10
     Code
       es
     Output


### PR DESCRIPTION
Closes #227. Closes #228.