### PR TITLE
docs: add slightly tweaked boilerplate CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,8 +34,7 @@ See the tidyverse guide on [how to create a great issue](https://code-review.tid
 
 *  We use [roxygen2](https://cran.r-project.org/package=roxygen2), with [Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html), for documentation.  
 
-*  We use [testthat](https://cran.r-project.org/package=testthat) for unit tests. 
-   Contributions with test cases included are easier to accept.  
+*  We use [testthat](https://cran.r-project.org/package=testthat) for unit tests. Please add test cases for the change you are proposing, or ask us for help.
 
 ### Test files
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,24 +4,29 @@ This outlines how to propose a change to igraph.
 
 ## Fixing typos
 
-You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the _source_ file. 
+You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, 
+as long as the changes are made in the _source_ file. 
 This generally means you'll need to edit [roxygen2 comments](https://roxygen2.r-lib.org/articles/roxygen2.html) in an `.R`, not a `.Rd` file. 
 You can find the `.R` file that generates the `.Rd` by reading the comment in the first line.
 
 ## Bigger changes
 
 If you want to make a bigger change, it's a good idea to first file an issue and make sure someone from the team agrees that it’s needed. 
-If you’ve found a bug, please file an issue that illustrates the bug with a minimal 
-[reprex](https://www.tidyverse.org/help/#reprex) (this will also help you write a unit test, if needed).
+If you’ve found a bug, 
+please file an issue that illustrates the bug with a minimal [reprex](https://www.tidyverse.org/help/#reprex) 
+(this will also help you write a unit test, if needed).
 See the tidyverse guide on [how to create a great issue](https://code-review.tidyverse.org/issues/) for more advice.
 
 ### Pull request process
 
-*   Fork the package and clone onto your computer. If you haven't done this before, you can use `usethis::create_from_github("igraph/rigraph", fork = TRUE)`.
+*   Fork the package and clone onto your computer. 
+    If you haven't done this before, you can use `usethis::create_from_github("igraph/rigraph", fork = TRUE)`.
 
-*   Install all development dependencies with `pak::pak()`, and then make sure the package passes R CMD check by running `devtools::check()`. 
+*   Install all development dependencies with `pak::pak()`, 
+    and then make sure the package passes R CMD check by running `devtools::check()`. 
     If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing. 
-*   Create a Git branch for your pull request (PR). You can use [usethis](https://usethis.r-lib.org/articles/pr-functions.html), GitHub Desktop, etc.
+*   Create a Git branch for your pull request (PR). 
+    You can use [usethis](https://usethis.r-lib.org/articles/pr-functions.html), GitHub Desktop, etc.
 
 *   Make your changes, commit to git, and then create a PR.
     The title of your PR should briefly describe the change.
@@ -32,9 +37,12 @@ See the tidyverse guide on [how to create a great issue](https://code-review.tid
 *   New code should follow the tidyverse [style guide](https://style.tidyverse.org). 
     You can use the [styler](https://CRAN.R-project.org/package=styler) package to apply these styles, but please don't restyle code that has nothing to do with your PR.  
 
-*  We use [roxygen2](https://cran.r-project.org/package=roxygen2), with [Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html), for documentation.  
+*  We use [roxygen2](https://cran.r-project.org/package=roxygen2), 
+   with [Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html), 
+   for documentation.  
 
-*  We use [testthat](https://cran.r-project.org/package=testthat) for unit tests. Please add test cases for the change you are proposing, or ask us for help.
+*  We use [testthat](https://cran.r-project.org/package=testthat) for unit tests. 
+   Please add test cases for the change you are proposing, or ask us for help.
 
 ### Test files
 
@@ -44,6 +52,5 @@ This allows easy toggling between the two files thanks to `usethis::use_test()` 
 
 ## Code of Conduct
 
-Please note that the igraph project is released with a
-[Contributor Code of Conduct](https://igraph.org/code-of-conduct.html). By contributing to this
-project you agree to abide by its terms.
+Please note that the igraph project is released with a [Contributor Code of Conduct](https://igraph.org/code-of-conduct.html). 
+By contributing to this project you agree to abide by its terms.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,3 +42,9 @@ See the tidyverse guide on [how to create a great issue](https://code-review.tid
 We strive to align script and test names. 
 This is still a work-in-progress but the goal is to have code from `R/name.R` tested in `tests/testthat/test-name.R`.
 This allows easy toggling between the two files thanks to `usethis::use_test()` and `usethis::use_r()`.
+
+## Code of Conduct
+
+Please note that the igraph project is released with a
+[Contributor Code of Conduct](https://igraph.org/code-of-conduct.html). By contributing to this
+project you agree to abide by its terms.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to igraph
+
+This outlines how to propose a change to igraph.
+
+## Fixing typos
+
+You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the _source_ file. 
+This generally means you'll need to edit [roxygen2 comments](https://roxygen2.r-lib.org/articles/roxygen2.html) in an `.R`, not a `.Rd` file. 
+You can find the `.R` file that generates the `.Rd` by reading the comment in the first line.
+
+## Bigger changes
+
+If you want to make a bigger change, it's a good idea to first file an issue and make sure someone from the team agrees that it’s needed. 
+If you’ve found a bug, please file an issue that illustrates the bug with a minimal 
+[reprex](https://www.tidyverse.org/help/#reprex) (this will also help you write a unit test, if needed).
+See the tidyverse guide on [how to create a great issue](https://code-review.tidyverse.org/issues/) for more advice.
+
+### Pull request process
+
+*   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("igraph/rigraph", fork = TRUE)`.
+
+*   Install all development dependencies with `pak::pak()`, and then make sure the package passes R CMD check by running `devtools::check()`. 
+    If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing. 
+*   Create a Git branch for your pull request (PR). We recommend using `usethis::pr_init("brief-description-of-change")`.
+
+*   Make your changes, commit to git, and then create a PR by running `usethis::pr_push()`, and following the prompts in your browser.
+    The title of your PR should briefly describe the change.
+    The body of your PR should contain `Fixes #issue-number`.
+
+### Code style
+
+*   New code should follow the tidyverse [style guide](https://style.tidyverse.org). 
+    You can use the [styler](https://CRAN.R-project.org/package=styler) package to apply these styles, but please don't restyle code that has nothing to do with your PR.  
+
+*  We use [roxygen2](https://cran.r-project.org/package=roxygen2), with [Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html), for documentation.  
+
+*  We use [testthat](https://cran.r-project.org/package=testthat) for unit tests. 
+   Contributions with test cases included are easier to accept.  
+

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,13 +17,13 @@ See the tidyverse guide on [how to create a great issue](https://code-review.tid
 
 ### Pull request process
 
-*   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("igraph/rigraph", fork = TRUE)`.
+*   Fork the package and clone onto your computer. If you haven't done this before, you can use `usethis::create_from_github("igraph/rigraph", fork = TRUE)`.
 
 *   Install all development dependencies with `pak::pak()`, and then make sure the package passes R CMD check by running `devtools::check()`. 
     If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing. 
-*   Create a Git branch for your pull request (PR). We recommend using `usethis::pr_init("brief-description-of-change")`.
+*   Create a Git branch for your pull request (PR). You can use [usethis](https://usethis.r-lib.org/articles/pr-functions.html), GitHub Desktop, etc.
 
-*   Make your changes, commit to git, and then create a PR by running `usethis::pr_push()`, and following the prompts in your browser.
+*   Make your changes, commit to git, and then create a PR.
     The title of your PR should briefly describe the change.
     The body of your PR should contain `Fixes #issue-number`.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,3 +37,8 @@ See the tidyverse guide on [how to create a great issue](https://code-review.tid
 *  We use [testthat](https://cran.r-project.org/package=testthat) for unit tests. 
    Contributions with test cases included are easier to accept.  
 
+### Test files
+
+We strive to align script and test names. 
+This is still a work-in-progress but the goal is to have code from `R/name.R` tested in `tests/testthat/test-name.R`.
+This allows easy toggling between the two files thanks to `usethis::use_test()` and `usethis::use_r()`.


### PR DESCRIPTION
Fix #1422

cf https://github.com/igraph/rigraph/pull/1421#issuecomment-2203002998

The `CONTRIBUTING.md` guide is where R developers would expect to find these things, especially as pkgdown will link to the file automatically.