### PR TITLE
fix: remove `R_SEXP_to_hrg` use `R_SEXP_to_hrg_copy` to avoid memory leak

### DIFF
--- a/src/rinterface.c
+++ b/src/rinterface.c
@@ -7776,7 +7776,7 @@ SEXP R_igraph_hrg_fit(SEXP graph, SEXP hrg, SEXP start, SEXP steps) {
                                         /* Convert input */
   R_SEXP_to_igraph(graph, &c_graph);
   if (0 != R_SEXP_to_hrg_copy(hrg, &c_hrg)) {
-    igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
+    igraph_error("Insufficient memory to create HRG object", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_hrg_destroy, &c_hrg);
   IGRAPH_R_CHECK_BOOL(start);
@@ -7807,7 +7807,10 @@ SEXP R_igraph_hrg_sample(SEXP hrg) {
 
   SEXP r_result;
                                         /* Convert input */
-  R_SEXP_to_hrg(hrg, &c_hrg);
+  if (0 != R_SEXP_to_hrg_copy(hrg, &c_hrg)) {
+    igraph_error("Insufficient memory to create HRG object", __FILE__, __LINE__, IGRAPH_ENOMEM);
+  }
+  IGRAPH_FINALLY(igraph_hrg_destroy, &c_hrg);
                                         /* Call igraph */
   IGRAPH_R_CHECK(igraph_hrg_sample(&c_hrg, &c_sample));
 
@@ -7834,7 +7837,10 @@ SEXP R_igraph_hrg_sample_many(SEXP hrg, SEXP num_samples) {
 
   SEXP r_result;
                                         /* Convert input */
-  R_SEXP_to_hrg(hrg, &c_hrg);
+  if (0 != R_SEXP_to_hrg_copy(hrg, &c_hrg)) {
+    igraph_error("Insufficient memory to create HRG object", __FILE__, __LINE__, IGRAPH_ENOMEM);
+  }
+  IGRAPH_FINALLY(igraph_hrg_destroy, &c_hrg);
   if (0 != igraph_graph_list_init(&c_samples, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
@@ -7865,7 +7871,10 @@ SEXP R_igraph_hrg_game(SEXP hrg) {
 
   SEXP r_result;
                                         /* Convert input */
-  R_SEXP_to_hrg(hrg, &c_hrg);
+  if (0 != R_SEXP_to_hrg_copy(hrg, &c_hrg)) {
+    igraph_error("Insufficient memory to create HRG object", __FILE__, __LINE__, IGRAPH_ENOMEM);
+  }
+  IGRAPH_FINALLY(igraph_hrg_destroy, &c_hrg);
                                         /* Call igraph */
   IGRAPH_R_CHECK(igraph_hrg_game(&c_graph, &c_hrg));
 
@@ -7906,7 +7915,7 @@ SEXP R_igraph_hrg_consensus(SEXP graph, SEXP hrg, SEXP start, SEXP num_samples) 
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_weights);
   if (0 != R_SEXP_to_hrg_copy(hrg, &c_hrg)) {
-    igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
+    igraph_error("Insufficient memory to create HRG object", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_hrg_destroy, &c_hrg);
   IGRAPH_R_CHECK_BOOL(start);
@@ -7968,7 +7977,7 @@ SEXP R_igraph_hrg_predict(SEXP graph, SEXP hrg, SEXP start, SEXP num_samples, SE
   }
   IGRAPH_FINALLY(igraph_vector_destroy, &c_prob);
   if (0 != R_SEXP_to_hrg_copy(hrg, &c_hrg)) {
-    igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
+    igraph_error("Insufficient memory to create HRG object", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_hrg_destroy, &c_hrg);
   IGRAPH_R_CHECK_BOOL(start);
@@ -8018,7 +8027,7 @@ SEXP R_igraph_hrg_create(SEXP graph, SEXP prob) {
   SEXP r_result;
                                         /* Convert input */
   if (0 != igraph_hrg_init(&c_hrg, 0)) {
-    igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
+    igraph_error("Insufficient memory to create HRG object", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_hrg_destroy, &c_hrg);
   R_SEXP_to_igraph(graph, &c_graph);
@@ -8047,7 +8056,7 @@ SEXP R_igraph_hrg_resize(SEXP hrg, SEXP newsize) {
   SEXP r_result;
                                         /* Convert input */
   if (0 != R_SEXP_to_hrg_copy(hrg, &c_hrg)) {
-    igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
+    igraph_error("Insufficient memory to create HRG object", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }
   IGRAPH_FINALLY(igraph_hrg_destroy, &c_hrg);
   IGRAPH_R_CHECK_INT(newsize);
@@ -8074,7 +8083,10 @@ SEXP R_igraph_hrg_size(SEXP hrg) {
   igraph_integer_t c_result;
   SEXP r_result;
                                         /* Convert input */
-  R_SEXP_to_hrg(hrg, &c_hrg);
+  if (0 != R_SEXP_to_hrg_copy(hrg, &c_hrg)) {
+    igraph_error("Insufficient memory to create HRG object", __FILE__, __LINE__, IGRAPH_ENOMEM);
+  }
+  IGRAPH_FINALLY(igraph_hrg_destroy, &c_hrg);
                                         /* Call igraph */
   c_result=igraph_hrg_size(&c_hrg);
 
@@ -8100,7 +8112,10 @@ SEXP R_igraph_from_hrg_dendrogram(SEXP hrg) {
 
   SEXP r_result, r_names;
                                         /* Convert input */
-  R_SEXP_to_hrg(hrg, &c_hrg);
+  if (0 != R_SEXP_to_hrg_copy(hrg, &c_hrg)) {
+    igraph_error("Insufficient memory to create HRG object", __FILE__, __LINE__, IGRAPH_ENOMEM);
+  }
+  IGRAPH_FINALLY(igraph_hrg_destroy, &c_hrg);
   if (0 != igraph_vector_init(&c_prob, 0)) {
     igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
   }

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -3001,26 +3001,6 @@ SEXP R_igraph_hrg_to_SEXP(const igraph_hrg_t *hrg) {
   return result;
 }
 
-igraph_error_t R_SEXP_to_hrg(SEXP shrg, igraph_hrg_t *hrg) {
-  IGRAPH_CHECK(R_SEXP_to_vector_int_copy(VECTOR_ELT(shrg, 0), &hrg->left));
-  IGRAPH_FINALLY(igraph_vector_int_destroy, &hrg->left);
-
-  IGRAPH_CHECK(R_SEXP_to_vector_int_copy(VECTOR_ELT(shrg, 1), &hrg->right));
-  IGRAPH_FINALLY(igraph_vector_int_destroy, &hrg->right);
-
-  R_SEXP_to_vector(VECTOR_ELT(shrg, 2), &hrg->prob);
-
-  IGRAPH_CHECK(R_SEXP_to_vector_int_copy(VECTOR_ELT(shrg, 3), &hrg->edges));
-  IGRAPH_FINALLY(igraph_vector_int_destroy, &hrg->edges);
-
-  IGRAPH_CHECK(R_SEXP_to_vector_int_copy(VECTOR_ELT(shrg, 4), &hrg->vertices));
-  IGRAPH_FINALLY(igraph_vector_int_destroy, &hrg->vertices);
-
-  IGRAPH_FINALLY_CLEAN(4);
-
-  return IGRAPH_SUCCESS;
-}
-
 igraph_error_t R_SEXP_to_hrg_copy(SEXP shrg, igraph_hrg_t *hrg) {
   IGRAPH_CHECK(R_SEXP_to_vector_int_copy(VECTOR_ELT(shrg, 0), &hrg->left));
   IGRAPH_FINALLY(igraph_vector_int_destroy, &hrg->left);

--- a/tools/stimulus/types-RC.yaml
+++ b/tools/stimulus/types-RC.yaml
@@ -716,18 +716,26 @@ EDGE_ATTRIBUTE_COMBINATION:
 HRG:
     CALL: '&%C%'
     INCONV:
-        IN: R_SEXP_to_hrg(%I%, &%C%);
+        IN: |-
+            if (0 != R_SEXP_to_hrg_copy(%I%, &%C%)) {
+              igraph_error("Insufficient memory to create HRG object", __FILE__, __LINE__, IGRAPH_ENOMEM);
+            }
+            IGRAPH_FINALLY(igraph_hrg_destroy, &%C%);
         INOUT: |-
             if (0 != R_SEXP_to_hrg_copy(%I%, &%C%)) {
-              igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
+              igraph_error("Insufficient memory to create HRG object", __FILE__, __LINE__, IGRAPH_ENOMEM);
             }
             IGRAPH_FINALLY(igraph_hrg_destroy, &%C%);
         OUT: |-
             if (0 != igraph_hrg_init(&%C%, 0)) {
-              igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
+              igraph_error("Insufficient memory to create HRG object", __FILE__, __LINE__, IGRAPH_ENOMEM);
             }
             IGRAPH_FINALLY(igraph_hrg_destroy, &%C%);
     OUTCONV:
+        INOUT: |-
+            PROTECT(%I%=R_igraph_hrg_to_SEXP(&%C%));
+            igraph_hrg_destroy(&%C%);
+            IGRAPH_FINALLY_CLEAN(1);
         OUT: |-
             PROTECT(%I%=R_igraph_hrg_to_SEXP(&%C%));
             igraph_hrg_destroy(&%C%);


### PR DESCRIPTION
Closes https://github.com/igraph/rigraph/issues/1073