### PR TITLE
fix: fix the incorrect handling of the `sample` parameter in `sample_motifs()` and ensure that the default `sample.size` is integer

### DIFF
--- a/R/motifs.R
+++ b/R/motifs.R
@@ -201,6 +201,7 @@ count_motifs <- function(graph, size = 3, cut.prob = rep(0, size)) {
 #'   of the motif (the `size` argument). By default no cuts are made.
 #' @param sample.size The number of vertices to use as a starting point for
 #'   finding motifs. Only used if the `sample` argument is `NULL`.
+#'   The default is `ceiling(vcount(graph) / 10)` .
 #' @param sample If not `NULL` then it specifies the vertices to use as a
 #'   starting point for finding motifs.
 #' @return A numeric scalar, an estimate for the total number of motifs in
@@ -215,8 +216,13 @@ count_motifs <- function(graph, size = 3, cut.prob = rep(0, size)) {
 #' motifs(g, 3)
 #' count_motifs(g, 3)
 #' sample_motifs(g, 3)
-sample_motifs <- function(graph, size = 3, cut.prob = rep(0, size),
-                          sample.size = ceiling(vcount(graph) / 10), sample = NULL) {
+sample_motifs <- function(
+  graph,
+  size = 3,
+  cut.prob = rep(0, size),
+  sample.size = NULL,
+  sample = NULL
+) {
   ensure_igraph(graph)
   cut.prob <- as.numeric(cut.prob)
   if (length(cut.prob) != size) {
@@ -226,8 +232,13 @@ sample_motifs <- function(graph, size = 3, cut.prob = rep(0, size),
     )
   }
 
-  if (!is.null(sample)) {
+  if (is.null(sample)) {
+    if (is.null(sample.size)) {
+       sample.size <- ceiling(vcount(graph) / 10)
+    }
+  } else {
     sample <- as_igraph_vs(graph, sample) - 1
+    sample.size <- 0
   }
 
   on.exit(.Call(R_igraph_finalizer))

--- a/R/motifs.R
+++ b/R/motifs.R
@@ -216,7 +216,7 @@ count_motifs <- function(graph, size = 3, cut.prob = rep(0, size)) {
 #' count_motifs(g, 3)
 #' sample_motifs(g, 3)
 sample_motifs <- function(graph, size = 3, cut.prob = rep(0, size),
-                          sample.size = vcount(graph) / 10, sample = NULL) {
+                          sample.size = ceiling(vcount(graph) / 10), sample = NULL) {
   ensure_igraph(graph)
   cut.prob <- as.numeric(cut.prob)
   if (length(cut.prob) != size) {
@@ -226,10 +226,14 @@ sample_motifs <- function(graph, size = 3, cut.prob = rep(0, size),
     )
   }
 
+  if (!is.null(sample)) {
+    sample <- as_igraph_vs(graph, sample) - 1
+  }
+
   on.exit(.Call(R_igraph_finalizer))
   .Call(
     R_igraph_motifs_randesu_estimate, graph, as.numeric(size),
-    as.numeric(cut.prob), as.numeric(sample.size), as.numeric(sample)
+    as.numeric(cut.prob), as.numeric(sample.size), sample
   )
 }
 

--- a/man/graph.motifs.est.Rd
+++ b/man/graph.motifs.est.Rd
@@ -23,7 +23,8 @@ graph is cut at a certain level. Its length should be the same as the size
 of the motif (the \code{size} argument). By default no cuts are made.}
 
 \item{sample.size}{The number of vertices to use as a starting point for
-finding motifs. Only used if the \code{sample} argument is \code{NULL}.}
+finding motifs. Only used if the \code{sample} argument is \code{NULL}.
+The default is \code{ceiling(vcount(graph) / 10)} .}
 
 \item{sample}{If not \code{NULL} then it specifies the vertices to use as a
 starting point for finding motifs.}

--- a/man/sample_motifs.Rd
+++ b/man/sample_motifs.Rd
@@ -8,7 +8,7 @@ sample_motifs(
   graph,
   size = 3,
   cut.prob = rep(0, size),
-  sample.size = ceiling(vcount(graph)/10),
+  sample.size = NULL,
   sample = NULL
 )
 }
@@ -23,7 +23,8 @@ graph is cut at a certain level. Its length should be the same as the size
 of the motif (the \code{size} argument). By default no cuts are made.}
 
 \item{sample.size}{The number of vertices to use as a starting point for
-finding motifs. Only used if the \code{sample} argument is \code{NULL}.}
+finding motifs. Only used if the \code{sample} argument is \code{NULL}.
+The default is \code{ceiling(vcount(graph) / 10)} .}
 
 \item{sample}{If not \code{NULL} then it specifies the vertices to use as a
 starting point for finding motifs.}

--- a/man/sample_motifs.Rd
+++ b/man/sample_motifs.Rd
@@ -8,7 +8,7 @@ sample_motifs(
   graph,
   size = 3,
   cut.prob = rep(0, size),
-  sample.size = vcount(graph)/10,
+  sample.size = ceiling(vcount(graph)/10),
   sample = NULL
 )
 }

--- a/tests/testthat/test-motifs.R
+++ b/tests/testthat/test-motifs.R
@@ -51,12 +51,12 @@ test_that("sample_motifs works", {
   g <- make_graph(~ A-B-C-A-D-E-F-D-C-F)
   n <- vcount(g)
 
-  mc <- sample_motifs(g)
-  expect_true(0 <= mc && mc <= n*(n-1)*(n-2) / 6)
+  motif_count <- sample_motifs(g)
+  expect_true(0 <= motif_count && motif_count <= n*(n-1)*(n-2) / 6)
 
-  mc <- sample_motifs(g, sample = c("C", "D", "E", "F"))
-  expect_true(0 <= mc && mc <= n*(n-1)*(n-2) / 6)
+  motif_count_letters <- sample_motifs(g, sample = c("C", "D", "E", "F"))
+  expect_true(0 <= motif_count_letters && motif_count_letters <= n*(n-1)*(n-2) / 6)
 
-  mc <- sample_motifs(g, sample = V(g))
-  expect_true(0 <= mc && mc <= n*(n-1)*(n-2) / 6)
+  motif_count_all <- sample_motifs(g, sample = V(g))
+  expect_true(0 <= motif_count_all && motif_count_all <= n*(n-1)*(n-2) / 6)
 })

--- a/tests/testthat/test-motifs.R
+++ b/tests/testthat/test-motifs.R
@@ -44,3 +44,19 @@ test_that("motif finding works", {
 
   expect_equal(m5 / m, c(NA, NA, 0.439985332979302, NA, 0.440288166730411, 0.346938775510204, 0.44159753136382, 0.452054794520548, NaN, 0.323076923076923, NaN, 0.347826086956522, NaN, NaN, NaN, NaN))
 })
+
+test_that("sample_motifs works", {
+  withr::local_seed(20041103)
+
+  g <- make_graph(~ A-B-C-A-D-E-F-D-C-F)
+  n <- vcount(g)
+
+  mc <- sample_motifs(g)
+  expect_true(0 <= mc && mc <= n*(n-1)*(n-2) / 6)
+
+  mc <- sample_motifs(g, sample = c("C", "D", "E", "F"))
+  expect_true(0 <= mc && mc <= n*(n-1)*(n-2) / 6)
+
+  mc <- sample_motifs(g, sample = V(g))
+  expect_true(0 <= mc && mc <= n*(n-1)*(n-2) / 6)
+})

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -74,6 +74,7 @@ test_that("basic plot test, spheres", {
 
 test_that("rglplot() works", {
   skip_if_not_installed("rgl")
+  skip_if(basename(commandArgs())[[1]] == "RDcsan")
 
   # https://stackoverflow.com/a/46320771/5489251
   withr::local_envvar(RGL_USE_NULL = TRUE)


### PR DESCRIPTION
@krlmlr Please use this fix instead of the one in #1565, which doesn't seem correct. This also fixes a bad default value for the `sample.size` parameter. Recent igraph errors for non-integer values.