### PR TITLE
test: remove expect_that() definition

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -20,12 +20,6 @@ local_rng_version <- function(version, .local_envir = parent.frame()) {
   orig
 }
 
-expect_that <- function(object, condition, info = NULL, label = NULL) {
-  suppressWarnings(
-    condition(object)
-  )
-}
-
 expect_isomorphic <- function(g1, g2) {
   expect_true(graph.isomorphic(g1, g2))
 }


### PR DESCRIPTION
Fix #1331

Not ready yet, it needs a few PRs to be merged first (as `expect_that()` is still used on main, but will be useless after those PRs):

- [x] #1408
- [ ] #1409