### PR TITLE
docs: remove misleading comment about warning given as no warning is given

### DIFF
--- a/R/centrality.R
+++ b/R/centrality.R
@@ -1029,7 +1029,7 @@ eigen_centrality <- function(graph,
 #' strength(g, mode = "out")
 #' strength(g, mode = "in")
 #'
-#' # No weights, a warning is given
+#' # No weights
 #' g <- make_ring(10)
 #' strength(g)
 #' @family centrality

--- a/man/strength.Rd
+++ b/man/strength.Rd
@@ -43,7 +43,7 @@ strength(g)
 strength(g, mode = "out")
 strength(g, mode = "in")
 
-# No weights, a warning is given
+# No weights
 g <- make_ring(10)
 strength(g)
 }


### PR DESCRIPTION
Fix #1293
cc @szhorvat 