### PR TITLE
fix: Change ownership rules of attribute objects

### DIFF
--- a/src/rinterface.h
+++ b/src/rinterface.h
@@ -35,10 +35,10 @@ void R_igraph_interrupt(void);
 
 #define IGRAPH_R_CHECK(func) \
     do { \
+        R_igraph_attribute_clean_preserve_list(); \
         R_igraph_set_in_r_check(true); \
         igraph_error_type_t __c = func; \
         R_igraph_set_in_r_check(false); \
-        R_igraph_attribute_clean_preserve_list(); \
         R_igraph_warning(); \
         if (__c == IGRAPH_INTERRUPTED) { R_igraph_interrupt(); } \
         else if (__c != IGRAPH_SUCCESS) { R_igraph_error(); } \

--- a/src/rinterface.h
+++ b/src/rinterface.h
@@ -27,6 +27,7 @@
 
 SEXP R_igraph_add_env(SEXP graph);
 
+void R_igraph_attribute_clean_preserve_list();
 void R_igraph_set_in_r_check(bool set);
 void R_igraph_error(void);
 void R_igraph_warning(void);
@@ -37,6 +38,7 @@ void R_igraph_interrupt(void);
         R_igraph_set_in_r_check(true); \
         igraph_error_type_t __c = func; \
         R_igraph_set_in_r_check(false); \
+        R_igraph_attribute_clean_preserve_list(); \
         R_igraph_warning(); \
         if (__c == IGRAPH_INTERRUPTED) { R_igraph_interrupt(); } \
         else if (__c != IGRAPH_SUCCESS) { R_igraph_error(); } \

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -5822,10 +5822,6 @@ SEXP R_igraph_decompose(SEXP graph, SEXP pmode, SEXP pmaxcompno,
   SEXP result;
   long int i;
 
-  R_PreserveObject(R_igraph_attribute_protected=NEW_LIST(100));
-  R_igraph_attribute_protected_size=0;
-  IGRAPH_FINALLY(R_igraph_attribute_protected_destroy, 0);
-
   R_SEXP_to_igraph(graph, &g);
   igraph_vector_ptr_init(&comps, 0);
   IGRAPH_FINALLY(igraph_vector_ptr_destroy, &comps);
@@ -5839,8 +5835,7 @@ SEXP R_igraph_decompose(SEXP graph, SEXP pmode, SEXP pmaxcompno,
   igraph_vector_ptr_destroy(&comps);
 
   UNPROTECT(1);
-  IGRAPH_FINALLY_CLEAN(2);
-  R_igraph_attribute_protected_destroy(0);
+  IGRAPH_FINALLY_CLEAN(1);
 
   return result;
 }
@@ -7151,10 +7146,6 @@ SEXP R_igraph_neighborhood_graphs(SEXP graph, SEXP pvids, SEXP porder,
   igraph_integer_t mindist=INTEGER(pmindist)[0];
   SEXP result;
 
-  R_PreserveObject(R_igraph_attribute_protected=NEW_LIST(100));
-  R_igraph_attribute_protected_size=0;
-  IGRAPH_FINALLY(R_igraph_attribute_protected_destroy, 0);
-
   R_SEXP_to_igraph(graph, &g);
   R_SEXP_to_igraph_vs(pvids, &g, &vids);
   igraph_vector_ptr_init(&res, 0);
@@ -7170,8 +7161,6 @@ SEXP R_igraph_neighborhood_graphs(SEXP graph, SEXP pvids, SEXP porder,
   igraph_vs_destroy(&vids);
 
   UNPROTECT(1);
-  IGRAPH_FINALLY_CLEAN(1);
-  R_igraph_attribute_protected_destroy(0);
 
   return result;
 }
@@ -9291,10 +9280,6 @@ SEXP R_igraph_graphlets(SEXP graph, SEXP weights, SEXP niter) {
   SEXP Mu;
   SEXP result, names;
 
-  R_PreserveObject(R_igraph_attribute_protected=NEW_LIST(100));
-  R_igraph_attribute_protected_size=0;
-  IGRAPH_FINALLY(R_igraph_attribute_protected_destroy, 0);
-
   /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
   if (!Rf_isNull(weights)) { R_SEXP_to_vector(weights, &c_weights); }
@@ -9326,8 +9311,6 @@ SEXP R_igraph_graphlets(SEXP graph, SEXP weights, SEXP niter) {
   SET_NAMES(result, names);
 
   UNPROTECT(4);
-  IGRAPH_FINALLY_CLEAN(1);
-  R_igraph_attribute_protected_destroy(0);
 
   return(result);
 }
@@ -9345,10 +9328,6 @@ SEXP R_igraph_graphlets_candidate_basis(SEXP graph, SEXP weights) {
   SEXP thresholds;
 
   SEXP result, names;
-
-  R_PreserveObject(R_igraph_attribute_protected=NEW_LIST(100));
-  R_igraph_attribute_protected_size=0;
-  IGRAPH_FINALLY(R_igraph_attribute_protected_destroy, 0);
 
   /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
@@ -9380,8 +9359,6 @@ SEXP R_igraph_graphlets_candidate_basis(SEXP graph, SEXP weights) {
   SET_NAMES(result, names);
 
   UNPROTECT(4);
-  IGRAPH_FINALLY_CLEAN(1);
-  R_igraph_attribute_protected_destroy(0);
 
   return(result);
 }

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -357,8 +357,13 @@ void R_igraph_attribute_add_to_preserve_list(SEXP attr) {
 void R_igraph_attribute_clean_preserve_list() {
   if (R_igraph_attribute_preserve_list) {
     // Mark the entire list available for garbage collection.
-    // Attributes that have been assigned to a graph object will remain protected.
+    // Attributes that have been assigned to an R graph object will remain protected.
     // Dangling attributes will be GC-ed eventually.
+
+    // This is called *before* entering an igraph function that might allocate
+    // attributes; after such a function returns, we need to keep preserving
+    // all attributes because they may be put into R graph objects
+    // and returned to R.
     SETCDR(R_igraph_attribute_preserve_list, R_NilValue);
   }
 }

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -378,10 +378,6 @@ int R_igraph_attribute_init(igraph_t *graph, igraph_vector_ptr_t *attr) {
   // The "preserve list" Will be cleared with the next invocation of IGRAPH_R_CHECK().
   // Adding to that list ensures that the attributes aren't GC-ed prematurely.
   R_igraph_attribute_add_to_preserve_list(result);
-  SET_VECTOR_ELT(result, 0, NEW_NUMERIC(3));
-  REAL(VECTOR_ELT(result, 0))[0]=0; /* R objects */
-  REAL(VECTOR_ELT(result, 0))[1]=1; /* igraph_t objects */
-  REAL(VECTOR_ELT(result, 0))[2]=1; /* whether the graph is safe */
   for (i=1; i<3; i++) {
     SET_VECTOR_ELT(result, i+1, NEW_LIST(0)); /* gal, val, eal */
   }

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -340,6 +340,31 @@ int R_SEXP_to_attr_comb(SEXP input, igraph_attribute_combination_t *comb) {
   return 0;
 }
 
+static SEXP R_igraph_attribute_preserve_list;
+
+void R_igraph_attribute_add_to_preserve_list(SEXP attr) {
+  if (!R_igraph_attribute_preserve_list) {
+    // We don't care about freeing this, typically this is just a single node
+    R_igraph_attribute_preserve_list = Rf_cons(R_NilValue, R_NilValue);
+    R_PreserveObject(R_igraph_attribute_preserve_list);
+  }
+
+  // Create a new node, add it to the head of the list.
+  SEXP node = Rf_cons(attr, CDR(R_igraph_attribute_preserve_list));
+  SETCDR(R_igraph_attribute_preserve_list, node);
+}
+
+void R_igraph_attribute_clean_preserve_list() {
+  if (R_igraph_attribute_preserve_list) {
+    // Mark the entire list available for garbage collection.
+    // Attributes that have been assigned to a graph object will remain protected.
+    // Dangling attributes will be GC-ed eventually.
+    SETCDR(R_igraph_attribute_preserve_list, R_NilValue);
+  }
+}
+
+
+
 static SEXP R_igraph_attribute_protected=0;
 static long int R_igraph_attribute_protected_size=0;
 
@@ -378,7 +403,10 @@ int R_igraph_attribute_init(igraph_t *graph, igraph_vector_ptr_t *attr) {
     REAL(VECTOR_ELT(result, 0))[3] = R_igraph_attribute_protected_size;
     R_igraph_attribute_protected_size += 1;
   } else {
-    R_PreserveObject(result=NEW_LIST(4));
+    result=NEW_LIST(4);
+    // The "preserve list" Will be cleared with the next invocation of IGRAPH_R_CHECK().
+    // Adding to that list ensures that the attributes aren't GC-ed prematurely.
+    R_igraph_attribute_add_to_preserve_list(result);
     SET_VECTOR_ELT(result, 0, NEW_NUMERIC(3));
   }
   REAL(VECTOR_ELT(result, 0))[0]=0; /* R objects */
@@ -445,11 +473,6 @@ int R_igraph_attribute_init(igraph_t *graph, igraph_vector_ptr_t *attr) {
 void R_igraph_attribute_destroy(igraph_t *graph) {
   SEXP attr=graph->attr;
   REAL(VECTOR_ELT(attr, 0))[1] -= 1; /* refcount for igraph_t */
-  if (!R_igraph_attribute_protected &&
-      REAL(VECTOR_ELT(attr, 0))[1]==0 &&
-      REAL(VECTOR_ELT(attr, 0))[2]==1) {
-    R_ReleaseObject(attr);
-  }
   graph->attr=0;
 }
 
@@ -465,10 +488,6 @@ int R_igraph_attribute_copy(igraph_t *to, const igraph_t *from,
   if (ga && va && ea) {
     to->attr=from->attr;
     REAL(VECTOR_ELT(fromattr, 0))[1] += 1; /* refcount only */
-    if (!R_igraph_attribute_protected &&
-        REAL(VECTOR_ELT(fromattr, 0))[1] == 1) {
-      R_PreserveObject(to->attr);
-    }
   } else {
     R_igraph_attribute_init(to,0); /* Sets up many things */
     SEXP toattr=to->attr;
@@ -592,14 +611,10 @@ SEXP R_igraph_attribute_add_vertices_dup(SEXP attr) {
   if (R_igraph_attribute_protected) {
     PROTECT(newattr); px++;
   } else {
-    R_PreserveObject(newattr);
+    R_igraph_attribute_add_to_preserve_list(newattr);
   }
 
   REAL(VECTOR_ELT(attr, 0))[1] -= 1;
-  if (!R_igraph_attribute_protected &&
-      REAL(VECTOR_ELT(attr, 0))[1] == 0) {
-    R_ReleaseObject(attr);
-  }
   REAL(VECTOR_ELT(newattr, 0))[0] = 0;
   REAL(VECTOR_ELT(newattr, 0))[1] = 1;
   if (R_igraph_attribute_protected) {
@@ -778,13 +793,9 @@ int R_igraph_attribute_permute_vertices_same(const igraph_t *graph,
     if (R_igraph_attribute_protected) {
       PROTECT(newattr); px++;
     } else {
-      R_PreserveObject(newattr);
+      R_igraph_attribute_add_to_preserve_list(newattr);
     }
     REAL(VECTOR_ELT(attr, 0))[1] -= 1;
-    if (!R_igraph_attribute_protected &&
-        REAL(VECTOR_ELT(attr, 0))[1] == 0) {
-      R_ReleaseObject(attr);
-    }
     REAL(VECTOR_ELT(newattr, 0))[0] = 0;
     REAL(VECTOR_ELT(newattr, 0))[1] = 1;
     if (R_igraph_attribute_protected) {
@@ -895,14 +906,10 @@ SEXP R_igraph_attribute_add_edges_dup(SEXP attr) {
   if (R_igraph_attribute_protected) {
     PROTECT(newattr); px++;
   } else {
-    R_PreserveObject(newattr);
+    R_igraph_attribute_add_to_preserve_list(newattr);
   }
 
   REAL(VECTOR_ELT(attr, 0))[1] -= 1;
-  if (!R_igraph_attribute_protected &&
-      REAL(VECTOR_ELT(attr, 0))[1] == 0) {
-    R_ReleaseObject(attr);
-  }
   REAL(VECTOR_ELT(newattr, 0))[0] = 0;
   REAL(VECTOR_ELT(newattr, 0))[1] = 1;
   if (R_igraph_attribute_protected) {
@@ -1162,13 +1169,9 @@ int R_igraph_attribute_permute_edges_same(const igraph_t *graph,
     if (R_igraph_attribute_protected) {
       PROTECT(newattr); px++;
     } else {
-      R_PreserveObject(newattr);
+      R_igraph_attribute_add_to_preserve_list(newattr);
     }
     REAL(VECTOR_ELT(attr, 0))[1] -= 1;
-    if (!R_igraph_attribute_protected &&
-        REAL(VECTOR_ELT(attr, 0))[1] == 0) {
-      R_ReleaseObject(attr);
-    }
     REAL(VECTOR_ELT(newattr, 0))[0] = 0;
     REAL(VECTOR_ELT(newattr, 0))[1] = 1;
     if (R_igraph_attribute_protected) {
@@ -3752,7 +3755,7 @@ int R_SEXP_to_igraph_copy(SEXP graph, igraph_t *res) {
   /* attributes */
   REAL(VECTOR_ELT(VECTOR_ELT(graph, igraph_t_idx_attr), 0))[0] = 1; /* R objects */
   REAL(VECTOR_ELT(VECTOR_ELT(graph, igraph_t_idx_attr), 0))[1] = 1; /* igraph_t objects */
-  R_PreserveObject(res->attr=VECTOR_ELT(graph, igraph_t_idx_attr));
+  res->attr=VECTOR_ELT(graph, igraph_t_idx_attr);
 
   return 0;
 }

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -298,7 +298,12 @@ test_that("vertex attributes are destroyed when the graph is destroyed", {
   gc()
   expect_false(finalized)
 
+  # Called for the side effect of clearing the protect list
+  make_empty_graph()
+  expect_false(finalized)
+
   rm(g)
+
   gc()
   expect_true(finalized)
 })
@@ -330,7 +335,12 @@ test_that("edge attributes are destroyed when the graph is destroyed", {
   gc()
   expect_false(finalized)
 
+  # Called for the side effect of clearing the protect list
+  make_empty_graph()
+  expect_false(finalized)
+
   rm(g)
+
   gc()
   expect_true(finalized)
 })

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -254,3 +254,83 @@ test_that("setting NULL attributes works and doesn't change the input (#466)", {
   expect_identical(set_edge_attr(g, "foo", value = NULL), g)
   expect_identical(set_edge_attr(g, "foo", 1:3, value = NULL), g)
 })
+
+test_that("GRAPH attributes are destroyed when the graph is destroyed", {
+  finalized <- FALSE
+  finalizer <- function(e) {
+    finalized <<- TRUE
+  }
+
+  env <- new.env(parent = emptyenv())
+  reg.finalizer(env, finalizer)
+
+  g <- make_ring(1)
+  g$a <- list(env)
+  rm(env)
+  gc()
+  expect_false(finalized)
+
+  rm(g)
+  gc()
+  expect_true(finalized)
+})
+
+test_that("vertex attributes are destroyed when the graph is destroyed", {
+  finalized <- FALSE
+  finalizer <- function(e) {
+    finalized <<- TRUE
+  }
+
+  env <- new.env(parent = emptyenv())
+  reg.finalizer(env, finalizer)
+
+  g <- make_ring(1)
+  V(g)$a <- list(env)
+  rm(env)
+  gc()
+  expect_false(finalized)
+
+  g <- add_vertices(g, 1)
+  gc()
+  expect_false(finalized)
+
+  g <- delete_vertices(g, 2)
+  gc()
+  expect_false(finalized)
+
+  rm(g)
+  gc()
+  expect_true(finalized)
+})
+
+test_that("edge attributes are destroyed when the graph is destroyed", {
+  finalized <- FALSE
+  finalizer <- function(e) {
+    finalized <<- TRUE
+  }
+
+  env <- new.env(parent = emptyenv())
+  reg.finalizer(env, finalizer)
+
+  g <- make_ring(2)
+  E(g)$a <- list(env)
+  rm(env)
+  gc()
+  expect_false(finalized)
+
+  g <- add_vertices(g, 1)
+  gc()
+  expect_false(finalized)
+
+  g <- add_edges(g, c(2, 3))
+  gc()
+  expect_false(finalized)
+
+  g <- delete_edges(g, 2)
+  gc()
+  expect_false(finalized)
+
+  rm(g)
+  gc()
+  expect_true(finalized)
+})

--- a/tests/testthat/test-decompose.graph.R
+++ b/tests/testthat/test-decompose.graph.R
@@ -35,3 +35,13 @@ test_that("decompose keeps attributes", {
   expect_that(E(d[[1]])$name, equals(e1))
   expect_that(E(d[[2]])$name, equals(e2))
 })
+
+test_that("decompose protects correctly", {
+  g <- make_graph(integer(), n = 10001)
+  V(g)$a <- 1
+
+  torture <- gctorture2(10001)
+  on.exit(gctorture2(torture))
+
+  length(decompose(g))
+})


### PR DESCRIPTION
Add a global preserve list to which attribute objects can be added while no corresponding R graph object exists. This list is cleared before the next call to an igraph function.

This will only leak memory if a single igraph function call initializes attributes many times without actually using them, and only before a second igraph function call is made.

The commits can be reviewed individually.

Closes #866.