### PR TITLE
chore: Install lock workflow to lock stale discussions after one year

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -1,0 +1,19 @@
+name: "Lock threads"
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v4
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: "365"
+          issue-lock-reason: ""
+          issue-lock-comment: >
+            This old thread has been automatically locked. If you think you have
+            found something related to this, please open a new issue and link to this
+            old issue if necessary.


### PR DESCRIPTION
Closes #1258.

@igraph/core-team @igraph/developers: When this is merged, your GH notifications might get flooded. Apologies, happy to arrange a time when it's good to merge.