### PR TITLE
refactor: Replace loop by `lapply()` when returning vertex and edge sets 

### DIFF
--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -818,16 +818,10 @@ get_k_shortest_paths_impl <- function(graph, weights=NULL, k, from, to, mode=c("
   # Function call
   res <- .Call(R_igraph_get_k_shortest_paths, graph, weights, k, from-1, to-1, mode)
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res$vertex.paths)) {
-      res$vertex.paths[[i_]] <- unsafe_create_vs(graph, res$vertex.paths[[i_]], verts = verts)
-    }
+    res$vertex.paths <- lapply(res$vertex.paths, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   if (igraph_opt("return.vs.es")) {
-    es <- E(graph)
-    for (i_ in seq_along(res$edge.paths)) {
-      res$edge.paths[[i_]] <- unsafe_create_es(graph, res$edge.paths[[i_]], es = es)
-    }
+    res$edge.paths <- lapply(res$edge.paths, unsafe_create_es, graph = graph, es = E(graph))
   }
   res
 }
@@ -887,16 +881,10 @@ get_widest_paths_impl <- function(graph, from, to=V(graph), weights=NULL, mode=c
   # Function call
   res <- .Call(R_igraph_get_widest_paths, graph, from-1, to-1, weights, mode)
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res$vertices)) {
-      res$vertices[[i_]] <- unsafe_create_vs(graph, res$vertices[[i_]], verts = verts)
-    }
+    res$vertices <- lapply(res$vertices, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   if (igraph_opt("return.vs.es")) {
-    es <- E(graph)
-    for (i_ in seq_along(res$edges)) {
-      res$edges[[i_]] <- unsafe_create_es(graph, res$edges[[i_]], es = es)
-    }
+    res$edges <- lapply(res$edges, unsafe_create_es, graph = graph, es = E(graph))
   }
   res
 }
@@ -2256,22 +2244,13 @@ biconnected_components_impl <- function(graph) {
   # Function call
   res <- .Call(R_igraph_biconnected_components, graph)
   if (igraph_opt("return.vs.es")) {
-    es <- E(graph)
-    for (i_ in seq_along(res$tree.edges)) {
-      res$tree.edges[[i_]] <- unsafe_create_es(graph, res$tree.edges[[i_]], es = es)
-    }
+    res$tree.edges <- lapply(res$tree.edges, unsafe_create_es, graph = graph, es = E(graph))
   }
   if (igraph_opt("return.vs.es")) {
-    es <- E(graph)
-    for (i_ in seq_along(res$component.edges)) {
-      res$component.edges[[i_]] <- unsafe_create_es(graph, res$component.edges[[i_]], es = es)
-    }
+    res$component.edges <- lapply(res$component.edges, unsafe_create_es, graph = graph, es = E(graph))
   }
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res$components)) {
-      res$components[[i_]] <- unsafe_create_vs(graph, res$components[[i_]], verts = verts)
-    }
+    res$components <- lapply(res$components, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   if (igraph_opt("return.vs.es")) {
     res$articulation.points <- create_vs(graph, res$articulation.points)
@@ -2302,10 +2281,7 @@ cliques_impl <- function(graph, min=0, max=0) {
   # Function call
   res <- .Call(R_igraph_cliques, graph, min, max)
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res)) {
-      res[[i_]] <- unsafe_create_vs(graph, res[[i_]], verts = verts)
-    }
+    res <- lapply(res, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   res
 }
@@ -2331,10 +2307,7 @@ largest_cliques_impl <- function(graph) {
   # Function call
   res <- .Call(R_igraph_largest_cliques, graph)
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res)) {
-      res[[i_]] <- unsafe_create_vs(graph, res[[i_]], verts = verts)
-    }
+    res <- lapply(res, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   res
 }
@@ -2350,10 +2323,7 @@ maximal_cliques_subset_impl <- function(graph, subset, outfile=NULL, min.size=0,
   # Function call
   res <- .Call(R_igraph_maximal_cliques_subset, graph, subset-1, outfile, min.size, max.size)
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res$res)) {
-      res$res[[i_]] <- unsafe_create_vs(graph, res$res[[i_]], verts = verts)
-    }
+    res$res <- lapply(res$res, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   if (!details) {
     res <- res$res
@@ -2404,10 +2374,7 @@ weighted_cliques_impl <- function(graph, vertex.weights=NULL, min.weight=0, max.
   # Function call
   res <- .Call(R_igraph_weighted_cliques, graph, vertex.weights, min.weight, max.weight, maximal)
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res)) {
-      res[[i_]] <- unsafe_create_vs(graph, res[[i_]], verts = verts)
-    }
+    res <- lapply(res, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   res
 }
@@ -2428,10 +2395,7 @@ largest_weighted_cliques_impl <- function(graph, vertex.weights=NULL) {
   # Function call
   res <- .Call(R_igraph_largest_weighted_cliques, graph, vertex.weights)
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res)) {
-      res[[i_]] <- unsafe_create_vs(graph, res[[i_]], verts = verts)
-    }
+    res <- lapply(res, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   res
 }
@@ -2628,10 +2592,7 @@ graphlets_impl <- function(graph, weights=NULL, niter=1000) {
   # Function call
   res <- .Call(R_igraph_graphlets, graph, weights, niter)
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res$cliques)) {
-      res$cliques[[i_]] <- unsafe_create_vs(graph, res$cliques[[i_]], verts = verts)
-    }
+    res$cliques <- lapply(res$cliques, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   res
 }
@@ -3026,16 +2987,10 @@ all_st_cuts_impl <- function(graph, source, target) {
   # Function call
   res <- .Call(R_igraph_all_st_cuts, graph, source-1, target-1)
   if (igraph_opt("return.vs.es")) {
-    es <- E(graph)
-    for (i_ in seq_along(res$cuts)) {
-      res$cuts[[i_]] <- unsafe_create_es(graph, res$cuts[[i_]], es = es)
-    }
+    res$cuts <- lapply(res$cuts, unsafe_create_es, graph = graph, es = E(graph))
   }
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res$partition1s)) {
-      res$partition1s[[i_]] <- unsafe_create_vs(graph, res$partition1s[[i_]], verts = verts)
-    }
+    res$partition1s <- lapply(res$partition1s, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   res
 }
@@ -3064,16 +3019,10 @@ all_st_mincuts_impl <- function(graph, source, target, capacity=NULL) {
   # Function call
   res <- .Call(R_igraph_all_st_mincuts, graph, source-1, target-1, capacity)
   if (igraph_opt("return.vs.es")) {
-    es <- E(graph)
-    for (i_ in seq_along(res$cuts)) {
-      res$cuts[[i_]] <- unsafe_create_es(graph, res$cuts[[i_]], es = es)
-    }
+    res$cuts <- lapply(res$cuts, unsafe_create_es, graph = graph, es = E(graph))
   }
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res$partition1s)) {
-      res$partition1s[[i_]] <- unsafe_create_vs(graph, res$partition1s[[i_]], verts = verts)
-    }
+    res$partition1s <- lapply(res$partition1s, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   res
 }
@@ -3121,10 +3070,7 @@ all_minimal_st_separators_impl <- function(graph) {
   # Function call
   res <- .Call(R_igraph_all_minimal_st_separators, graph)
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res)) {
-      res[[i_]] <- unsafe_create_vs(graph, res[[i_]], verts = verts)
-    }
+    res <- lapply(res, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   res
 }
@@ -3137,10 +3083,7 @@ minimum_size_separators_impl <- function(graph) {
   # Function call
   res <- .Call(R_igraph_minimum_size_separators, graph)
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res)) {
-      res[[i_]] <- unsafe_create_vs(graph, res[[i_]], verts = verts)
-    }
+    res <- lapply(res, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   res
 }
@@ -3561,10 +3504,7 @@ automorphism_group_impl <- function(graph, colors=NULL, sh=c("fm", "f", "fs", "f
   # Function call
   res <- .Call(R_igraph_automorphism_group, graph, colors, sh)
   if (igraph_opt("return.vs.es")) {
-    verts <- V(graph)
-    for (i_ in seq_along(res$generators)) {
-      res$generators[[i_]] <- unsafe_create_vs(graph, res$generators[[i_]], verts = verts)
-    }
+    res$generators <- lapply(res$generators, unsafe_create_vs, graph = graph, verts = V(graph))
   }
   if (!details) {
     res <- res$generators
@@ -3827,10 +3767,7 @@ fundamental_cycles_impl <- function(graph, start=NULL, bfs.cutoff, weights=NULL)
   # Function call
   res <- .Call(R_igraph_fundamental_cycles, graph, start-1, bfs.cutoff, weights)
   if (igraph_opt("return.vs.es")) {
-    es <- E(graph)
-    for (i_ in seq_along(res)) {
-      res[[i_]] <- unsafe_create_es(graph, res[[i_]], es = es)
-    }
+    res <- lapply(res, unsafe_create_es, graph = graph, es = E(graph))
   }
   res
 }
@@ -3854,10 +3791,7 @@ minimum_cycle_basis_impl <- function(graph, bfs.cutoff, complete, use.cycle.orde
   # Function call
   res <- .Call(R_igraph_minimum_cycle_basis, graph, bfs.cutoff, complete, use.cycle.order, weights)
   if (igraph_opt("return.vs.es")) {
-    es <- E(graph)
-    for (i_ in seq_along(res)) {
-      res[[i_]] <- unsafe_create_es(graph, res[[i_]], es = es)
-    }
+    res <- lapply(res, unsafe_create_es, graph = graph, es = E(graph))
   }
   res
 }

--- a/tools/stimulus/types-RR.yaml
+++ b/tools/stimulus/types-RR.yaml
@@ -289,10 +289,7 @@ VERTEXSET_LIST:
     OUTCONV:
         OUT: |-
             if (igraph_opt("return.vs.es")) {
-              verts <- V(%I1%)
-              for (i_ in seq_along(%I%)) {
-                %I%[[i_]] <- unsafe_create_vs(%I1%, %I%[[i_]], verts = verts)
-              }
+              %I% <- lapply(%I%, unsafe_create_vs, graph = %I1%, verts = V(%I1%))
             }
 
 VERTEXSETLIST_INT:
@@ -303,10 +300,7 @@ EDGESET_LIST:
     OUTCONV:
         OUT: |-
             if (igraph_opt("return.vs.es")) {
-              es <- E(%I1%)
-              for (i_ in seq_along(%I%)) {
-                %I%[[i_]] <- unsafe_create_es(%I1%, %I%[[i_]], es = es)
-              }
+              %I% <- lapply(%I%, unsafe_create_es, graph = %I1%, es = E(%I1%))
             }
 
 'ARPACKSTORAGE':


### PR DESCRIPTION
Prompted by #1028.