### PR TITLE
docs: improve cross-links from make_() manual page

### DIFF
--- a/R/make.R
+++ b/R/make.R
@@ -790,8 +790,6 @@ graph.atlas <- function(n) { # nocov start
 #'
 #' @param ... Parameters, see details below.
 #'
-#' @seealso simplified with_edge_ with_graph_ with_vertex_
-#'   without_loops without_multiples
 #' @export
 #' @examples
 #' r <- make_(ring(10))
@@ -803,6 +801,8 @@ graph.atlas <- function(n) { # nocov start
 #' ran <- sample_(degseq(c(3, 3, 3, 3, 3, 3), method = "configuration"), simplified())
 #' degree(ran)
 #' is_simple(ran)
+#' @family deterministic constructors
+#' @family constructor modifiers
 make_ <- function(...) {
   me <- attr(sys.function(), "name") %||% "construct"
   extracted <- .extract_constructor_and_modifiers(..., .operation = me, .variant = "make")

--- a/man/graph_from_atlas.Rd
+++ b/man/graph_from_atlas.Rd
@@ -42,6 +42,7 @@ graph_from_atlas(sample(0:1252, 1))
 Other deterministic constructors: 
 \code{\link{graph_from_edgelist}()},
 \code{\link{graph_from_literal}()},
+\code{\link{make_}()},
 \code{\link{make_chordal_ring}()},
 \code{\link{make_empty_graph}()},
 \code{\link{make_full_citation_graph}()},

--- a/man/graph_from_edgelist.Rd
+++ b/man/graph_from_edgelist.Rd
@@ -38,6 +38,7 @@ graph_from_edgelist(cbind(1:10, c(2:10, 1)))
 Other deterministic constructors: 
 \code{\link{graph_from_atlas}()},
 \code{\link{graph_from_literal}()},
+\code{\link{make_}()},
 \code{\link{make_chordal_ring}()},
 \code{\link{make_empty_graph}()},
 \code{\link{make_full_citation_graph}()},

--- a/man/graph_from_literal.Rd
+++ b/man/graph_from_literal.Rd
@@ -129,6 +129,7 @@ g6
 Other deterministic constructors: 
 \code{\link{graph_from_atlas}()},
 \code{\link{graph_from_edgelist}()},
+\code{\link{make_}()},
 \code{\link{make_chordal_ring}()},
 \code{\link{make_empty_graph}()},
 \code{\link{make_full_citation_graph}()},

--- a/man/make_.Rd
+++ b/man/make_.Rd
@@ -42,6 +42,28 @@ degree(ran)
 is_simple(ran)
 }
 \seealso{
-simplified with_edge_ with_graph_ with_vertex_
-without_loops without_multiples
+Other deterministic constructors: 
+\code{\link{graph_from_atlas}()},
+\code{\link{graph_from_edgelist}()},
+\code{\link{graph_from_literal}()},
+\code{\link{make_chordal_ring}()},
+\code{\link{make_empty_graph}()},
+\code{\link{make_full_citation_graph}()},
+\code{\link{make_full_graph}()},
+\code{\link{make_graph}()},
+\code{\link{make_lattice}()},
+\code{\link{make_ring}()},
+\code{\link{make_star}()},
+\code{\link{make_tree}()}
+
+Constructor modifiers (and related functions)
+\code{\link{simplified}()},
+\code{\link{with_edge_}()},
+\code{\link{with_graph_}()},
+\code{\link{with_vertex_}()},
+\code{\link{without_attr}()},
+\code{\link{without_loops}()},
+\code{\link{without_multiples}()}
 }
+\concept{constructor modifiers}
+\concept{deterministic constructors}

--- a/man/make_chordal_ring.Rd
+++ b/man/make_chordal_ring.Rd
@@ -46,6 +46,7 @@ Other deterministic constructors:
 \code{\link{graph_from_atlas}()},
 \code{\link{graph_from_edgelist}()},
 \code{\link{graph_from_literal}()},
+\code{\link{make_}()},
 \code{\link{make_empty_graph}()},
 \code{\link{make_full_citation_graph}()},
 \code{\link{make_full_graph}()},

--- a/man/make_empty_graph.Rd
+++ b/man/make_empty_graph.Rd
@@ -31,6 +31,7 @@ Other deterministic constructors:
 \code{\link{graph_from_atlas}()},
 \code{\link{graph_from_edgelist}()},
 \code{\link{graph_from_literal}()},
+\code{\link{make_}()},
 \code{\link{make_chordal_ring}()},
 \code{\link{make_full_citation_graph}()},
 \code{\link{make_full_graph}()},

--- a/man/make_full_citation_graph.Rd
+++ b/man/make_full_citation_graph.Rd
@@ -32,6 +32,7 @@ Other deterministic constructors:
 \code{\link{graph_from_atlas}()},
 \code{\link{graph_from_edgelist}()},
 \code{\link{graph_from_literal}()},
+\code{\link{make_}()},
 \code{\link{make_chordal_ring}()},
 \code{\link{make_empty_graph}()},
 \code{\link{make_full_graph}()},

--- a/man/make_full_graph.Rd
+++ b/man/make_full_graph.Rd
@@ -33,6 +33,7 @@ Other deterministic constructors:
 \code{\link{graph_from_atlas}()},
 \code{\link{graph_from_edgelist}()},
 \code{\link{graph_from_literal}()},
+\code{\link{make_}()},
 \code{\link{make_chordal_ring}()},
 \code{\link{make_empty_graph}()},
 \code{\link{make_full_citation_graph}()},

--- a/man/make_graph.Rd
+++ b/man/make_graph.Rd
@@ -197,6 +197,7 @@ Other deterministic constructors:
 \code{\link{graph_from_atlas}()},
 \code{\link{graph_from_edgelist}()},
 \code{\link{graph_from_literal}()},
+\code{\link{make_}()},
 \code{\link{make_chordal_ring}()},
 \code{\link{make_empty_graph}()},
 \code{\link{make_full_citation_graph}()},

--- a/man/make_lattice.Rd
+++ b/man/make_lattice.Rd
@@ -62,6 +62,7 @@ Other deterministic constructors:
 \code{\link{graph_from_atlas}()},
 \code{\link{graph_from_edgelist}()},
 \code{\link{graph_from_literal}()},
+\code{\link{make_}()},
 \code{\link{make_chordal_ring}()},
 \code{\link{make_empty_graph}()},
 \code{\link{make_full_citation_graph}()},

--- a/man/make_ring.Rd
+++ b/man/make_ring.Rd
@@ -39,6 +39,7 @@ Other deterministic constructors:
 \code{\link{graph_from_atlas}()},
 \code{\link{graph_from_edgelist}()},
 \code{\link{graph_from_literal}()},
+\code{\link{make_}()},
 \code{\link{make_chordal_ring}()},
 \code{\link{make_empty_graph}()},
 \code{\link{make_full_citation_graph}()},

--- a/man/make_star.Rd
+++ b/man/make_star.Rd
@@ -38,6 +38,7 @@ Other deterministic constructors:
 \code{\link{graph_from_atlas}()},
 \code{\link{graph_from_edgelist}()},
 \code{\link{graph_from_literal}()},
+\code{\link{make_}()},
 \code{\link{make_chordal_ring}()},
 \code{\link{make_empty_graph}()},
 \code{\link{make_full_citation_graph}()},

--- a/man/make_tree.Rd
+++ b/man/make_tree.Rd
@@ -39,6 +39,7 @@ Other deterministic constructors:
 \code{\link{graph_from_atlas}()},
 \code{\link{graph_from_edgelist}()},
 \code{\link{graph_from_literal}()},
+\code{\link{make_}()},
 \code{\link{make_chordal_ring}()},
 \code{\link{make_empty_graph}()},
 \code{\link{make_full_citation_graph}()},

--- a/man/roxygen/meta.R
+++ b/man/roxygen/meta.R
@@ -12,6 +12,7 @@ list(
     foreign = "Foreign format readers",
     games = "Random graph models (games)",
     scg = "Spectral Coarse Graining",
-    sgm = "Graph matching"
+    sgm = "Graph matching",
+    `constructor modifiers` = "Constructor modifiers (and related functions)"
     )
 )

--- a/man/simplified.Rd
+++ b/man/simplified.Rd
@@ -14,7 +14,8 @@ sample_(pa(10, m = 3, algorithm = "bag"))
 sample_(pa(10, m = 3, algorithm = "bag"), simplified())
 }
 \seealso{
-Other constructor modifiers: 
+Constructor modifiers (and related functions)
+\code{\link{make_}()},
 \code{\link{with_edge_}()},
 \code{\link{with_graph_}()},
 \code{\link{with_vertex_}()},

--- a/man/with_edge_.Rd
+++ b/man/with_edge_.Rd
@@ -23,7 +23,8 @@ make_(
   plot()
 }
 \seealso{
-Other constructor modifiers: 
+Constructor modifiers (and related functions)
+\code{\link{make_}()},
 \code{\link{simplified}()},
 \code{\link{with_graph_}()},
 \code{\link{with_vertex_}()},

--- a/man/with_graph_.Rd
+++ b/man/with_graph_.Rd
@@ -16,7 +16,8 @@ Constructor modifier to add graph attributes
 make_(ring(10), with_graph_(name = "10-ring"))
 }
 \seealso{
-Other constructor modifiers: 
+Constructor modifiers (and related functions)
+\code{\link{make_}()},
 \code{\link{simplified}()},
 \code{\link{with_edge_}()},
 \code{\link{with_vertex_}()},

--- a/man/with_vertex_.Rd
+++ b/man/with_vertex_.Rd
@@ -24,7 +24,8 @@ make_(
   plot()
 }
 \seealso{
-Other constructor modifiers: 
+Constructor modifiers (and related functions)
+\code{\link{make_}()},
 \code{\link{simplified}()},
 \code{\link{with_edge_}()},
 \code{\link{with_graph_}()},

--- a/man/without_attr.Rd
+++ b/man/without_attr.Rd
@@ -17,7 +17,8 @@ g2 <- make_(ring(10), without_attr())
 g2
 }
 \seealso{
-Other constructor modifiers: 
+Constructor modifiers (and related functions)
+\code{\link{make_}()},
 \code{\link{simplified}()},
 \code{\link{with_edge_}()},
 \code{\link{with_graph_}()},

--- a/man/without_loops.Rd
+++ b/man/without_loops.Rd
@@ -15,7 +15,8 @@ make_(full_graph(5, loops = TRUE))
 make_(full_graph(5, loops = TRUE), without_loops())
 }
 \seealso{
-Other constructor modifiers: 
+Constructor modifiers (and related functions)
+\code{\link{make_}()},
 \code{\link{simplified}()},
 \code{\link{with_edge_}()},
 \code{\link{with_graph_}()},

--- a/man/without_multiples.Rd
+++ b/man/without_multiples.Rd
@@ -14,7 +14,8 @@ sample_(pa(10, m = 3, algorithm = "bag"))
 sample_(pa(10, m = 3, algorithm = "bag"), without_multiples())
 }
 \seealso{
-Other constructor modifiers: 
+Constructor modifiers (and related functions)
+\code{\link{make_}()},
 \code{\link{simplified}()},
 \code{\link{with_edge_}()},
 \code{\link{with_graph_}()},


### PR DESCRIPTION
Fix #1417

To me making `make_()` part of both families has no real downside, it'll be easier to maintain the cross-links this way, and the text in the rest of the manual page is clear enough.