### PR TITLE
test: prevent `decompose()` test from being reported as skipped

### DIFF
--- a/tests/testthat/test-decompose.graph.R
+++ b/tests/testthat/test-decompose.graph.R
@@ -43,5 +43,5 @@ test_that("decompose protects correctly", {
   torture <- gctorture2(10001)
   on.exit(gctorture2(torture))
 
-  length(decompose(g))
+  expect_equal(length(decompose(g)), 10001)
 })


### PR DESCRIPTION
I guess this test didn't need any explicit check, but without one it will be reported as skipped.