### PR TITLE
fix: fix includig diagonal elements in dense adjacency matrices

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -155,7 +155,7 @@ get.adjedgelist <- function(graph, mode = c("all", "out", "in", "total"), loops 
 ###################################################################
 
 get.adjacency.dense <- function(graph, type = c("both", "upper", "lower"),
-                                attr = NULL, weights = NULL, loops = FALSE, names = TRUE) {
+                                attr = NULL, weights = NULL, loops = c("once", "twice", "ignore"), names = TRUE) {
   ensure_igraph(graph)
 
   type <- igraph.match.arg(type)
@@ -165,13 +165,23 @@ get.adjacency.dense <- function(graph, type = c("both", "upper", "lower"),
     "both" = 2
   )
 
+  if (is.logical(loops)) {
+    loops <- ifelse(loops, "once", "ignore")
+  }
+  loops <- igraph.match.arg(loops)
+  loops <- switch(loops,
+    "ignore" = 0L,
+    "twice" = 1L,
+    "once" = 2L
+  )
+
   if (!is.null(weights)) weights <- as.numeric(weights)
 
   if (is.null(attr)) {
     on.exit(.Call(R_igraph_finalizer))
     res <- .Call(
       R_igraph_get_adjacency, graph, as.numeric(type), weights,
-      as.logical(loops)
+      loops
     )
   } else {
     attr <- as.character(attr)
@@ -348,7 +358,7 @@ as_adjacency_matrix <- function(graph, type = c("both", "upper", "lower"),
   if (sparse) {
     get.adjacency.sparse(graph, type = type, attr = attr, names = names)
   } else {
-    get.adjacency.dense(graph, type = type, attr = attr, weights = NULL, names = names)
+    get.adjacency.dense(graph, type = type, attr = attr, weights = NULL, names = names, loops = "once")
   }
 }
 

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -167,6 +167,10 @@ get.adjacency.dense <- function(graph, type = c("both", "upper", "lower"),
 
   if (is.logical(loops)) {
     loops <- ifelse(loops, "once", "ignore")
+    lifecycle::deprecate_soft(
+      "2.0.4", "get.adjacency.dense(loops = 'must be a character')",
+      details = sprintf("Converting to get.adjacency.dense (loops = '%s')", loops)
+    )
   }
   loops <- igraph.match.arg(loops)
   loops <- switch(loops,

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -4796,7 +4796,7 @@ SEXP R_igraph_get_adjacency(SEXP graph, SEXP ptype, SEXP pweights, SEXP ploops) 
   igraph_t g;
   igraph_matrix_t res;
   igraph_integer_t type=(igraph_integer_t) REAL(ptype)[0];
-  igraph_bool_t loops=LOGICAL(ploops)[0];
+  igraph_loops_t loops = (igraph_loops_t) INTEGER(ploops)[0];
   igraph_vector_t weights;
   SEXP result;
 


### PR DESCRIPTION
Fixes #1429

This does fix the issue reported in #1429, and is ready to go right now in that sense. But you may want to polish it up to prepare the ground for future improvements.  I leave it in your hands @Antonov548 @krlmlr 

You may also want to add some tests (weighted and unweighted undirected case).