### PR TITLE
chore: Update vendored sources to igraph/igraph@1f153e9ca1b7e03ae4387d2500b4ccf4d3bc2703

### DIFF
--- a/src/vendor/cigraph/CHANGELOG.md
+++ b/src/vendor/cigraph/CHANGELOG.md
@@ -31,6 +31,7 @@
  - `igraph_read_graph_pajek()` now warns about duplicate vertex IDs in input files.
  - The documented `igraph_strvector_resize_min()` was missing from headers.
  - `igraph_feedback_arc_set()` now validates the edge weights.
+ - `igraph_layout_lgl()` was not working correctly since igraph 0.10.0 due to a poor choice of initial coordinates. This is now fixed.
 
 ### Deprecated
 

--- a/src/vendor/cigraph/src/layout/large_graph.c
+++ b/src/vendor/cigraph/src/layout/large_graph.c
@@ -187,7 +187,7 @@ igraph_error_t igraph_layout_lgl(const igraph_t *graph, igraph_matrix_t *res,
 
     /* Place the vertices randomly */
     IGRAPH_CHECK(igraph_layout_random(graph, res));
-    igraph_matrix_scale(res, 1e6);
+    igraph_matrix_scale(res, sqrt(area / M_PI));
 
     /* This is the grid for calculating the vertices near to a given vertex */
     IGRAPH_CHECK(igraph_2dgrid_init(&grid, res,
@@ -231,7 +231,13 @@ igraph_error_t igraph_layout_lgl(const igraph_t *graph, igraph_matrix_t *res,
             igraph_integer_t par = VECTOR(parents)[vid];
 
             if (par < 0) {
-                /* this is either the root vertex or an unreachable node */
+                if (par == -1) {
+                    /* this is either the root vertex ... */
+                    MATRIX(*res, vid, 0) = 0;
+                    MATRIX(*res, vid, 1) = 0;
+                } else {
+                    /* ... or an unreachable node */
+                }
                 continue;
             }
 

--- a/src/vendor/igraph_version.h
+++ b/src/vendor/igraph_version.h
@@ -28,11 +28,11 @@
 
 __BEGIN_DECLS
 
-#define IGRAPH_VERSION "0.10.13-119-gfd54b8d8e"
+#define IGRAPH_VERSION "0.10.13-120-g1f153e9ca"
 #define IGRAPH_VERSION_MAJOR 0
 #define IGRAPH_VERSION_MINOR 10
 #define IGRAPH_VERSION_PATCH 13
-#define IGRAPH_VERSION_PRERELEASE "119-gfd54b8d8e"
+#define IGRAPH_VERSION_PRERELEASE "120-g1f153e9ca"
 
 IGRAPH_EXPORT void igraph_version(const char **version_string,
                                   int *major,


### PR DESCRIPTION
This is to bring the fix https://github.com/igraph/igraph/issues/2676 to R.

CC @maelle 

I'm going ahead with adding the mergequeue label, as this is a single fix that shouldn't break packages if the introduction of the bug in R/igraph 2.0 didn't. Let me know if you prefer I don't do this in the future @krlmlr.