### PR TITLE
test: Add skip condition for `rglplot` test

### DIFF
--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -66,7 +66,9 @@ test_that("basic plot test, spheres", {
   )
 })
 
-test_that("rgplot() works", {
+test_that("rglplot() works", {
+  skip_if_not_installed("rgl")
+  
   # https://stackoverflow.com/a/46320771/5489251
   withr::local_envvar(RGL_USE_NULL = TRUE)
   withr::local_seed(42)


### PR DESCRIPTION
The `rgl` package is a `Suggests` dependency. As such, testing of functions depending on `rgl` should skip if it is not installed. This PR adds such a skip condition.

Test failures due to lack of skip condition were encountered during [Conda Forge builds of v2.0.3](https://github.com/conda-forge/r-igraph-feedstock/pull/59).