### PR TITLE
fix: support LOOPS type

### DIFF
--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -69,9 +69,10 @@ get_all_eids_between_impl <- function(graph, from, to, directed=TRUE) {
   res
 }
 
-sparse_adjacency_impl <- function(adjmatrix, mode=DIRECTED, loops=ONCE) {
+sparse_adjacency_impl <- function(adjmatrix, mode=DIRECTED, loops=c("once", "twice", "ignore")) {
   # Argument checks
   requireNamespace("Matrix", quietly = TRUE); adjmatrix <- as(as(as(adjmatrix, "dMatrix"), "generalMatrix"), "CsparseMatrix")
+  loops <- igraph.handle.loops.arg(loops)
 
   on.exit( .Call(R_igraph_finalizer) )
   # Function call
@@ -80,9 +81,10 @@ sparse_adjacency_impl <- function(adjmatrix, mode=DIRECTED, loops=ONCE) {
   res
 }
 
-sparse_weighted_adjacency_impl <- function(adjmatrix, mode=DIRECTED, loops=ONCE) {
+sparse_weighted_adjacency_impl <- function(adjmatrix, mode=DIRECTED, loops=c("once", "twice", "ignore")) {
   # Argument checks
   requireNamespace("Matrix", quietly = TRUE); adjmatrix <- as(as(as(adjmatrix, "dMatrix"), "generalMatrix"), "CsparseMatrix")
+  loops <- igraph.handle.loops.arg(loops)
 
   on.exit( .Call(R_igraph_finalizer) )
   # Function call
@@ -2738,7 +2740,7 @@ from_hrg_dendrogram_impl <- function(hrg) {
   res
 }
 
-get_adjacency_sparse_impl <- function(graph, type=c("both", "upper", "lower"), weights=NULL, loops=ONCE) {
+get_adjacency_sparse_impl <- function(graph, type=c("both", "upper", "lower"), weights=NULL, loops=c("once", "twice", "ignore")) {
   # Argument checks
   ensure_igraph(graph)
   type <- switch(igraph.match.arg(type), "upper"=0L, "lower"=1L, "both"=2L)
@@ -2750,6 +2752,7 @@ get_adjacency_sparse_impl <- function(graph, type=c("both", "upper", "lower"), w
   } else {
     weights <- NULL
   }
+  loops <- igraph.handle.loops.arg(loops)
 
   on.exit( .Call(R_igraph_finalizer) )
   # Function call

--- a/R/other.R
+++ b/R/other.R
@@ -187,6 +187,23 @@ igraph.match.arg <- function(arg, choices, several.ok = FALSE) {
   match.arg(arg = arg, choices = choices, several.ok = several.ok)
 }
 
+igraph.handle.loops.arg <- function(arg) {
+  if (is.logical(arg)) {
+    if (arg) {
+      loops_out <- 1L
+    } else {
+      loops_out <- 0L
+    }
+  } else {
+    loops_out <- switch(match.arg(arg, c("twice", "once", "ignore")),
+      "ignore" = 0L,
+      "twice" = 1L,
+      "once" = 2L
+    )
+  }
+  loops_out
+}
+
 igraph.i.spMatrix <- function(M) {
   if (M$type == "triplet") {
     Matrix::sparseMatrix(dims = M$dim, i = M$i + 1L, j = M$p + 1L, x = M$x)

--- a/tools/stimulus/types-RR.yaml
+++ b/tools/stimulus/types-RR.yaml
@@ -471,3 +471,10 @@ GETADJACENCY:
     DEFAULT:
         BOTH: c("both", "upper", "lower")
     INCONV: '%I% <- switch(igraph.match.arg(%I%), "upper"=0L, "lower"=1L, "both"=2L)'
+
+LOOPS:
+    DEFAULT:
+        TWICE:  c("twice", "once", "ignore")
+        ONCE:   c("once", "twice", "ignore")
+        IGNORE: c("ignore", "twice", "once")
+    INCONV: '%I% <- igraph.handle.loops.arg(%I%)'


### PR DESCRIPTION
Fix #1008 

Not yet used, so not ready to merge. Need to come back to this when the adjacency matrix functions are cleaned up.