### PR TITLE
feat!: as_adjacency_matrix() should use weights instead of attr parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -70,5 +70,5 @@ Config/testthat/start-first: vs-es, scan, vs-operators, weakref,
     watts.strogatz.game
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.0.9000
+RoxygenNote: 7.3.1
 SystemRequirements: gmp, libxml2, glpk (>= 4.57)

--- a/R/attributes.R
+++ b/R/attributes.R
@@ -1003,6 +1003,16 @@ is_weighted <- function(graph) {
   "weight" %in% edge_attr_names(graph)
 }
 
+get_weights <- function(graph, call = rlang::caller_env()) {
+  if (!is_weighted(graph)) {
+    cli::cli_abort(
+      "The graph must have weights",
+      call = call
+    )
+  }
+  edge_attr(graph, "weight")
+}
+
 #' @rdname make_bipartite_graph
 #' @export
 is_bipartite <- function(graph) {

--- a/R/centrality.R
+++ b/R/centrality.R
@@ -1486,26 +1486,19 @@ alpha.centrality.dense <- function(graph, nodes = V(graph), alpha = 1,
 
   exo <- rep(exo, length.out = vcount(graph))
   exo <- matrix(exo, ncol = 1)
-
-  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
-    ## weights == NULL and there is a "weight" edge attribute
-    attr <- "weight"
-  } else if (is.null(weights)) {
-    ## weights == NULL, but there is no "weight" edge attribute
-    attr <- NULL
+  if (is.null(weights) && is_weighted(graph)) {
+    weights <- get_weights(graph)
   } else if (is.character(weights) && length(weights) == 1) {
     ## name of an edge attribute, nothing to do
-    attr <- "weight"
-  } else if (any(!is.na(weights))) {
-    ## weights != NULL and weights != rep(NA, x)
-    graph <- set_edge_attr(graph, "weight", value = as.numeric(weights))
-    attr <- "weight"
-  } else {
-    ## weights != NULL, but weights == rep(NA, x)
-    attr <- NULL
+    ## ???
+    weights <- get_weights(graph)
   }
 
-  d <- t(as_adj(graph, attr = attr, sparse = FALSE))
+  if (is.na(weights)) {
+    weights <- NULL
+  }
+
+  d <- t(as_adjacency_matrix(graph, weights = weights, sparse = FALSE))
   if (!loops) {
     diag(d) <- 0
   }

--- a/R/centrality.R
+++ b/R/centrality.R
@@ -1486,6 +1486,7 @@ alpha.centrality.dense <- function(graph, nodes = V(graph), alpha = 1,
 
   exo <- rep(exo, length.out = vcount(graph))
   exo <- matrix(exo, ncol = 1)
+
   if (is.null(weights) && is_weighted(graph)) {
     weights <- get_weights(graph)
   } else if (is.character(weights) && length(weights) == 1) {
@@ -1494,6 +1495,7 @@ alpha.centrality.dense <- function(graph, nodes = V(graph), alpha = 1,
     weights <- get_weights(graph)
   }
 
+  # seems weights = NA happens
   if (!is.null(weights) && length(weights) == 1 && is.na(weights)) {
     weights <- NULL
   }

--- a/R/centrality.R
+++ b/R/centrality.R
@@ -1494,7 +1494,7 @@ alpha.centrality.dense <- function(graph, nodes = V(graph), alpha = 1,
     weights <- get_weights(graph)
   }
 
-  if (is.na(weights)) {
+  if (!is.null(weights) && length(weights) == 1 && is.na(weights)) {
     weights <- NULL
   }
 

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -228,7 +228,8 @@ get.adjacency.dense <- function(graph, type = c("both", "upper", "lower"),
 }
 
 get.adjacency.sparse <- function(graph, type = c("both", "upper", "lower"),
-                                 attr = NULL, edges = FALSE, names = TRUE) {
+                                 attr = NULL, edges = FALSE, names = TRUE,
+                                 weights = NULL) {
   ensure_igraph(graph)
 
   type <- igraph.match.arg(type)
@@ -321,7 +322,8 @@ get.adjacency.sparse <- function(graph, type = c("both", "upper", "lower"),
 #'   right triangle of the matrix is used, `lower`: the lower left triangle
 #'   of the matrix is used. `both`: the whole matrix is used, a symmetric
 #'   matrix is returned.
-#' @param attr Either `NULL` or a character string giving an edge
+#' @param attr `r lifecycle::badge("deprecated")` Use `weights` instead.
+#'   Either `NULL` or a character string giving an edge
 #'   attribute name. If `NULL` a traditional adjacency matrix is returned.
 #'   If not `NULL` then the values of the given edge attribute are included
 #'   in the adjacency matrix. If the graph has multiple edges, the edge attribute
@@ -333,6 +335,7 @@ get.adjacency.sparse <- function(graph, type = c("both", "upper", "lower"),
 #'   numeric. If the `sparse` argument is `FALSE`, then character is
 #'   also allowed. The reason for the difference is that the `Matrix`
 #'   package does not support character sparse matrices yet.
+#' @param weights A vector of numeric weights.
 #' @param edges `r lifecycle::badge("deprecated")` Logical scalar, whether to return the edge ids in the matrix.
 #'   For non-existant edges zero is returned.
 #' @param names Logical constant, whether to assign row and column names
@@ -357,7 +360,8 @@ get.adjacency.sparse <- function(graph, type = c("both", "upper", "lower"),
 #' @export
 as_adjacency_matrix <- function(graph, type = c("both", "upper", "lower"),
                                 attr = NULL, edges = FALSE, names = TRUE,
-                                sparse = igraph_opt("sparsematrices")) {
+                                sparse = igraph_opt("sparsematrices"),
+                                weights = NULL) {
   ensure_igraph(graph)
 
   if (!missing(edges) && isTRUE(edges)) {
@@ -365,9 +369,22 @@ as_adjacency_matrix <- function(graph, type = c("both", "upper", "lower"),
   }
 
   if (sparse) {
-    get.adjacency.sparse(graph, type = type, attr = attr, edges = edges, names = names)
+    get.adjacency.sparse(
+      graph,
+      type = type,
+      attr = attr,
+      edges = edges,
+      names = names,
+      weights = weights
+    )
   } else {
-    get.adjacency.dense(graph, type = type, attr = attr, weights = NULL, names = names)
+    get.adjacency.dense(
+      graph,
+      type = type,
+      attr = attr,
+      weights = weights,
+      names = names
+    )
   }
 }
 

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -383,6 +383,10 @@ as_adjacency_matrix <- function(graph, type = c("both", "upper", "lower"),
     )
   }
 
+  if (!is.null(attr) && !is.null(weights)) {
+    cli::cli_abort("Can't provide both {.arg attr} and {.arg weights} arguments.")
+  }
+
   if (sparse) {
     get.adjacency.sparse(
       graph,

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -155,7 +155,8 @@ get.adjedgelist <- function(graph, mode = c("all", "out", "in", "total"), loops 
 ###################################################################
 
 get.adjacency.dense <- function(graph, type = c("both", "upper", "lower"),
-                                attr = NULL, weights = NULL, loops = FALSE, names = TRUE) {
+                                attr = NULL, weights = NULL, loops = FALSE, names = TRUE,
+                                call = rlang::caller_env()) {
   ensure_igraph(graph)
 
   type <- igraph.match.arg(type)
@@ -176,17 +177,18 @@ get.adjacency.dense <- function(graph, type = c("both", "upper", "lower"),
   } else {
     attr <- as.character(attr)
     if (!attr %in% edge_attr_names(graph)) {
-      cli::cli_abort("Can't find edge attribute {.var {attr}}.")
+      cli::cli_abort("Can't find edge attribute {.var {attr}}.", call = call)
     }
     exattr <- edge_attr(graph, attr)
 
     res <- switch(
       typeof(exattr),
       logical = matrix(FALSE, nrow = vcount(graph), ncol = vcount(graph)),
-      numeric = matrix(0, nrow = vcount(graph), ncol = vcount(graph)),
+      double = matrix(0, nrow = vcount(graph), ncol = vcount(graph)),
       cli::cli_abort(
         "The edge attribute {.val exattr} must be either numeric or logical,
-        not {.obj_type_friendly {exattr}}."
+        not {.obj_type_friendly {exattr}}.",
+        call = call
       )
     )
 

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -176,7 +176,7 @@ get.adjacency.dense <- function(graph, type = c("both", "upper", "lower"),
   } else {
     attr <- as.character(attr)
     if (!attr %in% edge_attr_names(graph)) {
-      stop("no such edge attribute")
+      cli::cli_abort("Can't find edge attribute {.var {attr}}.")
     }
     exattr <- edge_attr(graph, attr)
     if (is.logical(exattr)) {

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -258,25 +258,41 @@ get.adjacency.sparse <- function(graph, type = c("both", "upper", "lower"),
   }
 
   if (is_directed(graph)) {
-    res <- Matrix::sparseMatrix(dims = c(vc, vc), i = el[, 1], j = el[, 2], x = value, use.last.ij = use.last.ij)
+    res <- Matrix::sparseMatrix(
+      dims = c(vc, vc),
+      i = el[, 1],
+      j = el[, 2],
+      x = value,
+      use.last.ij = use.last.ij
+    )
   } else {
     if (type == "upper") {
       ## upper
       res <- Matrix::sparseMatrix(
-        dims = c(vc, vc), i = pmin(el[, 1], el[, 2]),
-        j = pmax(el[, 1], el[, 2]), x = value, use.last.ij = use.last.ij
+        dims = c(vc, vc),
+        i = pmin(el[, 1], el[, 2]),
+        j = pmax(el[, 1], el[, 2]),
+        x = value,
+        use.last.ij = use.last.ij
       )
     } else if (type == "lower") {
       ## lower
       res <- Matrix::sparseMatrix(
-        dims = c(vc, vc), i = pmax(el[, 1], el[, 2]),
-        j = pmin(el[, 1], el[, 2]), x = value, use.last.ij = use.last.ij
+        dims = c(vc, vc),
+        i = pmax(el[, 1], el[, 2]),
+        j = pmin(el[, 1], el[, 2]),
+        x = value,
+        use.last.ij = use.last.ij
       )
     } else if (type == "both") {
       ## both
       res <- Matrix::sparseMatrix(
-        dims = c(vc, vc), i = pmin(el[, 1], el[, 2]),
-        j = pmax(el[, 1], el[, 2]), x = value, symmetric = TRUE, use.last.ij = use.last.ij
+        dims = c(vc, vc),
+        i = pmin(el[, 1], el[, 2]),
+        j = pmax(el[, 1], el[, 2]),
+        x = value,
+        symmetric = TRUE,
+        use.last.ij = use.last.ij
       )
       res <- as(res, "generalMatrix")
     }

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -313,7 +313,7 @@ get.adjacency.sparse <- function(graph, type = c("both", "upper", "lower"),
 #'   argument is ignored if `edges` is `TRUE`.
 #'
 #'   Note that this works only for certain attribute types. If the `sparse`
-#'   argumen is `TRUE`, then the attribute must be either logical or
+#'   argument is `TRUE`, then the attribute must be either logical or
 #'   numeric. If the `sparse` argument is `FALSE`, then character is
 #'   also allowed. The reason for the difference is that the `Matrix`
 #'   package does not support character sparse matrices yet.

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -245,6 +245,8 @@ get.adjacency.sparse <- function(graph, type = c("both", "upper", "lower"),
   if (edges) {
     value <- seq_len(nrow(el))
     use.last.ij <- TRUE
+  } else if (!is.null(weights)) {
+    value <- weights
   } else if (!is.null(attr)) {
     attr <- as.character(attr)
     if (!attr %in% edge_attr_names(graph)) {

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -179,16 +179,17 @@ get.adjacency.dense <- function(graph, type = c("both", "upper", "lower"),
       cli::cli_abort("Can't find edge attribute {.var {attr}}.")
     }
     exattr <- edge_attr(graph, attr)
-    if (is.logical(exattr)) {
-      res <- matrix(FALSE, nrow = vcount(graph), ncol = vcount(graph))
-    } else if (is.numeric(exattr)) {
-      res <- matrix(0, nrow = vcount(graph), ncol = vcount(graph))
-    } else {
-      stop(
-        "Matrices must be either numeric or logical, ",
-        "and the edge attribute is not"
+
+    res <- switch(
+      typeof(exattr),
+      logical = matrix(FALSE, nrow = vcount(graph), ncol = vcount(graph)),
+      numeric = matrix(0, nrow = vcount(graph), ncol = vcount(graph)),
+      cli::cli_abort(
+        "The edge attribute {.val exattr} must be either numeric or logical,
+        not {.obj_type_friendly {exattr}}."
       )
-    }
+    )
+
     if (is_directed(graph)) {
       for (i in seq(length.out = ecount(graph))) {
         e <- ends(graph, i, names = FALSE)

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -182,11 +182,11 @@ get.adjacency.dense <- function(graph, type = c("both", "upper", "lower"),
     exattr <- edge_attr(graph, attr)
 
     res <- switch(
-      typeof(exattr),
+      mode(exattr),
       logical = matrix(FALSE, nrow = vcount(graph), ncol = vcount(graph)),
-      double = matrix(0, nrow = vcount(graph), ncol = vcount(graph)),
+      numeric = matrix(0, nrow = vcount(graph), ncol = vcount(graph)),
       cli::cli_abort(
-        "The edge attribute {.val exattr} must be either numeric or logical,
+        "The edge attribute {.val {attr}} must be either numeric or logical,
         not {.obj_type_friendly {exattr}}.",
         call = call
       )
@@ -256,7 +256,7 @@ get.adjacency.sparse <- function(graph, type = c("both", "upper", "lower"),
     value_ok_type <- (is.numeric(value) || is.logical(value))
     if (!value_ok_type) {
       cli::cli_abort(
-        "The edge attribute {.val exattr} must be either numeric or logical,
+        "The edge attribute {.val {attr}} must be either numeric or logical,
         not {.obj_type_friendly {exattr}}.",
         call = call
       )

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -161,8 +161,7 @@
                        weights = NULL) {
   ## TODO: make it faster, don't need the whole matrix usually
 
-  ################################################################
-  ## Argument checks
+  ## Argument checks ----
   if (!missing(attr)) {
     lifecycle::deprecate_soft(
       when = "2.0.1",
@@ -175,7 +174,7 @@
     cli::cli_abort("Can't provide both {.arg attr} and {.arg weights} arguments.")
   }
 
-  if (is.null(weights) && missing(attr)) {
+  if (is.null(weights) && is.null(attr)) {
     if (is_weighted(x)) {
       weights <- get_weights(x)
     }
@@ -200,7 +199,7 @@
     }
   }
 
-  ##################################################################
+  ## calculations ----
 
   if (!missing(from)) {
     res <- get.edge.ids(x, rbind(from, to), error = FALSE)

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -144,8 +144,10 @@
 #' @param sparse Logical scalar, whether to return sparse matrices.
 #' @param edges Logical scalar, whether to return edge ids.
 #' @param drop Ignored.
-#' @param attr If not `NULL`, then it should be the name of an edge
+#' @param attr `r lifecycle::badge("deprecated")` Use `weights` instead.
+#' If not `NULL`, then it should be the name of an edge
 #'   attribute. This attribute is queried and returned.
+#' @param weights A vector of numeric weights.
 #' @return A scalar or matrix. See details below.
 #'
 #' @family structural queries
@@ -155,11 +157,23 @@
 `[.igraph` <- function(x, i, j, ..., from, to,
                        sparse = igraph_opt("sparsematrices"),
                        edges = FALSE, drop = TRUE,
-                       attr = if (is_weighted(x)) "weight" else NULL) {
+                       attr = if (is_weighted(x)) "weight" else NULL,
+                       weights) {
   ## TODO: make it faster, don't need the whole matrix usually
 
   ################################################################
   ## Argument checks
+  if (!missing(attr)) {
+    lifecycle::deprecate_soft(
+      when = "2.0.1",
+      what = "as_adjacency_matrix(attr = )",
+      details = "Use the weights arguments instead."
+    )
+  }
+
+  if (!is.null(attr) && !is.null(weights)) {
+    cli::cli_abort("Can't provide both {.arg attr} and {.arg weights} arguments.")
+  }
   if ((!missing(from) || !missing(to)) &&
     (!missing(i) || !missing(j))) {
     stop("Cannot give 'from'/'to' together with regular indices")
@@ -196,27 +210,27 @@
     res
   } else if (missing(i) && missing(j)) {
     if (missing(edges)) {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr)
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, weights = weights)
     } else {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges, weights = weights)
     }
   } else if (missing(j)) {
     if (missing(edges)) {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr)[i, , drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, weights = weights)[i, , drop = drop]
     } else {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)[i, , drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges, weights = weights)[i, , drop = drop]
     }
   } else if (missing(i)) {
     if (missing(edges)) {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr)[, j, drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, weights = weights)[, j, drop = drop]
     } else {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)[, j, drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges, weights = weights)[, j, drop = drop]
     }
   } else {
     if (missing(edges)) {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr)[i, j, drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, weights = weights)[i, j, drop = drop]
     } else {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)[i, j, drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges, weights = weights)[i, j, drop = drop]
     }
   }
 }

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -209,6 +209,8 @@
       if (any(res != 0)) {
         res[res != 0] <- edge_attr(x, attr, res[res != 0])
       }
+    } else if (!is.null(weights)) {
+      # TODO how to use weights here?!
     } else {
       res <- as.logical(res) + 0
     }

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -200,6 +200,17 @@
   }
 
   ## calculations ----
+  arguments <- list(
+    graph = x,
+    sparse = sparse,
+    weights = weights
+  )
+  if (!missing(attr)) {
+    arguments[["attr"]] <- attr
+  }
+  if (!missing(edges)) {
+    arguments[["edges"]] <- edges
+  }
 
   if (!missing(from)) {
     res <- get.edge.ids(x, rbind(from, to), error = FALSE)
@@ -216,29 +227,13 @@
     }
     res
   } else if (missing(i) && missing(j)) {
-    if (missing(edges)) {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, weights = weights)
-    } else {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges, weights = weights)
-    }
+    do.call(as_adjacency_matrix, args = arguments)
   } else if (missing(j)) {
-    if (missing(edges)) {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, weights = weights)[i, , drop = drop]
-    } else {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges, weights = weights)[i, , drop = drop]
-    }
+    do.call(as_adjacency_matrix, args = arguments)[i, , drop = drop]
   } else if (missing(i)) {
-    if (missing(edges)) {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, weights = weights)[, j, drop = drop]
-    } else {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges, weights = weights)[, j, drop = drop]
-    }
+    do.call(as_adjacency_matrix, args = arguments)[, j, drop = drop]
   } else {
-    if (missing(edges)) {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, weights = weights)[i, j, drop = drop]
-    } else {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges, weights = weights)[i, j, drop = drop]
-    }
+    do.call(as_adjacency_matrix, args = arguments)[i, j, drop = drop]
   }
 }
 

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -196,27 +196,27 @@
     res
   } else if (missing(i) && missing(j)) {
     if (missing(edges)) {
-      as_adj(x, sparse = sparse, attr = attr)
+      as_adjacency_matrix(x, sparse = sparse, attr = attr)
     } else {
-      as_adj(x, sparse = sparse, attr = attr, edges = edges)
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)
     }
   } else if (missing(j)) {
     if (missing(edges)) {
-      as_adj(x, sparse = sparse, attr = attr)[i, , drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr)[i, , drop = drop]
     } else {
-      as_adj(x, sparse = sparse, attr = attr, edges = edges)[i, , drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)[i, , drop = drop]
     }
   } else if (missing(i)) {
     if (missing(edges)) {
-      as_adj(x, sparse = sparse, attr = attr)[, j, drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr)[, j, drop = drop]
     } else {
-      as_adj(x, sparse = sparse, attr = attr, edges = edges)[, j, drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)[, j, drop = drop]
     }
   } else {
     if (missing(edges)) {
-      as_adj(x, sparse = sparse, attr = attr)[i, j, drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr)[i, j, drop = drop]
     } else {
-      as_adj(x, sparse = sparse, attr = attr, edges = edges)[i, j, drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)[i, j, drop = drop]
     }
   }
 }

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -196,27 +196,27 @@
     res
   } else if (missing(i) && missing(j)) {
     if (missing(edges)) {
-      as_adj(x, sparse = sparse, attr = attr)
+      as_adjacency_matrixacency_matrix(x, sparse = sparse, attr = attr)
     } else {
-      as_adj(x, sparse = sparse, attr = attr, edges = edges)
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)
     }
   } else if (missing(j)) {
     if (missing(edges)) {
-      as_adj(x, sparse = sparse, attr = attr)[i, , drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr)[i, , drop = drop]
     } else {
-      as_adj(x, sparse = sparse, attr = attr, edges = edges)[i, , drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)[i, , drop = drop]
     }
   } else if (missing(i)) {
     if (missing(edges)) {
-      as_adj(x, sparse = sparse, attr = attr)[, j, drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr)[, j, drop = drop]
     } else {
-      as_adj(x, sparse = sparse, attr = attr, edges = edges)[, j, drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)[, j, drop = drop]
     }
   } else {
     if (missing(edges)) {
-      as_adj(x, sparse = sparse, attr = attr)[i, j, drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr)[i, j, drop = drop]
     } else {
-      as_adj(x, sparse = sparse, attr = attr, edges = edges)[i, j, drop = drop]
+      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)[i, j, drop = drop]
     }
   }
 }
@@ -280,7 +280,7 @@
 #' @export
 `[[.igraph` <- function(x, i, j, from, to, ..., directed = TRUE,
                         edges = FALSE, exact = TRUE) {
-  getfun <- if (edges) as_adj_edge_list else as_adj_list
+  getfun <- if (edges) as_adjacency_matrix_edge_list else as_adjacency_matrix_list
 
   if (!missing(i) && !missing(from)) stop("Cannot give both 'i' and 'from'")
   if (!missing(j) && !missing(to)) stop("Cannot give both 'j' and 'to'")

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -196,27 +196,27 @@
     res
   } else if (missing(i) && missing(j)) {
     if (missing(edges)) {
-      as_adjacency_matrixacency_matrix(x, sparse = sparse, attr = attr)
+      as_adj(x, sparse = sparse, attr = attr)
     } else {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)
+      as_adj(x, sparse = sparse, attr = attr, edges = edges)
     }
   } else if (missing(j)) {
     if (missing(edges)) {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr)[i, , drop = drop]
+      as_adj(x, sparse = sparse, attr = attr)[i, , drop = drop]
     } else {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)[i, , drop = drop]
+      as_adj(x, sparse = sparse, attr = attr, edges = edges)[i, , drop = drop]
     }
   } else if (missing(i)) {
     if (missing(edges)) {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr)[, j, drop = drop]
+      as_adj(x, sparse = sparse, attr = attr)[, j, drop = drop]
     } else {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)[, j, drop = drop]
+      as_adj(x, sparse = sparse, attr = attr, edges = edges)[, j, drop = drop]
     }
   } else {
     if (missing(edges)) {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr)[i, j, drop = drop]
+      as_adj(x, sparse = sparse, attr = attr)[i, j, drop = drop]
     } else {
-      as_adjacency_matrix(x, sparse = sparse, attr = attr, edges = edges)[i, j, drop = drop]
+      as_adj(x, sparse = sparse, attr = attr, edges = edges)[i, j, drop = drop]
     }
   }
 }
@@ -280,7 +280,7 @@
 #' @export
 `[[.igraph` <- function(x, i, j, from, to, ..., directed = TRUE,
                         edges = FALSE, exact = TRUE) {
-  getfun <- if (edges) as_adjacency_matrix_edge_list else as_adjacency_matrix_list
+  getfun <- if (edges) as_adj_edge_list else as_adj_list
 
   if (!missing(i) && !missing(from)) stop("Cannot give both 'i' and 'from'")
   if (!missing(j) && !missing(to)) stop("Cannot give both 'j' and 'to'")

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -157,7 +157,7 @@
 `[.igraph` <- function(x, i, j, ..., from, to,
                        sparse = igraph_opt("sparsematrices"),
                        edges = FALSE, drop = TRUE,
-                       attr = if (is_weighted(x)) "weight" else NULL,
+                       attr = NULL,
                        weights = NULL) {
   ## TODO: make it faster, don't need the whole matrix usually
 
@@ -173,6 +173,12 @@
 
   if (!is.null(attr) && !is.null(weights)) {
     cli::cli_abort("Can't provide both {.arg attr} and {.arg weights} arguments.")
+  }
+
+  if (is.null(weights) && missing(attr)) {
+    if (is_weighted(x)) {
+      weights <- get_weights(x)
+    }
   }
   if ((!missing(from) || !missing(to)) &&
     (!missing(i) || !missing(j))) {

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -158,7 +158,7 @@
                        sparse = igraph_opt("sparsematrices"),
                        edges = FALSE, drop = TRUE,
                        attr = if (is_weighted(x)) "weight" else NULL,
-                       weights) {
+                       weights = NULL) {
   ## TODO: make it faster, don't need the whole matrix usually
 
   ################################################################

--- a/man/arpack.Rd
+++ b/man/arpack.Rd
@@ -184,7 +184,7 @@ eigen(laplacian_matrix(make_star(10, mode = "undirected")))
 if (require(Matrix)) {
   set.seed(42)
   g <- sample_gnp(1000, 5 / 1000)
-  M <- as_adj(g, sparse = TRUE)
+  M <- as_adjacency_matrix(g, sparse = TRUE)
   f2 <- function(x, extra = NULL) {
     cat(".")
     as.vector(M \%*\% x)

--- a/man/as_adjacency_matrix.Rd
+++ b/man/as_adjacency_matrix.Rd
@@ -11,7 +11,8 @@ as_adjacency_matrix(
   attr = NULL,
   edges = FALSE,
   names = TRUE,
-  sparse = igraph_opt("sparsematrices")
+  sparse = igraph_opt("sparsematrices"),
+  weights = NULL
 )
 
 as_adj(
@@ -20,7 +21,8 @@ as_adj(
   attr = NULL,
   edges = FALSE,
   names = TRUE,
-  sparse = igraph_opt("sparsematrices")
+  sparse = igraph_opt("sparsematrices"),
+  weights = NULL
 )
 }
 \arguments{
@@ -32,7 +34,8 @@ right triangle of the matrix is used, \code{lower}: the lower left triangle
 of the matrix is used. \code{both}: the whole matrix is used, a symmetric
 matrix is returned.}
 
-\item{attr}{Either \code{NULL} or a character string giving an edge
+\item{attr}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} instead.
+Either \code{NULL} or a character string giving an edge
 attribute name. If \code{NULL} a traditional adjacency matrix is returned.
 If not \code{NULL} then the values of the given edge attribute are included
 in the adjacency matrix. If the graph has multiple edges, the edge attribute
@@ -40,7 +43,7 @@ of an arbitrarily chosen edge (for the multiple edges) is included. This
 argument is ignored if \code{edges} is \code{TRUE}.
 
 Note that this works only for certain attribute types. If the \code{sparse}
-argumen is \code{TRUE}, then the attribute must be either logical or
+argument is \code{TRUE}, then the attribute must be either logical or
 numeric. If the \code{sparse} argument is \code{FALSE}, then character is
 also allowed. The reason for the difference is that the \code{Matrix}
 package does not support character sparse matrices yet.}
@@ -55,6 +58,8 @@ is present in the graph.}
 \item{sparse}{Logical scalar, whether to create a sparse matrix. The
 \sQuote{\code{Matrix}} package must be installed for creating sparse
 matrices.}
+
+\item{weights}{A vector of numeric weights.}
 }
 \value{
 A \code{vcount(graph)} by \code{vcount(graph)} (usually) numeric

--- a/man/get.adjacency.Rd
+++ b/man/get.adjacency.Rd
@@ -22,7 +22,8 @@ right triangle of the matrix is used, \code{lower}: the lower left triangle
 of the matrix is used. \code{both}: the whole matrix is used, a symmetric
 matrix is returned.}
 
-\item{attr}{Either \code{NULL} or a character string giving an edge
+\item{attr}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} instead.
+Either \code{NULL} or a character string giving an edge
 attribute name. If \code{NULL} a traditional adjacency matrix is returned.
 If not \code{NULL} then the values of the given edge attribute are included
 in the adjacency matrix. If the graph has multiple edges, the edge attribute
@@ -30,7 +31,7 @@ of an arbitrarily chosen edge (for the multiple edges) is included. This
 argument is ignored if \code{edges} is \code{TRUE}.
 
 Note that this works only for certain attribute types. If the \code{sparse}
-argumen is \code{TRUE}, then the attribute must be either logical or
+argument is \code{TRUE}, then the attribute must be either logical or
 numeric. If the \code{sparse} argument is \code{FALSE}, then character is
 also allowed. The reason for the difference is that the \code{Matrix}
 package does not support character sparse matrices yet.}

--- a/man/spectrum.Rd
+++ b/man/spectrum.Rd
@@ -65,7 +65,7 @@ kite <- make_graph("Krackhardt_kite")
 spectrum(kite)[c("values", "vectors")]
 
 ## Double check
-eigen(as_adj(kite, sparse = FALSE))$vectors[, 1]
+eigen(as_adjacency_matrix(kite, sparse = FALSE))$vectors[, 1]
 
 ## Should be the same as 'eigen_centrality' (but rescaled)
 cor(eigen_centrality(kite)$vector, spectrum(kite)$vectors)
@@ -75,7 +75,7 @@ spectrum(kite, which = list(pos = "SM", howmany = 2))$values
 
 }
 \seealso{
-\code{\link[=as_adj]{as_adj()}} to create a (sparse) adjacency matrix.
+\code{\link[=as_adjacency_matrix]{as_adjacency_matrix()}} to create a (sparse) adjacency matrix.
 
 Centrality measures
 \code{\link{alpha_centrality}()},

--- a/man/sub-.igraph.Rd
+++ b/man/sub-.igraph.Rd
@@ -14,7 +14,8 @@
   sparse = igraph_opt("sparsematrices"),
   edges = FALSE,
   drop = TRUE,
-  attr = if (is_weighted(x)) "weight" else NULL
+  attr = NULL,
+  weights = NULL
 )
 }
 \arguments{
@@ -48,8 +49,11 @@ well.}
 
 \item{drop}{Ignored.}
 
-\item{attr}{If not \code{NULL}, then it should be the name of an edge
+\item{attr}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} instead.
+If not \code{NULL}, then it should be the name of an edge
 attribute. This attribute is queried and returned.}
+
+\item{weights}{A vector of numeric weights.}
 }
 \value{
 A scalar or matrix. See details below.

--- a/tests/testthat/test-constraint.R
+++ b/tests/testthat/test-constraint.R
@@ -1,8 +1,15 @@
 test_that("constraint works", {
-  constraint.orig <- function(graph, nodes = V(graph), attr = NULL) {
+  constraint.orig <- function(graph, nodes = V(graph), weighted = FALSE) {
     ensure_igraph(graph)
     idx <- degree(graph) != 0
-    A <- as_adj(graph, attr = attr, sparse = FALSE)
+
+    if (weighted) {
+      weights <- get_weights(graph)
+    } else {
+      weights <- NULL
+    }
+
+    A <- as_adjacency_matrix(graph, weights = weights, sparse = FALSE)
     A <- A[idx, idx]
     n <- sum(idx)
 
@@ -33,6 +40,6 @@ test_that("constraint works", {
   set.seed(42)
   E(karate)$weight <- sample(1:10, replace = TRUE, ecount(karate))
   wc1 <- constraint(karate)
-  wc2 <- constraint.orig(karate, attr = "weight")
+  wc2 <- constraint.orig(karate, weighted = TRUE)
   expect_that(wc1, equals(wc2))
 })

--- a/tests/testthat/test-graphNEL.R
+++ b/tests/testthat/test-graphNEL.R
@@ -22,8 +22,8 @@ test_that("graphNEL conversion works", {
   expect_true(graph.isomorphic(g, g2))
   expect_that(V(g)$name, equals(V(g2)$name))
 
-  A <- as_adj(g, attr = "weight", sparse = FALSE)
-  A2 <- as_adj(g2, attr = "weight", sparse = FALSE)
+  A <- as_adjacency_matrix(g, weights = get_weights(g), sparse = FALSE)
+  A2 <- as_adjacency_matrix(g2, weights = get_weights(g2), sparse = FALSE)
   expect_that(A, equals(A))
   expect_that(g$name, equals(g2$name))
 })

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -240,8 +240,6 @@ test_that("[[ queries edges with vertex names", {
   )
 })
 test_that("[ handles from and to properly", {
-  g <- make_test_named_tree()
-
   g <- make_tree(20)
   expect_that(g[from = c(1, 2, 2, 3), to = c(3, 4, 8, 7)], equals(c(1, 1, 0, 1)))
 


### PR DESCRIPTION
Fix #906 

- How to use weights in the indexing function.
- That function has an attr argument that is passed to as_adjacency_matrix(). Should we double all calls based on whether attr is missing or not, to avoid the deprecation message.