### PR TITLE
feat: Add `p.value` and `p.precision` arguments to `fit_power_law()` to control the computation of the p-value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,6 @@ igraph.Rcheck/
 inst/doc
 cran
 /CRAN-SUBMISSION
-docs
+/docs
+/compile_commands.json
+/.cache

--- a/R/fit.R
+++ b/R/fit.R
@@ -93,7 +93,12 @@ power.law.fit <- function(x, xmin = NULL, start = 2, force.continuous = FALSE, i
 #'   sample vector contains integer values only (by chance). If this argument is
 #'   false, igraph will assume a continuous distribution if at least one sample
 #'   is non-integer and assume a discrete distribution otherwise.
-#' @param p.precision The desired precision of the p-value calculation. The
+#' @param p.value `r lifecycle::badge("experimental")`
+#'
+#'   Set to `TRUE` to compute the p-value with `implementation = "plfit"`.
+#' @param p.precision `r lifecycle::badge("experimental")`
+#'
+#'   The desired precision of the p-value calculation. The
 #'   precision ultimately depends on the number of resampling attempts. The
 #'   number of resampling trials is determined by 0.25 divided by the square
 #'   of the required precision. For instance, a required precision of 0.01

--- a/R/fit.R
+++ b/R/fit.R
@@ -94,6 +94,11 @@ power.law.fit <- function(x, xmin = NULL, start = 2, force.continuous = FALSE, i
 #'   sample vector contains integer values only (by chance). If this argument is
 #'   false, igraph will assume a continuous distribution if at least one sample
 #'   is non-integer and assume a discrete distribution otherwise.
+#' @param p.precision The desired precision of the p-value calculation. The
+#'   precision ultimately depends on the number of resampling attempts. The
+#'   number of resampling trials is determined by 0.25 divided by the square
+#'   of the required precision. For instance, a required precision of 0.01
+#'   means that 2500 samples will be drawn.
 #' @param implementation Character scalar. Which implementation to use. See
 #'   details below.
 #' @param \dots Additional arguments, passed to the maximum likelihood
@@ -150,6 +155,7 @@ fit_power_law <- function(
     xmin = NULL,
     start = 2,
     force.continuous = FALSE,
+    p.precision = 0.01,
     implementation = c("plfit", "R.mle", "plfit.p"),
     ...) {
   implementation <- igraph.match.arg(implementation)
@@ -162,7 +168,8 @@ fit_power_law <- function(
       x,
       xmin = xmin,
       force.continuous = force.continuous,
-      p.value = (implementation == "plfit.p")
+      p.value = (implementation == "plfit.p"),
+      p.precision = p.precision
     )
   }
 }
@@ -202,7 +209,7 @@ power.law.fit.old <- function(x, xmin = NULL, start = 2, ...) {
   alpha
 }
 
-power.law.fit.new <- function(data, xmin = -1, force.continuous = FALSE, p.value = FALSE) {
+power.law.fit.new <- function(data, xmin = -1, force.continuous = FALSE, p.value = FALSE, p.precision = 0.01) {
   # Argument checks
   data <- as.numeric(data)
   xmin <- as.numeric(xmin)
@@ -210,7 +217,7 @@ power.law.fit.new <- function(data, xmin = -1, force.continuous = FALSE, p.value
 
   on.exit(.Call(R_igraph_finalizer))
   # Function call
-  res <- .Call(R_igraph_power_law_fit_new, data, xmin, force.continuous, p.value)
+  res <- .Call(R_igraph_power_law_fit_new, data, xmin, force.continuous, p.value, p.precision)
 
   res
 }

--- a/man/fit_power_law.Rd
+++ b/man/fit_power_law.Rd
@@ -40,7 +40,13 @@ is non-integer and assume a discrete distribution otherwise.}
 \item{implementation}{Character scalar. Which implementation to use. See
 details below.}
 
-\item{p.precision}{The desired precision of the p-value calculation. The
+\item{p.value}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
+Set to \code{TRUE} to compute the p-value with \code{implementation = "plfit"}.}
+
+\item{p.precision}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
+
+The desired precision of the p-value calculation. The
 precision ultimately depends on the number of resampling attempts. The
 number of resampling trials is determined by 0.25 divided by the square
 of the required precision. For instance, a required precision of 0.01

--- a/man/fit_power_law.Rd
+++ b/man/fit_power_law.Rd
@@ -9,8 +9,9 @@ fit_power_law(
   xmin = NULL,
   start = 2,
   force.continuous = FALSE,
-  p.precision = 0.01,
-  implementation = c("plfit", "R.mle", "plfit.p"),
+  implementation = c("plfit", "R.mle"),
+  p.value = FALSE,
+  p.precision = NULL,
   ...
 )
 }
@@ -36,14 +37,14 @@ sample vector contains integer values only (by chance). If this argument is
 false, igraph will assume a continuous distribution if at least one sample
 is non-integer and assume a discrete distribution otherwise.}
 
+\item{implementation}{Character scalar. Which implementation to use. See
+details below.}
+
 \item{p.precision}{The desired precision of the p-value calculation. The
 precision ultimately depends on the number of resampling attempts. The
 number of resampling trials is determined by 0.25 divided by the square
 of the required precision. For instance, a required precision of 0.01
 means that 2500 samples will be drawn.}
-
-\item{implementation}{Character scalar. Which implementation to use. See
-details below.}
 
 \item{\dots}{Additional arguments, passed to the maximum likelihood
 optimizing function, \code{\link[stats4:mle]{stats4::mle()}}, if the \sQuote{\code{R.mle}}
@@ -56,7 +57,7 @@ Depends on the \code{implementation} argument. If it is
 be used to calculate confidence intervals and log-likelihood. See
 \code{\link[stats4:mle-class]{stats4::mle-class()}} for details.
 
-If \code{implementation} is \sQuote{\code{plfit}} or \sQuote{\code{plfit.p}}, then the result is a
+If \code{implementation} is \sQuote{\code{plfit}}, then the result is a
 named list with entries:
 \item{continuous}{Logical scalar, whether the
 fitted power-law distribution was continuous or discrete.}
@@ -68,7 +69,7 @@ than \code{xmin} were used from the input vector.}
 \item{KS.stat}{Numeric scalar, the test statistic of a Kolmogorov-Smirnov test
 that compares the fitted distribution with the input vector.
 Smaller scores denote better fit.}
-\item{KS.p}{Only for \code{plfit.p}. Numeric scalar, the p-value of the Kolmogorov-Smirnov
+\item{KS.p}{Only for \code{p.value = TRUE}. Numeric scalar, the p-value of the Kolmogorov-Smirnov
 test. Small p-values (less than 0.05) indicate that the test rejected the
 hypothesis that the original data could have been drawn from the fitted
 power-law distribution.}
@@ -105,8 +106,7 @@ parameters of the fitted distribution. See references below for the details.
 
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 
-Pass \sQuote{\code{plfit.p}} instead of \sQuote{\code{plfit}} as the \code{implementation}
-argument to include the p-value in the output.
+Pass \code{p.value = TRUE} to include the p-value in the output.
 This is not returned by default because the computation may be slow.
 }
 \examples{

--- a/man/fit_power_law.Rd
+++ b/man/fit_power_law.Rd
@@ -9,6 +9,7 @@ fit_power_law(
   xmin = NULL,
   start = 2,
   force.continuous = FALSE,
+  p.precision = 0.01,
   implementation = c("plfit", "R.mle", "plfit.p"),
   ...
 )
@@ -34,6 +35,12 @@ distribution for the \sQuote{\code{plfit}} implementation, even if the
 sample vector contains integer values only (by chance). If this argument is
 false, igraph will assume a continuous distribution if at least one sample
 is non-integer and assume a discrete distribution otherwise.}
+
+\item{p.precision}{The desired precision of the p-value calculation. The
+precision ultimately depends on the number of resampling attempts. The
+number of resampling trials is determined by 0.25 divided by the square
+of the required precision. For instance, a required precision of 0.01
+means that 2500 samples will be drawn.}
 
 \item{implementation}{Character scalar. Which implementation to use. See
 details below.}

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -355,7 +355,7 @@ extern SEXP R_igraph_path_length_hist(SEXP, SEXP);
 extern SEXP R_igraph_permute_vertices(SEXP, SEXP);
 extern SEXP R_igraph_personalized_pagerank(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_igraph_personalized_pagerank_vs(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-extern SEXP R_igraph_power_law_fit_new(SEXP, SEXP, SEXP, SEXP);
+extern SEXP R_igraph_power_law_fit_new(SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_igraph_preference_game(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_igraph_pseudo_diameter(SEXP, SEXP, SEXP, SEXP);
 extern SEXP R_igraph_pseudo_diameter_dijkstra(SEXP, SEXP, SEXP, SEXP, SEXP);
@@ -808,7 +808,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"R_igraph_permute_vertices",                           (DL_FUNC) &R_igraph_permute_vertices,                            2},
     {"R_igraph_personalized_pagerank",                      (DL_FUNC) &R_igraph_personalized_pagerank,                       8},
     {"R_igraph_personalized_pagerank_vs",                   (DL_FUNC) &R_igraph_personalized_pagerank_vs,                    8},
-    {"R_igraph_power_law_fit_new",                          (DL_FUNC) &R_igraph_power_law_fit_new,                           4},
+    {"R_igraph_power_law_fit_new",                          (DL_FUNC) &R_igraph_power_law_fit_new,                           5},
     {"R_igraph_preference_game",                            (DL_FUNC) &R_igraph_preference_game,                             7},
     {"R_igraph_pseudo_diameter",                            (DL_FUNC) &R_igraph_pseudo_diameter,                             4},
     {"R_igraph_pseudo_diameter_dijkstra",                   (DL_FUNC) &R_igraph_pseudo_diameter_dijkstra,                    5},

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -8331,11 +8331,11 @@ SEXP R_igraph_incident_edges(SEXP pgraph, SEXP pe, SEXP pmode) {
   return result;
 }
 
-SEXP R_igraph_power_law_fit_new(SEXP data, SEXP xmin, SEXP force_continuous, SEXP compute_pvalue)
+SEXP R_igraph_power_law_fit_new(SEXP data, SEXP xmin, SEXP force_continuous, SEXP compute_pvalue, SEXP precision)
 {
   igraph_vector_t c_data;
   igraph_plfit_result_t c_res;
-  igraph_real_t c_xmin;
+  igraph_real_t c_xmin, c_precision;
   igraph_bool_t c_force_continuous, c_compute_pvalue;
   SEXP result, names;
 
@@ -8348,13 +8348,15 @@ SEXP R_igraph_power_law_fit_new(SEXP data, SEXP xmin, SEXP force_continuous, SEX
   c_force_continuous = LOGICAL(force_continuous)[0];
   IGRAPH_R_CHECK_BOOL(compute_pvalue);
   c_compute_pvalue = LOGICAL(compute_pvalue)[0];
+  IGRAPH_R_CHECK_REAL(precision);
+  c_precision = REAL(precision)[0];
 
   // Can't use the generated `R_igraph_power_law_fit()` because we need `c_res` to compute the p-value
   IGRAPH_R_CHECK(igraph_power_law_fit(&c_data, &c_res, c_xmin, c_force_continuous));
 
   if (c_compute_pvalue) {
     igraph_real_t p;
-    igraph_plfit_result_calculate_p_value(&c_res, &p, 0.001);
+    IGRAPH_R_CHECK(igraph_plfit_result_calculate_p_value(&c_res, &p, c_precision));
 
     PROTECT(result=NEW_LIST(6));
     PROTECT(names=NEW_CHARACTER(6));

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -24,5 +24,5 @@ test_that("fit_power_law() works", {
   fit <- fit_power_law(d, p.value = TRUE)
 
   expect_equal(fit[names(fit) != "KS.p"], expected)
-  expect_equal(fit$KS.p, expected_p)
+  expect_equal(fit$KS.p, expected_p, tolerance = 1e-2)
 })

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -1,0 +1,28 @@
+test_that("fit_power_law() works", {
+  # g <- sample_pa(100) # increase this number to have a better estimate
+  # d <- degree(g, mode = "in")
+  d <- c(
+    9, 3, 8, 1, 10, 4, 8, 0, 4, 4, 5, 2, 2, 7, 2, 0, 0, 0, 1, 0, 5, 0, 1, 2, 0, 0,
+    1, 3, 0, 1, 1, 0, 0, 0, 0, 2, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 0,
+    0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0
+  )
+
+  expected <- list(
+    continuous = FALSE,
+    alpha = 1.9113310272735056,
+    xmin = 1,
+    logLik = -65.06453615610745,
+    KS.stat = 0.07720553650317852
+  )
+  fit <- fit_power_law(d)
+
+  expect_equal(fit, expected)
+
+  set.seed(20241017)
+  expected_p <- 0.2308
+  fit <- fit_power_law(d, p.value = TRUE)
+
+  expect_equal(fit[names(fit) != "KS.p"], expected)
+  expect_equal(fit$KS.p, expected_p)
+})


### PR DESCRIPTION
…led in `fit_power_law()` with the plfit method


This PR is to help make quicker progress on #1158. It is not finished: a decision must be made on the interface of requesting a p-value calculation. Please see https://github.com/igraph/rigraph/issues/1158#issuecomment-2393117859

Can someone please take this over from here?