### PR TITLE
sample_forestfire() tests and example :fire:

### DIFF
--- a/R/games.R
+++ b/R/games.R
@@ -2178,9 +2178,14 @@ sample_fitness_pl <- static_power_law_game_impl
 #' @export
 #' @examples
 #'
+#' fire <- sample_forestfire(50, fw.prob = 0.37, bw.factor = 0.32 / 0.37)
+#' plot(fire)
+#'
 #' g <- sample_forestfire(10000, fw.prob = 0.37, bw.factor = 0.32 / 0.37)
 #' dd1 <- degree_distribution(g, mode = "in")
 #' dd2 <- degree_distribution(g, mode = "out")
+#' # The forest fire model produces graphs with a heavy tail degree distribution.
+#' # Note that some in- or out-degrees are zero which will be excluded from the logarithmic plot.
 #' plot(seq(along.with = dd1) - 1, dd1, log = "xy")
 #' points(seq(along.with = dd2) - 1, dd2, col = 2, pch = 2)
 sample_forestfire <- forest_fire_game_impl

--- a/man/sample_forestfire.Rd
+++ b/man/sample_forestfire.Rd
@@ -55,9 +55,14 @@ implementation is based on this.
 }
 \examples{
 
+fire <- sample_forestfire(50, fw.prob = 0.37, bw.factor = 0.32 / 0.37)
+plot(fire)
+
 g <- sample_forestfire(10000, fw.prob = 0.37, bw.factor = 0.32 / 0.37)
 dd1 <- degree_distribution(g, mode = "in")
 dd2 <- degree_distribution(g, mode = "out")
+# The forest fire model produces graphs with a heavy tail degree distribution.
+# Note that some in- or out-degrees are zero which will be excluded from the logarithmic plot.
 plot(seq(along.with = dd1) - 1, dd1, log = "xy")
 points(seq(along.with = dd2) - 1, dd2, col = 2, pch = 2)
 }

--- a/tests/testthat/test-forestfire.R
+++ b/tests/testthat/test-forestfire.R
@@ -1,27 +1,34 @@
-test_that("sample_forestfire() works", {
+test_that("sample_forestfire() works -- sparse", {
+  withr::local_seed(20231029)
+  N <- 5000
+  xv <- log(2:N)
+
+  g1 <- sample_forestfire(N, fw.prob = 0.35, bw.factor = 0.2 / 0.35)
+  yv1 <- log(cumsum(degree(g1, mode = "out"))[-1])
+
+  expect_equal(coef(lm(yv1 ~ xv))[[2]], 1.04, tolerance = 0.05)
+})
+
+test_that("sample_forestfire() works -- densifying", {
   withr::local_seed(20231029)
 
   N <- 5000
   xv <- log(2:N)
 
-  # sparse
-  g1 <- sample_forestfire(N, fw.prob = 0.35, bw.factor = 0.2 / 0.35)
-  yv1 <- log(cumsum(degree(g1, mode = "out"))[-1])
-  #   Min. 1st Qu.  Median    Mean 3rd Qu.    Max.
-  # 0.9746  1.0280  1.0399  1.0393  1.0524  1.0918
-  expect_equal(coef(lm(yv1 ~ xv))[[2]], 1.04, tolerance = 0.05)
-
-  # densifying
   g2 <- sample_forestfire(N, fw.prob = 0.37, bw.factor = 0.32 / 0.37)
   yv2 <- log(cumsum(degree(g2, mode = "out"))[-1])
-  #  Min. 1st Qu.  Median    Mean 3rd Qu.    Max.
-  # 1.086   1.190   1.215   1.216   1.245   1.364
-  expect_equal(coef(lm(yv2 ~ xv))[[2]], 1.21, tolerance = 0.05)
 
-  # dense
+  expect_equal(coef(lm(yv2 ~ xv))[[2]], 1.21, tolerance = 0.05)
+})
+
+test_that("sample_forestfire() works -- dense", {
+  withr::local_seed(20231029)
+
+  N <- 5000
+  xv <- log(2:N)
+
   g3 <- sample_forestfire(N, fw.prob = 0.38, bw.factor = 0.38 / 0.37)
   yv3 <- log(cumsum(degree(g3, mode = "out"))[-1])
-  #  Min. 1st Qu.  Median    Mean 3rd Qu.    Max.
-  # 1.896   1.994   2.033   2.038   2.089   2.224
-  expect_equal(coef(lm(yv3 ~ xv))[[2]], 2.04, tolerance = 0.05)
+
+  expect_equal(coef(lm(yv3 ~ xv))[[2]], 1.9, tolerance = 0.05)
 })


### PR DESCRIPTION
Fix #1292

- test: refactor sample_forestfire() tests to make them smaller and more self-contained
- docs: simplify example to not have to deal with log of 0