### PR TITLE
feat: `is_tree(details = TRUE)` designates the first vertex as root for non-trees

### DIFF
--- a/R/trees.R
+++ b/R/trees.R
@@ -21,8 +21,10 @@
 #'   or also a possible root (`TRUE`)
 #' @return When `details` is `FALSE`, a logical value that indicates
 #'   whether the graph is a tree. When `details` is `TRUE`, a named
-#'   list with two entries: \item{res}{Logical value that indicates whether the
-#'   graph is a tree.} \item{root}{The root vertex of the tree; undefined if
+#'   list with two entries:
+#'   \item{res}{Logical value that indicates whether the
+#'   graph is a tree.}
+#'   \item{root}{The root vertex of the tree; undefined if
 #'   the graph is not a tree.}
 #'
 #' @keywords graphs
@@ -34,7 +36,13 @@
 #'
 #' @family trees
 #' @export
-is_tree <- is_tree_impl
+is_tree <- function(graph, mode = c("out", "in", "all", "total"), details = FALSE) {
+  out <- is_tree_impl(graph, mode, details)
+  if (isTRUE(details) && !out$res && vcount(graph) > 0) {
+    out$root <- V(graph)[1]
+  }
+  out
+}
 
 #' Convert a tree graph to its Prüfer sequence
 #'

--- a/man/is_tree.Rd
+++ b/man/is_tree.Rd
@@ -20,8 +20,10 @@ or also a possible root (\code{TRUE})}
 \value{
 When \code{details} is \code{FALSE}, a logical value that indicates
 whether the graph is a tree. When \code{details} is \code{TRUE}, a named
-list with two entries: \item{res}{Logical value that indicates whether the
-graph is a tree.} \item{root}{The root vertex of the tree; undefined if
+list with two entries:
+\item{res}{Logical value that indicates whether the
+graph is a tree.}
+\item{root}{The root vertex of the tree; undefined if
 the graph is not a tree.}
 }
 \description{

--- a/tests/testthat/test-trees.R
+++ b/tests/testthat/test-trees.R
@@ -1,7 +1,11 @@
 test_that("is_tree works for non-trees", {
   g <- make_graph("zachary")
   expect_false(is_tree(g))
-  expect_equal(ignore_attr = TRUE, is_tree(g, details = TRUE), list(res = FALSE, root = V(g)[numeric(0)]))
+  expect_equal(
+    ignore_attr = TRUE,
+    is_tree(g, details = TRUE),
+    list(res = FALSE, root = V(g)[1])
+  )
 
   g <- sample_pa(15, m = 3)
   expect_false(is_tree(g))


### PR DESCRIPTION
.