### PR TITLE
feat: `all_shortest_paths()` returns the vertex list in both `res` and `vpaths` components

### DIFF
--- a/R/structural.properties.R
+++ b/R/structural.properties.R
@@ -638,6 +638,9 @@ all_shortest_paths <- function(graph, from,
     res$res <- lapply(res$res, unsafe_create_vs, graph = graph, verts = V(graph))
   }
 
+  # Transitional, eventually, remove $res
+  res$vpaths <- res$res
+
   res
 }
 

--- a/tests/testthat/test-get.all.shortest.paths.R
+++ b/tests/testthat/test-get.all.shortest.paths.R
@@ -29,7 +29,7 @@ test_that("all_shortest_paths works", {
   sp1 <- all_shortest_paths(g, "s", "t", weights = NA)
 
   expect_that(
-    sortlist(sp1$res),
+    sortlist(sp1$vpaths),
     equals(list(c(1, 2, 7), c(1, 3, 7)))
   )
   expect_that(
@@ -40,7 +40,7 @@ test_that("all_shortest_paths works", {
   sp2 <- all_shortest_paths(g, "s", "t")
 
   expect_that(
-    sortlist(sp2$res),
+    sortlist(sp2$vpaths),
     equals(list(c(1, 2, 3, 4, 7), c(1, 2, 7), c(1, 3, 7)))
   )
   expect_that(sp2$nrgeo, equals(c(1, 1, 2, 1, 1, 1, 3)))

--- a/tests/testthat/test-get.shortest.paths.R
+++ b/tests/testthat/test-get.shortest.paths.R
@@ -20,8 +20,8 @@ test_that("shortest_paths works", {
 
   g <- graph_from_data_frame(as.data.frame(edges))
 
-  all1 <- all_shortest_paths(g, "s", "t", weights = NA)$res
-  all2 <- all_shortest_paths(g, "s", "t")$res
+  all1 <- all_shortest_paths(g, "s", "t", weights = NA)$vpaths
+  all2 <- all_shortest_paths(g, "s", "t")$vpaths
 
   s1 <- shortest_paths(g, "s", "t", weights = NA)
   s2 <- get.shortest.paths(g, "s", "t")


### PR DESCRIPTION
Are we doing this only because in 0.10 there will be an `edges` component?