### PR TITLE
Fixes for Makevars.in for unix (revert accidental file updates) 

### DIFF
--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -1,15 +1,15 @@
 include sources.mk
 
-LIB_XML ?= $(MINGW_PREFIX)
-GLPK_HOME ?= $(MINGW_PREFIX)
-LIB_GMP ?= $(MINGW_PREFIX)
+PKG_CFLAGS=$(C_VISIBILITY)
+PKG_CXXFLAGS=$(CXX_VISIBILITY)
+PKG_FFLAGS=$(F_VISIBILITY)
 
 PKG_CPPFLAGS=@cflags@ -DUSING_R -I. -Ivendor -Ivendor/cigraph/src -Ivendor/cigraph/include -Ivendor/cigraph/vendor \
 	-DNDEBUG -DNTIMER -DNPRINT -DINTERNAL_ARPACK -DIGRAPH_THREAD_LOCAL= \
 	-DPRPACK_IGRAPH_SUPPORT \
 	-D_GNU_SOURCE=1
 
-PKG_LIBS = -L"${LIB_XML}/lib" -lxml2 -lz -lstdc++ -L"${GLPK_HOME}/lib" \
-  -lglpk -lgmp -L"${LIB_GMP}/lib" "${BLAS_LIBS}" "${LAPACK_LIBS}"
+PKG_LIBS = -L"${LIB_XML}/lib" -lxml2 -lz -L"${GLPK_HOME}/lib" \
+  -lglpk -lgmp -L"${LIB_GMP}/lib" $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 
 OBJECTS=${SOURCES}


### PR DESCRIPTION
I think you may have accidentally copied a wrong version of [src/Makevars.in](https://github.com/igraph/rigraph/blob/main/src/Makevars.in) in #840. What you have now is a broken version of a Windows Makevars, not the unix one.

This PR restores it to the correct version from before #840 plus a small improvement to use the new `sources.mk`.