### PR TITLE
WIP: fix: Avoid storing attributes in global preserve list

### DIFF
--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -445,11 +445,6 @@ int R_igraph_attribute_init(igraph_t *graph, igraph_vector_ptr_t *attr) {
 void R_igraph_attribute_destroy(igraph_t *graph) {
   SEXP attr=graph->attr;
   REAL(VECTOR_ELT(attr, 0))[1] -= 1; /* refcount for igraph_t */
-  if (!R_igraph_attribute_protected &&
-      REAL(VECTOR_ELT(attr, 0))[1]==0 &&
-      REAL(VECTOR_ELT(attr, 0))[2]==1) {
-    R_ReleaseObject(attr);
-  }
   graph->attr=0;
 }
 
@@ -465,10 +460,6 @@ int R_igraph_attribute_copy(igraph_t *to, const igraph_t *from,
   if (ga && va && ea) {
     to->attr=from->attr;
     REAL(VECTOR_ELT(fromattr, 0))[1] += 1; /* refcount only */
-    if (!R_igraph_attribute_protected &&
-        REAL(VECTOR_ELT(fromattr, 0))[1] == 1) {
-      R_PreserveObject(to->attr);
-    }
   } else {
     R_igraph_attribute_init(to,0); /* Sets up many things */
     SEXP toattr=to->attr;
@@ -591,15 +582,9 @@ SEXP R_igraph_attribute_add_vertices_dup(SEXP attr) {
 
   if (R_igraph_attribute_protected) {
     PROTECT(newattr); px++;
-  } else {
-    R_PreserveObject(newattr);
   }
 
   REAL(VECTOR_ELT(attr, 0))[1] -= 1;
-  if (!R_igraph_attribute_protected &&
-      REAL(VECTOR_ELT(attr, 0))[1] == 0) {
-    R_ReleaseObject(attr);
-  }
   REAL(VECTOR_ELT(newattr, 0))[0] = 0;
   REAL(VECTOR_ELT(newattr, 0))[1] = 1;
   if (R_igraph_attribute_protected) {
@@ -777,14 +762,8 @@ int R_igraph_attribute_permute_vertices_same(const igraph_t *graph,
     SEXP newattr = Rf_duplicate(attr);
     if (R_igraph_attribute_protected) {
       PROTECT(newattr); px++;
-    } else {
-      R_PreserveObject(newattr);
     }
     REAL(VECTOR_ELT(attr, 0))[1] -= 1;
-    if (!R_igraph_attribute_protected &&
-        REAL(VECTOR_ELT(attr, 0))[1] == 0) {
-      R_ReleaseObject(attr);
-    }
     REAL(VECTOR_ELT(newattr, 0))[0] = 0;
     REAL(VECTOR_ELT(newattr, 0))[1] = 1;
     if (R_igraph_attribute_protected) {
@@ -894,15 +873,9 @@ SEXP R_igraph_attribute_add_edges_dup(SEXP attr) {
 
   if (R_igraph_attribute_protected) {
     PROTECT(newattr); px++;
-  } else {
-    R_PreserveObject(newattr);
   }
 
   REAL(VECTOR_ELT(attr, 0))[1] -= 1;
-  if (!R_igraph_attribute_protected &&
-      REAL(VECTOR_ELT(attr, 0))[1] == 0) {
-    R_ReleaseObject(attr);
-  }
   REAL(VECTOR_ELT(newattr, 0))[0] = 0;
   REAL(VECTOR_ELT(newattr, 0))[1] = 1;
   if (R_igraph_attribute_protected) {
@@ -1161,14 +1134,8 @@ int R_igraph_attribute_permute_edges_same(const igraph_t *graph,
     SEXP newattr=Rf_duplicate(attr);
     if (R_igraph_attribute_protected) {
       PROTECT(newattr); px++;
-    } else {
-      R_PreserveObject(newattr);
     }
     REAL(VECTOR_ELT(attr, 0))[1] -= 1;
-    if (!R_igraph_attribute_protected &&
-        REAL(VECTOR_ELT(attr, 0))[1] == 0) {
-      R_ReleaseObject(attr);
-    }
     REAL(VECTOR_ELT(newattr, 0))[0] = 0;
     REAL(VECTOR_ELT(newattr, 0))[1] = 1;
     if (R_igraph_attribute_protected) {
@@ -3095,6 +3062,9 @@ SEXP R_igraph_to_SEXP(const igraph_t *graph) {
 
   /* Attributes */
   SET_VECTOR_ELT(result, igraph_t_idx_attr, graph->attr);
+  if (!R_igraph_attribute_protected) {
+    R_ReleaseObject(graph->attr);
+  }
   REAL(VECTOR_ELT(graph->attr, 0))[0] += 1;
 
   /* Environment for vertex/edge seqs */
@@ -3752,7 +3722,7 @@ int R_SEXP_to_igraph_copy(SEXP graph, igraph_t *res) {
   /* attributes */
   REAL(VECTOR_ELT(VECTOR_ELT(graph, igraph_t_idx_attr), 0))[0] = 1; /* R objects */
   REAL(VECTOR_ELT(VECTOR_ELT(graph, igraph_t_idx_attr), 0))[1] = 1; /* igraph_t objects */
-  R_PreserveObject(res->attr=VECTOR_ELT(graph, igraph_t_idx_attr));
+  res->attr=VECTOR_ELT(graph, igraph_t_idx_attr);
 
   return 0;
 }


### PR DESCRIPTION
The current implementation seems to call `R_PreserveObject()` and `R_ReleaseObject()` way too often. This is R's global "preserve" list of objects that are never freed.

With the new implementation, we only add to the global list directly after initializing the attributes. As soon as we return the constructed object as an `SEXP` to R, the attributes are removed from the global preserve list.

The only problem I see is if we initialize the attributes and then exit with an error. The attribute vector will remain in the global preserve list forever, a memory leak. In fact, we should not use the global preserve list for that, but maintain or own list that we free unconditionally when returning to R.

This is only possible because we now check all igraph function calls and don't longjmp.