### PR TITLE
docs: remove incorrect claim about handling of complete graphs by `is_separator()` and `is_min_separator()`

### DIFF
--- a/R/flow.R
+++ b/R/flow.R
@@ -883,9 +883,6 @@ max_flow <- maxflow_impl
 #' separator. A vertex set is a vertex separator if its removal results a
 #' disconnected graph.
 #'
-#' In the special case of a fully connected graph with \eqn{n} vertices, each
-#' set of \eqn{n-1} vertices is considered to be a vertex separator.
-#'
 #' @param graph The input graph. It may be directed, but edge directions are
 #'   ignored.
 #' @param candidate A numeric vector giving the vertex ids of the candidate
@@ -904,10 +901,7 @@ is_separator <- is_separator_impl
 #'
 #' `is_min_separator()` decides whether the supplied vertex set is a minimal
 #' vertex separator. A minimal vertex separator is a vertex separator, such
-#' that none of its subsets is a vertex separator.
-#'
-#' In the special case of a fully connected graph with \eqn{n} vertices, each
-#' set of \eqn{n-1} vertices is considered to be a vertex separator.
+#' that none of its proper subsets are a vertex separator.
 #'
 #' @param graph The input graph. It may be directed, but edge directions are
 #'   ignored.

--- a/man/is_min_separator.Rd
+++ b/man/is_min_separator.Rd
@@ -23,10 +23,7 @@ Check whether a given set of vertices is a minimal vertex separator.
 \details{
 \code{is_min_separator()} decides whether the supplied vertex set is a minimal
 vertex separator. A minimal vertex separator is a vertex separator, such
-that none of its subsets is a vertex separator.
-
-In the special case of a fully connected graph with \eqn{n} vertices, each
-set of \eqn{n-1} vertices is considered to be a vertex separator.
+that none of its proper subsets are a vertex separator.
 }
 \examples{
 # The graph from the Moody-White paper

--- a/man/is_separator.Rd
+++ b/man/is_separator.Rd
@@ -25,9 +25,6 @@ Check whether a given set of vertices is a vertex separator.
 \code{is_separator()} decides whether the supplied vertex set is a vertex
 separator. A vertex set is a vertex separator if its removal results a
 disconnected graph.
-
-In the special case of a fully connected graph with \eqn{n} vertices, each
-set of \eqn{n-1} vertices is considered to be a vertex separator.
 }
 \seealso{
 Other flow: 


### PR DESCRIPTION
See https://github.com/igraph/igraph/pull/2509 as well.