### PR TITLE
ci: run examples with sanitizer

### DIFF
--- a/.github/workflows/build-and-check.yml
+++ b/.github/workflows/build-and-check.yml
@@ -251,3 +251,4 @@ jobs:
             cd rigraph
             RDcsan CMD INSTALL . --no-byte-compile
             TESTTHAT_PARALLEL=false CI=true RDcsan -q -e 'testthat::test_local(reporter = c("location", "summary"), load_package = "installed")'
+            RDcsan -q -e 'source("tools/run_examples.R")'

--- a/tools/run_examples.R
+++ b/tools/run_examples.R
@@ -4,7 +4,6 @@ library(igraph)
 library(magrittr)
 
 rd_files <- list.files("./man", pattern = "\\.Rd$", full.names = TRUE)
-
 exfile <- tempfile()
 
 for (rd_file in rd_files) {
@@ -13,8 +12,6 @@ for (rd_file in rd_files) {
   if (!file.exists(exfile)) {
     next
   }
-
   example <- readLines(exfile)
-
   eval(parse(text = paste(example, collapse = "\n")))
 }

--- a/tools/run_examples.R
+++ b/tools/run_examples.R
@@ -1,0 +1,20 @@
+#! /usr/bin/env Rscript
+
+library(igraph)
+library(magrittr)
+
+rd_files <- list.files("./man", pattern = "\\.Rd$", full.names = TRUE)
+
+exfile <- tempfile()
+
+for (rd_file in rd_files) {
+  tools::Rd2ex(rd_file, out = exfile)
+
+  if (!file.exists(exfile)) {
+    next
+  }
+
+  example <- readLines(exfile)
+
+  eval(parse(text = paste(example, collapse = "\n")))
+}


### PR DESCRIPTION
Closes: https://github.com/igraph/rigraph/issues/1195

Proof that it detects memory leaks in examples: https://github.com/igraph/rigraph/pull/1286