### PR TITLE
fix: Link Fortran runtime on Windows as needed by arpack.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -11,6 +11,6 @@ PKG_CPPFLAGS = -I"${LIB_XML}/include/libxml2" -I"${LIB_XML}/include" -DLIBXML_ST
         -D_GNU_SOURCE=1
 
 PKG_LIBS = -L"${LIB_XML}/lib" -lxml2 -liconv -lz -lws2_32 -lstdc++ \
-  -lglpk -lgmp $(BLAS_LIBS) $(LAPACK_LIBS) -llzma
+  -lglpk -lgmp $(BLAS_LIBS) $(LAPACK_LIBS) $(FLIBS) -llzma
 
 OBJECTS=${SOURCES}


### PR DESCRIPTION
Fortran libraries (Fortran runtime) is needed e.g. by arpack. This change is to fix building on LLVM/aarch64. 