### PR TITLE
docs: add link to discussion forum

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -256,3 +256,8 @@ authors:
     href: "https://github.com/GroteGnoom"
   Kirill Müller:
     href: "https://krlmlr.info/"
+
+home:
+  links:
+  - text: Discussion forum
+    href: https://igraph.discourse.group/


### PR DESCRIPTION
@szhorvat which version do you prefer, link above under links or in a separate section? In the screenshot below I am showing both options at once.

![image](https://github.com/igraph/rigraph/assets/8360597/0c04f0c3-9d13-447b-9899-c54007b5406e)
