### PR TITLE
refactor/type-refactorings

### DIFF
--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -91,9 +91,10 @@ sparse_weighted_adjacency_impl <- function(adjmatrix, mode=DIRECTED, loops=ONCE)
   res
 }
 
-wheel_impl <- function(n, mode=OUT, center=0) {
+wheel_impl <- function(n, mode=c("out", "in", "undirected", "mutual"), center=0) {
   # Argument checks
   n <- as.numeric(n)
+  mode <- switch(igraph.match.arg(mode), "out"=0L, "in"=1L, "undirected"=2L, "mutual"=3L)
   center <- as.numeric(center)
 
   on.exit( .Call(R_igraph_finalizer) )
@@ -131,9 +132,10 @@ triangular_lattice_impl <- function(dimvector, directed=FALSE, mutual=FALSE) {
   res
 }
 
-symmetric_tree_impl <- function(branches, type=OUT) {
+symmetric_tree_impl <- function(branches, type=c("out", "in", "undirected")) {
   # Argument checks
   branches <- as.numeric(branches)
+  type <- switch(igraph.match.arg(type), "out"=0L, "in"=1L, "undirected"=2L)
 
   on.exit( .Call(R_igraph_finalizer) )
   # Function call
@@ -142,10 +144,11 @@ symmetric_tree_impl <- function(branches, type=OUT) {
   res
 }
 
-regular_tree_impl <- function(h, k=3, type=UNDIRECTED) {
+regular_tree_impl <- function(h, k=3, type=c("undirected", "out", "in")) {
   # Argument checks
   h <- as.numeric(h)
   k <- as.numeric(k)
+  type <- switch(igraph.match.arg(type), "out"=0L, "in"=1L, "undirected"=2L)
 
   on.exit( .Call(R_igraph_finalizer) )
   # Function call
@@ -3872,9 +3875,10 @@ to_prufer_impl <- function(graph) {
   res
 }
 
-tree_from_parent_vector_impl <- function(parents, type=OUT) {
+tree_from_parent_vector_impl <- function(parents, type=c("out", "in", "undirected")) {
   # Argument checks
   parents <- as.numeric(parents)-1
+  type <- switch(igraph.match.arg(type), "out"=0L, "in"=1L, "undirected"=2L)
 
   on.exit( .Call(R_igraph_finalizer) )
   # Function call

--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -2737,9 +2737,10 @@ from_hrg_dendrogram_impl <- function(hrg) {
   res
 }
 
-get_adjacency_sparse_impl <- function(graph, type=BOTH, weights=NULL, loops=ONCE) {
+get_adjacency_sparse_impl <- function(graph, type=c("both", "upper", "lower"), weights=NULL, loops=ONCE) {
   # Argument checks
   ensure_igraph(graph)
+  type <- switch(igraph.match.arg(type), "upper"=0L, "lower"=1L, "both"=2L)
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }

--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -1192,6 +1192,19 @@ ecc_impl <- function(graph, eids=E(graph), k=3, offset=FALSE, normalize=TRUE) {
   res
 }
 
+reciprocity_impl <- function(graph, ignore.loops=TRUE, mode=c('default', 'ratio')) {
+  # Argument checks
+  ensure_igraph(graph)
+  ignore.loops <- as.logical(ignore.loops)
+  mode <- switch(igraph.match.arg(mode), "default"=0L, "ratio"=1L)
+
+  on.exit( .Call(R_igraph_finalizer) )
+  # Function call
+  res <- .Call(R_igraph_reciprocity, graph, ignore.loops, mode)
+
+  res
+}
+
 feedback_arc_set_impl <- function(graph, weights=NULL, algo=c("approx_eades", "exact_ip")) {
   # Argument checks
   ensure_igraph(graph)

--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -774,7 +774,7 @@ distances_floyd_warshall_impl <- function(graph, from=V(graph), to=V(graph), wei
   res
 }
 
-voronoi_impl <- function(graph, generators, weights=NULL, mode=c("out", "in", "all", "total"), tiebreaker=RANDOM) {
+voronoi_impl <- function(graph, generators, weights=NULL, mode=c("out", "in", "all", "total"), tiebreaker=c("random", "first", "last")) {
   # Argument checks
   ensure_igraph(graph)
   generators <- as_igraph_vs(graph, generators)
@@ -787,6 +787,7 @@ voronoi_impl <- function(graph, generators, weights=NULL, mode=c("out", "in", "a
     weights <- NULL
   }
   mode <- switch(igraph.match.arg(mode), "out"=1L, "in"=2L, "all"=3L, "total"=3L)
+  tiebreaker <- switch(igraph.match.arg(tiebreaker), "first"=0L, "last"=1L, "random"=2L)
 
   on.exit( .Call(R_igraph_finalizer) )
   # Function call

--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -2184,10 +2184,11 @@ bipartite_game_impl <- function(type, n1, n2, p=0.0, m=0, directed=FALSE, mode=c
   res
 }
 
-get_laplacian_impl <- function(graph, mode=c("out", "in", "all", "total"), normalization=UNNORMALIZED, weights=NULL) {
+get_laplacian_impl <- function(graph, mode=c("out", "in", "all", "total"), normalization=c("unnormalized", "symmetric", "left", "right"), weights=NULL) {
   # Argument checks
   ensure_igraph(graph)
   mode <- switch(igraph.match.arg(mode), "out"=1L, "in"=2L, "all"=3L, "total"=3L)
+  normalization <- switch(igraph.match.arg(normalization), "unnormalized"=0L, "symmetric"=1L, "left"=2L, "right"=3L)
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }
@@ -2204,10 +2205,11 @@ get_laplacian_impl <- function(graph, mode=c("out", "in", "all", "total"), norma
   res
 }
 
-get_laplacian_sparse_impl <- function(graph, mode=c("out", "in", "all", "total"), normalization=UNNORMALIZED, weights=NULL) {
+get_laplacian_sparse_impl <- function(graph, mode=c("out", "in", "all", "total"), normalization=c("unnormalized", "symmetric", "left", "right"), weights=NULL) {
   # Argument checks
   ensure_igraph(graph)
   mode <- switch(igraph.match.arg(mode), "out"=1L, "in"=2L, "all"=3L, "total"=3L)
+  normalization <- switch(igraph.match.arg(normalization), "unnormalized"=0L, "symmetric"=1L, "left"=2L, "right"=3L)
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
     weights <- E(graph)$weight
   }

--- a/R/structural.properties.R
+++ b/R/structural.properties.R
@@ -1452,20 +1452,7 @@ constraint <- function(graph, nodes = V(graph), weights = NULL) {
 #' g <- sample_gnp(20, 5 / 20, directed = TRUE)
 #' reciprocity(g)
 #'
-reciprocity <- function(graph, ignore.loops = TRUE,
-                        mode = c("default", "ratio")) {
-  ensure_igraph(graph)
-  mode <- switch(igraph.match.arg(mode),
-    "default" = 0,
-    "ratio" = 1
-  )
-
-  on.exit(.Call(R_igraph_finalizer))
-  .Call(
-    R_igraph_reciprocity, graph, as.logical(ignore.loops),
-    as.numeric(mode)
-  )
-}
+reciprocity <- reciprocity_impl
 
 
 #' Graph density

--- a/src/rinterface.c
+++ b/src/rinterface.c
@@ -3496,6 +3496,34 @@ SEXP R_igraph_ecc(SEXP graph, SEXP eids, SEXP k, SEXP offset, SEXP normalize) {
 }
 
 /*-------------------------------------------/
+/ igraph_reciprocity                         /
+/-------------------------------------------*/
+SEXP R_igraph_reciprocity(SEXP graph, SEXP ignore_loops, SEXP mode) {
+                                        /* Declarations */
+  igraph_t c_graph;
+  igraph_real_t c_res;
+  igraph_bool_t c_ignore_loops;
+  igraph_reciprocity_t c_mode;
+  SEXP res;
+
+  SEXP r_result;
+                                        /* Convert input */
+  R_SEXP_to_igraph(graph, &c_graph);
+  c_ignore_loops=LOGICAL(ignore_loops)[0];
+  c_mode = (igraph_reciprocity_t) Rf_asInteger(mode);
+                                        /* Call igraph */
+  IGRAPH_R_CHECK(igraph_reciprocity(&c_graph, &c_res, c_ignore_loops, c_mode));
+
+                                        /* Convert output */
+  PROTECT(res=NEW_NUMERIC(1));
+  REAL(res)[0]=c_res;
+  r_result = res;
+
+  UNPROTECT(1);
+  return(r_result);
+}
+
+/*-------------------------------------------/
 / igraph_feedback_arc_set                    /
 /-------------------------------------------*/
 SEXP R_igraph_feedback_arc_set(SEXP graph, SEXP weights, SEXP algo) {

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -6132,23 +6132,6 @@ SEXP R_igraph_es_pairs(SEXP graph, SEXP pp, SEXP pdir) {
   return result;
 }
 
-SEXP R_igraph_reciprocity(SEXP graph, SEXP pignore_loops, SEXP pmode) {
-
-  igraph_t g;
-  igraph_bool_t ignore_loops=LOGICAL(pignore_loops)[0];
-  igraph_real_t res;
-  igraph_reciprocity_t mode=REAL(pmode)[0];
-  SEXP result;
-
-  R_SEXP_to_igraph(graph, &g);
-  IGRAPH_R_CHECK(igraph_reciprocity(&g, &res, ignore_loops, mode));
-  PROTECT(result=NEW_NUMERIC(1));
-  REAL(result)[0]=res;
-
-  UNPROTECT(1);
-  return result;
-}
-
 SEXP R_igraph_layout_reingold_tilford(SEXP graph, SEXP proot,
                                       SEXP pmode, SEXP prootlevel, SEXP pcirc) {
 

--- a/tests/testthat/test-reciprocity.R
+++ b/tests/testthat/test-reciprocity.R
@@ -1,0 +1,5 @@
+test_that("reciprocity works", {
+  g <- make_graph(c(1,2, 2,1, 2,3, 3,4, 4,4), directed = TRUE)
+  expect_equal(reciprocity(g), 0.5)
+  expect_equal(reciprocity(g, ignore.loops = FALSE), 0.6)
+})

--- a/tools/build-requirements.txt
+++ b/tools/build-requirements.txt
@@ -3,4 +3,4 @@
 # environment to detect when to re-create the virtualenv so the hash
 # needs to change whenever a package is updated.
 
-git+https://github.com/igraph/stimulus@0.20.0#egg=stimulus
+git+https://github.com/igraph/stimulus@0.21.2#egg=stimulus

--- a/tools/stimulus/functions-R.yaml
+++ b/tools/stimulus/functions-R.yaml
@@ -463,7 +463,6 @@ igraph_transitivity_barrat:
 igraph_ecc:
 
 igraph_reciprocity:
-    IGNORE: RR, RC
 
 igraph_constraint:
     IGNORE: RR, RC

--- a/tools/stimulus/types-RC.yaml
+++ b/tools/stimulus/types-RC.yaml
@@ -719,10 +719,6 @@ HRG:
             igraph_hrg_destroy(&%C%);
             IGRAPH_FINALLY_CLEAN(1);
 
-RECIP:
-    INCONV:
-        IN: '%C%=REAL(%I%)[0];'
-
 SPARSEMAT:
     CALL: '&%C%'
     CTYPE: igraph_sparsemat_t

--- a/tools/stimulus/types-RC.yaml
+++ b/tools/stimulus/types-RC.yaml
@@ -723,11 +723,6 @@ RECIP:
     INCONV:
         IN: '%C%=REAL(%I%)[0];'
 
-SCGDIR:
-    CTYPE: igraph_integer_t
-    INCONV:
-        IN: '%C%=REAL(%I%)[0];'
-
 SPARSEMAT:
     CALL: '&%C%'
     CTYPE: igraph_sparsemat_t

--- a/tools/stimulus/types-RR.yaml
+++ b/tools/stimulus/types-RR.yaml
@@ -477,3 +477,8 @@ VORONOI_TIEBREAKER:
     DEFAULT:
         RANDOM: c("random", "first", "last")
     INCONV: '%I% <- switch(igraph.match.arg(%I%), "first"=0L, "last"=1L, "random"=2L)'
+
+GETADJACENCY:
+    DEFAULT:
+        BOTH: c("both", "upper", "lower")
+    INCONV: '%I% <- switch(igraph.match.arg(%I%), "upper"=0L, "lower"=1L, "both"=2L)'

--- a/tools/stimulus/types-RR.yaml
+++ b/tools/stimulus/types-RR.yaml
@@ -337,28 +337,6 @@ RECIP:
         Default: c('default', 'ratio')
     INCONV: '%I% <- switch(igraph.match.arg(%I%), ''default''=0, ''ratio''=1)'
 
-SCGMAT:
-    DEFAULT:
-        Default: c("symmetric", "laplacian", "stochastic")
-    INCONV: |-
-        %I% <- switch(igraph.match.arg(%I%), "symmetric"=1, "laplacian"=2, "stochastic"=3)
-
-SCGALGO:
-    DEFAULT:
-        Default: c("optimum", "interv_km", "interv", "exact_scg")
-    INCONV: |-
-        %I% <- switch(igraph.match.arg(%I%), "optimum"=1, "interv_km"=2, "interv"=3, "exact_scg"=4)
-
-SCGNORM:
-    DEFAULT:
-        Default: c("row", "col")
-    INCONV: '%I% <- switch(igraph.match.arg(%I%), "row"=1, "col"=2)'
-
-SCGDIR:
-    DEFAULT:
-        Default: c("default", "left", "right")
-    INCONV: '%I% <- switch(igraph.match.arg(%I%), "default"=1, "left"=2, "right"=3)'
-
 SPARSEMAT:
     INCONV: requireNamespace("Matrix", quietly = TRUE); %I% <- as(as(as(%I%, "dMatrix"), "generalMatrix"), "CsparseMatrix")
 

--- a/tools/stimulus/types-RR.yaml
+++ b/tools/stimulus/types-RR.yaml
@@ -334,8 +334,8 @@ HRG:
 
 RECIP:
     DEFAULT:
-        Default: c('default', 'ratio')
-    INCONV: '%I% <- switch(igraph.match.arg(%I%), ''default''=0, ''ratio''=1)'
+        DEFAULT: c("default", "ratio")
+    INCONV: '%I% <- switch(igraph.match.arg(%I%), "default"=0L, "ratio"=1L)'
 
 SPARSEMAT:
     INCONV: requireNamespace("Matrix", quietly = TRUE); %I% <- as(as(as(%I%, "dMatrix"), "generalMatrix"), "CsparseMatrix")

--- a/tools/stimulus/types-RR.yaml
+++ b/tools/stimulus/types-RR.yaml
@@ -472,3 +472,8 @@ TREE_MODE:
         OUT: c("out", "in", "undirected")
         UNDIRECTED: c("undirected", "out", "in")
     INCONV: '%I% <- switch(igraph.match.arg(%I%), "out"=0L, "in"=1L, "undirected"=2L)'
+
+VORONOI_TIEBREAKER:
+    DEFAULT:
+        RANDOM: c("random", "first", "last")
+    INCONV: '%I% <- switch(igraph.match.arg(%I%), "first"=0L, "last"=1L, "random"=2L)'

--- a/tools/stimulus/types-RR.yaml
+++ b/tools/stimulus/types-RR.yaml
@@ -380,6 +380,11 @@ EIGENWHICHPOS:
         ASE: c("lm", "la", "sa")
     INCONV: '%I% <- switch(igraph.match.arg(%I%), "lm"=0L, "la"=2L, "sa"=3L)'
 
+LAPLACIAN_NORMALIZATION:
+    DEFAULT:
+        UNNORMALIZED: c("unnormalized", "symmetric", "left", "right")
+    INCONV: '%I% <- switch(igraph.match.arg(%I%), "unnormalized"=0L, "symmetric"=1L, "left"=2L, "right"=3L)'
+
 SIRLIST: {}
 
 PAGERANKALGO:

--- a/tools/stimulus/types-RR.yaml
+++ b/tools/stimulus/types-RR.yaml
@@ -461,3 +461,14 @@ FAS_ALGORITHM:
         APPROX_EADES: c("approx_eades", "exact_ip")
     INCONV: |-
         %I% <- switch(igraph.match.arg(%I%), "exact_ip"=0L, "approx_eades"=1L)
+
+WHEEL_MODE:
+    DEFAULT:
+        OUT: c("out", "in", "undirected", "mutual")
+    INCONV: '%I% <- switch(igraph.match.arg(%I%), "out"=0L, "in"=1L, "undirected"=2L, "mutual"=3L)'
+
+TREE_MODE:
+    DEFAULT:
+        OUT: c("out", "in", "undirected")
+        UNDIRECTED: c("undirected", "out", "in")
+    INCONV: '%I% <- switch(igraph.match.arg(%I%), "out"=0L, "in"=1L, "undirected"=2L)'


### PR DESCRIPTION
These are multi-semi related commits. Please take a look.

Some of the "no visible binding for global variable" warnings are eliminated.

 @krlmlr: We need to implement conversion for the `LOOPS` type as well, but this is a bit special and I need help. Can you assist please? The mappings should be as follows:

 - `"ignore"`: `0`
 - `"twice"`: `1` (yes, that's right, "twice" maps to one)
 - `"once"`: `2`
 - `TRUE`: `1` (just like `"twice"`)
 - `FALSE`: `0` (just like `"ignore"`)

The logical values should be supported for backwards compatibility. I don't think these can be handled with `igraph.march.arg`.