### PR TITLE
fix: workaround for deprecated enum values not being supported with old GCC

### DIFF
--- a/src/vendor/igraph_config.h
+++ b/src/vendor/igraph_config.h
@@ -35,7 +35,7 @@ __BEGIN_DECLS
  */
 #define IGRAPH_INTEGER_SIZE 64
 
-#define IGRAPH_DEPRECATED_ENUMVAL __attribute__ ((deprecated))
+#define IGRAPH_DEPRECATED_ENUMVAL /* empty */
 
 /**
  * \define IGRAPH_BOOL_TYPE


### PR DESCRIPTION
@krlmlr Quick workaround for #1189 in the interest of getting the quickfix release out soon.