### PR TITLE
feat: rename sample_degseq() method and add the edge.switching.simple method

### DIFF
--- a/R/games.R
+++ b/R/games.R
@@ -752,37 +752,45 @@ random.graph.game <- erdos.renyi.game
 #' It is often useful to create a graph with given vertex degrees. This function
 #' creates such a graph in a randomized manner.
 #'
-#' The \dQuote{configuration} method (formerly called "simple") connects the out-stubs of the edges (undirected
-#' graphs) or the out-stubs and in-stubs (directed graphs) together. This way
-#' loop edges and also multiple edges may be generated. This method is not
-#' adequate if one needs to generate simple graphs with a given degree
-#' sequence. The multiple and loop edges can be deleted, but then the degree
-#' sequence is distorted and there is nothing to ensure that the graphs are
-#' sampled uniformly.
+#' The \dQuote{configuration} method (formerly called "simple") implements the
+#' configuration model. For undirected graphs, it puts all vertex IDs in a bag
+#' such that the multiplicity of a vertex in the bag is the same as its degree.
+#' Then it draws pairs from the bag until the bag becomes empty. This method may
+#'  generate both loop (self) edges and multiple edges. For directed graphs,
+#'  the algorithm is basically the same, but two separate bags are used
+#'  for the in- and out-degrees. Undirected graphs are generated
+#'  with probability proportional to \eqn{(\prod_{i<j} A_{ij} ! \prod_i A_{ii} !!)^{-1}},
+#'  where A denotes the adjacency matrix and !! denotes the double factorial.
+#'  Here A is assumed to have twice the number of self-loops on its diagonal.
+#'  The corresponding expression for directed graphs is \eqn{(\prod_{i,j} A_{ij}!)^{-1}}.
+#'   Thus the probability of all simple graphs
+#'   (which only have 0s and 1s in the adjacency matrix)
+#'   is the same, while that of non-simple ones depends on their edge and
+#'   self-loop multiplicities.
 #'
 #' The \dQuote{fast.heur.simple} method (formerly called "simple.no.multiple")
-#'  is similar to \dQuote{configuration}, but
-#' tries to avoid multiple and loop edges and restarts the generation from
-#' scratch if it gets stuck. It is not guaranteed to sample uniformly from the
-#' space of all possible graphs with the given sequence, but it is relatively
-#' fast and it will eventually succeed if the provided degree sequence is
-#' graphical, but there is no upper bound on the number of iterations.
+#' generates simple graphs.
+#' It is similar to \dQuote{configuration} but tries to avoid multiple and
+#' loop edges and restarts the generation from scratch if it gets stuck.
+#' It can generate all simple realizations of a degree sequence,
+#' but it is not guaranteed to sample them uniformly.
+#' This method is relatively fast and it will eventually succeed
+#' if the provided degree sequence is graphical, but there is no upper bound on
+#' the number of iterations.
 #'
 #' The \dQuote{configuration.simple} method (formerly called "simple.no.multiple.uniform")
-#' is a variant of
-#' \dQuote{fast.heur.simple} with the added benefit of sampling uniformly
-#' from the set of all possible simple graphs with the given degree sequence.
-#' Ensuring uniformity has some performance implications, though.
+#' is
+#' identical to \dQuote{configuration}, but if the generated graph is not simple,
+#' it rejects it and re-starts the generation.
+#' It generates all simple graphs with the same probability.
 #'
-#' The \dQuote{vl} method is a more sophisticated generator. The algorithm and
-#' the implementation was done by Fabien Viger and Matthieu Latapy. This
-#' generator always generates undirected, connected simple graphs, it is an
-#' error to pass the `in.deg` argument to it.  The algorithm relies on
-#' first creating an initial (possibly unconnected) simple undirected graph
-#' with the given degree sequence (if this is possible at all). Then some
-#' rewiring is done to make the graph connected. Finally a Monte-Carlo
-#' algorithm is used to randomize the graph. The \dQuote{vl} samples from the
-#' undirected, connected simple graphs uniformly.
+#' The \dQuote{vl} method samples undirected connected graphs approximately uniformly.
+#' It is a Monte Carlo method based on degree-preserving edge switches.
+#' This generator should be favoured if undirected and connected graphs are to be
+#'  generated and execution time is not a concern. igraph uses
+#'  the original implementation of Fabien Viger; for the algorithm, see
+#'  <https://www-complexnetworks.lip6.fr/~latapy/FV/generation.html>
+#'  and the paper <https://arxiv.org/abs/cs/0502085>.
 #'
 #' The \dQuote{edge.switching.simple} is an MCMC sampler based on
 #' degree-preserving edge switches. It generates simple undirected or directed graphs.

--- a/R/games.R
+++ b/R/games.R
@@ -930,12 +930,13 @@ sample_degseq <- function(out.deg, in.deg = NULL,
     method <- "configuration.simple"
   }
 
+  # numbers from https://github.com/igraph/igraph/blob/640083c88bf85fd322ff7b748b9b4e16ebe32aa2/include/igraph_constants.h#L94
   method1 <- switch(method,
     "configuration" = 0,
     "vl" = 1,
     "fast.heur.simple" = 2,
     "configuration.simple" = 3,
-    "edge.switching.simple" = 4 #TODO: check number and see where it comes from
+    "edge.switching.simple" = 4
   )
   if (!is.null(in.deg)) {
     in.deg <- as.numeric(in.deg)

--- a/R/make.R
+++ b/R/make.R
@@ -171,7 +171,7 @@
 #' r2 <- make_(ring(10), with_vertex_(color = "red", name = LETTERS[1:10]))
 #' l2 <- make_(lattice(c(3, 3, 3)), with_edge_(weight = 2))
 #'
-#' ran <- sample_(degseq(c(3, 3, 3, 3, 3, 3), method = "simple"), simplified())
+#' ran <- sample_(degseq(c(3, 3, 3, 3, 3, 3), method = "configuration"), simplified())
 #' degree(ran)
 #' is_simple(ran)
 make_ <- function(...) {

--- a/man/degree.sequence.game.Rd
+++ b/man/degree.sequence.game.Rd
@@ -19,9 +19,7 @@ should be even. For directed graphs its sum should be the same as the sum of
 \item{in.deg}{For directed graph, the in-degree sequence. By default this is
 \code{NULL} and an undirected graph is created.}
 
-\item{method}{Character, the method for generating the graph. Right now the
-\dQuote{simple}, \dQuote{simple.no.multiple} and \dQuote{vl} methods are
-implemented.}
+\item{method}{Character, the method for generating the graph. See Details.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/make_.Rd
+++ b/man/make_.Rd
@@ -37,7 +37,7 @@ l <- make_(lattice(c(3, 3, 3)))
 r2 <- make_(ring(10), with_vertex_(color = "red", name = LETTERS[1:10]))
 l2 <- make_(lattice(c(3, 3, 3)), with_edge_(weight = 2))
 
-ran <- sample_(degseq(c(3, 3, 3, 3, 3, 3), method = "simple"), simplified())
+ran <- sample_(degseq(c(3, 3, 3, 3, 3, 3), method = "configuration"), simplified())
 degree(ran)
 is_simple(ran)
 }

--- a/man/sample_degseq.Rd
+++ b/man/sample_degseq.Rd
@@ -8,7 +8,8 @@
 sample_degseq(
   out.deg,
   in.deg = NULL,
-  method = c("simple", "vl", "simple.no.multiple", "simple.no.multiple.uniform")
+  method = c("configuration", "vl", "fast.heur.simple", "configuration.simple",
+    "edge.switching.simple")
 )
 
 degseq(..., deterministic = FALSE)
@@ -22,9 +23,7 @@ should be even. For directed graphs its sum should be the same as the sum of
 \item{in.deg}{For directed graph, the in-degree sequence. By default this is
 \code{NULL} and an undirected graph is created.}
 
-\item{method}{Character, the method for generating the graph. Right now the
-\dQuote{simple}, \dQuote{simple.no.multiple} and \dQuote{vl} methods are
-implemented.}
+\item{method}{Character, the method for generating the graph. See Details.}
 
 \item{...}{Passed to \code{realize_degseq()} if \sQuote{deterministic} is true,
 or to \code{sample_degseq()} otherwise.}
@@ -39,7 +38,7 @@ It is often useful to create a graph with given vertex degrees. This function
 creates such a graph in a randomized manner.
 }
 \details{
-The \dQuote{simple} method connects the out-stubs of the edges (undirected
+The \dQuote{configuration} method (formerly called "simple") connects the out-stubs of the edges (undirected
 graphs) or the out-stubs and in-stubs (directed graphs) together. This way
 loop edges and also multiple edges may be generated. This method is not
 adequate if one needs to generate simple graphs with a given degree
@@ -47,15 +46,17 @@ sequence. The multiple and loop edges can be deleted, but then the degree
 sequence is distorted and there is nothing to ensure that the graphs are
 sampled uniformly.
 
-The \dQuote{simple.no.multiple} method is similar to \dQuote{simple}, but
+The \dQuote{fast.heur.simple} method (formerly called "simple.no.multiple")
+is similar to \dQuote{configuration}, but
 tries to avoid multiple and loop edges and restarts the generation from
 scratch if it gets stuck. It is not guaranteed to sample uniformly from the
 space of all possible graphs with the given sequence, but it is relatively
 fast and it will eventually succeed if the provided degree sequence is
 graphical, but there is no upper bound on the number of iterations.
 
-The \dQuote{simple.no.multiple.uniform} method is a variant of
-\dQuote{simple.no.multiple} with the added benefit of sampling uniformly
+The \dQuote{configuration.simple} method (formerly called "simple.no.multiple.uniform")
+is a variant of
+\dQuote{fast.heur.simple} with the added benefit of sampling uniformly
 from the set of all possible simple graphs with the given degree sequence.
 Ensuring uniformity has some performance implications, though.
 
@@ -68,6 +69,9 @@ with the given degree sequence (if this is possible at all). Then some
 rewiring is done to make the graph connected. Finally a Monte-Carlo
 algorithm is used to randomize the graph. The \dQuote{vl} samples from the
 undirected, connected simple graphs uniformly.
+
+The \dQuote{edge.switching.simple} is an MCMC sampler based on
+degree-preserving edge switches. It generates simple undirected or directed graphs.
 }
 \examples{
 

--- a/man/sample_degseq.Rd
+++ b/man/sample_degseq.Rd
@@ -38,37 +38,45 @@ It is often useful to create a graph with given vertex degrees. This function
 creates such a graph in a randomized manner.
 }
 \details{
-The \dQuote{configuration} method (formerly called "simple") connects the out-stubs of the edges (undirected
-graphs) or the out-stubs and in-stubs (directed graphs) together. This way
-loop edges and also multiple edges may be generated. This method is not
-adequate if one needs to generate simple graphs with a given degree
-sequence. The multiple and loop edges can be deleted, but then the degree
-sequence is distorted and there is nothing to ensure that the graphs are
-sampled uniformly.
+The \dQuote{configuration} method (formerly called "simple") implements the
+configuration model. For undirected graphs, it puts all vertex IDs in a bag
+such that the multiplicity of a vertex in the bag is the same as its degree.
+Then it draws pairs from the bag until the bag becomes empty. This method may
+generate both loop (self) edges and multiple edges. For directed graphs,
+the algorithm is basically the same, but two separate bags are used
+for the in- and out-degrees. Undirected graphs are generated
+with probability proportional to \eqn{(\prod_{i<j} A_{ij} ! \prod_i A_{ii} !!)^{-1}},
+where A denotes the adjacency matrix and !! denotes the double factorial.
+Here A is assumed to have twice the number of self-loops on its diagonal.
+The corresponding expression for directed graphs is \eqn{(\prod_{i,j} A_{ij}!)^{-1}}.
+Thus the probability of all simple graphs
+(which only have 0s and 1s in the adjacency matrix)
+is the same, while that of non-simple ones depends on their edge and
+self-loop multiplicities.
 
 The \dQuote{fast.heur.simple} method (formerly called "simple.no.multiple")
-is similar to \dQuote{configuration}, but
-tries to avoid multiple and loop edges and restarts the generation from
-scratch if it gets stuck. It is not guaranteed to sample uniformly from the
-space of all possible graphs with the given sequence, but it is relatively
-fast and it will eventually succeed if the provided degree sequence is
-graphical, but there is no upper bound on the number of iterations.
+generates simple graphs.
+It is similar to \dQuote{configuration} but tries to avoid multiple and
+loop edges and restarts the generation from scratch if it gets stuck.
+It can generate all simple realizations of a degree sequence,
+but it is not guaranteed to sample them uniformly.
+This method is relatively fast and it will eventually succeed
+if the provided degree sequence is graphical, but there is no upper bound on
+the number of iterations.
 
 The \dQuote{configuration.simple} method (formerly called "simple.no.multiple.uniform")
-is a variant of
-\dQuote{fast.heur.simple} with the added benefit of sampling uniformly
-from the set of all possible simple graphs with the given degree sequence.
-Ensuring uniformity has some performance implications, though.
+is
+identical to \dQuote{configuration}, but if the generated graph is not simple,
+it rejects it and re-starts the generation.
+It generates all simple graphs with the same probability.
 
-The \dQuote{vl} method is a more sophisticated generator. The algorithm and
-the implementation was done by Fabien Viger and Matthieu Latapy. This
-generator always generates undirected, connected simple graphs, it is an
-error to pass the \code{in.deg} argument to it.  The algorithm relies on
-first creating an initial (possibly unconnected) simple undirected graph
-with the given degree sequence (if this is possible at all). Then some
-rewiring is done to make the graph connected. Finally a Monte-Carlo
-algorithm is used to randomize the graph. The \dQuote{vl} samples from the
-undirected, connected simple graphs uniformly.
+The \dQuote{vl} method samples undirected connected graphs approximately uniformly.
+It is a Monte Carlo method based on degree-preserving edge switches.
+This generator should be favoured if undirected and connected graphs are to be
+generated and execution time is not a concern. igraph uses
+the original implementation of Fabien Viger; for the algorithm, see
+\url{https://www-complexnetworks.lip6.fr/~latapy/FV/generation.html}
+and the paper \url{https://arxiv.org/abs/cs/0502085}.
 
 The \dQuote{edge.switching.simple} is an MCMC sampler based on
 degree-preserving edge switches. It generates simple undirected or directed graphs.

--- a/tests/testthat/test-games.R
+++ b/tests/testthat/test-games.R
@@ -107,6 +107,16 @@ test_that("sample_degseq() works -- configuration.simple", {
   expect_equal(degree(simple_nmu_graph, mode = "in"), degree(g, mode = "in"))
 })
 
+test_that("sample_degseq() works -- edge.switching.simple", {
+  g <- sample_gnp(1000, 1 / 1000)
+  simple_switch_graph <- sample_degseq(degree(g, mode = "out"),
+    degree(g, mode = "in"),
+    method = "edge.switching.simple"
+  )
+  expect_equal(degree(simple_switch_graph, mode = "out"), degree(g, mode = "out"))
+  expect_equal(degree(simple_switch_graph, mode = "in"), degree(g, mode = "in"))
+})
+
 test_that("sample_degseq supports the sample_(...) syntax", {
   degs <- rep(4, 20)
   g1 <- sample_(degseq(degs))

--- a/tests/testthat/test-games.R
+++ b/tests/testthat/test-games.R
@@ -108,7 +108,7 @@ test_that("sample_degseq() works -- configuration.simple", {
 })
 
 test_that("sample_degseq() works -- edge.switching.simple", {
-  g <- sample_gnp(1000, 1 / 1000)
+  g <- sample_gnp(1000, 1 / 1000, directed = TRUE)
   simple_switch_graph <- sample_degseq(degree(g, mode = "out"),
     degree(g, mode = "in"),
     method = "edge.switching.simple"

--- a/tests/testthat/test-games.R
+++ b/tests/testthat/test-games.R
@@ -107,7 +107,7 @@ test_that("sample_degseq() works -- configuration.simple", {
   expect_equal(degree(simple_nmu_graph, mode = "in"), degree(g, mode = "in"))
 })
 
-test_that("sample_degseq() works -- edge.switching.simple", {
+test_that("sample_degseq() works -- edge.switching.simple directed", {
   g <- sample_gnp(1000, 1 / 1000, directed = TRUE)
   simple_switch_graph <- sample_degseq(degree(g, mode = "out"),
     degree(g, mode = "in"),
@@ -115,6 +115,15 @@ test_that("sample_degseq() works -- edge.switching.simple", {
   )
   expect_equal(degree(simple_switch_graph, mode = "out"), degree(g, mode = "out"))
   expect_equal(degree(simple_switch_graph, mode = "in"), degree(g, mode = "in"))
+})
+
+test_that("sample_degseq() works -- edge.switching.simple undirected", {
+  g <- sample_gnp(1000, 1 / 1000, directed = FALSE)
+  simple_switch_graph <- sample_degseq(
+    degree(g, mode = "all"),
+    method = "edge.switching.simple"
+  )
+  expect_equal(degree(simple_switch_graph, mode = "all"), degree(g, mode = "all"))
 })
 
 test_that("sample_degseq supports the sample_(...) syntax", {

--- a/tests/testthat/test-games.R
+++ b/tests/testthat/test-games.R
@@ -1,6 +1,6 @@
-test_that("sample_degseq() works -- simple generator", {
+test_that("sample_degseq() works -- 'configuration' generator", {
   degrees <- rep(2, 100)
-  undirected_graph <- sample_degseq(degrees)
+  undirected_graph <- sample_degseq(degrees, method = "configuration")
   expect_equal(degree(undirected_graph), degrees)
 
   directed_graph <- sample_degseq(1:10, 10:1)
@@ -10,14 +10,14 @@ test_that("sample_degseq() works -- simple generator", {
 
 test_that("sample_degseq() works -- sample_gnp()", {
   erdos_renyi <- sample_gnp(1000, 1 / 1000)
-  new_graph <- sample_degseq(degree(erdos_renyi), method = "simple")
+  new_graph <- sample_degseq(degree(erdos_renyi), method = "configuration")
   expect_that(degree(new_graph), equals(degree(erdos_renyi)))
 
   directed_erdos_renyi <- sample_gnp(1000, 2 / 1000, directed = TRUE)
   new_directed_graph <- sample_degseq(
     degree(directed_erdos_renyi, mode = "out"),
     degree(directed_erdos_renyi, mode = "in"),
-    method = "simple"
+    method = "configuration"
   )
   expect_equal(
     degree(new_directed_graph, mode = "out"),
@@ -29,11 +29,11 @@ test_that("sample_degseq() works -- sample_gnp()", {
   )
 })
 
-test_that("sample_degseq() works -- simple generator, connected", {
+test_that("sample_degseq() works -- 'configuration' generator, connected", {
 
   original_graph <- largest_component(sample_gnp(1000, 2 / 1000))
 
-  simple_graph <- sample_degseq(degree(original_graph), method = "simple")
+  simple_graph <- sample_degseq(degree(original_graph), method = "configuration")
   expect_equal(degree(simple_graph), degree(original_graph))
 
   vl_graph <- sample_degseq(degree(simple_graph), method = "vl")
@@ -85,23 +85,23 @@ test_that("sample_degseq() works -- Power-law degree error", {
     transform = function(x) sub("\\:[0-9]+", ":<linenumber>", x))
 })
 
-test_that("sample_degseq() works -- simple.no.multiple", {
+test_that("sample_degseq() works -- fast.heur.simple", {
   g <- sample_gnp(1000, 1 / 1000)
 
   simple_nm_graph <- sample_degseq(
     degree(g, mode = "out"),
     degree(g, mode = "in"),
-    method = "simple.no.multiple"
+    method = "fast.heur.simple"
   )
   expect_equal(degree(simple_nm_graph, mode = "out"), degree(g, mode = "out"))
   expect_equal(degree(simple_nm_graph, mode = "in"), degree(g, mode = "in"))
 })
 
-test_that("sample_degseq() works -- simple.no.multiple.uniform", {
+test_that("sample_degseq() works -- configuration.simple", {
   g <- sample_gnp(1000, 1 / 1000)
   simple_nmu_graph <- sample_degseq(degree(g, mode = "out"),
     degree(g, mode = "in"),
-    method = "simple.no.multiple.uniform"
+    method = "configuration.simple"
   )
   expect_equal(degree(simple_nmu_graph, mode = "out"), degree(g, mode = "out"))
   expect_equal(degree(simple_nmu_graph, mode = "in"), degree(g, mode = "in"))


### PR DESCRIPTION
Fix  #876

See @szhorvat, a new feature exposed after all the boring refactoring PRs. :grin: :innocent: Some questions

- where do the numbers corresponding to the method come from? I assumed the new one was 4.
- what could be a better test for the new method?