### PR TITLE
fix: do not rely on `which` program during configuration

### DIFF
--- a/configure
+++ b/configure
@@ -1,19 +1,19 @@
 #!/bin/sh
 
-# Use pkg-config or xml2-config to get the include directories for libxml-2.0
-xml2_include_paths=""
-if which xml2-config >/dev/null 2>&1; then
-    xml2_include_paths=$(xml2-config --cflags)
-elif which pkg-config >/dev/null 2>&1; then
-    xml2_include_paths=$(pkg-config --cflags libxml-2.0)
+# Use xml2-config or pkg-config to get the include directories for libxml-2.0
+libxml2_cflags=""
+if xml2-config --version >/dev/null 2>&1; then
+    libxml2_cflags=$(xml2-config --cflags)
+elif pkg-config --version >/dev/null 2>&1; then
+    libxml2_cflags=$(pkg-config --cflags libxml-2.0)
 else
     echo "Error: Neither xml2-config nor pkg-config is available"
     exit 1
 fi
 
-if [ -n "$xml2_include_paths" ]; then
-    PKG_CFLAGS="$xml2_include_paths"
-    echo "libxml2 include directories: $xml2_include_paths"
+if [ -n "$libxml2_cflags" ]; then
+    PKG_CFLAGS="$libxml2_cflags"
+    echo "libxml2 include directories: $libxml2_cflags"
 else
     echo "Error: libxml2 include directory not found"
     exit 1

--- a/configure
+++ b/configure
@@ -4,8 +4,10 @@
 libxml2_cflags=""
 if xml2-config --version >/dev/null 2>&1; then
     libxml2_cflags=$(xml2-config --cflags)
+    libxml2_libs=$(xml2-config --libs)
 elif pkg-config --version >/dev/null 2>&1; then
     libxml2_cflags=$(pkg-config --cflags libxml-2.0)
+    libxml2_libs=$(pkg-config --libs --static libxml-2.0)
 else
     echo "Error: Neither xml2-config nor pkg-config is available"
     exit 1
@@ -19,8 +21,16 @@ else
     exit 1
 fi
 
+if [ -n "$libxml2_libs" ]; then
+    PKG_LIBS="$libxml2_libs"
+    echo "libxml2 library link flags: $libxml2_libs"
+else
+    echo "Error: libxml2 library link flags not found"
+    exit 1
+fi
+
 echo "# Generated from Makevars.in, do not edit by hand" > src/Makevars.new
-sed -e "s|@cflags@|$PKG_CFLAGS|" src/Makevars.in >> src/Makevars.new
+sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" src/Makevars.in >> src/Makevars.new
 if [ ! -f src/Makevars ] || (which diff > /dev/null && ! diff -q src/Makevars src/Makevars.new); then
     cp -f src/Makevars.new src/Makevars
 fi

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -10,6 +10,6 @@ PKG_CPPFLAGS=-DUSING_R -I. -Ivendor -Ivendor/cigraph/src -Ivendor/cigraph/includ
  	-DHAVE_GFORTRAN=1 \
 	-D_GNU_SOURCE=1
 
-PKG_LIBS = -lxml2 -lz -lglpk -lgmp $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
+PKG_LIBS = -lglpk -lgmp @libs@ $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 
 OBJECTS=${SOURCES}


### PR DESCRIPTION
This PR avoids reliance on the `which` utility, which may not be present on all systems. It addresses complaints like this one: https://github.com/NixOS/nixpkgs/issues/286406

It also renamed `xml2_include_paths` to `lilbxml2_cflags` to better reflect what this variable contains.
