### PR TITLE
refactor: eliminate manual edits from autogenerated files

### DIFF
--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -215,6 +215,21 @@ realize_degree_sequence_impl <- function(out.deg, in.deg=NULL, allowed.edge.type
   res
 }
 
+realize_bipartite_degree_sequence_impl <- function(degrees1, degrees2, allowed.edge.types=c("simple", "loops", "multi", "all"), method=c("smallest", "largest", "index")) {
+  # Argument checks
+  degrees1 <- as.numeric(degrees1)
+  degrees2 <- as.numeric(degrees2)
+  allowed.edge.types <- switch(igraph.match.arg(allowed.edge.types),
+    "simple"=0L, "loop"=1L, "loops"=1L, "multi"=6L, "multiple"=6L, "all"=7L)
+  method <- switch(igraph.match.arg(method), "smallest"=0L, "largest"=1L, "index"=2L)
+
+  on.exit( .Call(R_igraph_finalizer) )
+  # Function call
+  res <- .Call(R_igraph_realize_bipartite_degree_sequence, degrees1, degrees2, allowed.edge.types, method)
+
+  res
+}
+
 circulant_impl <- function(n, shifts, directed=FALSE) {
   # Argument checks
   n <- as.numeric(n)
@@ -2257,6 +2272,17 @@ bridges_impl <- function(graph) {
   res
 }
 
+is_biconnected_impl <- function(graph) {
+  # Argument checks
+  ensure_igraph(graph)
+
+  on.exit( .Call(R_igraph_finalizer) )
+  # Function call
+  res <- .Call(R_igraph_is_biconnected, graph)
+
+  res
+}
+
 cliques_impl <- function(graph, min=0, max=0) {
   # Argument checks
   ensure_igraph(graph)
@@ -3229,9 +3255,6 @@ subisomorphic_vf2_impl <- function(graph1, graph2, vertex.color1=NULL, vertex.co
   res
 }
 
-# get_subisomorphisms_vf2_callback_impl gives LTO warnings
-# wrong number of arguments to  R_igraph_get_subisomorphisms_vf2_callback()
-
 count_subisomorphisms_vf2_impl <- function(graph1, graph2, vertex.color1, vertex.color2, edge.color1, edge.color2) {
   # Argument checks
   ensure_igraph(graph1)
@@ -3816,7 +3839,6 @@ stochastic_imitation_impl <- function(graph, vid, algo, quantities, strategies, 
   res
 }
 
-
 vertex_path_from_edge_path_impl <- function(graph, start, edge.path, mode=c("out", "in", "all", "total")) {
   # Argument checks
   ensure_igraph(graph)
@@ -3835,3 +3857,4 @@ vertex_path_from_edge_path_impl <- function(graph, start, edge.path, mode=c("out
   }
   res
 }
+

--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -985,9 +985,7 @@ edge_betweenness_subset_impl <- function(graph, eids=E(graph), directed=TRUE, so
   on.exit( .Call(R_igraph_finalizer) )
   # Function call
   res <- .Call(R_igraph_edge_betweenness_subset, graph, eids-1, directed, sources-1, targets-1, weights)
-if (igraph_opt("add.vertex.names") && is_named(graph)) {
-    names(res) <- vertex_attr(graph, "name", V(graph))
-  }
+
   res
 }
 

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -247,6 +247,7 @@ extern SEXP R_igraph_induced_subgraph(void *, void *, void *);
 extern SEXP R_igraph_induced_subgraph_map(void *, void *, void *);
 extern SEXP R_igraph_intersection(void *, void *);
 extern SEXP R_igraph_is_acyclic(void *);
+extern SEXP R_igraph_is_biconnected(void *);
 extern SEXP R_igraph_is_bipartite(void *);
 extern SEXP R_igraph_is_chordal(void *, void *, void *, void *, void *);
 extern SEXP R_igraph_is_connected(void *, void *);
@@ -375,6 +376,7 @@ extern SEXP R_igraph_read_graph_graphml(void *, void *);
 extern SEXP R_igraph_read_graph_lgl(void *, void *, void *, void *);
 extern SEXP R_igraph_read_graph_ncol(void *, void *, void *, void *, void *);
 extern SEXP R_igraph_read_graph_pajek(void *);
+extern SEXP R_igraph_realize_bipartite_degree_sequence(void *, void *, void *, void *);
 extern SEXP R_igraph_realize_degree_sequence(void *, void *, void *, void *);
 extern SEXP R_igraph_recent_degree_aging_game(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
 extern SEXP R_igraph_reciprocity(void *, void *, void *);
@@ -705,6 +707,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"R_igraph_induced_subgraph_map",                       (DL_FUNC) &R_igraph_induced_subgraph_map,                        3},
     {"R_igraph_intersection",                               (DL_FUNC) &R_igraph_intersection,                                2},
     {"R_igraph_is_acyclic",                                 (DL_FUNC) &R_igraph_is_acyclic,                                  1},
+    {"R_igraph_is_biconnected",                             (DL_FUNC) &R_igraph_is_biconnected,                              1},
     {"R_igraph_is_bipartite",                               (DL_FUNC) &R_igraph_is_bipartite,                                1},
     {"R_igraph_is_chordal",                                 (DL_FUNC) &R_igraph_is_chordal,                                  5},
     {"R_igraph_is_connected",                               (DL_FUNC) &R_igraph_is_connected,                                2},
@@ -833,6 +836,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"R_igraph_read_graph_lgl",                             (DL_FUNC) &R_igraph_read_graph_lgl,                              4},
     {"R_igraph_read_graph_ncol",                            (DL_FUNC) &R_igraph_read_graph_ncol,                             5},
     {"R_igraph_read_graph_pajek",                           (DL_FUNC) &R_igraph_read_graph_pajek,                            1},
+    {"R_igraph_realize_bipartite_degree_sequence",          (DL_FUNC) &R_igraph_realize_bipartite_degree_sequence,           4},
     {"R_igraph_realize_degree_sequence",                    (DL_FUNC) &R_igraph_realize_degree_sequence,                     4},
     {"R_igraph_recent_degree_aging_game",                   (DL_FUNC) &R_igraph_recent_degree_aging_game,                   10},
     {"R_igraph_reciprocity",                                (DL_FUNC) &R_igraph_reciprocity,                                 3},

--- a/tools/stimulus/functions-R.yaml
+++ b/tools/stimulus/functions-R.yaml
@@ -82,9 +82,13 @@ igraph_create:
 igraph_adjacency:
     IGNORE: RR
 
+# TODO: temporarily disabled
 igraph_sparse_adjacency:
+    IGNORE: RR, RC
 
+# TODO: temporarily disabled
 igraph_sparse_weighted_adjacency:
+    IGNORE: RR, RC
 
 igraph_weighted_adjacency:
     IGNORE: RR
@@ -167,7 +171,9 @@ igraph_generalized_petersen:
 
 igraph_turan:
 
+# TODO: temporarily disabled
 igraph_weighted_sparsemat:
+    IGNORE: RR, RC
 
 #######################################
 # Constructors, games
@@ -748,7 +754,9 @@ igraph_largest_cliques:
 igraph_maximal_cliques:
     IGNORE: RR, RC, RInit
 
+# TODO: temporarily disabled
 igraph_maximal_cliques_subset:
+    IGNORE: RR, RC
 
 igraph_maximal_cliques_callback:
     IGNORE: RR, RC, RInit
@@ -1012,7 +1020,9 @@ igraph_from_hrg_dendrogram:
 igraph_get_adjacency:
     IGNORE: RR, RC
 
+# TODO: temporarily disabled
 igraph_get_adjacency_sparse:
+    IGNORE: RR
 
 igraph_get_edgelist:
     IGNORE: RR, RC
@@ -1047,7 +1057,9 @@ igraph_read_graph_pajek:
 igraph_read_graph_graphml:
     IGNORE: RR, RC
 
+# TODO: temporarily disabled
 igraph_read_graph_dimacs_flow:
+    IGNORE: RR, RC
 
 igraph_read_graph_graphdb:
     IGNORE: RR, RC
@@ -1076,8 +1088,9 @@ igraph_write_graph_graphml:
 igraph_write_graph_pajek:
     IGNORE: RR, RC
 
+# TODO: temporarily disabled
 igraph_write_graph_dimacs_flow:
-    IGNORE: RR
+    IGNORE: RR, RC
     PARAMS: |-
         INOUT GRAPH graph, OUTFILE outstream, VERTEX source=0, VERTEX target=0,
         VECTOR capacity
@@ -1272,7 +1285,11 @@ igraph_subisomorphic:
 
 igraph_subisomorphic_vf2:
 
+# TODO: temporarily disabled
+# get_subisomorphisms_vf2_callback_impl gives LTO warnings
+# wrong number of arguments to  R_igraph_get_subisomorphisms_vf2_callback()
 igraph_get_subisomorphisms_vf2_callback:
+    IGNORE: RR, RC
 
 igraph_count_subisomorphisms_vf2:
 
@@ -1360,13 +1377,21 @@ igraph_convex_hull:
 
 igraph_dim_select:
 
+# Not needed in R
 igraph_almost_equals:
+    IGNORE: RR, RC
 
+# Not needed in R
 igraph_cmp_epsilon:
+    IGNORE: RR, RC
 
+# TODO: temporarily disabled
 igraph_eigen_matrix:
+    IGNORE: RR, RC
 
+# TODO: temporarily disabled
 igraph_eigen_matrix_symmetric:
+    IGNORE: RR, RC
 
 igraph_solve_lsap:
 
@@ -1455,17 +1480,22 @@ igraph_stochastic_imitation:
 igraph_convergence_degree:
     IGNORE: RR, RC, RInit
 
+# Not needed in R
 igraph_has_attribute_table:
+    IGNORE: RR, RC
 
 #######################################
 # Progress, status handling
 #######################################
 
 igraph_progress:
+    IGNORE: RR, RC
 
 igraph_status:
+    IGNORE: RR, RC
 
 igraph_strerror:
+    IGNORE: RR, RC
 
 #######################################
 # Other functions, documented, graph related
@@ -1486,3 +1516,4 @@ igraph_vertex_path_from_edge_path:
 #######################################
 
 igraph_version:
+    IGNORE: RR, RC

--- a/tools/stimulus/functions-R.yaml
+++ b/tools/stimulus/functions-R.yaml
@@ -416,8 +416,6 @@ igraph_edge_betweenness_cutoff:
     IGNORE: RR
 
 igraph_edge_betweenness_subset:
-    DEPS: |-
-        eids ON graph, weights ON graph V(graph), res ON graph V(graph), sources ON graph, targets ON graph
 
 igraph_harmonic_centrality:
     IGNORE: RR, RC, RInit


### PR DESCRIPTION
@krlmlr Can we please have this merged now to reduce the pain of having to untangle manual edits to autogenerated files whenever re-running stimulus?

Issues opened:

 - https://github.com/igraph/stimulus/issues/6

Explanation of changes:

 - `is_bipartite` and `realize_bipartite_degree_sequence` are new in 0.10.9, hence added due to the C core update
 - `has_attribute_table` and `igraph_version` were edited to fix a compiler warning, but we don't actually use them, so removed; issue opened in stimulus
 - `get_subisomorphisms_vf2_callback`: the generated R code for this was manually removed, and it's simpler to also remove the generated C code until we actually need it.

Ref: #1176