### PR TITLE
docs: add DOI to CITATION

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -13,14 +13,33 @@ note <- sprintf("R package version %s", meta$Version)
 year <- format(Sys.Date(), "%Y")
 authors <- meta$`Authors@R`
 authors <- utils:::.read_authors_at_R_field(authors)
-authors <- Filter(function(e) {!(is.null(e$given) && is.null(e$family)) && !is.na(match("aut", e$role))}, authors)
+authors <- Filter(function(e) {
+  !(is.null(e$given) && is.null(e$family)) && !is.na(match("aut", e$role))
+}, authors)
 authors <- format(authors, include = c("given", "family"))
-# TODO fix abbreviation of Szabolcs' name
-authors <- paste(paste(head(authors, -1L), collapse = ", "), tail(authors, 1L), sep = " and ")
-bibentry(bibtype = "Manual",
-         title = "{igraph}: Network Analysis and Visualization in R",
-         author = authors,
-         year = year,
-         note = note,
-         doi = "10.5281/zenodo.7682609",
-	 url = "https://CRAN.R-project.org/package=igraph")
+
+# Step 1: Get text citation and replace there the abb.
+entry_for_txt <- format(bibentry(
+  bibtype = "Manual",
+  title = "{igraph}: Network Analysis and Visualization in R",
+  author = authors,
+  year = year,
+  note = note,
+  doi = "10.5281/zenodo.7682609",
+  url = "https://CRAN.R-project.org/package=igraph"
+), style = "text")
+
+txt <- gsub("Horvát S", "Horvát Sz", entry_for_txt)
+
+aut_new <- sub("Szabolcs", "{\\\\relax Sz}abolcs", authors)
+
+bibentry(
+  bibtype = "Manual",
+  title = "{igraph}: Network Analysis and Visualization in R",
+  author = aut_new,
+  year = year,
+  note = note,
+  doi = "10.5281/zenodo.7682609",
+  url = "https://CRAN.R-project.org/package=igraph",
+  textVersion = txt
+)

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -8,7 +8,6 @@ bibentry(bibtype="Article",
          year=2006,
          url="https://igraph.org")
 
-year <- sub("-.*", "", meta$Date)
 note <- sprintf("R package version %s", meta$Version)
 # https://github.com/cran/lidR/blob/f0dae39007c9d174f6e1962ff236fd8826f1501d/inst/CITATION#L21
 year <- format(Sys.Date(), "%Y")
@@ -16,6 +15,8 @@ authors <- meta$`Authors@R`
 authors <- utils:::.read_authors_at_R_field(authors)
 authors <- Filter(function(e) {!(is.null(e$given) && is.null(e$family)) && !is.na(match("aut", e$role))}, authors)
 authors <- format(authors, include = c("given", "family"))
+# fix abbreviation of Szabolcs' name
+authors <- sub("Szabolcs", "{S} zabolcs", authors)
 authors <- paste(paste(head(authors, -1L), collapse = ", "), tail(authors, 1L), sep = " and ")
 bibentry(bibtype = "Manual",
          title = "{igraph}: Network Analysis and Visualization in R",

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -8,3 +8,19 @@ bibentry(bibtype="Article",
          year=2006,
          url="https://igraph.org")
 
+year <- sub("-.*", "", meta$Date)
+note <- sprintf("R package version %s", meta$Version)
+# https://github.com/cran/lidR/blob/f0dae39007c9d174f6e1962ff236fd8826f1501d/inst/CITATION#L21
+year <- format(Sys.Date(), "%Y")
+authors <- meta$`Authors@R`
+authors <- utils:::.read_authors_at_R_field(authors)
+authors <- Filter(function(e) {!(is.null(e$given) && is.null(e$family)) && !is.na(match("aut", e$role))}, authors)
+authors <- format(authors, include = c("given", "family"))
+authors <- paste(paste(head(authors, -1L), collapse = ", "), tail(authors, 1L), sep = " and ")
+bibentry(bibtype = "Manual",
+         title = "{igraph}: Network Analysis and Visualization in R",
+         author = authors,
+         year = year,
+         note = note,
+         doi = "10.5281/zenodo.7682609",
+	 url = "https://CRAN.R-project.org/package=igraph")

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -15,8 +15,7 @@ authors <- meta$`Authors@R`
 authors <- utils:::.read_authors_at_R_field(authors)
 authors <- Filter(function(e) {!(is.null(e$given) && is.null(e$family)) && !is.na(match("aut", e$role))}, authors)
 authors <- format(authors, include = c("given", "family"))
-# fix abbreviation of Szabolcs' name
-authors <- sub("Szabolcs", "{S} zabolcs", authors)
+# TODO fix abbreviation of Szabolcs' name
 authors <- paste(paste(head(authors, -1L), collapse = ", "), tail(authors, 1L), sep = " and ")
 bibentry(bibtype = "Manual",
          title = "{igraph}: Network Analysis and Visualization in R",


### PR DESCRIPTION
Fix #711 
The package whose citation I used as example is GPL-3 licenced https://github.com/cran/lidR/blob/f0dae39007c9d174f6e1962ff236fd8826f1501d/DESCRIPTION#L22

``` r
citation("igraph")
#> 
#> To cite 'igraph' in publications use:
#> 
#>   Csardi G, Nepusz T (2006). "The igraph software package for complex
#>   network research." _InterJournal_, *Complex Systems*, 1695.
#>   <https://igraph.org>.
#> 
#> Csárdi G, Nepusz T, Traag V, Horvát S, Zanini F, Noom D, Müller K
#> (2023). _igraph: Network Analysis and Visualization in R_.
#> doi:10.5281/zenodo.7682609 <https://doi.org/10.5281/zenodo.7682609>, R
#> package version 1.4.99.9002,
#> <https://CRAN.R-project.org/package=igraph>.
#> 
#> To see these entries in BibTeX format, use 'print(<citation>,
#> bibtex=TRUE)', 'toBibtex(.)', or set
#> 'options(citation.bibtex.max=999)'.
```

<sup>Created on 2023-04-11 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

How it looks on the authors page

![image](https://user-images.githubusercontent.com/8360597/231198424-42f50dc4-8a4f-429f-88fc-d21295c60512.png)
