### PR TITLE
docs: Improve `min_st_separators()` documentation

### DIFF
--- a/R/flow.R
+++ b/R/flow.R
@@ -812,12 +812,14 @@ dominator_tree <- function(graph, root, mode = c("out", "in", "all", "total")) {
 #'
 #' chvatal <- make_graph("chvatal")
 #' min_st_separators(chvatal)
-#'
-#' # Note that {1, 3} is returned despite its subset {1} being a separator
-#' # as well. This is because {1, 3} is minimal with respect to separating
-#' # vertices 2 and 4.
+#' @section Note:
+#' Note that \eqn{1, 3} is returned despite its subset \eqn{1} being a separator
+#' as well. This is because \eqn{1, 3} is minimal with respect to separating
+#' vertices 2 and 4.
+#' ```{r}
 #' g <- make_graph(~ 0-1-2-3-4-1)
 #' min_st_separators(g)
+#' ```
 #' @family flow
 min_st_separators <- all_minimal_st_separators_impl
 

--- a/R/flow.R
+++ b/R/flow.R
@@ -812,12 +812,18 @@ dominator_tree <- function(graph, root, mode = c("out", "in", "all", "total")) {
 #'
 #' chvatal <- make_graph("chvatal")
 #' min_st_separators(chvatal)
+#' # https://github.com/r-lib/roxygen2/issues/1092
 #' @section Note:
 #' Note that the code below returns `{1, 3}` despite its subset `{1}` being a
 #' separator as well. This is because `{1, 3}` is minimal with respect to
 #' separating vertices 2 and 4.
-#' ```{r}
-#' # option to not show IDs, but you as an user don't need it
+#'
+#' ```{r, eval=FALSE}
+#' g <- make_graph(~ 0-1-2-3-4-1)
+#' min_st_separators(g)
+#' ```
+#'
+#' ```{r, echo=FALSE}
 #' local_igraph_options(print.id = FALSE)
 #' g <- make_graph(~ 0-1-2-3-4-1)
 #' min_st_separators(g)

--- a/R/flow.R
+++ b/R/flow.R
@@ -817,6 +817,8 @@ dominator_tree <- function(graph, root, mode = c("out", "in", "all", "total")) {
 #' separator as well. This is because `{1, 3}` is minimal with respect to
 #' separating vertices 2 and 4.
 #' ```{r}
+#' # option to not show IDs, but you as an user don't need it
+#' local_igraph_options(print.id = FALSE)
 #' g <- make_graph(~ 0-1-2-3-4-1)
 #' min_st_separators(g)
 #' ```

--- a/R/flow.R
+++ b/R/flow.R
@@ -783,15 +783,15 @@ dominator_tree <- function(graph, root, mode = c("out", "in", "all", "total")) {
 
 #' Minimum size vertex separators
 #'
-#' List all vertex sets that are minimal (s,t) separators for some s and t, in
-#' an undirected graph.
+#' List all vertex sets that are minimal \eqn{(s,t)} separators for some
+#' \eqn{s} and \eqn{t}, in an undirected graph.
 #'
 #' A \eqn{(s,t)} vertex separator is a set of vertices, such that after their
 #' removal from the graph, there is no path between \eqn{s} and \eqn{t} in the
 #' graph.
 #'
-#' A \eqn{(s,t)} vertex separator is minimal if none of its subsets is an
-#' \eqn{(s,t)} vertex separator.
+#' A \eqn{(s,t)} vertex separator is minimal if none of its proper subsets is
+#' an \eqn{(s,t)} vertex separator for the same \eqn{s} and \eqn{t}.
 #'
 #' @param graph The input graph. It may be directed, but edge directions are
 #'   ignored.
@@ -812,6 +812,12 @@ dominator_tree <- function(graph, root, mode = c("out", "in", "all", "total")) {
 #'
 #' chvatal <- make_graph("chvatal")
 #' min_st_separators(chvatal)
+#'
+#' # Note that {1, 3} is returned despite its subset {1} being a separator
+#' # as well. This is because {1, 3} is minimal with respect to separating
+#' # vertices 2 and 4.
+#' g <- make_graph(~ 0-1-2-3-4-1)
+#' min_st_separators(g)
 #' @family flow
 min_st_separators <- all_minimal_st_separators_impl
 

--- a/R/flow.R
+++ b/R/flow.R
@@ -813,9 +813,9 @@ dominator_tree <- function(graph, root, mode = c("out", "in", "all", "total")) {
 #' chvatal <- make_graph("chvatal")
 #' min_st_separators(chvatal)
 #' @section Note:
-#' Note that \eqn{1, 3} is returned despite its subset \eqn{1} being a separator
-#' as well. This is because \eqn{1, 3} is minimal with respect to separating
-#' vertices 2 and 4.
+#' Note that the code below returns `{1, 3}` despite its subset `{1}` being a
+#' separator as well. This is because `{1, 3}` is minimal with respect to
+#' separating vertices 2 and 4.
 #' ```{r}
 #' g <- make_graph(~ 0-1-2-3-4-1)
 #' min_st_separators(g)

--- a/man/min_st_separators.Rd
+++ b/man/min_st_separators.Rd
@@ -27,6 +27,28 @@ graph.
 A \eqn{(s,t)} vertex separator is minimal if none of its proper subsets is
 an \eqn{(s,t)} vertex separator for the same \eqn{s} and \eqn{t}.
 }
+\section{Note}{
+
+Note that \eqn{1, 3} is returned despite its subset \eqn{1} being a separator
+as well. This is because \eqn{1, 3} is minimal with respect to separating
+vertices 2 and 4.
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{g <- make_graph(~ 0-1-2-3-4-1)
+min_st_separators(g)
+#> [[1]]
+#> + 1/5 vertex, named, from 5568ea3:
+#> [1] 1
+#> 
+#> [[2]]
+#> + 2/5 vertices, named, from 5568ea3:
+#> [1] 2 4
+#> 
+#> [[3]]
+#> + 2/5 vertices, named, from 5568ea3:
+#> [1] 1 3
+}\if{html}{\out{</div>}}
+}
+
 \examples{
 
 ring <- make_ring(4)
@@ -34,12 +56,6 @@ min_st_separators(ring)
 
 chvatal <- make_graph("chvatal")
 min_st_separators(chvatal)
-
-# Note that {1, 3} is returned despite its subset {1} being a separator
-# as well. This is because {1, 3} is minimal with respect to separating
-# vertices 2 and 4.
-g <- make_graph(~ 0-1-2-3-4-1)
-min_st_separators(g)
 }
 \references{
 Anne Berry, Jean-Paul Bordat and Olivier Cogis: Generating All

--- a/man/min_st_separators.Rd
+++ b/man/min_st_separators.Rd
@@ -16,16 +16,16 @@ A list of numeric vectors. Each vector contains a vertex set
 graph, for some \eqn{s} and \eqn{t}.
 }
 \description{
-List all vertex sets that are minimal (s,t) separators for some s and t, in
-an undirected graph.
+List all vertex sets that are minimal \eqn{(s,t)} separators for some
+\eqn{s} and \eqn{t}, in an undirected graph.
 }
 \details{
 A \eqn{(s,t)} vertex separator is a set of vertices, such that after their
 removal from the graph, there is no path between \eqn{s} and \eqn{t} in the
 graph.
 
-A \eqn{(s,t)} vertex separator is minimal if none of its subsets is an
-\eqn{(s,t)} vertex separator.
+A \eqn{(s,t)} vertex separator is minimal if none of its proper subsets is
+an \eqn{(s,t)} vertex separator for the same \eqn{s} and \eqn{t}.
 }
 \examples{
 
@@ -34,6 +34,12 @@ min_st_separators(ring)
 
 chvatal <- make_graph("chvatal")
 min_st_separators(chvatal)
+
+# Note that {1, 3} is returned despite its subset {1} being a separator
+# as well. This is because {1, 3} is minimal with respect to separating
+# vertices 2 and 4.
+g <- make_graph(~ 0-1-2-3-4-1)
+min_st_separators(g)
 }
 \references{
 Anne Berry, Jean-Paul Bordat and Olivier Cogis: Generating All

--- a/man/min_st_separators.Rd
+++ b/man/min_st_separators.Rd
@@ -29,22 +29,22 @@ an \eqn{(s,t)} vertex separator for the same \eqn{s} and \eqn{t}.
 }
 \section{Note}{
 
-Note that \eqn{1, 3} is returned despite its subset \eqn{1} being a separator
-as well. This is because \eqn{1, 3} is minimal with respect to separating
-vertices 2 and 4.
+Note that the code below returns \verb{\{1, 3\}} despite its subset \code{{1}} being a
+separator as well. This is because \verb{\{1, 3\}} is minimal with respect to
+separating vertices 2 and 4.
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{g <- make_graph(~ 0-1-2-3-4-1)
 min_st_separators(g)
 #> [[1]]
-#> + 1/5 vertex, named, from 5568ea3:
+#> + 1/5 vertex, named, from 8f9f5c8:
 #> [1] 1
 #> 
 #> [[2]]
-#> + 2/5 vertices, named, from 5568ea3:
+#> + 2/5 vertices, named, from 8f9f5c8:
 #> [1] 2 4
 #> 
 #> [[3]]
-#> + 2/5 vertices, named, from 5568ea3:
+#> + 2/5 vertices, named, from 8f9f5c8:
 #> [1] 1 3
 }\if{html}{\out{</div>}}
 }

--- a/man/min_st_separators.Rd
+++ b/man/min_st_separators.Rd
@@ -33,11 +33,11 @@ Note that the code below returns \verb{\{1, 3\}} despite its subset \code{{1}} b
 separator as well. This is because \verb{\{1, 3\}} is minimal with respect to
 separating vertices 2 and 4.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{# option to not show IDs, but you as an user don't need it
-local_igraph_options(print.id = FALSE)
-g <- make_graph(~ 0-1-2-3-4-1)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{g <- make_graph(~ 0-1-2-3-4-1)
 min_st_separators(g)
-#> [[1]]
+}\if{html}{\out{</div>}}
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{#> [[1]]
 #> + 1/5 vertex, named:
 #> [1] 1
 #> 
@@ -58,6 +58,7 @@ min_st_separators(ring)
 
 chvatal <- make_graph("chvatal")
 min_st_separators(chvatal)
+# https://github.com/r-lib/roxygen2/issues/1092
 }
 \references{
 Anne Berry, Jean-Paul Bordat and Olivier Cogis: Generating All

--- a/man/min_st_separators.Rd
+++ b/man/min_st_separators.Rd
@@ -33,18 +33,20 @@ Note that the code below returns \verb{\{1, 3\}} despite its subset \code{{1}} b
 separator as well. This is because \verb{\{1, 3\}} is minimal with respect to
 separating vertices 2 and 4.
 
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{g <- make_graph(~ 0-1-2-3-4-1)
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{# option to not show IDs, but you as an user don't need it
+local_igraph_options(print.id = FALSE)
+g <- make_graph(~ 0-1-2-3-4-1)
 min_st_separators(g)
 #> [[1]]
-#> + 1/5 vertex, named, from 8f9f5c8:
+#> + 1/5 vertex, named:
 #> [1] 1
 #> 
 #> [[2]]
-#> + 2/5 vertices, named, from 8f9f5c8:
+#> + 2/5 vertices, named:
 #> [1] 2 4
 #> 
 #> [[3]]
-#> + 2/5 vertices, named, from 8f9f5c8:
+#> + 2/5 vertices, named:
 #> [1] 1 3
 }\if{html}{\out{</div>}}
 }

--- a/tests/testthat/_snaps/minimal.st.separators.md
+++ b/tests/testthat/_snaps/minimal.st.separators.md
@@ -1,0 +1,18 @@
+# min_st_separators() works for the note case
+
+    Code
+      min_st_separators(g)
+    Output
+      [[1]]
+      + 1/5 vertex, named, from something
+      [1] 1
+      
+      [[2]]
+      + 2/5 vertices, named, from something
+      [1] 2 4
+      
+      [[3]]
+      + 2/5 vertices, named, from something
+      [1] 1 3
+      
+

--- a/tests/testthat/test-minimal.st.separators.R
+++ b/tests/testthat/test-minimal.st.separators.R
@@ -6,3 +6,11 @@ test_that("min_st_separators works", {
 
   ## TODO: check that it is minimal
 })
+
+test_that("min_st_separators() works for the note case", {
+  g <- make_graph(~ 0-1-2-3-4-1)
+  expect_snapshot(
+    min_st_separators(g),
+    transform = function(x) gsub("from.*", "from something", x)
+  )
+})


### PR DESCRIPTION
@maelle Is this the best way to comment on examples? Can we comment using normal text that includes math instead of writing code comments? If yes, can you push to this branch and demonstrate?