### PR TITLE
refactor: auto-generate `are_adjacent()`, avoid deprecated `igraph_are_connected()` C function

### DIFF
--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -533,6 +533,25 @@ sample_dirichlet_impl <- function(n, alpha) {
   res
 }
 
+are_adjacent_impl <- function(graph, v1, v2) {
+  # Argument checks
+  ensure_igraph(graph)
+  v1 <- as_igraph_vs(graph, v1)
+  if (length(v1) == 0) {
+    stop("No vertex was specified")
+  }
+  v2 <- as_igraph_vs(graph, v2)
+  if (length(v2) == 0) {
+    stop("No vertex was specified")
+  }
+
+  on.exit( .Call(R_igraph_finalizer) )
+  # Function call
+  res <- .Call(R_igraph_are_adjacent, graph, v1-1, v2-1)
+
+  res
+}
+
 distances_impl <- function(graph, from=V(graph), to=V(graph), mode=c("out", "in", "all", "total")) {
   # Argument checks
   ensure_igraph(graph)

--- a/R/structure.info.R
+++ b/R/structure.info.R
@@ -59,12 +59,4 @@ are.connected <- function(graph, v1, v2) { # nocov start
 #' dg
 #' are_adjacent(ug, 1, 2)
 #' are_adjacent(ug, 2, 1)
-are_adjacent <- function(graph, v1, v2) {
-  ensure_igraph(graph)
-
-  on.exit(.Call(R_igraph_finalizer))
-  .Call(
-    R_igraph_are_connected, graph, as_igraph_vs(graph, v1) - 1,
-    as_igraph_vs(graph, v2) - 1
-  )
-}
+are_adjacent <- are_adjacent_impl

--- a/R/structure.info.R
+++ b/R/structure.info.R
@@ -43,8 +43,7 @@ are.connected <- function(graph, v1, v2) { # nocov start
 #' @param graph The graph.
 #' @param v1 The first vertex, tail in directed graphs.
 #' @param v2 The second vertex, head in directed graphs.
-#' @return A logical scalar, `TRUE` is a `(v1, v2)` exists in the
-#'   graph.
+#' @return A logical scalar, `TRUE` if edge `(v1, v2)` exists in the graph.
 #'
 #' @family structural queries
 #'

--- a/man/are_adjacent.Rd
+++ b/man/are_adjacent.Rd
@@ -14,8 +14,7 @@ are_adjacent(graph, v1, v2)
 \item{v2}{The second vertex, head in directed graphs.}
 }
 \value{
-A logical scalar, \code{TRUE} is a \verb{(v1, v2)} exists in the
-graph.
+A logical scalar, \code{TRUE} if edge \verb{(v1, v2)} exists in the graph.
 }
 \description{
 The order of the vertices only matters in directed graphs,

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -37,7 +37,7 @@ extern SEXP R_igraph_adjlist(void *, void *, void *);
 extern SEXP R_igraph_all_minimal_st_separators(void *);
 extern SEXP R_igraph_all_st_cuts(void *, void *, void *);
 extern SEXP R_igraph_all_st_mincuts(void *, void *, void *, void *);
-extern SEXP R_igraph_are_connected(void *, void *, void *);
+extern SEXP R_igraph_are_adjacent(void *, void *, void *);
 extern SEXP R_igraph_arpack(void *, void *, void *, void *, void *);
 extern SEXP R_igraph_arpack_unpack_complex(void *, void *, void *);
 extern SEXP R_igraph_articulation_points(void *);
@@ -496,7 +496,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"R_igraph_all_minimal_st_separators",                  (DL_FUNC) &R_igraph_all_minimal_st_separators,                   1},
     {"R_igraph_all_st_cuts",                                (DL_FUNC) &R_igraph_all_st_cuts,                                 3},
     {"R_igraph_all_st_mincuts",                             (DL_FUNC) &R_igraph_all_st_mincuts,                              4},
-    {"R_igraph_are_connected",                              (DL_FUNC) &R_igraph_are_connected,                               3},
+    {"R_igraph_are_adjacent",                               (DL_FUNC) &R_igraph_are_adjacent,                                3},
     {"R_igraph_arpack",                                     (DL_FUNC) &R_igraph_arpack,                                      5},
     {"R_igraph_arpack_unpack_complex",                      (DL_FUNC) &R_igraph_arpack_unpack_complex,                       3},
     {"R_igraph_articulation_points",                        (DL_FUNC) &R_igraph_articulation_points,                         1},

--- a/src/rinterface.c
+++ b/src/rinterface.c
@@ -1613,6 +1613,34 @@ SEXP R_igraph_sample_dirichlet(SEXP n, SEXP alpha) {
 }
 
 /*-------------------------------------------/
+/ igraph_are_adjacent                        /
+/-------------------------------------------*/
+SEXP R_igraph_are_adjacent(SEXP graph, SEXP v1, SEXP v2) {
+                                        /* Declarations */
+  igraph_t c_graph;
+  igraph_integer_t c_v1;
+  igraph_integer_t c_v2;
+  igraph_bool_t c_res;
+  SEXP res;
+
+  SEXP r_result;
+                                        /* Convert input */
+  R_SEXP_to_igraph(graph, &c_graph);
+  c_v1 = (igraph_integer_t) REAL(v1)[0];
+  c_v2 = (igraph_integer_t) REAL(v2)[0];
+                                        /* Call igraph */
+  IGRAPH_R_CHECK(igraph_are_adjacent(&c_graph, c_v1, c_v2, &c_res));
+
+                                        /* Convert output */
+  PROTECT(res=NEW_LOGICAL(1));
+  LOGICAL(res)[0]=c_res;
+  r_result = res;
+
+  UNPROTECT(1);
+  return(r_result);
+}
+
+/*-------------------------------------------/
 / igraph_closeness                           /
 /-------------------------------------------*/
 SEXP R_igraph_closeness(SEXP graph, SEXP vids, SEXP mode, SEXP weights, SEXP normalized) {

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -4771,23 +4771,6 @@ SEXP R_igraph_get_shortest_paths(SEXP graph, SEXP pfrom, SEXP pto,
   return result;
 }
 
-SEXP R_igraph_are_connected(SEXP graph, SEXP pv1, SEXP pv2) {
-
-  igraph_t g;
-  igraph_integer_t v1=(igraph_integer_t) REAL(pv1)[0];
-  igraph_integer_t v2=(igraph_integer_t) REAL(pv2)[0];
-  igraph_bool_t res;
-  SEXP result;
-
-  R_SEXP_to_igraph(graph, &g);
-  PROTECT(result=NEW_LOGICAL(1));
-  IGRAPH_R_CHECK(igraph_are_connected(&g, v1, v2, &res));
-  LOGICAL(result)[0]=res;
-
-  UNPROTECT(1);
-  return result;
-}
-
 SEXP R_igraph_star(SEXP pn, SEXP pmode, SEXP pcenter) {
 
   igraph_t g;

--- a/src/vendor/cigraph/CHANGELOG.md
+++ b/src/vendor/cigraph/CHANGELOG.md
@@ -4,8 +4,25 @@
 
 ### Fixed
 
- - `igraph_is_forest()` determined that a graph is not a directed forest, and the `roots` output parameter was set to `NULL`, it would incorrectly cache that the graph is also not an undirected forest.
+ - Fixed a corruption of the "finally" stack in `igraph_write_graph_gml()` for certain invalid GML files.
+ - Fixed a memory leak in `igraph_write_graph_lgl()` when vertex names were present but edge weights were not.
+ - Fixed the handling of duplicate edge IDs in `igraph_subgraph_from_edges()`.
+ - Fixed conversion of sparse matrices to dense with `igraph_sparsemat_as_matrix()` when sparse matrix object did not make use of its full allocated capacity.
+
+### Other
+
+ - Documentation improvements.
+
+## [0.10.10] - 2024-02-13
+
+### Fixed
+
+ - When `igraph_is_forest()` determined that a graph is not a directed forest, and the `roots` output parameter was set to `NULL`, it would incorrectly cache that the graph is also not an undirected forest.
  - `igraph_spanner()` now correctly ignores edge directions, and no longer crashes on directed graphs.
+
+### Deprecated
+
+ - `igraph_are_connected()` is renamed to `igraph_are_adjacent()`; the old name is kept available until at least igraph 1.0.
 
 ### Other
 
@@ -1278,7 +1295,8 @@ Some of the highlights are:
  - Provide proper support for Windows, using `__declspec(dllexport)` and `__declspec(dllimport)` for `DLL`s and static usage by using `#define IGRAPH_STATIC 1`.
  - Provided integer versions of `dqueue` and `stack` data types.
 
-[master]: https://github.com/igraph/igraph/compare/0.10.9..master
+[master]: https://github.com/igraph/igraph/compare/0.10.10..master
+[0.10.10]: https://github.com/igraph/igraph/compare/0.10.9..0.10.10
 [0.10.9]: https://github.com/igraph/igraph/compare/0.10.8..0.10.9
 [0.10.8]: https://github.com/igraph/igraph/compare/0.10.7..0.10.8
 [0.10.7]: https://github.com/igraph/igraph/compare/0.10.6..0.10.7

--- a/src/vendor/cigraph/include/igraph_community.h
+++ b/src/vendor/cigraph/include/igraph_community.h
@@ -100,7 +100,7 @@ IGRAPH_EXPORT igraph_error_t igraph_community_infomap(const igraph_t * graph,
                                            igraph_real_t *codelength);
 
 IGRAPH_EXPORT igraph_error_t igraph_community_edge_betweenness(const igraph_t *graph,
-                                                    igraph_vector_int_t *result,
+                                                    igraph_vector_int_t *removed_edges,
                                                     igraph_vector_t *edge_betweenness,
                                                     igraph_matrix_int_t *merges,
                                                     igraph_vector_int_t *bridges,

--- a/src/vendor/cigraph/include/igraph_structural.h
+++ b/src/vendor/cigraph/include/igraph_structural.h
@@ -40,7 +40,8 @@ __BEGIN_DECLS
 /* Basic query functions                              */
 /* -------------------------------------------------- */
 
-IGRAPH_EXPORT igraph_error_t igraph_are_connected(const igraph_t *graph, igraph_integer_t v1, igraph_integer_t v2, igraph_bool_t *res);
+IGRAPH_EXPORT igraph_error_t igraph_are_adjacent(const igraph_t *graph, igraph_integer_t v1, igraph_integer_t v2, igraph_bool_t *res);
+IGRAPH_EXPORT IGRAPH_DEPRECATED igraph_error_t igraph_are_connected(const igraph_t *graph, igraph_integer_t v1, igraph_integer_t v2, igraph_bool_t *res);
 IGRAPH_EXPORT igraph_error_t igraph_count_multiple(const igraph_t *graph, igraph_vector_int_t *res, igraph_es_t es);
 IGRAPH_EXPORT igraph_error_t igraph_count_multiple_1(const igraph_t *graph, igraph_integer_t *res, igraph_integer_t eid);
 IGRAPH_EXPORT igraph_error_t igraph_density(const igraph_t *graph, igraph_real_t *res,

--- a/src/vendor/cigraph/interfaces/functions.yaml
+++ b/src/vendor/cigraph/interfaces/functions.yaml
@@ -405,8 +405,13 @@ igraph_sample_dirichlet:
 # Basic query functions
 #######################################
 
+igraph_are_adjacent:
+    PARAMS: GRAPH graph, VERTEX v1, VERTEX v2, OUT BOOLEAN res
+    DEPS: v1 ON graph, v2 ON graph
+
 igraph_are_connected:
     PARAMS: GRAPH graph, VERTEX v1, VERTEX v2, OUT BOOLEAN res
+    DEPS: v1 ON graph, v2 ON graph
 
 #######################################
 # Structural properties
@@ -1611,7 +1616,7 @@ igraph_community_walktrap:
 
 igraph_community_edge_betweenness:
     PARAMS: |-
-        GRAPH graph, OUT VECTOR_INT result, OPTIONAL OUT VECTOR edge_betweenness,
+        GRAPH graph, OUT VECTOR_INT removed_edges, OPTIONAL OUT VECTOR edge_betweenness,
         OPTIONAL OUT MATRIX_INT merges, OPTIONAL OUT INDEX_VECTOR bridges,
         OPTIONAL OUT VECTOR modularity, OPTIONAL OUT VECTOR_INT membership,
         BOOLEAN directed=True, OPTIONAL EDGEWEIGHTS weights=NULL

--- a/src/vendor/cigraph/src/CMakeLists.txt
+++ b/src/vendor/cigraph/src/CMakeLists.txt
@@ -324,7 +324,7 @@ add_library(
 add_dependencies(igraph parsersources)
 
 # Set soname for the library
-set_target_properties(igraph PROPERTIES VERSION "3.1.4")
+set_target_properties(igraph PROPERTIES VERSION "3.1.5")
 set_target_properties(igraph PROPERTIES SOVERSION 3)
 
 # Add extra compiler definitions if needed

--- a/src/vendor/cigraph/src/community/edge_betweenness.c
+++ b/src/vendor/cigraph/src/community/edge_betweenness.c
@@ -364,7 +364,7 @@ static igraph_integer_t igraph_i_vector_which_max_not_null(const igraph_vector_t
  * \em weakly connected components are detected.
  *
  * \param graph The input graph.
- * \param result Pointer to an initialized vector, the result will be
+ * \param removed_edges Pointer to an initialized vector, the result will be
  *     stored here, the IDs of the removed edges in the order of their
  *     removal. It will be resized as needed. It may be \c NULL if
  *     the edge IDs are not needed by the caller.
@@ -406,7 +406,7 @@ static igraph_integer_t igraph_i_vector_which_max_not_null(const igraph_vector_t
  * \example examples/simple/igraph_community_edge_betweenness.c
  */
 igraph_error_t igraph_community_edge_betweenness(const igraph_t *graph,
-                                      igraph_vector_int_t *result,
+                                      igraph_vector_int_t *removed_edges,
                                       igraph_vector_t *edge_betweenness,
                                       igraph_matrix_int_t *merges,
                                       igraph_vector_int_t *bridges,
@@ -439,12 +439,12 @@ igraph_error_t igraph_community_edge_betweenness(const igraph_t *graph,
     /* Needed only for the weighted case */
     igraph_2wheap_t heap;
 
-    if (result == NULL) {
-        result = IGRAPH_CALLOC(1, igraph_vector_int_t);
-        IGRAPH_CHECK_OOM(result, "Insufficient memory for edge betweenness-based community detection.");
-        IGRAPH_FINALLY(igraph_free, result);
+    if (removed_edges == NULL) {
+        removed_edges = IGRAPH_CALLOC(1, igraph_vector_int_t);
+        IGRAPH_CHECK_OOM(removed_edges, "Insufficient memory for edge betweenness-based community detection.");
+        IGRAPH_FINALLY(igraph_free, removed_edges);
 
-        IGRAPH_VECTOR_INT_INIT_FINALLY(result, 0);
+        IGRAPH_VECTOR_INT_INIT_FINALLY(removed_edges, 0);
         result_owned = true;
     }
 
@@ -513,7 +513,7 @@ igraph_error_t igraph_community_edge_betweenness(const igraph_t *graph,
 
     IGRAPH_STACK_INT_INIT_FINALLY(&stack, no_of_nodes);
 
-    IGRAPH_CHECK(igraph_vector_int_resize(result, no_of_edges));
+    IGRAPH_CHECK(igraph_vector_int_resize(removed_edges, no_of_edges));
     if (edge_betweenness) {
         IGRAPH_CHECK(igraph_vector_resize(edge_betweenness, no_of_edges));
         if (no_of_edges > 0) {
@@ -699,7 +699,7 @@ igraph_error_t igraph_community_edge_betweenness(const igraph_t *graph,
         /* Now look for the smallest edge betweenness */
         /* and eliminate that edge from the network */
         maxedge = igraph_i_vector_which_max_not_null(&eb, passive);
-        VECTOR(*result)[e] = maxedge;
+        VECTOR(*removed_edges)[e] = maxedge;
         if (edge_betweenness) {
             VECTOR(*edge_betweenness)[e] = VECTOR(eb)[maxedge];
             if (!directed) {
@@ -752,14 +752,14 @@ igraph_error_t igraph_community_edge_betweenness(const igraph_t *graph,
     }
 
     if (merges || bridges || modularity || membership) {
-        IGRAPH_CHECK(igraph_community_eb_get_merges(graph, directed, result, weights, merges,
+        IGRAPH_CHECK(igraph_community_eb_get_merges(graph, directed, removed_edges, weights, merges,
                      bridges, modularity,
                      membership));
     }
 
     if (result_owned) {
-        igraph_vector_int_destroy(result);
-        IGRAPH_FREE(result);
+        igraph_vector_int_destroy(removed_edges);
+        IGRAPH_FREE(removed_edges);
         IGRAPH_FINALLY_CLEAN(2);
     }
 

--- a/src/vendor/cigraph/src/connectivity/separators.c
+++ b/src/vendor/cigraph/src/connectivity/separators.c
@@ -724,7 +724,7 @@ igraph_error_t igraph_minimum_size_separators(
             if (ii == j) {
                 continue;    /* the same vertex */
             }
-            IGRAPH_CHECK(igraph_are_connected(&graph_copy, ii, j, &conn));
+            IGRAPH_CHECK(igraph_are_adjacent(&graph_copy, ii, j, &conn));
             if (conn) {
                 continue;    /* they are connected */
             }

--- a/src/vendor/cigraph/src/core/sparsemat.c
+++ b/src/vendor/cigraph/src/core/sparsemat.c
@@ -2109,6 +2109,8 @@ void igraph_sparsemat_numeric_destroy(igraph_sparsemat_numeric_t *din) {
  *    sparse matrix.
  * \return Error code.
  *
+ * \sa \ref igraph_sparsemat_as_matrix() for the reverse conversion.
+ *
  * Time complexity: O(mn), the number of elements in the dense
  * matrix.
  */
@@ -2150,13 +2152,13 @@ static igraph_error_t igraph_i_sparsemat_as_matrix_cc(igraph_matrix_t *res,
     CS_INT *p = spmat->cs->p;
     CS_INT *i = spmat->cs->i;
     CS_ENTRY *x = spmat->cs->x;
-    CS_INT nzmax = spmat->cs->nzmax;
+    CS_INT elem_count = spmat->cs->p[ spmat->cs->n ];
 
     IGRAPH_CHECK(igraph_matrix_resize(res, nrow, ncol));
     igraph_matrix_null(res);
 
-    while (*p < nzmax) {
-        while (to < * (p + 1)) {
+    while (*p < elem_count) {
+        while (to < *(p + 1)) {
             MATRIX(*res, *i, from) += *x;
             to++;
             i++;
@@ -2198,6 +2200,8 @@ static igraph_error_t igraph_i_sparsemat_as_matrix_triplet(igraph_matrix_t *res,
  * \param spmat The input sparse matrix, in triplet or
  *    column-compressed format.
  * \return Error code.
+ *
+ * \sa \ref igraph_matrix_as_sparsemat() for the reverse conversion.
  *
  * Time complexity: O(mn), the number of elements in the dense
  * matrix.

--- a/src/vendor/cigraph/src/flow/flow.c
+++ b/src/vendor/cigraph/src/flow/flow.c
@@ -1750,20 +1750,20 @@ static igraph_error_t igraph_i_st_vertex_connectivity_check_errors(const igraph_
 
     switch (neighbors) {
     case IGRAPH_VCONN_NEI_ERROR:
-        IGRAPH_CHECK(igraph_are_connected(graph, source, target, &conn));
+        IGRAPH_CHECK(igraph_are_adjacent(graph, source, target, &conn));
         if (conn) {
             IGRAPH_ERROR("Source and target vertices connected.", IGRAPH_EINVAL);
         }
         break;
     case IGRAPH_VCONN_NEI_NEGATIVE:
-        IGRAPH_CHECK(igraph_are_connected(graph, source, target, &conn));
+        IGRAPH_CHECK(igraph_are_adjacent(graph, source, target, &conn));
         if (conn) {
             *res = -1;
             return IGRAPH_SUCCESS;
         }
         break;
     case IGRAPH_VCONN_NEI_NUMBER_OF_NODES:
-        IGRAPH_CHECK(igraph_are_connected(graph, source, target, &conn));
+        IGRAPH_CHECK(igraph_are_adjacent(graph, source, target, &conn));
         if (conn) {
             *res = no_of_nodes;
             return IGRAPH_SUCCESS;

--- a/src/vendor/cigraph/src/graph/basic_query.c
+++ b/src/vendor/cigraph/src/graph/basic_query.c
@@ -28,7 +28,7 @@
 
 /**
  * \ingroup structural
- * \function igraph_are_connected
+ * \function igraph_are_adjacent
  * \brief Decides whether two vertices are adjacent.
  *
  * Decides whether there are any edges that have \p v1 and \p v2
@@ -46,7 +46,7 @@
  * Time complexity: O( min(log(d1), log(d2)) ),
  * d1 is the (out-)degree of \p v1 and d2 is the (in-)degree of \p v2.
  */
-igraph_error_t igraph_are_connected(const igraph_t *graph,
+igraph_error_t igraph_are_adjacent(const igraph_t *graph,
                          igraph_integer_t v1, igraph_integer_t v2,
                          igraph_bool_t *res) {
 
@@ -61,4 +61,33 @@ igraph_error_t igraph_are_connected(const igraph_t *graph,
     *res = (eid >= 0);
 
     return IGRAPH_SUCCESS;
+}
+
+
+/**
+ * \ingroup structural
+ * \function igraph_are_connected
+ * \brief Decides whether two vertices are adjacent (deprecated alias).
+ *
+ * \deprecated-by igraph_are_adjacent 0.10.10
+ *
+ * Decides whether there are any edges that have \p v1 and \p v2
+ * as endpoints. This function is of course symmetric for undirected
+ * graphs.
+ *
+ * \param graph The graph object.
+ * \param v1 The first vertex.
+ * \param v2 The second vertex.
+ * \param res Boolean, \c true if there is an edge from
+ *         \p v1 to \p v2, \c false otherwise.
+ * \return The error code \c IGRAPH_EINVVID is returned if an invalid
+ *         vertex ID is given.
+ *
+ * Time complexity: O( min(log(d1), log(d2)) ),
+ * d1 is the (out-)degree of \p v1 and d2 is the (in-)degree of \p v2.
+ */
+igraph_error_t igraph_are_connected(const igraph_t *graph,
+                                   igraph_integer_t v1, igraph_integer_t v2,
+                                   igraph_bool_t *res) {
+    return igraph_are_adjacent(graph, v1, v2, res);
 }

--- a/src/vendor/cigraph/src/io/dl.c
+++ b/src/vendor/cigraph/src/io/dl.c
@@ -28,11 +28,11 @@
 #include "io/dl-header.h"
 #include "io/parsers/dl-parser.h"
 
-int igraph_dl_yylex_init_extra (igraph_i_dl_parsedata_t* user_defined,
-                                void* scanner);
-int igraph_dl_yylex_destroy (void *scanner );
-int igraph_dl_yyparse (igraph_i_dl_parsedata_t* context);
-void igraph_dl_yyset_in  (FILE * in_str, void* yyscanner );
+int igraph_dl_yylex_init_extra (igraph_i_dl_parsedata_t *user_defined,
+                                void *scanner);
+int igraph_dl_yylex_destroy(void *scanner);
+int igraph_dl_yyparse(igraph_i_dl_parsedata_t *context);
+void igraph_dl_yyset_in(FILE *in_str, void *yyscanner);
 
 /* for IGRAPH_FINALLY, which assumes that destructor functions return void */
 void igraph_dl_yylex_destroy_wrapper (void *scanner ) {

--- a/src/vendor/cigraph/src/io/gml.c
+++ b/src/vendor/cigraph/src/io/gml.c
@@ -1059,6 +1059,10 @@ igraph_error_t igraph_write_graph_gml(const igraph_t *graph, FILE *outstream,
             igraph_real_t val = VECTOR(*myid)[i];
             if (val != (igraph_integer_t) val) {
                 IGRAPH_WARNINGF("%g is not a valid integer id for GML files, ignoring all supplied ids.", val);
+                if (myid == &v_myid) {
+                    igraph_vector_destroy(&v_myid);
+                    IGRAPH_FINALLY_CLEAN(1);
+                }
                 myid = NULL;
                 break;
             }
@@ -1070,6 +1074,10 @@ igraph_error_t igraph_write_graph_gml(const igraph_t *graph, FILE *outstream,
         IGRAPH_CHECK(igraph_i_vector_is_duplicate_free(myid, &duplicate_free));
         if (! duplicate_free) {
             IGRAPH_WARNING("Duplicate id values found, ignoring supplies ids.");
+            if (myid == &v_myid) {
+                igraph_vector_destroy(&v_myid);
+                IGRAPH_FINALLY_CLEAN(1);
+            }
             myid = NULL;
         }
     }

--- a/src/vendor/cigraph/src/io/lgl.c
+++ b/src/vendor/cigraph/src/io/lgl.c
@@ -30,11 +30,11 @@
 #include "io/lgl-header.h"
 #include "io/parsers/lgl-parser.h"
 
-int igraph_lgl_yylex_init_extra (igraph_i_lgl_parsedata_t* user_defined,
-                                 void* scanner);
-int igraph_lgl_yylex_destroy (void *scanner );
-int igraph_lgl_yyparse (igraph_i_lgl_parsedata_t* context);
-void igraph_lgl_yyset_in  (FILE * in_str, void* yyscanner );
+int igraph_lgl_yylex_init_extra (igraph_i_lgl_parsedata_t *user_defined,
+                                 void *scanner);
+int igraph_lgl_yylex_destroy(void *scanner);
+int igraph_lgl_yyparse(igraph_i_lgl_parsedata_t *context);
+void igraph_lgl_yyset_in(FILE *in_str, void *yyscanner);
 
 /* for IGRAPH_FINALLY, which assumes that destructor functions return void */
 void igraph_lgl_yylex_destroy_wrapper (void *scanner ) {
@@ -247,6 +247,7 @@ igraph_error_t igraph_write_graph_lgl(const igraph_t *graph, FILE *outstream,
     igraph_eit_t it;
     igraph_integer_t actvertex = -1;
     igraph_attribute_type_t nametype, weighttype;
+    const igraph_integer_t vcount = igraph_vcount(graph), ecount = igraph_ecount(graph);
 
     IGRAPH_CHECK(igraph_eit_create(graph, igraph_ess_all(IGRAPH_EDGEORDER_FROM),
                                    &it));
@@ -301,8 +302,7 @@ igraph_error_t igraph_write_graph_lgl(const igraph_t *graph, FILE *outstream,
     } else if (weights == NULL) {
         /* No weights but use names */
         igraph_strvector_t nvec;
-        IGRAPH_CHECK(igraph_strvector_init(&nvec, igraph_vcount(graph)));
-        IGRAPH_FINALLY(igraph_strvector_destroy, &nvec);
+        IGRAPH_STRVECTOR_INIT_FINALLY(&nvec, vcount);
         IGRAPH_CHECK(igraph_i_attribute_get_string_vertex_attr(graph, names,
                      igraph_vss_all(),
                      &nvec));
@@ -326,11 +326,12 @@ igraph_error_t igraph_write_graph_lgl(const igraph_t *graph, FILE *outstream,
             }
             IGRAPH_EIT_NEXT(it);
         }
+        igraph_strvector_destroy(&nvec);
         IGRAPH_FINALLY_CLEAN(1);
     } else if (names == NULL) {
         /* No names but weights */
         igraph_vector_t wvec;
-        IGRAPH_VECTOR_INIT_FINALLY(&wvec, igraph_ecount(graph));
+        IGRAPH_VECTOR_INIT_FINALLY(&wvec, ecount);
         IGRAPH_CHECK(igraph_i_attribute_get_numeric_edge_attr(graph, weights,
                      igraph_ess_all(IGRAPH_EDGEORDER_ID),
                      &wvec));
@@ -358,9 +359,8 @@ igraph_error_t igraph_write_graph_lgl(const igraph_t *graph, FILE *outstream,
         /* Both names and weights */
         igraph_strvector_t nvec;
         igraph_vector_t wvec;
-        IGRAPH_VECTOR_INIT_FINALLY(&wvec, igraph_ecount(graph));
-        IGRAPH_CHECK(igraph_strvector_init(&nvec, igraph_vcount(graph)));
-        IGRAPH_FINALLY(igraph_strvector_destroy, &nvec);
+        IGRAPH_VECTOR_INIT_FINALLY(&wvec, ecount);
+        IGRAPH_STRVECTOR_INIT_FINALLY(&nvec, vcount);
         IGRAPH_CHECK(igraph_i_attribute_get_numeric_edge_attr(graph, weights,
                      igraph_ess_all(IGRAPH_EDGEORDER_ID),
                      &wvec));
@@ -397,15 +397,14 @@ igraph_error_t igraph_write_graph_lgl(const igraph_t *graph, FILE *outstream,
     }
 
     if (isolates) {
-        igraph_integer_t nov = igraph_vcount(graph);
+        igraph_integer_t nov = vcount;
         igraph_integer_t i;
         int ret = 0;
         igraph_integer_t deg;
         igraph_strvector_t nvec;
         const char *str;
 
-        IGRAPH_CHECK(igraph_strvector_init(&nvec, 1));
-        IGRAPH_FINALLY(igraph_strvector_destroy, &nvec);
+        IGRAPH_STRVECTOR_INIT_FINALLY(&nvec, 1);
         for (i = 0; i < nov; i++) {
             IGRAPH_CHECK(igraph_degree_1(graph, &deg, i, IGRAPH_ALL, IGRAPH_LOOPS));
             if (deg == 0) {

--- a/src/vendor/cigraph/src/io/ncol.c
+++ b/src/vendor/cigraph/src/io/ncol.c
@@ -30,11 +30,11 @@
 #include "io/ncol-header.h"
 #include "io/parsers/ncol-parser.h"
 
-int igraph_ncol_yylex_init_extra (igraph_i_ncol_parsedata_t* user_defined,
-                                  void* scanner);
-int igraph_ncol_yylex_destroy (void *scanner );
-int igraph_ncol_yyparse (igraph_i_ncol_parsedata_t* context);
-void igraph_ncol_yyset_in  (FILE * in_str, void* yyscanner );
+int igraph_ncol_yylex_init_extra (igraph_i_ncol_parsedata_t *user_defined,
+                                  void *scanner);
+int igraph_ncol_yylex_destroy(void *scanner);
+int igraph_ncol_yyparse(igraph_i_ncol_parsedata_t *context);
+void igraph_ncol_yyset_in(FILE *in_str, void *yyscanner);
 
 /* for IGRAPH_FINALLY, which assumes that destructor functions return void */
 void igraph_ncol_yylex_destroy_wrapper (void *scanner ) {

--- a/src/vendor/cigraph/src/io/pajek.c
+++ b/src/vendor/cigraph/src/io/pajek.c
@@ -37,11 +37,11 @@
 #include <ctype.h>
 #include <string.h>
 
-int igraph_pajek_yylex_init_extra(igraph_i_pajek_parsedata_t* user_defined,
-                                  void* scanner);
-int igraph_pajek_yylex_destroy (void *scanner );
-int igraph_pajek_yyparse (igraph_i_pajek_parsedata_t* context);
-void igraph_pajek_yyset_in  (FILE * in_str, void* yyscanner );
+int igraph_pajek_yylex_init_extra(igraph_i_pajek_parsedata_t *user_defined,
+                                  void *scanner);
+int igraph_pajek_yylex_destroy(void *scanner);
+int igraph_pajek_yyparse(igraph_i_pajek_parsedata_t *context);
+void igraph_pajek_yyset_in(FILE *in_str, void *yyscanner);
 
 /* for IGRAPH_FINALLY, which assumes that destructor functions return void */
 void igraph_pajek_yylex_destroy_wrapper (void *scanner ) {

--- a/src/vendor/cigraph/src/misc/matching.c
+++ b/src/vendor/cigraph/src/misc/matching.c
@@ -110,11 +110,11 @@ igraph_error_t igraph_is_matching(const igraph_t *graph,
             *result = false; return IGRAPH_SUCCESS;
         }
         /* Matched vertices must be connected */
-        IGRAPH_CHECK(igraph_are_connected(graph, i,
+        IGRAPH_CHECK(igraph_are_adjacent(graph, i,
                                           j, &conn));
         if (!conn) {
             /* Try the other direction -- for directed graphs */
-            IGRAPH_CHECK(igraph_are_connected(graph, j,
+            IGRAPH_CHECK(igraph_are_adjacent(graph, j,
                                               i, &conn));
             if (!conn) {
                 *result = false; return IGRAPH_SUCCESS;

--- a/src/vendor/cigraph/src/operators/compose.c
+++ b/src/vendor/cigraph/src/operators/compose.c
@@ -33,7 +33,7 @@
  *
  * The composition of graphs contains the same number of vertices as
  * the bigger graph of the two operands. It contains an (i,j) edge if
- * and only if there is a k vertex, such that the first graphs
+ * and only if there is a k vertex, such that the first graph
  * contains an (i,k) edge and the second graph a (k,j) edge.
  *
  * </para><para>This is of course exactly the composition of two

--- a/src/vendor/cigraph/src/operators/disjoint_union.c
+++ b/src/vendor/cigraph/src/operators/disjoint_union.c
@@ -37,6 +37,13 @@
  * and |E1|+|E2| edges.
  *
  * </para><para>
+ * The vertex and edge ordering of the graphs will be preserved.
+ * In other words, the vertex and edge IDs of the first graph map to
+ * identical values in the new graph, while the vertex and edge IDs
+ * of the second graph map to IDs incremented by the vertex and edge
+ * count of the first graph.
+ *
+ * </para><para>
  * Both graphs need to have the same directedness, i.e. either both
  * directed or both undirected.
  *
@@ -107,6 +114,10 @@ igraph_error_t igraph_disjoint_union(igraph_t *res, const igraph_t *left,
  * the graphs is formed.
  * The number of vertices and edges in the result is the total number
  * of vertices and edges in the graphs.
+ *
+ * </para><para>
+ * The vertex and edge ordering of the input graphs is preserved in
+ * the output graph.
  *
  * </para><para>
  * All graphs need to have the same directedness, i.e. either all

--- a/src/vendor/cigraph/src/operators/rewire.c
+++ b/src/vendor/cigraph/src/operators/rewire.c
@@ -155,7 +155,7 @@ igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_integer_t n, igraph_rewir
                         ok = 0;
                     }
                 } else {
-                    IGRAPH_CHECK(igraph_are_connected(graph, a, d, &ok));
+                    IGRAPH_CHECK(igraph_are_adjacent(graph, a, d, &ok));
                     ok = !ok;
                 }
             }
@@ -165,7 +165,7 @@ igraph_error_t igraph_i_rewire(igraph_t *graph, igraph_integer_t n, igraph_rewir
                         ok = 0;
                     }
                 } else {
-                    IGRAPH_CHECK(igraph_are_connected(graph, c, b, &ok));
+                    IGRAPH_CHECK(igraph_are_adjacent(graph, c, b, &ok));
                     ok = !ok;
                 }
             }

--- a/src/vendor/cigraph/src/paths/sparsifier.c
+++ b/src/vendor/cigraph/src/paths/sparsifier.c
@@ -395,7 +395,7 @@ igraph_error_t igraph_spanner(const igraph_t *graph, igraph_vector_int_t *spanne
         }
 
         // Commit the new clustering
-        igraph_vector_int_update(&clustering, &new_clustering);
+        igraph_vector_int_update(&clustering, &new_clustering); /* reserved */
 
         // Remove intra-cluster edges
         for (v = 0; v < no_of_nodes; v++) {

--- a/tests/testthat/test-are_adjacent.R
+++ b/tests/testthat/test-are_adjacent.R
@@ -4,10 +4,13 @@ test_that("are_adjacent works", {
   expect_true(are_adjacent(g, "B", "A"))
   expect_false(are_adjacent(g, "A", "D"))
 
-  g2 <- make_graph(c(1, 2, 2, 3, 3, 4), dir = FALSE)
+  g2 <- make_graph(c(1,2, 2,3, 3,4, 1,1, 3,4), directed = FALSE)
   expect_true(are_adjacent(g2, 1, 2))
   expect_true(are_adjacent(g2, 3, 2))
+  expect_true(are_adjacent(g2, 3, 4))
+  expect_true(are_adjacent(g2, 1, 1))
   expect_false(are_adjacent(g2, 4, 1))
+  expect_false(are_adjacent(g2, 3, 3))
 
   g3 <- graph_from_literal(A -+ B -+ C, B -+ D)
   expect_false(are_adjacent(g3, "A", "C"))

--- a/tools/stimulus/functions-R.yaml
+++ b/tools/stimulus/functions-R.yaml
@@ -316,6 +316,7 @@ igraph_sample_dirichlet:
 # Basic query functions
 #######################################
 
+# Deprecated in C core
 igraph_are_connected:
     IGNORE: RR, RC
 


### PR DESCRIPTION
Fixes #1253