### PR TITLE
fix: `bfs()` no longer pads `order` with zeros with `igraph_options(return.vs.es = FALSE)`

### DIFF
--- a/R/interface.R
+++ b/R/interface.R
@@ -525,7 +525,8 @@ get.edge.ids <- function(
     multi = NULL) {
   ensure_igraph(graph)
 
-  if (lifecycle::is_present(multi)) {
+  # FIXME: Change to lifecycle::is_present() when using deprecated
+  if (!is.null(multi)) {
     if (isTRUE(multi)) {
       lifecycle::deprecate_stop("2.0.0", "get.edge.ids(multi = )")
     }

--- a/R/structural.properties.R
+++ b/R/structural.properties.R
@@ -2149,6 +2149,8 @@ bfs <- function(
     if (father) res$father <- create_vs(graph, res$father, na_ok = TRUE)
     if (pred) res$pred <- create_vs(graph, res$pred, na_ok = TRUE)
     if (succ) res$succ <- create_vs(graph, res$succ, na_ok = TRUE)
+  } else {
+    if (order) res$order <- res$order[res$order != 0]
   }
 
   if (igraph_opt("add.vertex.names") && is_named(graph)) {

--- a/man/get.edge.ids.Rd
+++ b/man/get.edge.ids.Rd
@@ -67,8 +67,8 @@ Other structural queries:
 \code{\link{gorder}()},
 \code{\link{gsize}()},
 \code{\link{head_of}()},
-\code{\link{incident_edges}()},
 \code{\link{incident}()},
+\code{\link{incident_edges}()},
 \code{\link{is_directed}()},
 \code{\link{neighbors}()},
 \code{\link{tail_of}()}

--- a/tests/testthat/test-graph.bfs.R
+++ b/tests/testthat/test-graph.bfs.R
@@ -128,3 +128,11 @@ test_that("snapshot test", {
     )
   })
 })
+
+test_that("BFS does not pad order", {
+  g <- make_star(3)
+  expect_equal(as.numeric(bfs(g, root = 2, unreachable = FALSE)$order), c(2, 1))
+
+  local_igraph_options(return.vs.es = FALSE)
+  expect_equal(as.numeric(bfs(g, root = 2, unreachable = FALSE)$order), c(2, 1))
+})

--- a/tests/testthat/test-graph.dfs.R
+++ b/tests/testthat/test-graph.dfs.R
@@ -6,4 +6,7 @@ test_that("DFS uses 1-based root vertex index", {
 test_that("DFS does not pad order", {
   g <- make_star(3)
   expect_equal(as.numeric(dfs(g, root = 2, unreachable = FALSE)$order), c(2, 1))
+
+  local_igraph_options(return.vs.es = FALSE)
+  expect_equal(as.numeric(bfs(g, root = 2, unreachable = FALSE)$order), c(2, 1))
 })

--- a/tests/testthat/test-graphNEL.R
+++ b/tests/testthat/test-graphNEL.R
@@ -1,7 +1,7 @@
 test_that("graphNEL conversion works", {
   if (!requireNamespace("graph", quietly = TRUE)) skip("No graph package")
 
-  library(graph, warn.conflicts = FALSE)
+  suppressPackageStartupMessages(library(graph, warn.conflicts = FALSE))
 
   g <- sample_gnp(100, 5 / 100)
   N <- as_graphnel(g)


### PR DESCRIPTION
@jefferis: For https://github.com/natverse/nat/issues/517#issuecomment-1902167741.