### PR TITLE
fix: add default value for once

### DIFF
--- a/tools/stimulus/types-RR.yaml
+++ b/tools/stimulus/types-RR.yaml
@@ -477,3 +477,7 @@ OPTIMALITY:
         MINIMUM: c("minimum", "maximum")
         MAXIMUM: c("maximum", "minimum")
     INCONV: '%I% <- switch(igraph.match.arg(%I%), "minimum"=0L, "maximum"=1L)'
+
+LOOPS:
+    DEFAULT:
+        ONCE: '"once"'


### PR DESCRIPTION
Fix #1008 (#1011)

I cannot run the Makefile. I am trying to follow https://github.com/igraph/rigraph/blob/main/src/README.md 

```
le-cigraph clean
rm -rf src/core src/vendor src/include src/Makevars.in src/Makevars.ucrt src/Makevars.win src/config.h.in src/rinterface.c R/aaa-auto.R
git -C src/vendor/cigraph reset --hard
fatal: cannot change to 'src/vendor/cigraph': No such file or directory
make: *** [Makefile-cigraph:177: clean] Error 128
```

The git submodule commands ran without any error but then also probably didn't work, am I missing something obvious?

@ntamas