### PR TITLE
fix: Reduce frequency of interruption checks

### DIFF
--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -2348,6 +2348,10 @@ void checkInterruptFn(void *dummy) {
 }
 
 int R_igraph_interrupt_handler(void *data) {
+  /* Temporary improvement for https://github.com/igraph/rigraph/issues/940 */
+  static int iter = 0;
+  if (++iter < 16) return IGRAPH_SUCCESS;
+  iter = 0;
   /* We need to call R_CheckUserInterrupt() regularly to enable interruptions.
    * However, if an interruption is pending, R_CheckUserInterrupt() will
    * longjmp back to the top level so we cannot clean up ourselves by calling


### PR DESCRIPTION
@krlmlr In the interest of making progress and getting 1.6.0 out soon, I propose that for now we just limit interruption checks to every `n`th time. Shall we merge this PR now, and look for better solutions later?

Refs #940, #942