### PR TITLE
docs: Fix typo in `?articulation_points`

### DIFF
--- a/R/components.R
+++ b/R/components.R
@@ -200,7 +200,7 @@ decompose <- function(graph, mode = c("weak", "strong"), max.comps = NA,
 #' number of connected components in a graph. Similarly, bridges or cut-edges
 #' are edges whose removal increases the number of connected components in a
 #' graph. If the original graph was connected, then the removal of a single
-#' articulation point or a single bridge makes it undirected. If a graph
+#' articulation point or a single bridge makes it disconnected. If a graph
 #' contains no articulation points, then its vertex connectivity is at least
 # " two. If a graph contains no bridges, then its edge connectivity is at least
 #' two.

--- a/man/articulation_points.Rd
+++ b/man/articulation_points.Rd
@@ -26,7 +26,7 @@ Articulation points or cut vertices are vertices whose removal increases the
 number of connected components in a graph. Similarly, bridges or cut-edges
 are edges whose removal increases the number of connected components in a
 graph. If the original graph was connected, then the removal of a single
-articulation point or a single bridge makes it undirected. If a graph
+articulation point or a single bridge makes it disconnected. If a graph
 contains no articulation points, then its vertex connectivity is at least
 two.
 }


### PR DESCRIPTION
Closes #1178.