### PR TITLE
ci: Update lock.yaml

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -1,5 +1,8 @@
 name: "Lock threads"
-
+permissions:
+  issues: write
+  pull-requests: write
+  discussions: write
 on:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -8,10 +8,10 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v4
+      - uses: dessant/lock-threads@v5
         with:
           github-token: ${{ github.token }}
-          issue-lock-inactive-days: "365"
+          issue-inactive-days: "365"
           issue-lock-reason: ""
           issue-lock-comment: >
             This old thread has been automatically locked. If you think you have

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -4,6 +4,7 @@ permissions:
   pull-requests: write
   discussions: write
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
- There were two warnings on https://github.com/igraph/rigraph/actions/runs/8335586645
- The docs of the action show V5, the permissions field. https://github.com/dessant/lock-threads?tab=readme-ov-file#examples