### PR TITLE
fix!: Clean error message when trying to access a graph that has been saved with a newer or an older version of the package, `graph_version()` returns an object of class `"package_version"`

### DIFF
--- a/R/basic.R
+++ b/R/basic.R
@@ -40,6 +40,7 @@ is_igraph <- function(graph) {
     return(FALSE)
   }
 
+  warn_version(graph)
   TRUE
 }
 

--- a/R/versions.R
+++ b/R/versions.R
@@ -24,6 +24,8 @@
 
 pkg_graph_version <- "0.8.0"
 
+pkg_graph_version_obj <- as.package_version(pkg_graph_version)
+
 #' igraph data structure versions
 #'
 #' igraph's internal data representation changes sometimes between
@@ -46,11 +48,11 @@ pkg_graph_version <- "0.8.0"
 #' @export
 graph_version <- function(graph) {
   if (missing(graph)) {
-    pkg_graph_version
-  } else {
-    stopifnot(is_igraph(graph))
-    .Call(R_igraph_graph_version, graph)
+    return(pkg_graph_version_obj)
   }
+
+  stopifnot(is_igraph(graph))
+  as.package_version(.Call(R_igraph_graph_version, graph))
 }
 
 #' igraph data structure versions

--- a/R/versions.R
+++ b/R/versions.R
@@ -51,7 +51,9 @@ graph_version <- function(graph) {
     return(pkg_graph_version_obj)
   }
 
-  stopifnot(is_igraph(graph))
+  # Don't call is_igraph() here to avoid recursion
+  stopifnot(inherits(graph, "igraph"))
+
   as.package_version(.Call(R_igraph_graph_version, graph))
 }
 
@@ -76,7 +78,8 @@ graph_version <- function(graph) {
 #' @family versions
 #' @export
 upgrade_graph <- function(graph) {
-  stopifnot(is_igraph(graph))
+  # Don't call is_igraph() here to avoid recursion
+  stopifnot(inherits(graph, "igraph"))
 
   g_ver <- graph_version(graph)
   p_ver <- graph_version()

--- a/R/versions.R
+++ b/R/versions.R
@@ -103,16 +103,23 @@ warn_version <- function(graph) {
   # Don't call vcount_impl() to avoid recursion
   .Call(R_igraph_vcount, graph)
 
-  if (graph_version() != graph_version(graph)) {
+  # graph_version() calls is_igraph(), but that function must call warn_version() for safety
+  their_version <- as.package_version(.Call(R_igraph_graph_version, graph))
+
+  if (pkg_graph_version == their_version) {
+    return(FALSE)
+  }
+
+  if (pkg_graph_version > their_version) {
     message(
       "This graph was created by an old(er) igraph version.\n",
       "  Call upgrade_graph() on it to use with the current igraph version\n",
       "  For now we convert it on the fly..."
     )
-    TRUE
-  } else {
-    FALSE
+    return(TRUE)
   }
+
+  stop("This graph was created by a new(er) igraph version. Please install the latest version of igraph and try again.")
 }
 
 oldformats <- function() {

--- a/tests/testthat/_snaps/versions.md
+++ b/tests/testthat/_snaps/versions.md
@@ -1,150 +1,42 @@
 # reading of old igraph formats
 
     Code
+      s[["0.1.1"]]
+    Error <simpleError>
+      This graph was created by a now unsupported old igraph version.
+        Call upgrade_version() before using igraph functions on that object.
+
+---
+
+    Code
       s[["0.2"]]
-    Message <simpleMessage>
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-    Output
-      IGRAPH NA U--- 3 3 -- 
-      + attr: bar (v/c), foo (e/c)
-    Message <simpleMessage>
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-    Warning <simpleWarning>
-      'length(x) = 9 > 1' in coercion to 'logical(1)'
-    Output
-      + edges from 3:
-       + edges from FALSE:
-       + edges from c(0, 1,:
-       + edges from c(1, 2,:
-       + edges from c(0, 1,:
-       + edges from c(2, 0,:
-       + edges from c(0, 1,:
-       + edges from c(0, 1,:
-       + edges from list(c(:
-    Message <simpleMessage>
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-    Output
-      [1] 2--1 3--2 1--3
+    Error <simpleError>
+      This graph was created by a now unsupported old igraph version.
+        Call upgrade_version() before using igraph functions on that object.
 
 ---
 
     Code
       s[["0.4"]]
-    Message <simpleMessage>
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-    Output
-      IGRAPH NA U--- 3 3 -- 
-      + attr: bar (v/c), foo (e/c)
-    Message <simpleMessage>
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-    Warning <simpleWarning>
-      'length(x) = 9 > 1' in coercion to 'logical(1)'
-    Output
-      + edges from 3:
-       + edges from FALSE:
-       + edges from c(1, 2,:
-       + edges from c(0, 1,:
-       + edges from c(0, 2,:
-       + edges from c(0, 2,:
-       + edges from c(0, 0,:
-       + edges from c(0, 2,:
-       + edges from list(c(:
-    Message <simpleMessage>
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-    Output
-      [1] 1--2 2--3 1--3
+    Error <simpleError>
+      This graph was created by a now unsupported old igraph version.
+        Call upgrade_version() before using igraph functions on that object.
 
 ---
 
     Code
       s[["0.5"]]
-    Message <simpleMessage>
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-    Output
-      IGRAPH NA U--- 3 3 -- 
-      + attr: bar (v/c), foo (e/c)
-    Message <simpleMessage>
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-    Warning <simpleWarning>
-      'length(x) = 9 > 1' in coercion to 'logical(1)'
-    Output
-      + edges from 3:
-       + edges from FALSE:
-       + edges from c(1, 2,:
-       + edges from c(0, 1,:
-       + edges from c(0, 2,:
-       + edges from c(0, 2,:
-       + edges from c(0, 0,:
-       + edges from c(0, 2,:
-       + edges from list(c(:
-    Message <simpleMessage>
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-    Output
-      [1] 1--2 2--3 1--3
+    Error <simpleError>
+      This graph was created by a now unsupported old igraph version.
+        Call upgrade_version() before using igraph functions on that object.
 
 ---
 
     Code
       s[["0.6"]]
-    Message <simpleMessage>
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-    Output
-      IGRAPH NA U--- 3 3 -- Ring graph
-      + attr: name (g/c), mutual (g/l), circular (g/l), bar (v/c), foo (e/c)
-    Message <simpleMessage>
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-    Warning <simpleWarning>
-      'length(x) = 9 > 1' in coercion to 'logical(1)'
-    Output
-      + edges from 3:
-       + edges from FALSE:
-       + edges from c(1, 2,:
-       + edges from c(0, 1,:
-       + edges from c(0, 2,:
-       + edges from c(0, 2,:
-       + edges from c(0, 0,:
-       + edges from c(0, 2,:
-       + edges from list(c(:
-    Message <simpleMessage>
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
-    Output
-      [1] 1--2 2--3 1--3
+    Error <simpleError>
+      This graph was created by a now unsupported old igraph version.
+        Call upgrade_version() before using igraph functions on that object.
 
 ---
 
@@ -160,10 +52,6 @@
 
     Code
       s[["1.5.0"]]
-    Message <simpleMessage>
-      This graph was created by an old(er) igraph version.
-        Call upgrade_graph() on it to use with the current igraph version
-        For now we convert it on the fly...
     Error <simpleError>
-      REAL() can only be applied to a 'numeric', not a 'NULL'
+      This graph was created by a new(er) igraph version. Please install the latest version of igraph and try again.
 

--- a/tests/testthat/test-versions.R
+++ b/tests/testthat/test-versions.R
@@ -11,10 +11,10 @@ test_that("we can upgrade from 0.4.0 to 0.8.0", {
   g[[10]] <- NULL
   class(g) <- "igraph"
 
-  expect_equal(graph_version(g), "0.4.0")
+  expect_equal(graph_version(g), as.package_version("0.4.0"))
 
   g2 <- upgrade_graph(g)
-  expect_equal(graph_version(g2), "0.8.0")
+  expect_equal(graph_version(g2), as.package_version("0.8.0"))
 })
 
 test_that("reading of old igraph formats", {

--- a/tests/testthat/test-versions.R
+++ b/tests/testthat/test-versions.R
@@ -19,20 +19,19 @@ test_that("we can upgrade from 0.4.0 to 0.8.0", {
 
 test_that("reading of old igraph formats", {
   s <- oldsamples()
-  # Causes segfault
-  # expect_snapshot({
-  #   s[["0.1.1"]]
-  # })
-  expect_snapshot({
+  expect_snapshot(error = TRUE, {
+    s[["0.1.1"]]
+  })
+  expect_snapshot(error = TRUE, {
     s[["0.2"]]
   })
-  expect_snapshot({
+  expect_snapshot(error = TRUE, {
     s[["0.4"]]
   })
-  expect_snapshot({
+  expect_snapshot(error = TRUE, {
     s[["0.5"]]
   })
-  expect_snapshot({
+  expect_snapshot(error = TRUE, {
     s[["0.6"]]
   })
   expect_snapshot({


### PR DESCRIPTION
Closes #830