### PR TITLE
fix: Fix tests for dev waldo

### DIFF
--- a/tests/testthat/test-graph.bfs.R
+++ b/tests/testthat/test-graph.bfs.R
@@ -13,7 +13,7 @@ test_that("BFS works from multiple root vertices", {
 
   expect_that(
     as.vector(bfs(g, 1, unreachable = FALSE)$order),
-    equals(c(1, 2, 10, 3, 9, 4, 8, 5, 7, 6, rep(NaN, 10)))
+    equals(c(1, 2, 10, 3, 9, 4, 8, 5, 7, 6, rep(NA, 10)))
   )
 
   expect_that(


### PR DESCRIPTION
Which now correctly distinguishes between NA and NaN. I couldn't compile locally so this is a bit of guess, and you might want to verify with dev waldo yourself.