### PR TITLE
fix: Stimulus argument dependencies

### DIFF
--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -950,7 +950,7 @@ spanner_impl <- function(graph, stretch, weights) {
   # Function call
   res <- .Call(R_igraph_spanner, graph, stretch, weights)
   if (igraph_opt("return.vs.es")) {
-    res <- create_es(, res)
+    res <- create_es(graph, res)
   }
   res
 }
@@ -975,7 +975,7 @@ betweenness_subset_impl <- function(graph, vids=V(graph), directed=TRUE, sources
   # Function call
   res <- .Call(R_igraph_betweenness_subset, graph, vids-1, directed, sources-1, targets-1, weights)
   if (igraph_opt("add.vertex.names") && is_named(graph)) {
-    names(res) <- vertex_attr(graph, "name", )
+    names(res) <- vertex_attr(graph, "name", vids)
   }
   res
 }
@@ -1000,7 +1000,7 @@ edge_betweenness_subset_impl <- function(graph, eids=E(graph), directed=TRUE, so
   # Function call
   res <- .Call(R_igraph_edge_betweenness_subset, graph, eids-1, directed, sources-1, targets-1, weights)
   if (igraph_opt("add.vertex.names") && is_named(graph)) {
-    names(res) <- vertex_attr(graph, "name", )
+    names(res) <- vertex_attr(graph, "name", V(graph))
   }
   res
 }
@@ -1404,10 +1404,10 @@ hub_and_authority_scores_impl <- function(graph, scale=TRUE, weights=NULL, optio
   # Function call
   res <- .Call(R_igraph_hub_and_authority_scores, graph, scale, weights, options)
   if (igraph_opt("add.vertex.names") && is_named(graph)) {
-    names(res$hub.vector) <- vertex_attr(graph, "name", )
+    names(res$hub.vector) <- vertex_attr(graph, "name", V(graph))
   }
   if (igraph_opt("add.vertex.names") && is_named(graph)) {
-    names(res$authority.vector) <- vertex_attr(graph, "name", )
+    names(res$authority.vector) <- vertex_attr(graph, "name", V(graph))
   }
   res
 }
@@ -2095,7 +2095,7 @@ bfs_simple_impl <- function(graph, root, mode=c("out", "in", "all", "total")) {
   # Function call
   res <- .Call(R_igraph_bfs_simple, graph, root-1, mode)
   if (igraph_opt("return.vs.es")) {
-    res$order <- create_vs(, res$order)
+    res$order <- create_vs(graph, res$order)
   }
   res
 }
@@ -2122,8 +2122,8 @@ biadjacency_impl <- function(incidence, directed=FALSE, mode=c("all", "out", "in
   on.exit( .Call(R_igraph_finalizer) )
   # Function call
   res <- .Call(R_igraph_biadjacency, incidence, directed, mode, multiple)
-  if (igraph_opt("add.vertex.names") && is_named()) {
-    names(res$types) <- vertex_attr(, "name", )
+  if (igraph_opt("add.vertex.names") && is_named(graph)) {
+    names(res$types) <- vertex_attr(graph, "name", V(graph))
   }
   res
 }
@@ -2148,7 +2148,7 @@ is_bipartite_impl <- function(graph) {
   # Function call
   res <- .Call(R_igraph_is_bipartite, graph)
   if (igraph_opt("add.vertex.names") && is_named(graph)) {
-    names(res$type) <- vertex_attr(graph, "name", )
+    names(res$type) <- vertex_attr(graph, "name", V(graph))
   }
   res
 }
@@ -2166,7 +2166,7 @@ bipartite_game_impl <- function(type, n1, n2, p=0.0, m=0, directed=FALSE, mode=c
   # Function call
   res <- .Call(R_igraph_bipartite_game, type, n1, n2, p, m, directed, mode)
   if (igraph_opt("add.vertex.names") && is_named(graph)) {
-    names(res$types) <- vertex_attr(graph, "name", )
+    names(res$types) <- vertex_attr(graph, "name", V(graph))
   }
   res
 }
@@ -3948,7 +3948,7 @@ moran_process_impl <- function(graph, weights=NULL, quantities, strategies, mode
   # Function call
   res <- .Call(R_igraph_moran_process, graph, weights, quantities, strategies, mode)
   if (igraph_opt("add.vertex.names") && is_named(graph)) {
-    names(res$quantities) <- vertex_attr(graph, "name", )
+    names(res$quantities) <- vertex_attr(graph, "name", V(graph))
   }
   res
 }
@@ -4050,7 +4050,7 @@ vertex_path_from_edge_path_impl <- function(graph, start, edge.path, mode=c("out
   # Function call
   res <- .Call(R_igraph_vertex_path_from_edge_path, graph, start-1, edge.path-1, mode)
   if (igraph_opt("return.vs.es")) {
-    res <- create_vs(, res)
+    res <- create_vs(graph, res)
   }
   res
 }

--- a/tools/stimulus/functions-R.yaml
+++ b/tools/stimulus/functions-R.yaml
@@ -325,6 +325,9 @@ igraph_get_all_simple_paths:
     R:
       PP: get.all.simple.paths.pp
 
+igraph_spanner:
+    DEPS: weights ON graph, spanner ON graph
+
 igraph_subcomponent:
     IGNORE: RR, RC
 
@@ -334,11 +337,19 @@ igraph_betweenness:
 igraph_betweenness_cutoff:
     IGNORE: RR
 
+igraph_betweenness_subset:
+    DEPS: |-
+        vids ON graph, weights ON graph, res ON graph vids, sources ON graph, targets ON graph
+
 igraph_edge_betweenness:
     IGNORE: RR
 
 igraph_edge_betweenness_cutoff:
     IGNORE: RR
+
+igraph_edge_betweenness_subset:
+    DEPS: |-
+        eids ON graph, weights ON graph V(graph), res ON graph V(graph), sources ON graph, targets ON graph
 
 igraph_harmonic_centrality:
     # This is handled by igraph_harmonic_centrality_cutoff
@@ -428,9 +439,6 @@ igraph_get_all_eids_between:
     # in the argument list.
     DEPS: from ON graph, to ON graph, eids ON graph
 
-igraph_hub_and_authority_scores:
-    DEPS: weights ON graph, hub_vector ON graph, authority_vector ON graph
-
 igraph_pseudo_diameter:
     DEPS: start_vid ON graph
 
@@ -438,16 +446,16 @@ igraph_pseudo_diameter_dijkstra:
     DEPS: start_vid ON graph, weights ON graph
 
 igraph_bfs_simple:
-    DEPS: root ON graph
+    DEPS: root ON graph, order ON graph
 
 igraph_is_bipartite:
-    DEPS: type ON graph
+    DEPS: type ON graph V(graph)
 
 igraph_bipartite_game:
-    DEPS: types ON graph
+    DEPS: types ON graph V(graph)
 
 igraph_vertex_path_from_edge_path:
-    DEPS: start ON graph, edge_path ON graph
+    DEPS: start ON graph, vertex_path ON graph, edge_path ON graph
 
 igraph_eigenvector_centrality:
     # This is a temporary hack; we need to find a way to handle default values
@@ -469,6 +477,13 @@ igraph_authority_score:
     # dependencies: the graph and the vertex set, but we only have the graph
     # in the argument list.
     DEPS: weights ON graph, vector ON graph V(graph)
+
+igraph_hub_and_authority_scores:
+    # This is a temporary hack; we need to find a way to handle default values
+    # for dependencies. The problem is that the VERTEXINDEX type needs two
+    # dependencies: the graph and the vertex set, but we only have the graph
+    # in the argument list.
+    DEPS: weights ON graph, hub_vector ON graph V(graph), authority_vector ON graph V(graph)
 
 igraph_arpack_rssolve:
     IGNORE: RR, RC, RInit
@@ -532,6 +547,9 @@ igraph_bipartite_projection:
 
 igraph_create_bipartite:
     IGNORE: RR
+
+igraph_biadjacency:
+    DEPS: types ON graph V(graph)
 
 igraph_bipartite_game_gnp:
     IGNORE: RR
@@ -1141,6 +1159,13 @@ igraph_is_tree:
 #######################################
 # Coloring
 #######################################
+
+#######################################
+# Microscopic update
+#######################################
+
+igraph_moran_process:
+    DEPS: weights ON graph, quantities ON graph V(graph), strategies ON graph
 
 #######################################
 # Other, (yet) undocumented functions


### PR DESCRIPTION
The implementations are currently unused, otherwise tests would be failing.