### PR TITLE
test: remove top-level code in test-indexing.R

### DIFF
--- a/tests/testthat/helper-indexing.R
+++ b/tests/testthat/helper-indexing.R
@@ -1,9 +1,9 @@
-mm <- function(...) {
+vector_to_square_matrix <- function(...) {
   v <- as.numeric(as.vector(list(...)))
   matrix(v, nrow = sqrt(length(v)))
 }
 
-am <- function(x) {
+canonicalize_matrix <- function(x) {
   x <- as.matrix(x)
   dimnames(x) <- NULL
   x

--- a/tests/testthat/helper-indexing.R
+++ b/tests/testthat/helper-indexing.R
@@ -1,0 +1,24 @@
+mm <- function(...) {
+  v <- as.numeric(as.vector(list(...)))
+  matrix(v, nrow = sqrt(length(v)))
+}
+
+am <- function(x) {
+  x <- as.matrix(x)
+  dimnames(x) <- NULL
+  x
+}
+
+make_test_named_tree <- function() {
+  g <- make_tree(20)
+  V(g)$name <- letters[1:vcount(g)]
+  g
+}
+
+make_test_weighted_tree <- function() {
+  g <- make_tree(20)
+  V(g)$name <- letters[1:vcount(g)]
+  el <- as_edgelist(g, names = FALSE)
+  E(g)$weight <- el[, 1] * el[, 2]
+  g
+}

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -1,16 +1,5 @@
-mm <- function(...) {
-  v <- as.numeric(as.vector(list(...)))
-  matrix(v, nrow = sqrt(length(v)))
-}
-am <- function(x) {
-  x <- as.matrix(x)
-  dimnames(x) <- NULL
-  x
-}
-
-g <- make_tree(20)
-
 test_that("[ indexing works", {
+  g <- make_tree(20)
   ## Are these vertices connected?
   expect_that(g[1, 2], equals(1))
   expect_that(am(g[c(1, 1, 7), c(2, 3, 14)]), equals(mm(1, 1, 0, 1, 1, 0, 0, 0, 1)))
@@ -19,9 +8,8 @@ test_that("[ indexing works", {
   expect_that(am(g[c(8, 17), c(17, 8)]), equals(mm(1, 0, 0, 0)))
 })
 
-V(g)$name <- letters[1:vcount(g)]
-
 test_that("[ indexing works with symbolic names", {
+  g <- make_test_named_tree()
   ## The same with symbolic names
   expect_that(g["a", "b"], equals(1))
   expect_that(
@@ -40,6 +28,7 @@ test_that("[ indexing works with symbolic names", {
 })
 
 test_that("[ indexing works with logical vectors", {
+  g <- make_test_named_tree()
   ## Logical vectors
   lres <- structure(
     c(
@@ -59,6 +48,7 @@ test_that("[ indexing works with logical vectors", {
 })
 
 test_that("[ indexing works with negative indices", {
+  g <- make_test_named_tree()
   ## Negative indices
   nres <- structure(
     c(
@@ -79,10 +69,10 @@ test_that("[ indexing works with negative indices", {
   expect_that(as.matrix(g[2:3, -1]), equals(nres))
 })
 
-el <- as_edgelist(g, names = FALSE)
-E(g)$weight <- el[, 1] * el[, 2]
-
 test_that("[ indexing works with weighted graphs", {
+  g <- make_tree(20)
+  el <- as_edgelist(g, names = FALSE)
+  E(g)$weight <- el[, 1] * el[, 2]
   ## Weighted graphs
   expect_that(g[1, 2], equals(2))
   expect_that(am(g[c(1, 1, 7), c(2, 3, 14)]), equals(mm(2, 2, 0, 3, 3, 0, 0, 0, 98)))
@@ -95,6 +85,7 @@ test_that("[ indexing works with weighted graphs", {
 })
 
 test_that("[ indexing works with weighted graphs and symbolic names", {
+  g <- make_test_weighted_tree()
   ## Weighted graph, with symbolic names
   expect_that(g["a", "b"], equals(2))
   expect_that(
@@ -112,9 +103,8 @@ test_that("[ indexing works with weighted graphs and symbolic names", {
   expect_that(am(g[c("h", "q"), c("q", "h")]), equals(mm(136, 0, 0, 0)))
 })
 
-################################################################
-
 test_that("[[ indexing works", {
+  g <- make_test_named_tree()
   ## Adjacent vertices
   expect_that(g[[1, ]], is_equivalent_to(list(a = V(g)[2:3])))
   expect_that(g[[, 2]], is_equivalent_to(list(b = V(g)[1])))
@@ -138,6 +128,7 @@ test_that("[[ indexing works", {
 })
 
 test_that("[[ indexing works with symbolic names", {
+  g <- make_test_named_tree()
   ## Same with vertex names
   expect_that(g[["a", ]], is_equivalent_to(list(a = V(g)[2:3])))
   expect_that(g[[, "b"]], is_equivalent_to(list(b = V(g)[1])))
@@ -161,6 +152,7 @@ test_that("[[ indexing works with symbolic names", {
 })
 
 test_that("[[ indexing works with logical vectors", {
+  g <- make_test_named_tree()
   ## Logical vectors
   expect_that(
     g[[degree(g, mode = "in") == 0, ]],
@@ -169,6 +161,8 @@ test_that("[[ indexing works with logical vectors", {
 })
 
 test_that("[[ indexing works with filtering on both ends", {
+  g <- make_test_named_tree()
+
   ## Filtering on both ends
   expect_that(
     g[[1:10, 1:10]],
@@ -181,12 +175,12 @@ test_that("[[ indexing works with filtering on both ends", {
 })
 
 test_that("[[ indexing is consistent with length()", {
+  g <- make_test_named_tree()
   expect_that(length(g), equals(vcount(g)))
 })
 
-################################################################
-
 test_that("[ can query edge ids", {
+  g <- make_test_named_tree()
   ## Query edge ids
   expect_that(g[1, 2, edges = TRUE], equals(1))
   expect_that(
@@ -208,6 +202,7 @@ test_that("[ can query edge ids", {
 })
 
 test_that("[ can query edge ids with symbolic names", {
+  g <- make_test_named_tree()
   ## The same with symbolic names
   expect_that(g["a", "b", edges = TRUE], equals(1))
   expect_that(
@@ -228,9 +223,8 @@ test_that("[ can query edge ids with symbolic names", {
   )
 })
 
-################################################################
-
 test_that("[[ can query incident edges", {
+  g <- make_test_named_tree()
   ## Incident edges of vertices
   expect_that(g[[1, , edges = TRUE]], is_equivalent_to(list(a = E(g)[1:2])))
   expect_that(g[[, 2, edges = TRUE]], is_equivalent_to(list(b = E(g)[1])))
@@ -254,6 +248,7 @@ test_that("[[ can query incident edges", {
 })
 
 test_that("[[ queries edges with vertex names", {
+  g <- make_test_named_tree()
   ## Same with vertex names
   expect_that(
     g[["a", , edges = TRUE]],
@@ -291,10 +286,8 @@ test_that("[[ queries edges with vertex names", {
     ))
   )
 })
-
-#################################################################
-
 test_that("[ handles from and to properly", {
+  g <- make_test_named_tree()
   ## from & to
   g <- make_tree(20)
   expect_that(g[from = c(1, 2, 2, 3), to = c(3, 4, 8, 7)], equals(c(1, 1, 0, 1)))

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -2,10 +2,10 @@ test_that("[ indexing works", {
   g <- make_tree(20)
   ## Are these vertices connected?
   expect_that(g[1, 2], equals(1))
-  expect_that(am(g[c(1, 1, 7), c(2, 3, 14)]), equals(mm(1, 1, 0, 1, 1, 0, 0, 0, 1)))
-  expect_that(am(g[c(1, 1, 7), c(5, 3, 12)]), equals(mm(0, 0, 0, 1, 1, 0, 0, 0, 0)))
-  expect_that(am(g[c(1, 1, 1, 1), c(2, 3, 2, 2)]), equals(matrix(1, 4, 4)))
-  expect_that(am(g[c(8, 17), c(17, 8)]), equals(mm(1, 0, 0, 0)))
+  expect_that(canonicalize_matrix(g[c(1, 1, 7), c(2, 3, 14)]), equals(vector_to_square_matrix(1, 1, 0, 1, 1, 0, 0, 0, 1)))
+  expect_that(canonicalize_matrix(g[c(1, 1, 7), c(5, 3, 12)]), equals(vector_to_square_matrix(0, 0, 0, 1, 1, 0, 0, 0, 0)))
+  expect_that(canonicalize_matrix(g[c(1, 1, 1, 1), c(2, 3, 2, 2)]), equals(matrix(1, 4, 4)))
+  expect_that(canonicalize_matrix(g[c(8, 17), c(17, 8)]), equals(vector_to_square_matrix(1, 0, 0, 0)))
 })
 
 test_that("[ indexing works with symbolic names", {
@@ -13,18 +13,18 @@ test_that("[ indexing works with symbolic names", {
 
   expect_that(g["a", "b"], equals(1))
   expect_that(
-    am(g[c("a", "a", "g"), c("b", "c", "n")]),
-    equals(mm(1, 1, 0, 1, 1, 0, 0, 0, 1))
+    canonicalize_matrix(g[c("a", "a", "g"), c("b", "c", "n")]),
+    equals(vector_to_square_matrix(1, 1, 0, 1, 1, 0, 0, 0, 1))
   )
   expect_that(
-    am(g[c("a", "a", "g"), c("e", "c", "l")]),
-    equals(mm(0, 0, 0, 1, 1, 0, 0, 0, 0))
+    canonicalize_matrix(g[c("a", "a", "g"), c("e", "c", "l")]),
+    equals(vector_to_square_matrix(0, 0, 0, 1, 1, 0, 0, 0, 0))
   )
   expect_that(
-    am(g[c("a", "a", "a", "a"), c("b", "c", "b", "b")]),
+    canonicalize_matrix(g[c("a", "a", "a", "a"), c("b", "c", "b", "b")]),
     equals(matrix(1, 4, 4))
   )
-  expect_that(am(g[c("h", "q"), c("q", "h")]), equals(mm(1, 0, 0, 0)))
+  expect_that(canonicalize_matrix(g[c("h", "q"), c("q", "h")]), equals(vector_to_square_matrix(1, 0, 0, 0)))
 })
 
 test_that("[ indexing works with logical vectors", {
@@ -73,13 +73,13 @@ test_that("[ indexing works with weighted graphs", {
   g <- make_test_weighted_tree()
 
   expect_that(g[1, 2], equals(2))
-  expect_that(am(g[c(1, 1, 7), c(2, 3, 14)]), equals(mm(2, 2, 0, 3, 3, 0, 0, 0, 98)))
-  expect_that(am(g[c(1, 1, 7), c(5, 3, 12)]), equals(mm(0, 0, 0, 3, 3, 0, 0, 0, 0)))
+  expect_that(canonicalize_matrix(g[c(1, 1, 7), c(2, 3, 14)]), equals(vector_to_square_matrix(2, 2, 0, 3, 3, 0, 0, 0, 98)))
+  expect_that(canonicalize_matrix(g[c(1, 1, 7), c(5, 3, 12)]), equals(vector_to_square_matrix(0, 0, 0, 3, 3, 0, 0, 0, 0)))
   expect_that(
-    am(g[c(1, 1, 1, 1), c(2, 3, 2, 2)]),
-    equals(mm(2, 2, 2, 2, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2))
+    canonicalize_matrix(g[c(1, 1, 1, 1), c(2, 3, 2, 2)]),
+    equals(vector_to_square_matrix(2, 2, 2, 2, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2))
   )
-  expect_that(am(g[c(8, 17), c(17, 8)]), equals(mm(136, 0, 0, 0)))
+  expect_that(canonicalize_matrix(g[c(8, 17), c(17, 8)]), equals(vector_to_square_matrix(136, 0, 0, 0)))
 })
 
 test_that("[ indexing works with weighted graphs and symbolic names", {
@@ -87,18 +87,18 @@ test_that("[ indexing works with weighted graphs and symbolic names", {
 
   expect_that(g["a", "b"], equals(2))
   expect_that(
-    am(g[c("a", "a", "g"), c("b", "c", "n")]),
-    equals(mm(2, 2, 0, 3, 3, 0, 0, 0, 98))
+    canonicalize_matrix(g[c("a", "a", "g"), c("b", "c", "n")]),
+    equals(vector_to_square_matrix(2, 2, 0, 3, 3, 0, 0, 0, 98))
   )
   expect_that(
-    am(g[c("a", "a", "g"), c("e", "c", "l")]),
-    equals(mm(0, 0, 0, 3, 3, 0, 0, 0, 0))
+    canonicalize_matrix(g[c("a", "a", "g"), c("e", "c", "l")]),
+    equals(vector_to_square_matrix(0, 0, 0, 3, 3, 0, 0, 0, 0))
   )
   expect_that(
-    am(g[c("a", "a", "a", "a"), c("b", "c", "b", "b")]),
-    equals(mm(2, 2, 2, 2, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2))
+    canonicalize_matrix(g[c("a", "a", "a", "a"), c("b", "c", "b", "b")]),
+    equals(vector_to_square_matrix(2, 2, 2, 2, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2))
   )
-  expect_that(am(g[c("h", "q"), c("q", "h")]), equals(mm(136, 0, 0, 0)))
+  expect_that(canonicalize_matrix(g[c("h", "q"), c("q", "h")]), equals(vector_to_square_matrix(136, 0, 0, 0)))
 })
 
 test_that("[[ indexing works with adjacent vertices", {
@@ -181,20 +181,20 @@ test_that("[ can query edge ids", {
 
   expect_that(g[1, 2, edges = TRUE], equals(1))
   expect_that(
-    am(g[c(1, 1, 7), c(2, 3, 14), edges = TRUE]),
-    equals(mm(1, 1, 0, 2, 2, 0, 0, 0, 13))
+    canonicalize_matrix(g[c(1, 1, 7), c(2, 3, 14), edges = TRUE]),
+    equals(vector_to_square_matrix(1, 1, 0, 2, 2, 0, 0, 0, 13))
   )
   expect_that(
-    am(g[c(1, 1, 7), c(5, 3, 12), edges = TRUE]),
-    equals(mm(0, 0, 0, 2, 2, 0, 0, 0, 0))
+    canonicalize_matrix(g[c(1, 1, 7), c(5, 3, 12), edges = TRUE]),
+    equals(vector_to_square_matrix(0, 0, 0, 2, 2, 0, 0, 0, 0))
   )
   expect_that(
-    am(g[c(1, 1, 1, 1), c(2, 3, 2, 2), edges = TRUE]),
-    equals(mm(1, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1))
+    canonicalize_matrix(g[c(1, 1, 1, 1), c(2, 3, 2, 2), edges = TRUE]),
+    equals(vector_to_square_matrix(1, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1))
   )
   expect_that(
-    am(g[c(8, 17), c(17, 8), edges = TRUE]),
-    equals(mm(16, 0, 0, 0))
+    canonicalize_matrix(g[c(8, 17), c(17, 8), edges = TRUE]),
+    equals(vector_to_square_matrix(16, 0, 0, 0))
   )
 })
 
@@ -203,20 +203,20 @@ test_that("[ can query edge ids with symbolic names", {
 
   expect_that(g["a", "b", edges = TRUE], equals(1))
   expect_that(
-    am(g[c("a", "a", "g"), c("b", "c", "n"), edges = TRUE]),
-    equals(mm(1, 1, 0, 2, 2, 0, 0, 0, 13))
+    canonicalize_matrix(g[c("a", "a", "g"), c("b", "c", "n"), edges = TRUE]),
+    equals(vector_to_square_matrix(1, 1, 0, 2, 2, 0, 0, 0, 13))
   )
   expect_that(
-    am(g[c("a", "a", "g"), c("e", "c", "l"), edges = TRUE]),
-    equals(mm(0, 0, 0, 2, 2, 0, 0, 0, 0))
+    canonicalize_matrix(g[c("a", "a", "g"), c("e", "c", "l"), edges = TRUE]),
+    equals(vector_to_square_matrix(0, 0, 0, 2, 2, 0, 0, 0, 0))
   )
   expect_that(
-    am(g[c("a", "a", "a", "a"), c("b", "c", "b", "b"), edges = TRUE]),
-    equals(mm(1, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1))
+    canonicalize_matrix(g[c("a", "a", "a", "a"), c("b", "c", "b", "b"), edges = TRUE]),
+    equals(vector_to_square_matrix(1, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1))
   )
   expect_that(
-    am(g[c("h", "q"), c("q", "h"), edges = TRUE]),
-    equals(mm(16, 0, 0, 0))
+    canonicalize_matrix(g[c("h", "q"), c("q", "h"), edges = TRUE]),
+    equals(vector_to_square_matrix(16, 0, 0, 0))
   )
 })
 

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -70,9 +70,7 @@ test_that("[ indexing works with negative indices", {
 })
 
 test_that("[ indexing works with weighted graphs", {
-  g <- make_tree(20)
-  el <- as_edgelist(g, names = FALSE)
-  E(g)$weight <- el[, 1] * el[, 2]
+  g <- make_test_weighted_tree()
   ## Weighted graphs
   expect_that(g[1, 2], equals(2))
   expect_that(am(g[c(1, 1, 7), c(2, 3, 14)]), equals(mm(2, 2, 0, 3, 3, 0, 0, 0, 98)))

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -10,7 +10,7 @@ test_that("[ indexing works", {
 
 test_that("[ indexing works with symbolic names", {
   g <- make_test_named_tree()
-  ## The same with symbolic names
+
   expect_that(g["a", "b"], equals(1))
   expect_that(
     am(g[c("a", "a", "g"), c("b", "c", "n")]),
@@ -29,7 +29,7 @@ test_that("[ indexing works with symbolic names", {
 
 test_that("[ indexing works with logical vectors", {
   g <- make_test_named_tree()
-  ## Logical vectors
+
   lres <- structure(
     c(
       0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0,
@@ -49,7 +49,7 @@ test_that("[ indexing works with logical vectors", {
 
 test_that("[ indexing works with negative indices", {
   g <- make_test_named_tree()
-  ## Negative indices
+
   nres <- structure(
     c(
       0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0,
@@ -71,7 +71,7 @@ test_that("[ indexing works with negative indices", {
 
 test_that("[ indexing works with weighted graphs", {
   g <- make_test_weighted_tree()
-  ## Weighted graphs
+
   expect_that(g[1, 2], equals(2))
   expect_that(am(g[c(1, 1, 7), c(2, 3, 14)]), equals(mm(2, 2, 0, 3, 3, 0, 0, 0, 98)))
   expect_that(am(g[c(1, 1, 7), c(5, 3, 12)]), equals(mm(0, 0, 0, 3, 3, 0, 0, 0, 0)))
@@ -84,7 +84,7 @@ test_that("[ indexing works with weighted graphs", {
 
 test_that("[ indexing works with weighted graphs and symbolic names", {
   g <- make_test_weighted_tree()
-  ## Weighted graph, with symbolic names
+
   expect_that(g["a", "b"], equals(2))
   expect_that(
     am(g[c("a", "a", "g"), c("b", "c", "n")]),
@@ -101,9 +101,9 @@ test_that("[ indexing works with weighted graphs and symbolic names", {
   expect_that(am(g[c("h", "q"), c("q", "h")]), equals(mm(136, 0, 0, 0)))
 })
 
-test_that("[[ indexing works", {
+test_that("[[ indexing works with adjacent vertices", {
   g <- make_test_named_tree()
-  ## Adjacent vertices
+
   expect_that(g[[1, ]], is_equivalent_to(list(a = V(g)[2:3])))
   expect_that(g[[, 2]], is_equivalent_to(list(b = V(g)[1])))
   expect_that(
@@ -127,7 +127,7 @@ test_that("[[ indexing works", {
 
 test_that("[[ indexing works with symbolic names", {
   g <- make_test_named_tree()
-  ## Same with vertex names
+
   expect_that(g[["a", ]], is_equivalent_to(list(a = V(g)[2:3])))
   expect_that(g[[, "b"]], is_equivalent_to(list(b = V(g)[1])))
   expect_that(
@@ -151,7 +151,7 @@ test_that("[[ indexing works with symbolic names", {
 
 test_that("[[ indexing works with logical vectors", {
   g <- make_test_named_tree()
-  ## Logical vectors
+
   expect_that(
     g[[degree(g, mode = "in") == 0, ]],
     is_equivalent_to(list(a = V(g)[2:3]))
@@ -161,7 +161,6 @@ test_that("[[ indexing works with logical vectors", {
 test_that("[[ indexing works with filtering on both ends", {
   g <- make_test_named_tree()
 
-  ## Filtering on both ends
   expect_that(
     g[[1:10, 1:10]],
     is_equivalent_to(list(
@@ -179,7 +178,7 @@ test_that("[[ indexing is consistent with length()", {
 
 test_that("[ can query edge ids", {
   g <- make_test_named_tree()
-  ## Query edge ids
+
   expect_that(g[1, 2, edges = TRUE], equals(1))
   expect_that(
     am(g[c(1, 1, 7), c(2, 3, 14), edges = TRUE]),
@@ -201,7 +200,7 @@ test_that("[ can query edge ids", {
 
 test_that("[ can query edge ids with symbolic names", {
   g <- make_test_named_tree()
-  ## The same with symbolic names
+
   expect_that(g["a", "b", edges = TRUE], equals(1))
   expect_that(
     am(g[c("a", "a", "g"), c("b", "c", "n"), edges = TRUE]),
@@ -223,7 +222,7 @@ test_that("[ can query edge ids with symbolic names", {
 
 test_that("[[ can query incident edges", {
   g <- make_test_named_tree()
-  ## Incident edges of vertices
+
   expect_that(g[[1, , edges = TRUE]], is_equivalent_to(list(a = E(g)[1:2])))
   expect_that(g[[, 2, edges = TRUE]], is_equivalent_to(list(b = E(g)[1])))
   expect_that(
@@ -247,7 +246,7 @@ test_that("[[ can query incident edges", {
 
 test_that("[[ queries edges with vertex names", {
   g <- make_test_named_tree()
-  ## Same with vertex names
+
   expect_that(
     g[["a", , edges = TRUE]],
     is_equivalent_to(list(a = E(g)[1:2]))
@@ -286,7 +285,7 @@ test_that("[[ queries edges with vertex names", {
 })
 test_that("[ handles from and to properly", {
   g <- make_test_named_tree()
-  ## from & to
+
   g <- make_tree(20)
   expect_that(g[from = c(1, 2, 2, 3), to = c(3, 4, 8, 7)], equals(c(1, 1, 0, 1)))
 
@@ -328,7 +327,6 @@ test_that("[[ returns vertex and edges sequences", {
 })
 
 test_that("[[ handles from and to properly even if the graph has conflicting vertex attributes", {
-  ## from & to
   g <- make_tree(20)
   V(g)$i <- 200:219
   V(g)$j <- 200:219

--- a/tests/testthat/test-indexing2.R
+++ b/tests/testthat/test-indexing2.R
@@ -1,9 +1,3 @@
-am <- function(x) {
-  x <- as.matrix(x)
-  dimnames(x) <- NULL
-  x
-}
-
 test_that("[ can add and delete edges", {
   g <- make_empty_graph(10)
   A <- matrix(0, 10, 10)

--- a/tests/testthat/test-indexing2.R
+++ b/tests/testthat/test-indexing2.R
@@ -3,22 +3,22 @@ test_that("[ can add and delete edges", {
   A <- matrix(0, 10, 10)
 
   A[1, 2] <- g[1, 2] <- TRUE
-  expect_that(am(g[]), equals(A))
+  expect_that(canonicalize_matrix(g[]), equals(A))
 
   A[2, 1] <- g[2, 1] <- TRUE
-  expect_that(am(g[]), equals(A))
+  expect_that(canonicalize_matrix(g[]), equals(A))
 
   g[2, 1] <- NULL
   A[2, 1] <- 0
-  expect_that(am(g[]), equals(A))
+  expect_that(canonicalize_matrix(g[]), equals(A))
 
   A[1, 2] <- g[1, 2] <- FALSE
-  expect_that(am(g[]), equals(A))
+  expect_that(canonicalize_matrix(g[]), equals(A))
 
   g <- make_empty_graph(10)
   A <- matrix(0, 10, 10)
   A[-1, 1] <- g[-1, 1] <- 1
-  expect_that(am(g[]), equals(A))
+  expect_that(canonicalize_matrix(g[]), equals(A))
 })
 
 test_that("[ can set weights and delete weighted edges", {
@@ -26,20 +26,20 @@ test_that("[ can set weights and delete weighted edges", {
   A <- matrix(0, 10, 10)
   g <- set_edge_attr(g, "weight", c(), 1)
   A[1, 2] <- g[1, 2] <- 1
-  expect_that(am(g[]), equals(A))
+  expect_that(canonicalize_matrix(g[]), equals(A))
 
   A[2, 1] <- g[2, 1] <- 2
-  expect_that(am(g[]), equals(A))
+  expect_that(canonicalize_matrix(g[]), equals(A))
 
   A[1, 2] <- g[1, 2] <- 3
-  expect_that(am(g[]), equals(A))
+  expect_that(canonicalize_matrix(g[]), equals(A))
 
   A[1:2, 2:3] <- g[1:2, 2:3] <- -1
-  expect_that(am(g[]), equals(A))
+  expect_that(canonicalize_matrix(g[]), equals(A))
 
   g[1, 2] <- NULL
   A[1, 2] <- 0
-  expect_that(am(g[]), equals(A))
+  expect_that(canonicalize_matrix(g[]), equals(A))
 })
 
 test_that("[ can add edges and ste weights via vertex names", {
@@ -50,15 +50,15 @@ test_that("[ can add edges and ste weights via vertex names", {
 
   A["a", "b"] <- g["a", "b"] <- TRUE
   A["b", "c"] <- g["b", "c"] <- TRUE
-  expect_that(am(g[]), equals(am(A)))
+  expect_that(canonicalize_matrix(g[]), equals(canonicalize_matrix(A)))
 
   A[c("a", "f"), c("f", "a")] <- g[c("a", "f"), c("f", "a")] <- TRUE
-  expect_that(am(g[]), equals(am(A)))
+  expect_that(canonicalize_matrix(g[]), equals(canonicalize_matrix(A)))
 
   A[A == 1] <- NA
   A[c("a", "c", "h"), c("a", "b", "c")] <-
     g[c("a", "c", "h"), c("a", "b", "c"), attr = "weight"] <- 3
-  expect_that(am(g[]), equals(am(A)))
+  expect_that(canonicalize_matrix(g[]), equals(canonicalize_matrix(A)))
 })
 
 test_that("[ and the from-to notation", {
@@ -73,7 +73,7 @@ test_that("[ and the from-to notation", {
     g[from = c("a", "c", "h", "d"), to = c("a", "b", "c", "e")],
     equals(c(1, 1, 1, 0))
   )
-  expect_that(am(g[]), equals(am(A)))
+  expect_that(canonicalize_matrix(g[]), equals(canonicalize_matrix(A)))
 
   g[from = c("a", "c", "h", "a"), to = c("a", "a", "a", "e"), attr = "weight"] <- 3
   A[A != 0] <- NA
@@ -82,7 +82,7 @@ test_that("[ and the from-to notation", {
     from = c("a", "c", "h", "a", "c", "c"),
     to = c("a", "a", "a", "e", "f", "b")
   ], equals(c(3, 3, 3, 3, 0, NA)))
-  expect_that(am(g[]), equals(am(A)))
+  expect_that(canonicalize_matrix(g[]), equals(canonicalize_matrix(A)))
 })
 
 test_that("[ and from-to with multiple values", {
@@ -103,5 +103,5 @@ test_that("[ and from-to with multiple values", {
     from = c("a", "c", "h", "a", "c", "c"),
     to = c("a", "a", "a", "e", "f", "b")
   ], equals(c(5:8, 0, NA)))
-  expect_that(am(g[]), equals(am(A)))
+  expect_that(canonicalize_matrix(g[]), equals(canonicalize_matrix(A)))
 })


### PR DESCRIPTION
@szhorvat if `am()` and `mm()` had longer names, what would those be? I'd like to replace them with longer, more informative names.

Removing top-level code in test files help make each test more self-contained, therefore easier to re-run interactively when it fails (as happens in #1080)

Part of #1082 