### PR TITLE
fix: The internal `R_igraph_restore_pointer()` no longer leaks memory

### DIFF
--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -2906,6 +2906,7 @@ void R_igraph_restore_pointer(SEXP graph) {
 
   igraph_empty(&g, n, directed);
   igraph_add_edges(&g, &v, NULL);
+  igraph_vector_destroy(&v);
   R_igraph_set_pointer(graph, &g);
 }
 


### PR DESCRIPTION
Fixes #811 

- add missed `igraph_vector_destroy` in `R_igraph_restore_pointer` for edges vector