### PR TITLE
fix: `identical_graphs()` now correctly detects identical graphs without node or edge attributes

### DIFF
--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -379,7 +379,10 @@ int R_igraph_attribute_init(igraph_t *graph, igraph_vector_ptr_t *attr) {
   // Adding to that list ensures that the attributes aren't GC-ed prematurely.
   R_igraph_attribute_add_to_preserve_list(result);
   for (i=1; i<3; i++) {
-    SET_VECTOR_ELT(result, i+1, NEW_LIST(0)); /* gal, val, eal */
+    SEXP attr = PROTECT(NEW_LIST(0));
+    SET_NAMES(attr, NEW_CHARACTER(0));
+    SET_VECTOR_ELT(result, i+1, attr); /* gal, val, eal */
+    UNPROTECT(1);
   }
   graph->attr=result;
 

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -97,8 +97,8 @@ test_that("we can query all attributes at once", {
   g <- make_graph(c(1, 2, 1, 3, 2, 4))
 
   expect_equal(graph_attr(g), structure(list(), .Names = character(0)))
-  expect_equal(vertex_attr(g), list())
-  expect_equal(edge_attr(g), list())
+  expect_equal(unname(vertex_attr(g)), list())
+  expect_equal(unname(edge_attr(g)), list())
 
   g$name <- "toy"
   g$layout <- cbind(1:4, 1:4)

--- a/tests/testthat/test-constructor-modifiers.R
+++ b/tests/testthat/test-constructor-modifiers.R
@@ -113,3 +113,18 @@ test_that("with_graph_", {
   expect_equal(g$color, g2$color)
   expect_equal(g$foo, g2$foo)
 })
+
+
+test_that("adding and removing attributes", {
+  g <- make_empty_graph()
+  g2 <- make_empty_graph()
+
+  g$foo <- "bar"
+  g <- delete_graph_attr(g, "foo")
+  E(g)$foo <- "bar"
+  g <- delete_edge_attr(g, "foo")
+  V(g)$foo <- "bar"
+  g <- delete_vertex_attr(g, "foo")
+
+  expect_true(identical_graphs(g, g2))
+})


### PR DESCRIPTION
Closes #756.