### PR TITLE
fix: Restore `NA` padding for `dfs(unreachable = FALSE)$order` and `$order.out` .

### DIFF
--- a/R/structural.properties.R
+++ b/R/structural.properties.R
@@ -2291,8 +2291,8 @@ dfs <- function(graph, root, mode = c("out", "in", "all", "total"),
   if (father) res$father <- res$father + 1
 
   if (igraph_opt("return.vs.es")) {
-    if (order) res$order <- V(graph)[.env$res$order, na_ok = TRUE]
-    if (order.out) res$order.out <- V(graph)[.env$res$order.out, na_ok = TRUE]
+    if (order) res$order <- create_vs(graph, res$order, na_ok = TRUE)
+    if (order.out) res$order.out <- create_vs(graph, res$order.out, na_ok = TRUE)
     if (father) res$father <- create_vs(graph, res$father, na_ok = TRUE)
   }
 

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,6 +1,6 @@
 ## revdepcheck results
 
-We checked 19 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
+We checked 17 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
 
  * We saw 17 new problems
  * We failed to check 0 packages

--- a/tests/testthat/test-graph.dfs.R
+++ b/tests/testthat/test-graph.dfs.R
@@ -1,4 +1,9 @@
 test_that("DFS uses 1-based root vertex index", {
   g <- make_ring(3)
-  expect_that(dfs(g, root = 1)$root, equals(1))
+  expect_equal(dfs(g, root = 1)$root, 1)
+})
+
+test_that("DFS pads order with NA", {
+  g <- make_star(3)
+  expect_equal(as.numeric(dfs(g, root = 2, unreachable = FALSE)$order), c(2, 1, NA))
 })


### PR DESCRIPTION
For https://github.com/natverse/nat/issues/517.