### PR TITLE
fix: `free_graph` use `igraph_free` to delete graph

### DIFF
--- a/src/rinterface.c
+++ b/src/rinterface.c
@@ -148,7 +148,6 @@ SEXP R_igraph_empty(SEXP n, SEXP directed) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -198,7 +197,6 @@ SEXP R_igraph_full_citation(SEXP n, SEXP directed) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -228,7 +226,6 @@ SEXP R_igraph_extended_chordal_ring(SEXP nodes, SEXP W, SEXP directed) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -258,7 +255,6 @@ SEXP R_igraph_lcf_vector(SEXP n, SEXP shifts, SEXP repeats) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -290,7 +286,6 @@ SEXP R_igraph_adjlist(SEXP adjlist, SEXP mode, SEXP duplicate) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -331,7 +326,6 @@ SEXP R_igraph_full_bipartite(SEXP n1, SEXP n2, SEXP directed, SEXP mode) {
   PROTECT(r_names=NEW_CHARACTER(2));
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   PROTECT(types=R_igraph_0orvector_bool_to_SEXP(&c_types));
   igraph_vector_bool_destroy(&c_types);
@@ -371,7 +365,6 @@ SEXP R_igraph_realize_degree_sequence(SEXP out_deg, SEXP in_deg, SEXP allowed_ed
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -417,7 +410,6 @@ SEXP R_igraph_preference_game(SEXP nodes, SEXP types, SEXP type_dist, SEXP fixed
   PROTECT(r_names=NEW_CHARACTER(2));
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   PROTECT(node_type_vec=R_igraph_vector_to_SEXP(&c_node_type_vec));
   igraph_vector_destroy(&c_node_type_vec);
@@ -475,7 +467,6 @@ SEXP R_igraph_asymmetric_preference_game(SEXP nodes, SEXP out_types, SEXP in_typ
   PROTECT(r_names=NEW_CHARACTER(3));
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   PROTECT(node_type_in_vec=R_igraph_vector_to_SEXP(&c_node_type_in_vec));
   igraph_vector_destroy(&c_node_type_in_vec);
@@ -518,7 +509,6 @@ SEXP R_igraph_rewire_edges(SEXP graph, SEXP prob, SEXP loops, SEXP multiple) {
 
                                         /* Convert output */
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -548,7 +538,6 @@ SEXP R_igraph_rewire_directed_edges(SEXP graph, SEXP prob, SEXP loops, SEXP mode
 
                                         /* Convert output */
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -582,7 +571,6 @@ SEXP R_igraph_forest_fire_game(SEXP nodes, SEXP fw_prob, SEXP bw_factor, SEXP am
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -616,7 +604,6 @@ SEXP R_igraph_static_fitness_game(SEXP no_of_edges, SEXP fitness_out, SEXP fitne
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -654,7 +641,6 @@ SEXP R_igraph_static_power_law_game(SEXP no_of_nodes, SEXP no_of_edges, SEXP exp
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -686,7 +672,6 @@ SEXP R_igraph_k_regular_game(SEXP no_of_nodes, SEXP k, SEXP directed, SEXP multi
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -721,7 +706,6 @@ SEXP R_igraph_sbm_game(SEXP n, SEXP pref_matrix, SEXP block_sizes, SEXP directed
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   igraph_vector_int_destroy(&c_block_sizes);
   IGRAPH_FINALLY_CLEAN(1);
@@ -757,7 +741,6 @@ SEXP R_igraph_hsbm_game(SEXP n, SEXP m, SEXP rho, SEXP C, SEXP p) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -792,7 +775,6 @@ SEXP R_igraph_hsbm_list_game(SEXP n, SEXP mlist, SEXP rholist, SEXP Clist, SEXP 
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   igraph_vector_int_destroy(&c_mlist);
   IGRAPH_FINALLY_CLEAN(1);
@@ -826,7 +808,6 @@ SEXP R_igraph_correlated_game(SEXP old_graph, SEXP corr, SEXP p, SEXP permutatio
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_new_graph);
   PROTECT(new_graph=R_igraph_to_SEXP(&c_new_graph));
-  IGRAPH_I_DESTROY(&c_new_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = new_graph;
 
@@ -864,11 +845,9 @@ SEXP R_igraph_correlated_pair_game(SEXP n, SEXP corr, SEXP p, SEXP directed, SEX
   PROTECT(r_names=NEW_CHARACTER(2));
   IGRAPH_FINALLY(igraph_destroy, &c_graph1);
   PROTECT(graph1=R_igraph_to_SEXP(&c_graph1));
-  IGRAPH_I_DESTROY(&c_graph1);
   IGRAPH_FINALLY_CLEAN(1);
   IGRAPH_FINALLY(igraph_destroy, &c_graph2);
   PROTECT(graph2=R_igraph_to_SEXP(&c_graph2));
-  IGRAPH_I_DESTROY(&c_graph2);
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(r_result, 0, graph1);
   SET_VECTOR_ELT(r_result, 1, graph2);
@@ -901,7 +880,6 @@ SEXP R_igraph_dot_product_game(SEXP vecs, SEXP directed) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -1514,7 +1492,6 @@ SEXP R_igraph_induced_subgraph(SEXP graph, SEXP vids, SEXP impl) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_res);
   PROTECT(res=R_igraph_to_SEXP(&c_res));
-  IGRAPH_I_DESTROY(&c_res);
   IGRAPH_FINALLY_CLEAN(1);
   igraph_vs_destroy(&c_vids);
   r_result = res;
@@ -1545,7 +1522,6 @@ SEXP R_igraph_subgraph_edges(SEXP graph, SEXP eids, SEXP delete_vertices) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_res);
   PROTECT(res=R_igraph_to_SEXP(&c_res));
-  IGRAPH_I_DESTROY(&c_res);
   IGRAPH_FINALLY_CLEAN(1);
   igraph_es_destroy(&c_eids);
   r_result = res;
@@ -1572,7 +1548,6 @@ SEXP R_igraph_reverse_edges(SEXP graph, SEXP eids) {
 
                                         /* Convert output */
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   igraph_es_destroy(&c_eids);
   r_result = graph;
@@ -1687,7 +1662,6 @@ SEXP R_igraph_simplify(SEXP graph, SEXP remove_multiple, SEXP remove_loops, SEXP
 
                                         /* Convert output */
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   igraph_attribute_combination_destroy(&c_edge_attr_comb);
   IGRAPH_FINALLY_CLEAN(1);
@@ -2145,7 +2119,6 @@ SEXP R_igraph_unfold_tree(SEXP graph, SEXP mode, SEXP roots) {
   PROTECT(r_names=NEW_CHARACTER(2));
   IGRAPH_FINALLY(igraph_destroy, &c_tree);
   PROTECT(tree=R_igraph_to_SEXP(&c_tree));
-  IGRAPH_I_DESTROY(&c_tree);
   IGRAPH_FINALLY_CLEAN(1);
   PROTECT(vertex_index=R_igraph_0orvector_to_SEXPp1(&c_vertex_index));
   igraph_vector_destroy(&c_vertex_index);
@@ -2793,7 +2766,6 @@ SEXP R_igraph_contract_vertices(SEXP graph, SEXP mapping, SEXP vertex_attr_comb)
 
                                         /* Convert output */
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   igraph_attribute_combination_destroy(&c_vertex_attr_comb);
   IGRAPH_FINALLY_CLEAN(1);
@@ -3172,7 +3144,6 @@ SEXP R_igraph_create_bipartite(SEXP types, SEXP edges, SEXP directed) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -3212,7 +3183,6 @@ SEXP R_igraph_incidence(SEXP incidence, SEXP directed, SEXP mode, SEXP multiple)
   PROTECT(r_names=NEW_CHARACTER(2));
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   PROTECT(types=R_igraph_vector_bool_to_SEXP(&c_types));
   igraph_vector_bool_destroy(&c_types);
@@ -3364,7 +3334,6 @@ SEXP R_igraph_bipartite_game_gnp(SEXP n1, SEXP n2, SEXP p, SEXP directed, SEXP m
   PROTECT(r_names=NEW_CHARACTER(2));
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   PROTECT(types=R_igraph_0orvector_bool_to_SEXP(&c_types));
   igraph_vector_bool_destroy(&c_types);
@@ -3415,7 +3384,6 @@ SEXP R_igraph_bipartite_game_gnm(SEXP n1, SEXP n2, SEXP m, SEXP directed, SEXP m
   PROTECT(r_names=NEW_CHARACTER(2));
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   PROTECT(types=R_igraph_0orvector_bool_to_SEXP(&c_types));
   igraph_vector_bool_destroy(&c_types);
@@ -4824,7 +4792,6 @@ SEXP R_igraph_hrg_game(SEXP hrg) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -4850,7 +4817,6 @@ SEXP R_igraph_hrg_dendrogram(SEXP hrg) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -5073,7 +5039,6 @@ SEXP R_igraph_to_directed(SEXP graph, SEXP mode) {
 
                                         /* Convert output */
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -5102,7 +5067,6 @@ SEXP R_igraph_to_undirected(SEXP graph, SEXP mode, SEXP edge_attr_comb) {
 
                                         /* Convert output */
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   igraph_attribute_combination_destroy(&c_edge_attr_comb);
   IGRAPH_FINALLY_CLEAN(1);
@@ -6076,7 +6040,6 @@ SEXP R_igraph_isoclass_create(SEXP size, SEXP number, SEXP directed) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 
@@ -6641,7 +6604,6 @@ SEXP R_igraph_permute_vertices(SEXP graph, SEXP permutation) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_res);
   PROTECT(res=R_igraph_to_SEXP(&c_res));
-  IGRAPH_I_DESTROY(&c_res);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = res;
 
@@ -6854,7 +6816,6 @@ SEXP R_igraph_simplify_and_colorize(SEXP graph) {
   PROTECT(r_names=NEW_CHARACTER(3));
   IGRAPH_FINALLY(igraph_destroy, &c_res);
   PROTECT(res=R_igraph_to_SEXP(&c_res));
-  IGRAPH_I_DESTROY(&c_res);
   IGRAPH_FINALLY_CLEAN(1);
   PROTECT(vertex_color=R_igraph_vector_int_to_SEXP(&c_vertex_color));
   igraph_vector_int_destroy(&c_vertex_color);
@@ -7457,7 +7418,6 @@ SEXP R_igraph_from_prufer(SEXP prufer) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   igraph_vector_int_destroy(&c_prufer);
   IGRAPH_FINALLY_CLEAN(1);
@@ -7549,7 +7509,6 @@ SEXP R_igraph_tree_game(SEXP n, SEXP directed, SEXP method) {
                                         /* Convert output */
   IGRAPH_FINALLY(igraph_destroy, &c_graph);
   PROTECT(graph=R_igraph_to_SEXP(&c_graph));
-  IGRAPH_I_DESTROY(&c_graph);
   IGRAPH_FINALLY_CLEAN(1);
   r_result = graph;
 

--- a/src/rinterface.c
+++ b/src/rinterface.c
@@ -4074,7 +4074,6 @@ SEXP R_igraph_layout_sugiyama(SEXP graph, SEXP layers, SEXP hgap, SEXP vgap, SEX
   IGRAPH_FINALLY_CLEAN(1);
   IGRAPH_FINALLY(igraph_destroy, &c_extd_graph);
   PROTECT(extd_graph=R_igraph_to_SEXP(&c_extd_graph));
-  IGRAPH_I_DESTROY(&c_extd_graph);
   IGRAPH_FINALLY_CLEAN(1);
   PROTECT(extd_to_orig_eids=R_igraph_0orvector_to_SEXPp1(&c_extd_to_orig_eids));
   igraph_vector_destroy(&c_extd_to_orig_eids);
@@ -5704,7 +5703,6 @@ SEXP R_igraph_dominator_tree(SEXP graph, SEXP root, SEXP mode) {
   IGRAPH_FINALLY_CLEAN(1);
   IGRAPH_FINALLY(igraph_destroy, &c_domtree);
   PROTECT(domtree=R_igraph_to_SEXP(&c_domtree));
-  IGRAPH_I_DESTROY(&c_domtree);
   IGRAPH_FINALLY_CLEAN(1);
   PROTECT(leftout=R_igraph_vector_to_SEXPp1(&c_leftout));
   igraph_vector_destroy(&c_leftout);

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -2762,12 +2762,7 @@ SEXP R_igraph_graph_env(SEXP graph) {
 static void free_graph(SEXP xp) {
   R_igraph_status_handler("Free graph external pointer.\n", NULL);
   igraph_t *graph = (igraph_t*)(R_ExternalPtrAddr(xp));
-  igraph_vector_destroy(&graph->from);
-  igraph_vector_destroy(&graph->to);
-  igraph_vector_destroy(&graph->oi);
-  igraph_vector_destroy(&graph->ii);
-  igraph_vector_destroy(&graph->os);
-  igraph_vector_destroy(&graph->is);
+  igraph_destroy(graph);
   IGRAPH_FREE(graph);
 }
 
@@ -3870,7 +3865,6 @@ SEXP R_igraph_add_edges(SEXP graph, SEXP edges) {
   IGRAPH_FINALLY(igraph_destroy, &g);
   IGRAPH_R_CHECK(igraph_add_edges(&g, &v, 0));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
   IGRAPH_FINALLY_CLEAN(1);
 
   UNPROTECT(1);
@@ -3887,7 +3881,6 @@ SEXP R_igraph_add_vertices(SEXP graph, SEXP pnv) {
   R_SEXP_to_igraph_copy(graph, &g);
   IGRAPH_R_CHECK(igraph_add_vertices(&g, nv, 0));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -3960,7 +3953,6 @@ SEXP R_igraph_delete_edges(SEXP graph, SEXP edges) {
   R_SEXP_to_igraph_es(edges, &g, &es);
   IGRAPH_R_CHECK(igraph_delete_edges(&g, es));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -3976,7 +3968,6 @@ SEXP R_igraph_delete_vertices(SEXP graph, SEXP vertices) {
   R_SEXP_to_igraph_vs(vertices, &g, &vs);
   IGRAPH_R_CHECK(igraph_delete_vertices(&g, vs));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
   igraph_vs_destroy(&vs);
 
   UNPROTECT(1);
@@ -4007,7 +3998,6 @@ SEXP R_igraph_create(SEXP edges, SEXP pn, SEXP pdirected) {
   R_SEXP_to_vector(edges, &v);
   IGRAPH_R_CHECK(igraph_create(&g, &v, n, directed));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -4234,7 +4224,6 @@ SEXP R_igraph_growing_random_game(SEXP pn, SEXP pm, SEXP pdirected,
 
   IGRAPH_R_CHECK(igraph_growing_random_game(&g, n, m, directed, citation));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -4340,7 +4329,6 @@ SEXP R_igraph_lattice(SEXP pdimvector, SEXP pnei, SEXP pdirected,
 
   IGRAPH_R_CHECK(igraph_lattice(&g, &dimvector, nei, directed, mutual, circular));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -4374,7 +4362,6 @@ SEXP R_igraph_barabasi_game(SEXP pn, SEXP ppower, SEXP pm, SEXP poutseq,
 
   IGRAPH_R_CHECK(igraph_barabasi_game(&g, n, power, m, myoutseq, outpref, A, directed, algo, ppstart));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -4399,7 +4386,6 @@ SEXP R_igraph_recent_degree_game(SEXP pn, SEXP ppower, SEXP pwindow,
 
   IGRAPH_R_CHECK(igraph_recent_degree_game(&g, n, power, window, m, &outseq, outpref, zero_appeal, directed));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -4671,7 +4657,6 @@ SEXP R_igraph_minimum_spanning_tree_unweighted(SEXP graph) {
   R_SEXP_to_igraph(graph, &g);
   IGRAPH_R_CHECK(igraph_minimum_spanning_tree_unweighted(&g, &mst));
   PROTECT(result=R_igraph_to_SEXP(&mst));
-  IGRAPH_I_DESTROY(&mst);
 
   UNPROTECT(1);
   return result;
@@ -4689,7 +4674,6 @@ SEXP R_igraph_minimum_spanning_tree_prim(SEXP graph, SEXP pweights) {
   R_SEXP_to_igraph(graph, &g);
   IGRAPH_R_CHECK(igraph_minimum_spanning_tree_prim(&g, &mst, &weights));
   PROTECT(result=R_igraph_to_SEXP(&mst));
-  IGRAPH_I_DESTROY(&mst);
 
   UNPROTECT(1);
   return result;
@@ -4847,7 +4831,6 @@ SEXP R_igraph_graph_adjacency(SEXP adjmatrix, SEXP pmode) {
   R_SEXP_to_matrix(adjmatrix, &adjm);
   IGRAPH_R_CHECK(igraph_adjacency(&g, &adjm, (igraph_adjacency_t) mode));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -4866,7 +4849,6 @@ SEXP R_igraph_weighted_adjacency(SEXP adjmatrix, SEXP pmode,
   R_SEXP_to_matrix(adjmatrix, &adjm);
   IGRAPH_R_CHECK(igraph_weighted_adjacency(&g, &adjm, (igraph_adjacency_t) mode, attr, loops));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -4882,7 +4864,6 @@ SEXP R_igraph_star(SEXP pn, SEXP pmode, SEXP pcenter) {
 
   IGRAPH_R_CHECK(igraph_star(&g, n, (igraph_star_mode_t) mode, center));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -4899,7 +4880,6 @@ SEXP R_igraph_ring(SEXP pn, SEXP pdirected, SEXP pmutual, SEXP pcircular) {
 
   IGRAPH_R_CHECK(igraph_ring(&g, n, directed, mutual, circular));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -4915,7 +4895,6 @@ SEXP R_igraph_tree(SEXP pn, SEXP pchildren, SEXP pmode) {
 
   IGRAPH_R_CHECK(igraph_tree(&g, n, children, (igraph_tree_mode_t) mode));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -4970,7 +4949,6 @@ SEXP R_igraph_erdos_renyi_game(SEXP pn, SEXP ptype,
   igraph_erdos_renyi_game(&g, (igraph_erdos_renyi_t) type, n, porm, directed,
                           loops);
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -4986,7 +4964,6 @@ SEXP R_igraph_full(SEXP pn, SEXP pdirected, SEXP ploops) {
 
   IGRAPH_R_CHECK(igraph_full(&g, n, directed, loops));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -5058,7 +5035,6 @@ SEXP R_igraph_degree_sequence_game(SEXP pout_seq, SEXP pin_seq,
   if (!Rf_isNull(pin_seq)) { R_SEXP_to_vector(pin_seq, &inseq); }
   IGRAPH_R_CHECK(igraph_degree_sequence_game(&g, &outseq, Rf_isNull(pin_seq) ? 0 : &inseq, (igraph_degseq_t) method));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -5180,7 +5156,6 @@ SEXP R_igraph_read_graph_edgelist(SEXP pvfile, SEXP pn, SEXP pdirected) {
   IGRAPH_R_CHECK(igraph_read_graph_edgelist(&g, file, n, directed));
   fclose(file);
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -5202,7 +5177,6 @@ SEXP R_igraph_read_graph_gml(SEXP pvfile) {
   IGRAPH_R_CHECK(igraph_read_graph_gml(&g, file));
   fclose(file);
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -5225,7 +5199,6 @@ SEXP R_igraph_read_graph_dl(SEXP pvfile, SEXP pdirected) {
   IGRAPH_R_CHECK(igraph_read_graph_dl(&g, file, directed));
   fclose(file);
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -5247,7 +5220,6 @@ SEXP R_igraph_read_graph_graphdb(SEXP pvfile, SEXP pdirected) {
   IGRAPH_R_CHECK(igraph_read_graph_graphdb(&g, file, directed));
   fclose(file);
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -5438,7 +5410,6 @@ SEXP R_igraph_read_graph_ncol(SEXP pvfile, SEXP ppredef,
   IGRAPH_R_CHECK(igraph_read_graph_ncol(&g, file, predefptr, names, weights, directed));
   fclose(file);
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -5506,7 +5477,6 @@ SEXP R_igraph_read_graph_lgl(SEXP pvfile, SEXP pnames, SEXP pweights, SEXP pdire
   IGRAPH_R_CHECK(igraph_read_graph_lgl(&g, file, names, weights, directed));
   fclose(file);
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -5570,7 +5540,6 @@ SEXP R_igraph_read_graph_pajek(SEXP pvfile) {
   IGRAPH_R_CHECK(igraph_read_graph_pajek(&g, file));
   fclose(file);
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -5594,7 +5563,6 @@ SEXP R_igraph_decompose(SEXP graph, SEXP pmode, SEXP pmaxcompno,
   PROTECT(result=NEW_LIST(igraph_vector_ptr_size(&comps)));
   for (i=0; i<igraph_vector_ptr_size(&comps); i++) {
     SET_VECTOR_ELT(result, i, R_igraph_to_SEXP(VECTOR(comps)[i]));
-    IGRAPH_I_DESTROY((igraph_t*)VECTOR(comps)[i]);
     igraph_free(VECTOR(comps)[i]);
   }
   igraph_vector_ptr_destroy(&comps);
@@ -5613,7 +5581,6 @@ SEXP R_igraph_atlas(SEXP pno) {
 
   IGRAPH_R_CHECK(igraph_atlas(&g, no));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -5668,7 +5635,6 @@ SEXP R_igraph_callaway_traits_game(SEXP pnodes, SEXP ptypes,
   R_SEXP_to_matrix(pmatrix, &matrix);
   IGRAPH_R_CHECK(igraph_callaway_traits_game(&g, nodes, types, epers, &type_dist, &matrix, directed, /* node_type_vec = */ 0));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -5690,7 +5656,6 @@ SEXP R_igraph_establishment_game(SEXP pnodes, SEXP ptypes, SEXP pk,
   R_SEXP_to_matrix(pmatrix, &matrix);
   IGRAPH_R_CHECK(igraph_establishment_game(&g, nodes, types, k, &type_dist, &matrix, directed, /* node_type_vec = */ 0));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -5809,7 +5774,6 @@ SEXP R_igraph_disjoint_union(SEXP pgraphs) {
   IGRAPH_R_CHECK(igraph_disjoint_union_many(&res, &ptrvec));
   igraph_vector_ptr_destroy(&ptrvec);
   PROTECT(result=R_igraph_to_SEXP(&res));
-  IGRAPH_I_DESTROY(&res);
 
   UNPROTECT(1);
   return result;
@@ -5844,7 +5808,6 @@ SEXP R_igraph_union(SEXP pgraphs, SEXP pedgemaps) {
   SET_STRING_ELT(names, 0, Rf_mkChar("graph"));
   SET_STRING_ELT(names, 1, Rf_mkChar("edgemaps"));
   SET_NAMES(result, names);
-  IGRAPH_I_DESTROY(&res);
   if (edgemaps) {
     for (i=0; i<igraph_vector_ptr_size(my_edgemaps); i++) {
       igraph_vector_destroy(VECTOR(*my_edgemaps)[i]);
@@ -5886,7 +5849,6 @@ SEXP R_igraph_intersection(SEXP pgraphs, SEXP pedgemaps) {
   SET_STRING_ELT(names, 0, Rf_mkChar("graph"));
   SET_STRING_ELT(names, 1, Rf_mkChar("edgemaps"));
   SET_NAMES(result, names);
-  IGRAPH_I_DESTROY(&res);
   if (edgemaps) {
     for (i=0; i<igraph_vector_ptr_size(my_edgemaps); i++) {
       igraph_vector_destroy(VECTOR(*my_edgemaps)[i]);
@@ -5909,7 +5871,6 @@ SEXP R_igraph_difference(SEXP pleft, SEXP pright) {
   R_SEXP_to_igraph(pright, &right);
   IGRAPH_R_CHECK(igraph_difference(&res, &left, &right));
   PROTECT(result=R_igraph_to_SEXP(&res));
-  IGRAPH_I_DESTROY(&res);
 
   UNPROTECT(1);
   return result;
@@ -5925,7 +5886,6 @@ SEXP R_igraph_complementer(SEXP pgraph, SEXP ploops) {
   R_SEXP_to_igraph(pgraph, &g);
   IGRAPH_R_CHECK(igraph_complementer(&res, &g, loops));
   PROTECT(result=R_igraph_to_SEXP(&res));
-  IGRAPH_I_DESTROY(&res);
 
   UNPROTECT(1);
   return result;
@@ -5951,13 +5911,11 @@ SEXP R_igraph_compose(SEXP pleft, SEXP pright, SEXP pedgemaps) {
   IGRAPH_R_CHECK(igraph_compose(&res, &left, &right, my_edgemap1, my_edgemap2));
   PROTECT(result=NEW_LIST(3));
   SET_VECTOR_ELT(result, 0, R_igraph_to_SEXP(&res));
-  IGRAPH_I_DESTROY(&res);
   SET_VECTOR_ELT(result, 2, R_igraph_0orvector_to_SEXP(my_edgemap2));
   if (edgemaps) {
     igraph_vector_destroy(my_edgemap2);
     IGRAPH_FINALLY_CLEAN(1);
   }
-  IGRAPH_I_DESTROY(&res);
   SET_VECTOR_ELT(result, 1, R_igraph_0orvector_to_SEXP(my_edgemap1));
   if (edgemaps) {
     igraph_vector_destroy(my_edgemap1);
@@ -5998,7 +5956,6 @@ SEXP R_igraph_barabasi_aging_game(SEXP pn, SEXP ppa_exp, SEXP paging_exp,
 
   IGRAPH_R_CHECK(igraph_barabasi_aging_game(&g, n, m, &out_seq, out_pref, pa_exp, aging_exp, aging_bin, zero_deg_appeal, zero_age_appeal, deg_coef, age_coef, directed));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -6026,7 +5983,6 @@ SEXP R_igraph_recent_degree_aging_game(SEXP pn, SEXP ppa_exp, SEXP paging_exp,
 
   IGRAPH_R_CHECK(igraph_recent_degree_aging_game(&g, n, m, &out_seq, out_pref, pa_exp, aging_exp, aging_bin, time_window, zero_appeal, directed));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -6195,7 +6151,6 @@ SEXP R_igraph_rewire(SEXP graph, SEXP pn, SEXP pmode) {
   R_SEXP_to_igraph_copy(graph, &g);
   IGRAPH_R_CHECK(igraph_rewire(&g, n, mode));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -6217,7 +6172,6 @@ SEXP R_igraph_read_graph_graphml(SEXP pvfile, SEXP pindex) {
   IGRAPH_R_CHECK(igraph_read_graph_graphml(&g, file, index));
   fclose(file);
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -6384,7 +6338,6 @@ SEXP R_igraph_grg_game(SEXP pn, SEXP pradius, SEXP ptorus,
   IGRAPH_R_CHECK(igraph_grg_game(&g, n, radius, torus, px, py));
   PROTECT(result=NEW_LIST(3));
   SET_VECTOR_ELT(result, 0, R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
   SET_VECTOR_ELT(result, 1, R_igraph_0orvector_to_SEXP(px));
   if (coords) { igraph_vector_destroy(px); }
   SET_VECTOR_ELT(result, 2, R_igraph_0orvector_to_SEXP(py));
@@ -6441,7 +6394,6 @@ SEXP R_igraph_read_graph_dimacs(SEXP pvfile, SEXP pdirected) {
     SET_VECTOR_ELT(result, 0, R_igraph_strvector_to_SEXP(&problem));
     igraph_strvector_destroy(&problem);
     SET_VECTOR_ELT(result, 1, R_igraph_to_SEXP(&g));
-    IGRAPH_I_DESTROY(&g);
     SET_VECTOR_ELT(result, 2, NEW_NUMERIC(1));
     REAL(VECTOR_ELT(result, 2))[0]=source;
     SET_VECTOR_ELT(result, 3, NEW_NUMERIC(1));
@@ -6454,7 +6406,6 @@ SEXP R_igraph_read_graph_dimacs(SEXP pvfile, SEXP pdirected) {
     SET_VECTOR_ELT(result, 0, R_igraph_strvector_to_SEXP(&problem));
     igraph_strvector_destroy(&problem);
     SET_VECTOR_ELT(result, 1, R_igraph_to_SEXP(&g));
-    IGRAPH_I_DESTROY(&g);
     SET_VECTOR_ELT(result, 2, R_igraph_vector_to_SEXP(&label));
     igraph_vector_destroy(&label);
   } else {
@@ -6919,7 +6870,6 @@ SEXP R_igraph_neighborhood_graphs(SEXP graph, SEXP pvids, SEXP porder,
   for (i=0; i<igraph_vector_ptr_size(&res); i++) {
     igraph_t *g=VECTOR(res)[i];
     SET_VECTOR_ELT(result, i, R_igraph_to_SEXP(g));
-    IGRAPH_I_DESTROY(g);
     igraph_free(g);
   }
   igraph_vector_ptr_destroy(&res);
@@ -6940,7 +6890,6 @@ SEXP R_igraph_connect_neighborhood(SEXP graph, SEXP porder, SEXP pmode) {
   R_SEXP_to_igraph_copy(graph, &g);
   IGRAPH_R_CHECK(igraph_connect_neighborhood(&g, order, (igraph_neimode_t) mode));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -6960,7 +6909,6 @@ SEXP R_igraph_watts_strogatz_game(SEXP pdim, SEXP psize, SEXP pnei, SEXP pp,
 
   IGRAPH_R_CHECK(igraph_watts_strogatz_game(&g, dim, size, nei, p, loops, multiple));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -7205,7 +7153,6 @@ SEXP R_igraph_lastcit_game(SEXP pnodes, SEXP pedges, SEXP pagebins,
   R_SEXP_to_vector(ppreference, &preference);
   IGRAPH_R_CHECK(igraph_lastcit_game(&g, nodes, edges, agebins, &preference, directed));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -7224,7 +7171,6 @@ SEXP R_igraph_cited_type_game(SEXP pnodes, SEXP pedges, SEXP ptypes,
   R_SEXP_to_vector(ppref, &pref);
   IGRAPH_R_CHECK(igraph_cited_type_game(&g, nodes, &types, &pref, edges, directed));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -7245,7 +7191,6 @@ SEXP R_igraph_citing_cited_type_game(SEXP pnodes, SEXP ptypes, SEXP ppref,
   R_SEXP_to_matrix(ppref, &pref);
   IGRAPH_R_CHECK(igraph_citing_cited_type_game(&g, nodes, &types, &pref, edges, directed));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -7528,7 +7473,6 @@ SEXP R_igraph_linegraph(SEXP graph) {
   R_SEXP_to_igraph(graph, &g);
   IGRAPH_R_CHECK(igraph_linegraph(&g, &lg));
   PROTECT(result=R_igraph_to_SEXP(&lg));
-  IGRAPH_I_DESTROY(&lg);
 
   UNPROTECT(1);
   return result;
@@ -7543,7 +7487,6 @@ SEXP R_igraph_de_bruijn(SEXP pm, SEXP pn) {
 
   IGRAPH_R_CHECK(igraph_de_bruijn(&g, m, n));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -7558,7 +7501,6 @@ SEXP R_igraph_kautz(SEXP pm, SEXP pn) {
 
   IGRAPH_R_CHECK(igraph_kautz(&g, m, n));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -7571,7 +7513,6 @@ SEXP R_igraph_famous(SEXP name) {
 
   IGRAPH_R_CHECK(igraph_famous(&g, CHAR(STRING_ELT(name, 0))));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -7752,7 +7693,6 @@ SEXP R_igraph_is_chordal(SEXP graph, SEXP alpha, SEXP alpham1,
   if (LOGICAL(pnewgraph)[0]) {
     IGRAPH_FINALLY(igraph_destroy, &c_newgraph);
     PROTECT(newgraph=R_igraph_to_SEXP(&c_newgraph));
-    IGRAPH_I_DESTROY(&c_newgraph);
     IGRAPH_FINALLY_CLEAN(1);
   } else {
     PROTECT(newgraph=R_NilValue);
@@ -8089,7 +8029,6 @@ SEXP R_igraph_cohesive_blocks(SEXP graph) {
   IGRAPH_FINALLY_CLEAN(1);
   IGRAPH_FINALLY(igraph_destroy, &c_blockTree);
   PROTECT(blockTree=R_igraph_to_SEXP(&c_blockTree));
-  IGRAPH_I_DESTROY(&c_blockTree);
   IGRAPH_FINALLY_CLEAN(1);
   SET_VECTOR_ELT(result, 0, blocks);
   SET_VECTOR_ELT(result, 1, cohesion);
@@ -8514,7 +8453,6 @@ SEXP R_igraph_scg_adjacency(SEXP graph, SEXP matrix, SEXP sparsmat, SEXP ev,
 
   if (do_scg_graph) {
     PROTECT(scg_graph=R_igraph_to_SEXP(&c_scg_graph));
-    IGRAPH_I_DESTROY(&c_scg_graph);
     UNPROTECT(1);
   } else {
     scg_graph=R_NilValue;
@@ -8711,7 +8649,6 @@ SEXP R_igraph_scg_stochastic(SEXP graph, SEXP matrix, SEXP sparsmat, SEXP ev,
 
   if (do_scg_graph) {
     PROTECT(scg_graph=R_igraph_to_SEXP(&c_scg_graph));
-    IGRAPH_I_DESTROY(&c_scg_graph);
   } else {
     PROTECT(scg_graph=R_NilValue);
   }
@@ -8883,7 +8820,6 @@ SEXP R_igraph_scg_laplacian(SEXP graph, SEXP matrix, SEXP sparsmat, SEXP ev,
 
   if (do_scg_graph) {
     PROTECT(scg_graph=R_igraph_to_SEXP(&c_scg_graph));
-    IGRAPH_I_DESTROY(&c_scg_graph);
   } else {
     PROTECT(scg_graph=R_NilValue);
   }
@@ -9351,7 +9287,6 @@ SEXP R_igraph_simple_interconnected_islands_game(SEXP islands_n, SEXP islands_si
 
   IGRAPH_R_CHECK(igraph_simple_interconnected_islands_game(&g, a, b, c, d));
   PROTECT(result=R_igraph_to_SEXP(&g));
-  IGRAPH_I_DESTROY(&g);
 
   UNPROTECT(1);
   return result;
@@ -9409,7 +9344,6 @@ SEXP R_igraph_bipartite_projection(SEXP graph, SEXP types, SEXP probe1,
   if (do_1) {
     IGRAPH_FINALLY(igraph_destroy, &c_proj1);
     PROTECT(proj1=R_igraph_to_SEXP(&c_proj1));
-    IGRAPH_I_DESTROY(&c_proj1);
     IGRAPH_FINALLY_CLEAN(1);
   } else {
     PROTECT(proj1=R_NilValue);
@@ -9417,7 +9351,6 @@ SEXP R_igraph_bipartite_projection(SEXP graph, SEXP types, SEXP probe1,
   if (do_2) {
     IGRAPH_FINALLY(igraph_destroy, &c_proj2);
     PROTECT(proj2=R_igraph_to_SEXP(&c_proj2));
-    IGRAPH_I_DESTROY(&c_proj2);
     IGRAPH_FINALLY_CLEAN(1);
   } else {
     PROTECT(proj2=R_NilValue);

--- a/tools/stimulus/types-RC.yaml
+++ b/tools/stimulus/types-RC.yaml
@@ -9,12 +9,10 @@ GRAPH:
     OUTCONV:
         INOUT: |-
             PROTECT(%I%=R_igraph_to_SEXP(&%C%));
-            IGRAPH_I_DESTROY(&%C%);
             IGRAPH_FINALLY_CLEAN(1);
         OUT: |-
             IGRAPH_FINALLY(igraph_destroy, &%C%);
             PROTECT(%I%=R_igraph_to_SEXP(&%C%));
-            IGRAPH_I_DESTROY(&%C%);
             IGRAPH_FINALLY_CLEAN(1);
 
 GRAPH_OR_0:

--- a/tools/stimulus/types-RC.yaml
+++ b/tools/stimulus/types-RC.yaml
@@ -27,12 +27,10 @@ GRAPH_OR_0:
     OUTCONV:
         INOUT: |-
             if (!Rf_isNull(%I%)) { PROTECT(%I%=R_igraph_to_SEXP(&%C%));
-            IGRAPH_I_DESTROY(&%C%);
             IGRAPH_FINALLY_CLEAN(1); }
         OUT: |-
             IGRAPH_FINALLY(igraph_destroy, &%C%);
             PROTECT(%I%=R_igraph_to_SEXP(&%C%));
-            IGRAPH_I_DESTROY(&%C%);
             IGRAPH_FINALLY_CLEAN(1);
 
 INTEGER:


### PR DESCRIPTION
`R_igraph_to_SEXP` move graph data in external pointer -> graph data shouldn't be deleted after `R_igraph_to_SEXP` call