### PR TITLE
fix: fix reading of LGL and NCOL files (broken in 2.0.0)

### DIFF
--- a/R/foreign.R
+++ b/R/foreign.R
@@ -296,7 +296,7 @@ read.graph.ncol <- function(file, predef = character(0), names = TRUE,
   on.exit(.Call(R_igraph_finalizer))
   .Call(
     R_igraph_read_graph_ncol, file, as.character(predef),
-    as.logical(names), as.numeric(weights), as.logical(directed)
+    as.logical(names), weights, as.logical(directed)
   )
 }
 
@@ -336,7 +336,7 @@ read.graph.lgl <- function(file, names = TRUE,
   on.exit(.Call(R_igraph_finalizer))
   .Call(
     R_igraph_read_graph_lgl, file,
-    as.logical(names), as.numeric(weights), as.logical(directed)
+    as.logical(names), weights, as.logical(directed)
   )
 }
 

--- a/tests/testthat/test-read_graph.R
+++ b/tests/testthat/test-read_graph.R
@@ -8,15 +8,15 @@ test_that("reading GraphML file works", {
 })
 
 test_that("reading graph in ncol format", {
-  library(igraph)
+  ncol_path <- tempfile("zoo", fileext = ".ncol")
   g <- make_graph(c(1, 2, 2, 3))
   write_graph(g, "zoo.ncol", "ncol")
-  expect_no_error(g2 <- read_graph("zoo.ncol", "ncol"))
+  expect_no_error(g2 <- read_graph(ncol_path, "ncol"))
 })
 
 test_that("reading graph in lgl format", {
-  library(igraph)
+  ncol_path <- tempfile("zoo", fileext = ".ncol")
   g <- make_graph(c(1, 2, 2, 3))
   write_graph(g, "zoo.lgl", "lgl")
-  expect_no_error(g2 <- read_graph("zoo.lgl", "lgl"))
+  expect_no_error(g2 <- read_graph(ncol_path, "lgl"))
 })

--- a/tests/testthat/test-read_graph.R
+++ b/tests/testthat/test-read_graph.R
@@ -6,3 +6,17 @@ test_that("reading GraphML file works", {
 
   expect_true(isomorphic(g2, g))
 })
+
+test_that("reading graph in ncol format", {
+  library(igraph)
+  g <- make_graph(c(1, 2, 2, 3))
+  write_graph(g, "zoo.ncol", "ncol")
+  expect_no_error(g2 <- read_graph("zoo.ncol", "ncol"))
+})
+
+test_that("reading graph in lgl format", {
+  library(igraph)
+  g <- make_graph(c(1, 2, 2, 3))
+  write_graph(g, "zoo.lgl", "lgl")
+  expect_no_error(g2 <- read_graph("zoo.lgl", "lgl"))
+})

--- a/tests/testthat/test-read_graph.R
+++ b/tests/testthat/test-read_graph.R
@@ -7,16 +7,16 @@ test_that("reading GraphML file works", {
   expect_true(isomorphic(g2, g))
 })
 
-test_that("reading graph in ncol format", {
-  ncol_path <- tempfile("zoo", fileext = ".ncol")
+test_that("reading graph in NCOL format", {
+  ncol_path <- tempfile("testfile", fileext = ".ncol")
   g <- make_graph(c(1, 2, 2, 3))
-  write_graph(g, "zoo.ncol", "ncol")
+  write_graph(g, ncol_path, "ncol")
   expect_no_error(g2 <- read_graph(ncol_path, "ncol"))
 })
 
-test_that("reading graph in lgl format", {
-  ncol_path <- tempfile("zoo", fileext = ".ncol")
+test_that("reading graph in LGL format", {
+  lgl_path <- tempfile("testfile", fileext = ".lgl")
   g <- make_graph(c(1, 2, 2, 3))
-  write_graph(g, "zoo.lgl", "lgl")
-  expect_no_error(g2 <- read_graph(ncol_path, "lgl"))
+  write_graph(g, lgl_path, "lgl")
+  expect_no_error(g2 <- read_graph(lgl_path, "lgl"))
 })


### PR DESCRIPTION
Fixes #1346

I'm sorry, I really don't have time for a test, but I hope someone can add one based on my first comment in #1346.