### PR TITLE
fix: remove unintended type conversions when using `disjoint_union()`

### DIFF
--- a/R/operators.R
+++ b/R/operators.R
@@ -252,14 +252,10 @@ disjoint_union <- function(...) {
       attr[[exattr[a]]] <- vctrs::vec_c(attr[[exattr[a]]], ea[[exattr[a]]])
     }
     for (a in seq_along(noattr)) {
-      attr[[noattr[a]]] <- vctrs::vec_c(attr[[noattr[a]]], rep(NA, ec[i]))
+      attr[[noattr[a]]] <- vctrs::vec_c(attr[[noattr[a]]], vctrs::unspecified(ec[[i]]))
     }
     for (a in seq_along(newattr)) {
-      if (cumec[i] == 0) {
-        attr[[newattr[a]]] <- ea[[newattr[a]]]
-      } else {
-        attr[[newattr[a]]] <- vctrs::vec_c(rep(NA, cumec[i]), ea[[newattr[a]]])
-      }
+      attr[[newattr[a]]] <- vctrs::vec_c(vctrs::unspecified(cumec[[i]]), ea[[newattr[a]]])
     }
   }
   edge.attributes(res) <- attr

--- a/R/operators.R
+++ b/R/operators.R
@@ -249,13 +249,17 @@ disjoint_union <- function(...) {
     noattr <- setdiff(names(attr), names(ea)) # existint and missing
     newattr <- setdiff(names(ea), names(attr)) # new
     for (a in seq_along(exattr)) {
-      attr[[exattr[a]]] <- c(attr[[exattr[a]]], ea[[exattr[a]]])
+      attr[[exattr[a]]] <- vctrs::vec_c(attr[[exattr[a]]], ea[[exattr[a]]])
     }
     for (a in seq_along(noattr)) {
-      attr[[noattr[a]]] <- c(attr[[noattr[a]]], rep(NA, ec[i]))
+      attr[[noattr[a]]] <- vctrs::vec_c(attr[[noattr[a]]], rep(NA, ec[i]))
     }
     for (a in seq_along(newattr)) {
-      attr[[newattr[a]]] <- c(rep(NA, cumec[i]), ea[[newattr[a]]])
+      if (cumec[i] == 0) {
+        attr[[newattr[a]]] <- ea[[newattr[a]]]
+      } else {
+        attr[[newattr[a]]] <- vctrs::vec_c(rep(NA, cumec[i]), ea[[newattr[a]]])
+      }
     }
   }
   edge.attributes(res) <- attr

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -30,6 +30,20 @@ test_that("disjoint_union() works", {
   )
 })
 
+test_that("disjoint_union() does not convert types", {
+  # https://github.com/igraph/rigraph/issues/761
+
+  g1 <- make_graph(~ A - -B)
+  g2 <- make_graph(~ D - -E)
+
+  g1 <- set_edge_attr(g1, "date", value = as.POSIXct(c("2021-01-01 01:01:01")))
+  g2 <- set_edge_attr(g2, "date", value = as.POSIXct(c("2021-03-03 03:03:03")))
+
+  u <- disjoint_union(g1, g2)
+
+  expect_s3_class(E(u)$date, c("POSIXct", "POSIXt"))
+})
+
 test_that("intersection() works", {
 
   g1 <- make_ring(10)


### PR DESCRIPTION
Fix #761

Including commits refactoring the test file before I added the test. :innocent: 