### PR TITLE
fix: Align the body of `graph.lattice()` with its replacement `make_lattice()`

### DIFF
--- a/R/make.R
+++ b/R/make.R
@@ -355,8 +355,17 @@ graph.lattice <- function(dimvector = NULL , length = NULL , dim = NULL , nei = 
     periodic <- circular
   }
 
+  if (is.numeric(length) && length != floor(length)) {
+    warning("length was rounded to the nearest integer")
+    length <- round(length)
+  }
+
   if (is.null(dimvector)) {
     dimvector <- rep(length, dim)
+  }
+
+  if (length(periodic) == 1) {
+    periodic <- rep(periodic, length(dimvector))
   }
 
   on.exit(.Call(R_igraph_finalizer))
@@ -366,7 +375,7 @@ graph.lattice <- function(dimvector = NULL , length = NULL , dim = NULL , nei = 
     res$dimvector <- dimvector
     res$nei <- nei
     res$mutual <- mutual
-    res$circular <- circular
+    res$circular <- periodic
   }
   res
 } # nocov end


### PR DESCRIPTION
This is the fix for BCT, at least it fixes the reprex :grin: 

I'm a bit worried about these functions we inlined, looking forward to deprecating the old versions for good so we don't have to backport all changes. :cold_sweat: 

``` r
s <- c("2", "11", "00", "10", "12", "011", "020", "021", "012", "022", 
"0100", "0102", "0101") 
init_g <- igraph::make_empty_graph(n=1)
igraph::V(init_g)$name <-""
g <- init_g
for (word in c(s)) {
   print(word)
    # turns "10100" into c("1","10","101","1010", 10100")
    subwords <- stringr::str_sub(word, 1, 1:nchar(word))
    # make a graph long enough to hold all those sub-words + start node
    subg <- igraph::graph.lattice(length(subwords)+1,directed=TRUE)
    # set vertex nodes to start node plus sub-words
    igraph::V(subg)$name <- c("",subwords)
    # merge *by name* into the existing graph
    g <- igraph::union(g, subg)
 }
#> [1] "2"
#> Warning: `graph.lattice()` was deprecated in igraph 2.0.4.
#> ℹ Please use `make_lattice()` instead.
#> This warning is displayed once every 8 hours.
#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was
#> generated.
#> [1] "11"
#> [1] "00"
#> [1] "10"
#> [1] "12"
#> [1] "011"
#> [1] "020"
#> [1] "021"
#> [1] "012"
#> [1] "022"
#> [1] "0100"
#> [1] "0102"
#> [1] "0101"
```

<sup>Created on 2024-07-19 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>