### PR TITLE
refactor: always use bundled mini-gmp

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -71,4 +71,4 @@ Config/testthat/start-first: vs-es, scan, vs-operators, weakref,
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
-SystemRequirements: gmp, libxml2, glpk (>= 4.57)
+SystemRequirements: libxml2, glpk (>= 4.57)

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -4,12 +4,12 @@ PKG_CFLAGS=$(C_VISIBILITY)
 PKG_CXXFLAGS=$(CXX_VISIBILITY)
 PKG_FFLAGS=$(F_VISIBILITY)
 
-PKG_CPPFLAGS=-DUSING_R -I. -Ivendor -Ivendor/cigraph/src -Ivendor/cigraph/include -Ivendor/cigraph/vendor @cflags@ \
-	-DNDEBUG -DNTIMER -DNPRINT -DINTERNAL_ARPACK -DIGRAPH_THREAD_LOCAL= \
-	-DPRPACK_IGRAPH_SUPPORT \
- 	-DHAVE_GFORTRAN=1 \
-	-D_GNU_SOURCE=1
+PKG_CPPFLAGS=-DUSING_R -I. -Ivendor -Ivendor/cigraph/src -Ivendor/cigraph/include -Ivendor/cigraph/vendor -Ivendor/mini-gmp @cflags@ \
+    -DNDEBUG -DNTIMER -DNPRINT -DINTERNAL_ARPACK -DIGRAPH_THREAD_LOCAL= \
+    -DPRPACK_IGRAPH_SUPPORT \
+    -DHAVE_GFORTRAN=1 \
+    -D_GNU_SOURCE=1
 
-PKG_LIBS = -lglpk -lgmp @libs@ $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
+PKG_LIBS = -lglpk @libs@ $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)
 
 OBJECTS=${SOURCES}

--- a/src/Makevars.in
+++ b/src/Makevars.in
@@ -5,7 +5,7 @@ PKG_CXXFLAGS=$(CXX_VISIBILITY)
 PKG_FFLAGS=$(F_VISIBILITY)
 
 PKG_CPPFLAGS=-DUSING_R -I. -Ivendor -Ivendor/cigraph/src -Ivendor/cigraph/include -Ivendor/cigraph/vendor -Ivendor/mini-gmp @cflags@ \
-    -DNDEBUG -DNTIMER -DNPRINT -DINTERNAL_ARPACK -DIGRAPH_THREAD_LOCAL= \
+    -DNDEBUG -DNTIMER -DNPRINT -DIGRAPH_THREAD_LOCAL= \
     -DPRPACK_IGRAPH_SUPPORT \
     -DHAVE_GFORTRAN=1 \
     -D_GNU_SOURCE=1

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -4,13 +4,13 @@ LIB_XML ?= $(R_TOOLS_SOFT)
 GLPK_HOME ?= $(R_TOOLS_SOFT)
 LIB_GMP ?= $(R_TOOLS_SOFT)
 
-PKG_CPPFLAGS = -I"${LIB_XML}/include/libxml2" -I"${LIB_XML}/include" -DLIBXML_STATIC -DUSING_R -I. -Ivendor -Ivendor/cigraph/src -Ivendor/cigraph/include -Ivendor/cigraph/vendor \
-        -DNDEBUG -DNTIMER -DNPRINT -DINTERNAL_ARPACK -DIGRAPH_THREAD_LOCAL= \
-        -DPRPACK_IGRAPH_SUPPORT \
-        -DHAVE_GFORTRAN=1 \
-        -D_GNU_SOURCE=1
+PKG_CPPFLAGS = -I"${LIB_XML}/include/libxml2" -I"${LIB_XML}/include" -DLIBXML_STATIC -DUSING_R -I. -Ivendor -Ivendor/cigraph/src -Ivendor/cigraph/include -Ivendor/cigraph/vendor -Ivendor/mini-gmp \
+    -DNDEBUG -DNTIMER -DNPRINT -DINTERNAL_ARPACK -DIGRAPH_THREAD_LOCAL= \
+    -DPRPACK_IGRAPH_SUPPORT \
+    -DHAVE_GFORTRAN=1 \
+    -D_GNU_SOURCE=1
 
 PKG_LIBS = -L"${LIB_XML}/lib" -lxml2 -liconv -lz -lws2_32 -lstdc++ \
-  -lglpk -lgmp $(BLAS_LIBS) $(LAPACK_LIBS) $(FLIBS) -llzma
+  -lglpk $(BLAS_LIBS) $(LAPACK_LIBS) $(FLIBS) -llzma
 
 OBJECTS=${SOURCES}

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -5,7 +5,7 @@ GLPK_HOME ?= $(R_TOOLS_SOFT)
 LIB_GMP ?= $(R_TOOLS_SOFT)
 
 PKG_CPPFLAGS = -I"${LIB_XML}/include/libxml2" -I"${LIB_XML}/include" -DLIBXML_STATIC -DUSING_R -I. -Ivendor -Ivendor/cigraph/src -Ivendor/cigraph/include -Ivendor/cigraph/vendor -Ivendor/mini-gmp \
-    -DNDEBUG -DNTIMER -DNPRINT -DINTERNAL_ARPACK -DIGRAPH_THREAD_LOCAL= \
+    -DNDEBUG -DNTIMER -DNPRINT -DIGRAPH_THREAD_LOCAL= \
     -DPRPACK_IGRAPH_SUPPORT \
     -DHAVE_GFORTRAN=1 \
     -D_GNU_SOURCE=1

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -5,7 +5,7 @@ GLPK_HOME ?= $(MINGW_PREFIX)
 LIB_GMP ?= $(MINGW_PREFIX)
 
 PKG_CPPFLAGS=-DUSING_R -I. -Ivendor -Ivendor/cigraph/src -Ivendor/cigraph/include -Ivendor/cigraph/vendor -Ivendor/mini-gmp \
-    -DNDEBUG -DNTIMER -DNPRINT -DINTERNAL_ARPACK -DIGRAPH_THREAD_LOCAL= \
+    -DNDEBUG -DNTIMER -DNPRINT -DIGRAPH_THREAD_LOCAL= \
     -DPRPACK_IGRAPH_SUPPORT \
     -DHAVE_GFORTRAN=1 \
     -D_GNU_SOURCE=1

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -4,13 +4,13 @@ LIB_XML ?= $(MINGW_PREFIX)
 GLPK_HOME ?= $(MINGW_PREFIX)
 LIB_GMP ?= $(MINGW_PREFIX)
 
-PKG_CPPFLAGS=-DUSING_R -I. -Ivendor -Ivendor/cigraph/src -Ivendor/cigraph/include -Ivendor/cigraph/vendor \
-	-DNDEBUG -DNTIMER -DNPRINT -DINTERNAL_ARPACK -DIGRAPH_THREAD_LOCAL= \
-	-DPRPACK_IGRAPH_SUPPORT \
-	-DHAVE_GFORTRAN=1 \
-	-D_GNU_SOURCE=1
+PKG_CPPFLAGS=-DUSING_R -I. -Ivendor -Ivendor/cigraph/src -Ivendor/cigraph/include -Ivendor/cigraph/vendor -Ivendor/mini-gmp \
+    -DNDEBUG -DNTIMER -DNPRINT -DINTERNAL_ARPACK -DIGRAPH_THREAD_LOCAL= \
+    -DPRPACK_IGRAPH_SUPPORT \
+    -DHAVE_GFORTRAN=1 \
+    -D_GNU_SOURCE=1
 
 PKG_LIBS = -lxml2 -lz -lstdc++ \
-  -lglpk -lgmp $(BLAS_LIBS) $(LAPACK_LIBS)
+  -lglpk $(BLAS_LIBS) $(LAPACK_LIBS)
 
 OBJECTS=${SOURCES}

--- a/src/vendor/config.h
+++ b/src/vendor/config.h
@@ -26,8 +26,8 @@
 
 /* #undef INTERNAL_BLAS */
 /* #undef INTERNAL_LAPACK */
-/* #undef INTERNAL_ARPACK */
 
+#define INTERNAL_ARPACK 1
 #define INTERNAL_GMP 1
 
 #define IGRAPH_F77_SAVE

--- a/src/vendor/config.h
+++ b/src/vendor/config.h
@@ -27,7 +27,8 @@
 /* #undef INTERNAL_BLAS */
 /* #undef INTERNAL_LAPACK */
 /* #undef INTERNAL_ARPACK */
-/* #undef INTERNAL_GMP */
+
+#define INTERNAL_GMP 1
 
 #define IGRAPH_F77_SAVE
 #define IGRAPH_THREAD_LOCAL


### PR DESCRIPTION
This is an experiment to see if using the bundled mini-gmp triggers any warnings CRAN would complain about. I noticed that we are already compiling `mini-gmp.c` even though we were not using it.

There are currently no disadvantages to using mini-gmp instead of the full-blown GMP, other than the risk of CRAN demanding source changes to fix warnings. We should not change mini-gmp ourselves it's too risky.