### PR TITLE
fix: `isomorphisms()` and `subgraph_isomorphisims(method = "vf2")` work again, regression introduced in 2.0.0

### DIFF
--- a/R/topology.R
+++ b/R/topology.R
@@ -110,7 +110,7 @@ graph.get.isomorphisms.vf2 <- function(graph1, graph2, vertex.color1,
     }
   }
   if (!is.null(vertex.color1)) {
-    vertex.color1 <- as.integer(vertex.color1) - 1L
+    vertex.color1 <- as.numeric(vertex.color1) - 1
   }
   if (missing(vertex.color2)) {
     if ("color" %in% vertex_attr_names(graph2)) {
@@ -120,7 +120,7 @@ graph.get.isomorphisms.vf2 <- function(graph1, graph2, vertex.color1,
     }
   }
   if (!is.null(vertex.color2)) {
-    vertex.color2 <- as.integer(vertex.color2) - 1L
+    vertex.color2 <- as.numeric(vertex.color2) - 1
   }
   if (missing(edge.color1)) {
     if ("color" %in% edge_attr_names(graph1)) {
@@ -130,7 +130,7 @@ graph.get.isomorphisms.vf2 <- function(graph1, graph2, vertex.color1,
     }
   }
   if (!is.null(edge.color1)) {
-    edge.color1 <- as.integer(edge.color1) - 1L
+    edge.color1 <- as.numeric(edge.color1) - 1
   }
   if (missing(edge.color2)) {
     if ("color" %in% edge_attr_names(graph2)) {
@@ -140,7 +140,7 @@ graph.get.isomorphisms.vf2 <- function(graph1, graph2, vertex.color1,
     }
   }
   if (!is.null(edge.color2)) {
-    edge.color2 <- as.integer(edge.color2) - 1L
+    edge.color2 <- as.numeric(edge.color2) - 1
   }
 
   on.exit(.Call(R_igraph_finalizer))
@@ -168,7 +168,7 @@ graph.get.subisomorphisms.vf2 <- function(graph1, graph2, vertex.color1,
     }
   }
   if (!is.null(vertex.color1)) {
-    vertex.color1 <- as.integer(vertex.color1) - 1L
+    vertex.color1 <- as.numeric(vertex.color1) - 1
   }
   if (missing(vertex.color2)) {
     if ("color" %in% vertex_attr_names(graph2)) {
@@ -178,7 +178,7 @@ graph.get.subisomorphisms.vf2 <- function(graph1, graph2, vertex.color1,
     }
   }
   if (!is.null(vertex.color2)) {
-    vertex.color2 <- as.integer(vertex.color2) - 1L
+    vertex.color2 <- as.numeric(vertex.color2) - 1
   }
   if (missing(edge.color1)) {
     if ("color" %in% edge_attr_names(graph1)) {
@@ -188,7 +188,7 @@ graph.get.subisomorphisms.vf2 <- function(graph1, graph2, vertex.color1,
     }
   }
   if (!is.null(edge.color1)) {
-    edge.color1 <- as.integer(edge.color1) - 1L
+    edge.color1 <- as.numeric(edge.color1) - 1
   }
   if (missing(edge.color2)) {
     if ("color" %in% edge_attr_names(graph2)) {
@@ -198,7 +198,7 @@ graph.get.subisomorphisms.vf2 <- function(graph1, graph2, vertex.color1,
     }
   }
   if (!is.null(edge.color2)) {
-    edge.color2 <- as.integer(edge.color2) - 1L
+    edge.color2 <- as.numeric(edge.color2) - 1
   }
 
   on.exit(.Call(R_igraph_finalizer))


### PR DESCRIPTION
Closes #1218.

@szhorvat: With this, I'm seeing:

``` r
motif <- igraph::make_empty_graph(directed = FALSE) +
  igraph::vertices("D1", "D2", type = c("type1", "type1")) +
  igraph::edges("D1", "D2", type = c("type2"))
igraph::subgraph_isomorphisms(
  target = motif, pattern = motif, method = "vf2",
  vertex.color1 = 2, vertex.color2 = 1
)
#> Error in graph.get.subisomorphisms.vf2(target, pattern, ...): At vendor/cigraph/src/isomorphism/vf2.c:1089 : Invalid vertex color vector length, Invalid value
```

<sup>Created on 2024-02-08 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

Do you expect this error?