### PR TITLE
docs: Fix error messages mentioning to mention `upgrade_graph()` instead of the nonexisting `upgrade_version()`

### DIFF
--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -2794,7 +2794,7 @@ igraph_t *R_igraph_get_pointer(SEXP graph) {
     if (Rf_xlength(graph) == 11) {
       Rf_error("This graph was created by igraph < 0.2.\n  Upgrading this format is not supported, sorry.");
     }
-    Rf_error("This graph was created by a now unsupported old igraph version.\n  Call upgrade_version() before using igraph functions on that object.");
+    Rf_error("This graph was created by a now unsupported old igraph version.\n  Call upgrade_graph() before using igraph functions on that object.");
   }
 
   SEXP xp=Rf_findVar(Rf_install("igraph"), R_igraph_graph_env(graph));

--- a/tests/testthat/_snaps/old-data-type.md
+++ b/tests/testthat/_snaps/old-data-type.md
@@ -5,5 +5,5 @@
     Condition
       Error in `warn_version()`:
       ! This graph was created by a now unsupported old igraph version.
-        Call upgrade_version() before using igraph functions on that object.
+        Call upgrade_graph() before using igraph functions on that object.
 

--- a/tests/testthat/_snaps/versions.md
+++ b/tests/testthat/_snaps/versions.md
@@ -22,7 +22,7 @@
     Condition
       Error in `warn_version()`:
       ! This graph was created by a now unsupported old igraph version.
-        Call upgrade_version() before using igraph functions on that object.
+        Call upgrade_graph() before using igraph functions on that object.
 
 # we can't upgrade from 0.5 to 1.5.0, on the fly
 
@@ -31,7 +31,7 @@
     Condition
       Error in `warn_version()`:
       ! This graph was created by a now unsupported old igraph version.
-        Call upgrade_version() before using igraph functions on that object.
+        Call upgrade_graph() before using igraph functions on that object.
 
 # we can't upgrade from 0.6 to 1.5.0, on the fly
 
@@ -40,7 +40,7 @@
     Condition
       Error in `warn_version()`:
       ! This graph was created by a now unsupported old igraph version.
-        Call upgrade_version() before using igraph functions on that object.
+        Call upgrade_graph() before using igraph functions on that object.
 
 # we can upgrade from 1.0.0 to 1.5.0, on the fly
 
@@ -81,7 +81,7 @@
     Condition
       Error in `warn_version()`:
       ! This graph was created by a now unsupported old igraph version.
-        Call upgrade_version() before using igraph functions on that object.
+        Call upgrade_graph() before using igraph functions on that object.
 
 ---
 
@@ -90,7 +90,7 @@
     Condition
       Error in `warn_version()`:
       ! This graph was created by a now unsupported old igraph version.
-        Call upgrade_version() before using igraph functions on that object.
+        Call upgrade_graph() before using igraph functions on that object.
 
 ---
 
@@ -99,7 +99,7 @@
     Condition
       Error in `warn_version()`:
       ! This graph was created by a now unsupported old igraph version.
-        Call upgrade_version() before using igraph functions on that object.
+        Call upgrade_graph() before using igraph functions on that object.
 
 ---
 


### PR DESCRIPTION
I tried to work with some old saved graphs and encountered the error message:

```
Error in warn_version(graph) : 
    This graph was created by a now unsupported old igraph version.
    Call upgrade_version() before using igraph functions on that object.
```

However, there is no `upgrade_version()` function exported by the `igraph` package, but there is an `upgrade_graph()` function which correctly upgrades the old objects.  This pull requests just modifies the incorrect error message (and the test results which expect the error output).