### PR TITLE
chore: Reduce size of archive

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -42,3 +42,4 @@ src/vendor/cigraph
 ^\.zenodo.json$
 
 ^AUTHORS-list\.md$
+^src/vendor$


### PR DESCRIPTION
Needs to be reverted after the 1.5.0 release.