### PR TITLE
fix: `sample_pa()` respects the `out.seq` and `out.dist` arguments again, regression introduced in igraph 2.0.0

### DIFF
--- a/tests/testthat/test-ba.game.R
+++ b/tests/testthat/test-ba.game.R
@@ -1,4 +1,6 @@
 test_that("sample_pa() works", {
+  withr::local_seed(20240209)
+
   g <- sample_pa(100, m = 2)
   expect_that(ecount(g), equals(197))
   expect_that(vcount(g), equals(100))
@@ -17,7 +19,7 @@ test_that("sample_pa() works", {
   g4 <- sample_pa(3, out.seq = 0:2, directed = FALSE)
   expect_equal(degree(g4), rep(2, 3))
 
-  g5 <- sample_pa(3, out.dist = 0:2, directed = FALSE)
+  g5 <- sample_pa(3, out.dist = rep(2, 1000), directed = FALSE)
   expect_equal(degree(g5), rep(2, 3))
 })
 

--- a/tests/testthat/test-ba.game.R
+++ b/tests/testthat/test-ba.game.R
@@ -1,4 +1,4 @@
-test_that("sample_pa works", {
+test_that("sample_pa() works", {
   g <- sample_pa(100, m = 2)
   expect_that(ecount(g), equals(197))
   expect_that(vcount(g), equals(100))
@@ -13,6 +13,12 @@ test_that("sample_pa works", {
   expect_that(ecount(g3), equals(198))
   expect_that(vcount(g3), equals(100))
   expect_false(is_simple(g3))
+
+  g4 <- sample_pa(3, out.seq = 0:2, directed = FALSE)
+  expect_equal(degree(g4), rep(2, 3))
+
+  g5 <- sample_pa(3, out.dist = 0:2, directed = FALSE)
+  expect_equal(degree(g5), rep(2, 3))
 })
 
 test_that("sample_pa can start from a graph", {


### PR DESCRIPTION
Closes #1224.

@krlmlr Let's hope CI passes. Can you please help with adding a test? While this is a stochastic function, `sample_pa(3, out.seq=0:2)` should always output the same thing as `make_full_citation_graph(3)`