### PR TITLE
docs: improved docs for shortest path functions

### DIFF
--- a/R/structural.properties.R
+++ b/R/structural.properties.R
@@ -699,10 +699,13 @@ degree_distribution <- function(graph, cumulative = FALSE, ...) {
 #' weighted graphs. The latter only works if the edge weights are non-negative.
 #'
 #' `all_shortest_paths()` calculates *all* shortest paths between
-#' pairs of vertices. More precisely, between the `from` vertex to the
-#' vertices given in `to`. It uses a breadth-first search for unweighted
-#' graphs and Dijkstra's algorithm for weighted ones. The latter only supports
-#' non-negative edge weights.
+#' pairs of vertices, including several shortest paths of the same length.
+#' More precisely, it computerd all shortest path starting at `from`, and
+#' ending at any vertex given in `to`. It uses a breadth-first search for
+#' unweighted graphs and Dijkstra's algorithm for weighted ones. The latter
+#' only supports non-negative edge weights. Caution: in multigraphs, the
+#' result size is exponentially large in the number of vertex pairs with
+#' multiple edges between them.
 #'
 #' `mean_distance()` calculates the average path length in a graph, by
 #' calculating the shortest paths between all pairs of vertices (both ways for
@@ -774,8 +777,8 @@ degree_distribution <- function(graph, cumulative = FALSE, ...) {
 #'
 #'   For `all_shortest_paths()` a list is returned, each list element
 #'   contains a shortest path from `from` to a vertex in `to`. The
-#'   shortest paths to the same vertex are collected into consecutive elements of
-#'   the list.
+#'   shortest paths to the same vertex are collected into consecutive elements
+#'   of the list.
 #'
 #'   For `mean_distance()` a single number is returned if `details=FALSE`,
 #'   or a named list with two entries: `res` is the mean distance as a numeric
@@ -785,8 +788,10 @@ degree_distribution <- function(graph, cumulative = FALSE, ...) {
 #'   `distance_table()` returns a named list with two entries: `res` is
 #'   a numeric vector, the histogram of distances, `unconnected` is a
 #'   numeric scalar, the number of pairs for which the first vertex is not
-#'   reachable from the second. The sum of the two entries is always \eqn{n(n-1)}
-#'   for directed graphs and \eqn{n(n-1)/2} for undirected graphs.
+#'   reachable from the second. In undirected and directed graphs, unorderde
+#'   and ordered pairs are considered, respectively. Therefore the sum of the
+#'   two entries is always \eqn{n(n-1)} for directed graphs and \eqn{n(n-1)/2}
+#'   for undirected graphs.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
 #' @references West, D.B. (1996). *Introduction to Graph Theory.* Upper
 #' Saddle River, N.J.: Prentice Hall.

--- a/man/distances.Rd
+++ b/man/distances.Rd
@@ -145,8 +145,8 @@ for each vertex, or \code{NULL}, if it was not requested.}
 
 For \code{all_shortest_paths()} a list is returned, each list element
 contains a shortest path from \code{from} to a vertex in \code{to}. The
-shortest paths to the same vertex are collected into consecutive elements of
-the list.
+shortest paths to the same vertex are collected into consecutive elements
+of the list.
 
 For \code{mean_distance()} a single number is returned if \code{details=FALSE},
 or a named list with two entries: \code{res} is the mean distance as a numeric
@@ -156,8 +156,10 @@ also as a numeric scalar.
 \code{distance_table()} returns a named list with two entries: \code{res} is
 a numeric vector, the histogram of distances, \code{unconnected} is a
 numeric scalar, the number of pairs for which the first vertex is not
-reachable from the second. The sum of the two entries is always \eqn{n(n-1)}
-for directed graphs and \eqn{n(n-1)/2} for undirected graphs.
+reachable from the second. In undirected and directed graphs, unorderde
+and ordered pairs are considered, respectively. Therefore the sum of the
+two entries is always \eqn{n(n-1)} for directed graphs and \eqn{n(n-1)/2}
+for undirected graphs.
 }
 \description{
 \code{distances()} calculates the length of all the shortest paths from
@@ -199,10 +201,13 @@ breadth-first search for unweighted graphs and Dijkstra's algorithm for
 weighted graphs. The latter only works if the edge weights are non-negative.
 
 \code{all_shortest_paths()} calculates \emph{all} shortest paths between
-pairs of vertices. More precisely, between the \code{from} vertex to the
-vertices given in \code{to}. It uses a breadth-first search for unweighted
-graphs and Dijkstra's algorithm for weighted ones. The latter only supports
-non-negative edge weights.
+pairs of vertices, including several shortest paths of the same length.
+More precisely, it computerd all shortest path starting at \code{from}, and
+ending at any vertex given in \code{to}. It uses a breadth-first search for
+unweighted graphs and Dijkstra's algorithm for weighted ones. The latter
+only supports non-negative edge weights. Caution: in multigraphs, the
+result size is exponentially large in the number of vertex pairs with
+multiple edges between them.
 
 \code{mean_distance()} calculates the average path length in a graph, by
 calculating the shortest paths between all pairs of vertices (both ways for


### PR DESCRIPTION
Whenever I regenerate docs, `RoxygenNote: 7.3.0.9000` in `DESCRIPTION` is changed to `RoxygenNote: 7.3.1`. Can we commit this small version-related change so I don't have keep excluding that file for fear of conflicts?