### PR TITLE
fix: preserve `as.undirected()` signature thanks to @jhollway

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -1253,7 +1253,9 @@ as.directed <- function(graph, mode = c("mutual", "arbitrary", "random", "acycli
 #' @inheritParams as_undirected
 #' @keywords internal
 #' @export
-as.undirected <- function(graph, mode = c("collapse", "each", "mutual")) {
+as.undirected <- function(graph,
+                          mode = c("collapse", "each", "mutual"),
+                          edge.attr.comb = igraph_opt("edge.attr.comb")) {
   lifecycle::deprecate_soft("2.1.0", "as.undirected()", "as_undirected()")
-  as_undirected(graph = graph, mode = mode)
+  as_undirected(graph = graph, mode = mode, edge.attr.comb = edge.attr.comb)
 }

--- a/man/as.undirected.Rd
+++ b/man/as.undirected.Rd
@@ -4,7 +4,11 @@
 \alias{as.undirected}
 \title{Convert between undirected and unundirected graphs}
 \usage{
-as.undirected(graph, mode = c("collapse", "each", "mutual"))
+as.undirected(
+  graph,
+  mode = c("collapse", "each", "mutual"),
+  edge.attr.comb = igraph_opt("edge.attr.comb")
+)
 }
 \arguments{
 \item{graph}{The graph to convert.}
@@ -13,6 +17,12 @@ as.undirected(graph, mode = c("collapse", "each", "mutual"))
 \code{as_directed()} it can be \code{mutual} or \code{arbitrary}. For
 \code{as_undirected()} it can be \code{each}, \code{collapse} or
 \code{mutual}. See details below.}
+
+\item{edge.attr.comb}{Specifies what to do with edge attributes, if
+\code{mode="collapse"} or \code{mode="mutual"}.  In these cases many edges
+might be mapped to a single one in the new graph, and their attributes are
+combined. Please see \code{\link[=attribute.combination]{attribute.combination()}} for details on
+this.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}


### PR DESCRIPTION
Fix #1535