### PR TITLE
chore: copy output integer vector

### DIFF
--- a/src/rinterface.c
+++ b/src/rinterface.c
@@ -106,7 +106,7 @@ int R_igraph_SEXP_to_vectorlist_int(SEXP vectorlist,
 int R_igraph_SEXP_to_matrixlist(SEXP matrixlist, igraph_vector_ptr_t *ptr);
 int R_SEXP_to_vector_bool(SEXP sv, igraph_vector_bool_t *v);
 int R_SEXP_to_vector_bool_copy(SEXP sv, igraph_vector_bool_t *v);
-int R_SEXP_to_vector_int(SEXP sv, igraph_vector_int_t *v);
+int R_SEXP_to_vector_int_copy(SEXP sv, igraph_vector_int_t *v);
 int R_SEXP_to_vector_long_copy(SEXP sv, igraph_vector_long_t *v);
 int R_SEXP_to_hrg(SEXP shrg, igraph_hrg_t *hrg);
 int R_SEXP_to_hrg_copy(SEXP shrg, igraph_hrg_t *hrg);
@@ -711,7 +711,7 @@ SEXP R_igraph_sbm_game(SEXP n, SEXP pref_matrix, SEXP block_sizes, SEXP directed
                                         /* Convert input */
   c_n=INTEGER(n)[0];
   R_SEXP_to_matrix(pref_matrix, &c_pref_matrix);
-  R_SEXP_to_vector_int(block_sizes, &c_block_sizes);
+  R_SEXP_to_vector_int_copy(block_sizes, &c_block_sizes);
   c_directed=LOGICAL(directed)[0];
   c_loops=LOGICAL(loops)[0];
                                         /* Call igraph */
@@ -778,7 +778,7 @@ SEXP R_igraph_hsbm_list_game(SEXP n, SEXP mlist, SEXP rholist, SEXP Clist, SEXP 
   SEXP r_result;
                                         /* Convert input */
   c_n=INTEGER(n)[0];
-  R_SEXP_to_vector_int(mlist, &c_mlist);
+  R_SEXP_to_vector_int_copy(mlist, &c_mlist);
   R_igraph_SEXP_to_vectorlist(rholist, &c_rholist);
   R_igraph_SEXP_to_matrixlist(Clist, &c_Clist);
   c_p=REAL(p)[0];
@@ -6103,10 +6103,10 @@ SEXP R_igraph_isomorphic_vf2(SEXP graph1, SEXP graph2, SEXP vertex_color1, SEXP 
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
-  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
-  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
-  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
+  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int_copy(vertex_color1, &c_vertex_color1); }
+  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int_copy(vertex_color2, &c_vertex_color2); }
+  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int_copy(edge_color1, &c_edge_color1); }
+  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int_copy(edge_color2, &c_edge_color2); }
   if (0 != igraph_vector_init(&c_map12, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -6165,10 +6165,10 @@ SEXP R_igraph_count_isomorphisms_vf2(SEXP graph1, SEXP graph2, SEXP vertex_color
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
-  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
-  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
-  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
+  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int_copy(vertex_color1, &c_vertex_color1); }
+  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int_copy(vertex_color2, &c_vertex_color2); }
+  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int_copy(edge_color1, &c_edge_color1); }
+  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int_copy(edge_color2, &c_edge_color2); }
   c_count=0;
                                         /* Call igraph */
   IGRAPH_R_CHECK(igraph_count_isomorphisms_vf2(&c_graph1, &c_graph2, (Rf_isNull(vertex_color1) ? 0 : &c_vertex_color1), (Rf_isNull(vertex_color2) ? 0 : &c_vertex_color2), (Rf_isNull(edge_color1) ? 0 : &c_edge_color1), (Rf_isNull(edge_color2) ? 0 : &c_edge_color2), &c_count, 0, 0, 0));
@@ -6203,10 +6203,10 @@ SEXP R_igraph_get_isomorphisms_vf2(SEXP graph1, SEXP graph2, SEXP vertex_color1,
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
-  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
-  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
-  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
+  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int_copy(vertex_color1, &c_vertex_color1); }
+  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int_copy(vertex_color2, &c_vertex_color2); }
+  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int_copy(edge_color1, &c_edge_color1); }
+  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int_copy(edge_color2, &c_edge_color2); }
   if (0 != igraph_vector_ptr_init(&c_maps, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -6249,10 +6249,10 @@ SEXP R_igraph_subisomorphic_vf2(SEXP graph1, SEXP graph2, SEXP vertex_color1, SE
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
-  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
-  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
-  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
+  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int_copy(vertex_color1, &c_vertex_color1); }
+  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int_copy(vertex_color2, &c_vertex_color2); }
+  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int_copy(edge_color1, &c_edge_color1); }
+  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int_copy(edge_color2, &c_edge_color2); }
   if (0 != igraph_vector_init(&c_map12, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -6311,10 +6311,10 @@ SEXP R_igraph_count_subisomorphisms_vf2(SEXP graph1, SEXP graph2, SEXP vertex_co
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
-  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
-  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
-  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
+  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int_copy(vertex_color1, &c_vertex_color1); }
+  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int_copy(vertex_color2, &c_vertex_color2); }
+  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int_copy(edge_color1, &c_edge_color1); }
+  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int_copy(edge_color2, &c_edge_color2); }
   c_count=0;
                                         /* Call igraph */
   IGRAPH_R_CHECK(igraph_count_subisomorphisms_vf2(&c_graph1, &c_graph2, (Rf_isNull(vertex_color1) ? 0 : &c_vertex_color1), (Rf_isNull(vertex_color2) ? 0 : &c_vertex_color2), (Rf_isNull(edge_color1) ? 0 : &c_edge_color1), (Rf_isNull(edge_color2) ? 0 : &c_edge_color2), &c_count, 0, 0, 0));
@@ -6349,10 +6349,10 @@ SEXP R_igraph_get_subisomorphisms_vf2(SEXP graph1, SEXP graph2, SEXP vertex_colo
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int(vertex_color1, &c_vertex_color1); }
-  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int(vertex_color2, &c_vertex_color2); }
-  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int(edge_color1, &c_edge_color1); }
-  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int(edge_color2, &c_edge_color2); }
+  if (!Rf_isNull(vertex_color1)) { R_SEXP_to_vector_int_copy(vertex_color1, &c_vertex_color1); }
+  if (!Rf_isNull(vertex_color2)) { R_SEXP_to_vector_int_copy(vertex_color2, &c_vertex_color2); }
+  if (!Rf_isNull(edge_color1)) { R_SEXP_to_vector_int_copy(edge_color1, &c_edge_color1); }
+  if (!Rf_isNull(edge_color2)) { R_SEXP_to_vector_int_copy(edge_color2, &c_edge_color2); }
   if (0 != igraph_vector_ptr_init(&c_maps, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -6412,7 +6412,7 @@ SEXP R_igraph_canonical_permutation(SEXP graph, SEXP colors, SEXP sh) {
   SEXP r_result, r_names;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!Rf_isNull(colors)) { R_SEXP_to_vector_int(colors, &c_colors); }
+  if (!Rf_isNull(colors)) { R_SEXP_to_vector_int_copy(colors, &c_colors); }
   if (0 != igraph_vector_init(&c_labeling, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -6493,8 +6493,8 @@ SEXP R_igraph_isomorphic_bliss(SEXP graph1, SEXP graph2, SEXP colors1, SEXP colo
                                         /* Convert input */
   R_SEXP_to_igraph(graph1, &c_graph1);
   R_SEXP_to_igraph(graph2, &c_graph2);
-  if (!Rf_isNull(colors1)) { R_SEXP_to_vector_int(colors1, &c_colors1); }
-  if (!Rf_isNull(colors2)) { R_SEXP_to_vector_int(colors2, &c_colors2); }
+  if (!Rf_isNull(colors1)) { R_SEXP_to_vector_int_copy(colors1, &c_colors1); }
+  if (!Rf_isNull(colors2)) { R_SEXP_to_vector_int_copy(colors2, &c_colors2); }
   if (0 != igraph_vector_init(&c_map12, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -6555,7 +6555,7 @@ SEXP R_igraph_automorphisms(SEXP graph, SEXP colors, SEXP sh) {
   SEXP r_result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!Rf_isNull(colors)) { R_SEXP_to_vector_int(colors, &c_colors); }
+  if (!Rf_isNull(colors)) { R_SEXP_to_vector_int_copy(colors, &c_colors); }
   c_sh = (igraph_bliss_sh_t) Rf_asInteger(sh);
                                         /* Call igraph */
   IGRAPH_R_CHECK(igraph_automorphisms(&c_graph, (Rf_isNull(colors) ? 0 : &c_colors), c_sh, &c_info));
@@ -6585,7 +6585,7 @@ SEXP R_igraph_automorphism_group(SEXP graph, SEXP colors, SEXP sh) {
   SEXP r_result, r_names;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!Rf_isNull(colors)) { R_SEXP_to_vector_int(colors, &c_colors); }
+  if (!Rf_isNull(colors)) { R_SEXP_to_vector_int_copy(colors, &c_colors); }
   if (0 != igraph_vector_ptr_init(&c_generators, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -7240,7 +7240,7 @@ SEXP R_igraph_from_prufer(SEXP prufer) {
 
   SEXP r_result;
                                         /* Convert input */
-  R_SEXP_to_vector_int(prufer, &c_prufer);
+  R_SEXP_to_vector_int_copy(prufer, &c_prufer);
                                         /* Call igraph */
   IGRAPH_R_CHECK(igraph_from_prufer(&c_graph, &c_prufer));
 

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -107,7 +107,7 @@ int R_igraph_SEXP_to_vectorlist_int(SEXP vectorlist,
 int R_igraph_SEXP_to_matrixlist(SEXP matrixlist, igraph_vector_ptr_t *ptr);
 int R_SEXP_to_vector_bool(SEXP sv, igraph_vector_bool_t *v);
 int R_SEXP_to_vector_bool_copy(SEXP sv, igraph_vector_bool_t *v);
-int R_SEXP_to_vector_int(SEXP sv, igraph_vector_int_t *v);
+int R_SEXP_to_vector_int_copy(SEXP sv, igraph_vector_int_t *v);
 int R_SEXP_to_vector_long_copy(SEXP sv, igraph_vector_long_t *v);
 int R_SEXP_to_hrg(SEXP shrg, igraph_hrg_t *hrg);
 int R_SEXP_to_hrg_copy(SEXP shrg, igraph_hrg_t *hrg);
@@ -3604,10 +3604,13 @@ int R_SEXP_to_vector_bool_copy(SEXP sv, igraph_vector_bool_t *v) {
   return 0;
 }
 
-int R_SEXP_to_vector_int(SEXP sv, igraph_vector_int_t *v) {
-  v->stor_begin=(int*) INTEGER(sv);
-  v->stor_end=v->stor_begin+GET_LENGTH(sv);
-  v->end=v->stor_end;
+int R_SEXP_to_vector_int_copy(SEXP sv, igraph_vector_int_t *v) {
+  long int i, n=GET_LENGTH(sv);
+  int *svv=INTEGER(sv);
+  igraph_vector_int_init(v, n);
+  for (i = 0; i<n; i++) {
+    VECTOR(*v)[i] = svv[i];
+  }
   return 0;
 }
 
@@ -7215,7 +7218,7 @@ SEXP R_igraph_maximal_cliques(SEXP graph, SEXP psubset,
   SEXP result;
 
   R_SEXP_to_igraph(graph, &g);
-  if (!Rf_isNull(psubset)) { R_SEXP_to_vector_int(psubset, &subset); }
+  if (!Rf_isNull(psubset)) { R_SEXP_to_vector_int_copy(psubset, &subset); }
   igraph_vector_ptr_init(&ptrvec,0);
   igraph_maximal_cliques_subset(&g, Rf_isNull(psubset) ? 0 : &subset,
                                 &ptrvec, /*no=*/ 0, /*file=*/ 0,
@@ -7248,7 +7251,7 @@ SEXP R_igraph_maximal_cliques_file(SEXP graph, SEXP psubset, SEXP file,
 #endif
 
   R_SEXP_to_igraph(graph, &g);
-  if (!Rf_isNull(psubset)) { R_SEXP_to_vector_int(psubset, &subset); }
+  if (!Rf_isNull(psubset)) { R_SEXP_to_vector_int_copy(psubset, &subset); }
 #if HAVE_OPEN_MEMSTREAM == 1
   stream=open_memstream(&bp, &size);
 #else
@@ -7285,7 +7288,7 @@ SEXP R_igraph_maximal_cliques_count(SEXP graph, SEXP psubset,
   SEXP result;
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
-  if (!Rf_isNull(psubset)) { R_SEXP_to_vector_int(psubset, &subset); }
+  if (!Rf_isNull(psubset)) { R_SEXP_to_vector_int_copy(psubset, &subset); }
   c_min_size=INTEGER(min_size)[0];
   c_max_size=INTEGER(max_size)[0];
                                         /* Call igraph */

--- a/tools/stimulus/rinterface.c.in
+++ b/tools/stimulus/rinterface.c.in
@@ -106,7 +106,7 @@ int R_igraph_SEXP_to_vectorlist_int(SEXP vectorlist,
 int R_igraph_SEXP_to_matrixlist(SEXP matrixlist, igraph_vector_ptr_t *ptr);
 int R_SEXP_to_vector_bool(SEXP sv, igraph_vector_bool_t *v);
 int R_SEXP_to_vector_bool_copy(SEXP sv, igraph_vector_bool_t *v);
-int R_SEXP_to_vector_int(SEXP sv, igraph_vector_int_t *v);
+int R_SEXP_to_vector_int_copy(SEXP sv, igraph_vector_int_t *v);
 int R_SEXP_to_vector_long_copy(SEXP sv, igraph_vector_long_t *v);
 int R_SEXP_to_hrg(SEXP shrg, igraph_hrg_t *hrg);
 int R_SEXP_to_hrg_copy(SEXP shrg, igraph_hrg_t *hrg);

--- a/tools/stimulus/types-RC.yaml
+++ b/tools/stimulus/types-RC.yaml
@@ -96,7 +96,7 @@ INDEX_VECTOR:
     CALL: '&%C%'
     CTYPE: igraph_vector_int_t
     INCONV:
-        IN: R_SEXP_to_vector_int(%I%, &%C%);
+        IN: R_SEXP_to_vector_int_copy(%I%, &%C%);
         OUT: |-
             if (0 != igraph_vector_int_init(&%C%, 0)) {
               igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
@@ -196,7 +196,7 @@ VECTOR_INT:
     CALL: '&%C%'
     CTYPE: igraph_vector_int_t
     INCONV:
-        IN: R_SEXP_to_vector_int(%I%, &%C%);
+        IN: R_SEXP_to_vector_int_copy(%I%, &%C%);
         OUT: |-
             if (0 != igraph_vector_int_init(&%C%, 0)) {
               igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
@@ -657,7 +657,7 @@ VERTEX_COLOR:
         OUT: '&%C%'
     CTYPE: igraph_vector_int_t
     INCONV:
-        IN: if (!Rf_isNull(%I%)) { R_SEXP_to_vector_int(%I%, &%C%); }
+        IN: if (!Rf_isNull(%I%)) { R_SEXP_to_vector_int_copy(%I%, &%C%); }
         OUT: |-
             if (0 != igraph_vector_int_init(&%C%, 0)) {
               igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
@@ -675,7 +675,7 @@ EDGE_COLOR:
         OUT: '&%C%'
     CTYPE: igraph_vector_int_t
     INCONV:
-        IN: if (!Rf_isNull(%I%)) { R_SEXP_to_vector_int(%I%, &%C%); }
+        IN: if (!Rf_isNull(%I%)) { R_SEXP_to_vector_int_copy(%I%, &%C%); }
         OUT: |-
             if (0 != igraph_vector_int_init(&%C%, 0)) {
               igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);


### PR DESCRIPTION
For 0.10 integer type will be `int64` and on R side such vectors should be copied with conversion to double type

for: https://github.com/igraph/rigraph/pull/840