### PR TITLE
fix: `sample_degseq()` works with old method names again

### DIFF
--- a/R/games.R
+++ b/R/games.R
@@ -921,7 +921,14 @@ random.graph.game <- erdos.renyi.game
 #'
 sample_degseq <- function(out.deg, in.deg = NULL,
                           method = c("configuration", "vl", "fast.heur.simple", "configuration.simple", "edge.switching.simple")) {
-  method <- igraph.match.arg(method)
+  method <- igraph.match.arg(
+    method,
+    values = c(
+      "configuration", "vl", "fast.heur.simple",
+      "configuration.simple", "edge.switching.simple",
+      "simple", "simple.no.multiple", "simple.no.multiple.uniform" # old names
+    )
+  )
 
   if (method == "simple") {
     lifecycle::deprecate_warn("2.0.4", "sample_degseq(method = 'must be configuration instead of simple')")

--- a/R/games.R
+++ b/R/games.R
@@ -921,6 +921,9 @@ random.graph.game <- erdos.renyi.game
 #'
 sample_degseq <- function(out.deg, in.deg = NULL,
                           method = c("configuration", "vl", "fast.heur.simple", "configuration.simple", "edge.switching.simple")) {
+  if (missing(method)) {
+    method <- method[1]
+  }
   method <- igraph.match.arg(
     method,
     values = c(

--- a/tests/testthat/test-games.R
+++ b/tests/testthat/test-games.R
@@ -138,3 +138,23 @@ test_that("sample_degseq supports the sample_(...) syntax", {
 
   expect_false(identical_graphs(g1, g2))
 })
+
+test_that("sample_degseq works() -- old method names", {
+
+  withr::local_options("lifecycle_verbosity" = "warning")
+
+  expect_warning(
+    sample_degseq(c(1, 1, 2, 2, 2), method = "simple"),
+    "must be"
+  )
+
+  expect_warning(
+    sample_degseq(c(1, 1, 2, 2, 2), method = "simple.no.multiple"),
+    "must be"
+  )
+
+  expect_warning(
+    sample_degseq(c(1, 1, 2, 2, 2), method = "simple.no.multiple.uniform"),
+    "must be"
+  )
+})


### PR DESCRIPTION
Fix #1392