### PR TITLE
docs: improve installation and troubleshooting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,22 @@ or Github, with the `devtools` package:
 devtools::install_github("igraph/rigraph")
 ```
 
+When compiling from sources, make sure that you have C, C++ and Fortran
+compilers, as well as development packages for `glpk`, `gmp` and `libxml2`.
+On Debian/Ubuntu, use `apt install libglpk-dev libgmp-dev libxml2-dev`.
+On Fedora, use `yum install glpk-devel gmp-devel libxml2-devel`.
+
 For installation from source on Windows, you need to have
 [RTools](https://cran.r-project.org/bin/windows/Rtools/) installed.
-Additionally, the three system requirements of `glpk`, `libxml2` and `gmp` are
-not optional, but hard requirements. For versions R >= 4.0 you can install these
-using
+For versions R >= 4.0 you can install the dependencies using:
 
 ```
-pacman -Sy mingw-w64-{i686,x86_64}-glpk mingw-w64-{i686,x86_64}-libxml2 mingw-w64-{i686,x86_64}-gmp
+pacman -Sy mingw-w64-{i686,x86_64}-glpk mingw-w64-{i686,x86_64}-gmp mingw-w64-{i686,x86_64}-libxml2
 ```
 
-See the package wiki for more information on [installation troubleshooting](https://r.igraph.org/articles/installation-troubleshooting).
+## Installation troubleshooting
+
+See the [Installation FAQ](https://r.igraph.org/articles/installation-troubleshooting).
 
 ## Documentation
 

--- a/vignettes/articles/installation-troubleshooting.Rmd
+++ b/vignettes/articles/installation-troubleshooting.Rmd
@@ -44,16 +44,18 @@ If you decide to try to compile from sources anyway, basic requirements are list
     - Instructions to install [Rtools for R4.2.x](https://cran.r-project.org/bin/windows/Rtools/rtools42/rtools.html) and [Rtools for R4.3.x](https://cran.r-project.org/bin/windows/Rtools/rtools43/rtools.html).
  - Make sure you have the GLPK C library installed. This is not the same as the Rglpk R package. Instructions for installing libraries for Rtools4 on Windows are [here](https://cran.r-project.org/bin/windows/Rtools/)
 
-## fatal error: glpk.h: No such file or directory
-
-This error occurs only on Windows, when trying to compile igraph from sources. Please refer to [the previous section](#cannot-compile-igraph-from-sources-on-windows-or-macos).
-
 ## Cannot compile igraph from sources on Linux
 
 Since CRAN does not provide binary packages for Linux, Linux users usually need to compile igraph from sources. In order to do so, make sure that you have all the prerequisites:
 
- - C, C++ and Fortran compilers. On Debian-based distros, use `sudo apt install build-essential gfortran`.
- - Development packages for `libxml2` and `glpk`. On Debian-based distros, use `sudo apt install libxml2-dev libglpk-dev`.
+ - C, C++ and Fortran compilers. On Debian-based distros, use `sudo apt install build-essential gfortran`. On Fedora, use `yum install gcc gcc-c++ gcc-gfortran`.
+ - Development packages for `glpk`, `gmp` and `libxml2`. On Debian-based distros, use `sudo apt install libglpk-dev libgmp-dev libxml2-dev`. On Fedora, use `yum install glpk-devel gmp-devel libxml2-devel`.
+
+## fatal error: glpk.h: No such file or directory
+
+If you are using Windows or macOS, please refer to [Cannot compile igraph from sources on Windows or macOS](#cannot-compile-igraph-from-sources-on-windows-or-macos).
+
+If you are using Linux, please refer to [Cannot compile igraph from sources on Linux](#cannot-compile-igraph-from-sources-on-linux).
 
 ## libgfortran.so.4: cannot open shared object file: No such file or directory
 


### PR DESCRIPTION
Since dependencies are no longer optional on Linux, more people are having installation trouble. I tried to improve the readme and troubleshooting instructions to be more helpful. Let's try to get this information online quickly. We can update it later if these dependencies are made optional again.

Ref #1183, https://github.com/igraph/rigraph/issues/490#issuecomment-1915695897