### PR TITLE
fix: Remove zeros from the `order` and `order.out` components returned by `dfs()`

### DIFF
--- a/R/structural.properties.R
+++ b/R/structural.properties.R
@@ -2309,6 +2309,9 @@ dfs <- function(graph, root, mode = c("out", "in", "all", "total"),
     if (order) res$order <- V(graph)[.env$res$order, na_ok = TRUE]
     if (order.out) res$order.out <- V(graph)[.env$res$order.out, na_ok = TRUE]
     if (father) res$father <- create_vs(graph, res$father, na_ok = TRUE)
+  } else {
+    if (order) res$order <- res$order[res$order != 0]
+    if (order.out) res$order.out <- res$order.out[res$order.out != 0]
   }
 
   if (igraph_opt("add.vertex.names") && is_named(graph)) {

--- a/tests/testthat/test-graph.dfs.R
+++ b/tests/testthat/test-graph.dfs.R
@@ -8,5 +8,6 @@ test_that("DFS does not pad order", {
   expect_equal(as.numeric(dfs(g, root = 2, unreachable = FALSE)$order), c(2, 1))
 
   local_igraph_options(return.vs.es = FALSE)
-  expect_equal(as.numeric(bfs(g, root = 2, unreachable = FALSE)$order), c(2, 1))
+  expect_equal(as.numeric(dfs(g, root = 2, unreachable = FALSE)$order), c(2, 1))
+  expect_equal(as.numeric(dfs(g, root = 2, unreachable = FALSE, order.out = TRUE)$order.out), c(1, 2))
 })


### PR DESCRIPTION
Closes #1174.