### PR TITLE
fix: `g + vertices(1, 2, foo = 3)` works again, regression introduced in igraph 2.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,8 @@ Imports:
     pkgconfig (>= 2.0.0),
     rlang,
     stats,
-    utils
+    utils,
+    vctrs
 Suggests:
     ape (>= 5.7-0.1),
     callr,

--- a/R/operators.R
+++ b/R/operators.R
@@ -1094,19 +1094,19 @@ path <- function(...) {
     ## Adding edges along a path, possibly with attributes
     ## Non-named arguments define the edges
     if (is.null(names(e2))) {
-      toadd <- unlist(e2, recursive = FALSE)
+      to_add <- unlist(e2, recursive = FALSE)
       attr <- list()
     } else {
-      toadd <- unlist(e2[names(e2) == ""])
+      to_add <- unlist(e2[names(e2) == ""])
       attr <- e2[names(e2) != ""]
     }
-    toadd <- as_igraph_vs(e1, toadd)
-    lt <- length(toadd)
+    to_add <- as_igraph_vs(e1, to_add)
+    lt <- length(to_add)
     if (lt > 2) {
-      toadd <- c(toadd[1], rep(toadd[2:(lt - 1)], each = 2), toadd[lt])
-      res <- add_edges(e1, toadd, attr = attr)
+      to_add <- c(to_add[1], rep(to_add[2:(lt - 1)], each = 2), to_add[lt])
+      res <- add_edges(e1, to_add, attr = attr)
     } else if (lt == 2) {
-      res <- add_edges(e1, toadd, attr = attr)
+      res <- add_edges(e1, to_add, attr = attr)
     } else {
       res <- e1
     }

--- a/R/operators.R
+++ b/R/operators.R
@@ -1094,7 +1094,7 @@ path <- function(...) {
       e2 <- c(list(name = nn), e2[rlang::have_name(e2)])
     }
     # When adding vertices via +, all unnamed arguments are interpreted as vertex names of the new vertices.
-    vertices_number <- length(unnamed_elements_indices)
+    vertices_number <- length(e2[["name"]])
     res <- add_vertices(e1, nv = vertices_number, attr = e2)
   } else if ("igraph.path" %in% class(e2)) {
     ## Adding edges along a path, possibly with attributes

--- a/R/operators.R
+++ b/R/operators.R
@@ -1079,7 +1079,7 @@ path <- function(...) {
   } else if ("igraph.vertex" %in% class(e2)) {
     ## Adding vertices, possibly with attributes
     ## If there is a single unnamed argument, that contains the vertex names
-    unnamed_elements_indices <- which(!rlang::have_name(e2))
+    unnamed_elements_indices <- which(names(e2) == "")
     if (length(unnamed_elements_indices) == 1) {
       e2 <- rlang::set_names(e2[unnamed_elements_indices], "name")
     } else if (is.null(names(e2))) {

--- a/R/operators.R
+++ b/R/operators.R
@@ -1079,23 +1079,17 @@ path <- function(...) {
   } else if ("igraph.vertex" %in% class(e2)) {
     ## Adding vertices, possibly with attributes
     ## If there is a single unnamed argument, that contains the vertex names
-    unnamed_elements_indices <- which(names(e2) == "")
-    if (length(unnamed_elements_indices) == 1) {
-      e2 <- rlang::set_names(e2[unnamed_elements_indices], "name")
-    } else if (is.null(names(e2))) {
-      ## No names at all, everything is a vertex name
-      e2 <- list(name = unlist(e2, recursive = FALSE))
-    } else if (length(unnamed_elements_indices) == 0) {
-      ## If there are no non-named arguments, we are fine
-    } else {
-      ## Otherwise, all unnamed arguments are collected and used as
-      ## vertex names
-      nn <- unlist(e2[unnamed_elements_indices], recursive = FALSE)
-      e2 <- c(list(name = nn), e2[rlang::have_name(e2)])
-    }
+    named <- rlang::have_name(e2)
+    unnamed_indices <- which(!named)
+
+    nn <- unlist(e2[unnamed_indices], recursive = FALSE)
+    e2 <- c(
+      if (!is.null(nn)) list(name = unname(nn)),
+      e2[named]
+    )
+
     # When adding vertices via +, all unnamed arguments are interpreted as vertex names of the new vertices.
-    vertices_number <- length(e2[["name"]])
-    res <- add_vertices(e1, nv = vertices_number, attr = e2)
+    res <- add_vertices(e1, nv = vctrs::vec_size_common(!!!e2), attr = e2)
   } else if ("igraph.path" %in% class(e2)) {
     ## Adding edges along a path, possibly with attributes
     ## Non-named arguments define the edges

--- a/R/operators.R
+++ b/R/operators.R
@@ -1079,22 +1079,23 @@ path <- function(...) {
   } else if ("igraph.vertex" %in% class(e2)) {
     ## Adding vertices, possibly with attributes
     ## If there is a single unnamed argument, that contains the vertex names
-    wn <- which(names(e2) == "")
-    if (length(wn) == 1) {
-      names(e2)[wn] <- "name"
+    unnamed_elements_indices <- which(!rlang::have_name(e2))
+    if (length(unnamed_elements_indices) == 1) {
+      e2 <- rlang::set_names(e2[unnamed_elements_indices], "name")
     } else if (is.null(names(e2))) {
       ## No names at all, everything is a vertex name
       e2 <- list(name = unlist(e2, recursive = FALSE))
-    } else if (length(wn) == 0) {
+    } else if (length(unnamed_elements_indices) == 0) {
       ## If there are no non-named arguments, we are fine
     } else {
       ## Otherwise, all unnamed arguments are collected and used as
       ## vertex names
-      nn <- unlist(e2[wn], recursive = FALSE)
-      e2 <- c(list(name = nn), e2[names(e2) != ""])
+      nn <- unlist(e2[unnamed_elements_indices], recursive = FALSE)
+      e2 <- c(list(name = nn), e2[rlang::have_name(e2)])
     }
-    la <- unique(sapply(e2, length))
-    res <- add_vertices(e1, la, attr = e2)
+    # When adding vertices via +, all unnamed arguments are interpreted as vertex names of the new vertices.
+    vertices_number <- length(unnamed_elements_indices)
+    res <- add_vertices(e1, nv = vertices_number, attr = e2)
   } else if ("igraph.path" %in% class(e2)) {
     ## Adding edges along a path, possibly with attributes
     ## Non-named arguments define the edges

--- a/tests/testthat/_snaps/operators.md
+++ b/tests/testthat/_snaps/operators.md
@@ -1,0 +1,4 @@
+# vertices() works
+
+    Length of new attribute value must be 1 or 2, the number of target vertices, not 3
+

--- a/tests/testthat/_snaps/operators.md
+++ b/tests/testthat/_snaps/operators.md
@@ -1,4 +1,4 @@
 # vertices() works
 
-    Length of new attribute value must be 1 or 2, the number of target vertices, not 3
+    Can't recycle `name` (size 2) to match `foo` (size 3).
 

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -104,4 +104,12 @@ test_that("vertices() works", {
   expect_true(is.na(V(g_mix_named_unnamed)$name[1]))
   expect_identical(unname(V(g_mix_named_unnamed)$name[2:3]), c("a", "b"))
   expect_equal(V(g_mix_named_unnamed)$foo, c( NA, 5, 5))
+
+  g_mix_bigger_attribute <- g + vertices("a", "b", foo = 5:6)
+  expect_s3_class(V(g_mix_bigger_attribute), "igraph.vs")
+  expect_true(is.na(V(g_mix_bigger_attribute)$name[1]))
+  expect_identical(unname(V(g_mix_bigger_attribute)$name[2:3]), c("a", "b"))
+  expect_equal(V(g_mix_bigger_attribute)$foo, c( NA, 5, 6))
+
+  expect_snapshot_error(g + vertices("a", "b", foo = 5:7))
 })

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -93,23 +93,42 @@ test_that("t() is aliased to edge reversal for graphs", {
 })
 
 test_that("vertices() works", {
-  g <- make_empty_graph(1)
-
-  g_all_unnamed <-  g + vertices("a", "b")
+  g_all_unnamed <-  make_empty_graph(1) + vertices("a", "b")
   expect_s3_class(V(g_all_unnamed), "igraph.vs")
-  expect_identical(V(g_all_unnamed)$name, c( NA, "a", "b"))
+  expect_identical(V(g_all_unnamed)$name, c(NA, "a", "b"))
 
-  g_mix_named_unnamed <- g + vertices("a", "b", foo = 5)
+  g_mix_named_unnamed <- make_empty_graph(1) + vertices("a", "b", foo = 5)
   expect_s3_class(V(g_mix_named_unnamed), "igraph.vs")
   expect_true(is.na(V(g_mix_named_unnamed)$name[1]))
-  expect_identical(unname(V(g_mix_named_unnamed)$name[2:3]), c("a", "b"))
-  expect_equal(V(g_mix_named_unnamed)$foo, c( NA, 5, 5))
+  expect_identical(V(g_mix_named_unnamed)$name[-1], c("a", "b"))
+  expect_equal(V(g_mix_named_unnamed)$foo, c(NA, 5, 5))
 
-  g_mix_bigger_attribute <- g + vertices("a", "b", foo = 5:6)
+  g_mix_bigger_attribute <- make_empty_graph(1) + vertices("a", "b", "c", foo = 5:7, bar = 8)
   expect_s3_class(V(g_mix_bigger_attribute), "igraph.vs")
-  expect_true(is.na(V(g_mix_bigger_attribute)$name[1]))
-  expect_identical(unname(V(g_mix_bigger_attribute)$name[2:3]), c("a", "b"))
-  expect_equal(V(g_mix_bigger_attribute)$foo, c( NA, 5, 6))
+  expect_identical(V(g_mix_bigger_attribute)$name, c(NA, "a", "b", "c"))
+  expect_equal(V(g_mix_bigger_attribute)$foo, c(NA, 5, 6, 7))
+  expect_equal(V(g_mix_bigger_attribute)$bar, c(NA, 8, 8, 8))
 
-  expect_snapshot_error(g + vertices("a", "b", foo = 5:7))
+  g_one_unnamed <- make_empty_graph(1) + vertices(letters)
+  expect_s3_class(V(g_one_unnamed), "igraph.vs")
+  expect_identical(V(g_one_unnamed)$name, c(NA, letters))
+
+  g_all_named <- make_empty_graph(1) + vertices(foo = 5:7)
+  expect_s3_class(V(g_all_named), "igraph.vs")
+  expect_null(V(g_all_named)$name)
+  expect_identical(V(g_all_named)$foo, c(NA, 5:7))
+
+  g_all_named_empty <- make_empty_graph(1) + vertices(foo = numeric())
+  expect_s3_class(V(g_all_named_empty), "igraph.vs")
+  expect_null(V(g_all_named_empty)$name)
+  expect_identical(V(g_all_named_empty)$foo, NA_real_)
+
+  g_none <- make_empty_graph(1) + vertices()
+  expect_s3_class(V(g_none), "igraph.vs")
+  expect_null(V(g_none)$name)
+
+  expect_snapshot_error(make_empty_graph(1) + vertices("a", "b", foo = 5:7))
+
+  # Undefined,
+  # make_empty_graph(1) + vertices("a", "b", name = "c")
 })

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -91,3 +91,17 @@ test_that("t() is aliased to edge reversal for graphs", {
   expect_that(vcount(t(g)), equals(vcount(g)))
   expect_that(as_edgelist(t(g)), equals(as_edgelist(g)[, c(2, 1)]))
 })
+
+test_that("vertices() works", {
+  g <- make_empty_graph(1)
+
+  g_all_unnamed <-  g + vertices("a", "b")
+  expect_s3_class(V(g_all_unnamed), "igraph.vs")
+  expect_identical(V(g_all_unnamed)$name, c( NA, "a", "b"))
+
+  g_mix_named_unnamed <- g + vertices("a", "b", foo = 5)
+  expect_s3_class(V(g_mix_named_unnamed), "igraph.vs")
+  expect_true(is.na(V(g_mix_named_unnamed)$name[1]))
+  expect_identical(unname(V(g_mix_named_unnamed)$name[2:3]), c("a", "b"))
+  expect_equal(V(g_mix_named_unnamed)$foo, c( NA, 5, 5))
+})


### PR DESCRIPTION
Fix  #1231

Partly refactoring for understanding for now.