### PR TITLE
refactor: remove for loops from weighted dense matrix creation (#1483)

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -845,15 +845,14 @@ get.incidence.dense <- function(graph, types, names, attr) {
     recode[!types] <- seq_len(n1)
     recode[types] <- seq_len(n2)
 
-    for (i in seq(length.out = ecount(graph))) {
-      eo <- ends(graph, i, names = FALSE)
-      e <- recode[eo]
-      if (!types[eo[1]]) {
-        res[e[1], e[2]] <- edge_attr(graph, attr, i)
-      } else {
-        res[e[2], e[1]] <- edge_attr(graph, attr, i)
-      }
-    }
+    el <- as_edgelist(graph, names = FALSE)
+    idx <- types[el[, 1]]
+    el[, 1] <- recode[el[, 1]]
+    el[, 2] <- recode[el[, 2]]
+
+    tmp <- el[idx, 2:1]
+    el[idx, ] <- tmp
+    res[el] <- edge_attr(graph, attr)
 
     if (names && "name" %in% vertex_attr_names(graph)) {
       rownames(res) <- V(graph)$name[which(!types)]

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -187,6 +187,7 @@ get.adjacency.dense <- function(graph, type = c("both", "upper", "lower"),
       loops
     )
   } else {
+    # faster than a specialized implementation
     res <- as.matrix(get.adjacency.sparse(graph, type = type, attr = attr, names = names))
   }
 

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -334,7 +334,6 @@ as_adjacency_matrix <- function(graph, type = c("both", "upper", "lower"),
 as_adj <- function(graph, type = c("both", "upper", "lower"),
                    attr = NULL, edges = deprecated(), names = TRUE,
                    sparse = igraph_opt("sparsematrices")) {
-
   lifecycle::deprecate_soft("2.1.0", "as_adj()", "as_adjacency_matrix()")
 
   as_adjacency_matrix(
@@ -843,16 +842,21 @@ get.incidence.dense <- function(graph, types, names, attr) {
     res <- matrix(0, n1, n2)
 
     recode <- numeric(vc)
+    # move from 1..n indexing to 1..n1 row indices for type == FALSE
+    # and 1..n2 col indices for type == TRUE
+    # recode holds the mapping [1..n] -> [1..n1,1..n2]
     recode[!types] <- seq_len(n1)
     recode[types] <- seq_len(n2)
 
     el <- as_edgelist(graph, names = FALSE)
     idx <- types[el[, 1]]
-    el[, 1] <- recode[el[, 1]]
-    el[, 2] <- recode[el[, 2]]
+    el[] <- recode[el]
 
-    tmp <- el[idx, 2:1]
-    el[idx, ] <- tmp
+    # switch order of source/target such that nodes with
+    # type == FALSE are in el[ ,1]
+    el[idx, ] <- el[idx, 2:1]
+    # el[ ,1] only holds values 1..n1 and el[ ,2] values 1..n2
+    # and we can populate the matrix
     res[el] <- edge_attr(graph, attr)
 
     if (names && "name" %in% vertex_attr_names(graph)) {

--- a/R/incidence.R
+++ b/R/incidence.R
@@ -44,11 +44,11 @@ graph.incidence.sparse <- function(incidence, directed, mode, multiple,
   el[, 2] <- el[, 2] + n1
 
   if (!is.null(weighted)) {
-    if (!directed || mode == 1) {
+    if (!directed || mode == "out") {
       ## nothing do to
-    } else if (mode == 2) {
+    } else if (mode == "in") {
       el[, 1:2] <- el[, c(2, 1)]
-    } else if (mode == 3) {
+    } else if (mode %in% c("all", "total")) {
       reversed_el <- el[, c(2, 1, 3)]
       names(reversed_el) <- names(el)
       el <- rbind(el, reversed_el)
@@ -66,11 +66,11 @@ graph.incidence.sparse <- function(incidence, directed, mode, multiple,
       el[, 3] <- el[, 3] != 0
     }
 
-    if (!directed || mode == 1) {
+    if (!directed || mode == "out") {
       ## nothing do to
-    } else if (mode == 2) {
+    } else if (mode == "in") {
       el[, 1:2] <- el[, c(2, 1)]
-    } else if (mode == 3) {
+    } else if (mode %in% c("all", "total")) {
       el <- rbind(el, el[, c(2, 1, 3)])
     }
 
@@ -96,11 +96,11 @@ graph.incidence.dense <- function(incidence, directed, mode, multiple,
     # move from separate row/col indexing to 1..n1+n2 indexing
     el[, 2] <- el[, 2] + n1
 
-    if (!directed || mode == 1) {
+    if (!directed || mode == "out") {
       ## nothing do to
-    } else if (mode == 2) {
+    } else if (mode == "in") {
       el[, 1:2] <- el[, c(2, 1)]
-    } else if (mode == 3) {
+    } else if (mode %in% c("all", "total")) {
       reversed_el <- el[, c(2, 1, 3)]
       names(reversed_el) <- names(el)
       el <- rbind(el, reversed_el)
@@ -115,6 +115,12 @@ graph.incidence.dense <- function(incidence, directed, mode, multiple,
     mode(incidence) <- "double"
     on.exit(.Call(R_igraph_finalizer))
     ## Function call
+    mode <- switch(mode,
+      "out" = 1,
+      "in" = 2,
+      "all" = 3,
+      "total" = 3
+    )
     res <- .Call(R_igraph_biadjacency, incidence, directed, mode, multiple)
     res <- set_vertex_attr(res$graph, "type", value = res$types)
   }
@@ -191,12 +197,8 @@ graph_from_biadjacency_matrix <- function(incidence, directed = FALSE,
                                           add.names = NULL) {
   # Argument checks
   directed <- as.logical(directed)
-  mode <- switch(igraph.match.arg(mode),
-    "out" = 1,
-    "in" = 2,
-    "all" = 3,
-    "total" = 3
-  )
+  mode <- igraph.match.arg(mode)
+
   multiple <- as.logical(multiple)
 
   if (!is.null(weighted)) {

--- a/R/incidence.R
+++ b/R/incidence.R
@@ -44,7 +44,6 @@ graph.incidence.sparse <- function(incidence, directed, mode, multiple,
   el[, 2] <- el[, 2] + n1
 
   if (!is.null(weighted)) {
-
     if (!directed || mode == 1) {
       ## nothing do to
     } else if (mode == 2) {
@@ -85,13 +84,16 @@ graph.incidence.sparse <- function(incidence, directed, mode, multiple,
 graph.incidence.dense <- function(incidence, directed, mode, multiple,
                                   weighted) {
   if (!is.null(weighted)) {
-
     n1 <- nrow(incidence)
     n2 <- ncol(incidence)
 
+    # create an edgelist from the nonzero entries of the
+    # incidence matrix
     idx <- which(incidence != 0, arr.ind = TRUE)
+    # add the value of the matrix. So a row is [s,t,incidence[s,t]]
     el <- cbind(idx, incidence[idx])
 
+    # move from separate row/col indexing to 1..n1+n2 indexing
     el[, 2] <- el[, 2] + n1
 
     if (!directed || mode == 1) {
@@ -199,7 +201,6 @@ graph_from_biadjacency_matrix <- function(incidence, directed = FALSE,
 
   if (!is.null(weighted)) {
     if (is.logical(weighted) && weighted) {
-
       if (multiple) {
         cli::cli_abort(c(
           "{.arg multiple} and {.arg weighted} cannot be both {.code TRUE}.",


### PR DESCRIPTION
This PR removes (nested) for loops for dense weighted matrices. Specifically:

- `get.adjacency.dense` when `attr != NULL`
- `graph.incidence.dense` when `weighted = TRUE`
- `get.incidence.dense` when `attr != NULL`