### PR TITLE
Prepare for libxml2 depending on bcrypt, use pkg-config.

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -5,14 +5,21 @@ LIB_XML ?= $(R_TOOLS_SOFT)
 GLPK_HOME ?= $(R_TOOLS_SOFT)
 LIB_GMP ?= $(R_TOOLS_SOFT)
 
-PKG_CPPFLAGS = -I"${LIB_XML}/include/libxml2" -I"${LIB_XML}/include" -DLIBXML_STATIC -DUSING_R -I. -Ivendor -Ivendor/cigraph/src -Ivendor/cigraph/include -Ivendor/cigraph/vendor -Ivendor/io/parsers -Ivendor/mini-gmp \
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+    PKG_CPPFLAGS = -I"${LIB_XML}/include/libxml2" -I"${LIB_XML}/include" -DLIBXML_STATIC
+    PKG_LIBS = -L"${LIB_XML}/lib" -lxml2 -liconv -lz -lws2_32 -lstdc++ -lglpk -llzma -lbcrypt
+else
+    PKG_CPPFLAGS = $(shell pkg-config --cflags libxml-2.0 glpk)
+    PKG_LIBS = $(shell pkg-config --libs libxml-2.0 glpk)
+endif
+
+PKG_CPPFLAGS += -DUSING_R -I. -Ivendor -Ivendor/cigraph/src -Ivendor/cigraph/include -Ivendor/cigraph/vendor -Ivendor/io/parsers -Ivendor/mini-gmp \
     -DNDEBUG -DNTIMER -DNPRINT -DIGRAPH_THREAD_LOCAL= \
     -DPRPACK_IGRAPH_SUPPORT \
     -DHAVE_GFORTRAN=1 \
     -D_GNU_SOURCE=1 \
     -DHAVE_LIBXML
 
-PKG_LIBS = -L"${LIB_XML}/lib" -lxml2 -liconv -lz -lws2_32 -lstdc++ \
-  -lglpk $(BLAS_LIBS) $(LAPACK_LIBS) $(FLIBS) -llzma
+PKG_LIBS += $(BLAS_LIBS) $(LAPACK_LIBS) $(FLIBS)
 
 OBJECTS=${SOURCES} ${MINIGMPSOURCES}


### PR DESCRIPTION
Some upcoming version of Rtools will ship with libxml2 which will depend on bcrypt. This patch updates linking on Windows for that. Also, the patch conditionally uses pkg-config (when available, which it is in current version of Rtools) to establish the dependencies so that such upgrades in the future should not require changes in the package.