### PR TITLE
chore: update stimulus to 0.21.4

### DIFF
--- a/tools/build-requirements.txt
+++ b/tools/build-requirements.txt
@@ -3,4 +3,4 @@
 # environment to detect when to re-create the virtualenv so the hash
 # needs to change whenever a package is updated.
 
-git+https://github.com/igraph/stimulus@0.21.2#egg=stimulus
+git+https://github.com/igraph/stimulus@0.21.4#egg=stimulus


### PR DESCRIPTION
This updates Stimulus to the latest version, fixing issues with generating empty argument lists. See https://github.com/igraph/stimulus/issues/6

Once this version is used to re-generate `rinterface.c`, issues like this will be fixed:

https://github.com/igraph/rigraph/blob/9cc95608d3838149824f3ad44af22fbd6ff60950/src/rinterface.c#L11506-L11507

Please do merge this now but do not re-generate the code until #1207 is merged.

@krlmlr OK to add Stimulus updates to the merge queue myself in the future?
