### PR TITLE
chore: Configure the RStudio IDE to use the extra roclets

### DIFF
--- a/igraph.Rproj
+++ b/igraph.Rproj
@@ -19,4 +19,4 @@ LineEndingConversion: Posix
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
-PackageRoxygenize: rd,collate,namespace
+PackageRoxygenize: rd,collate,namespace,igraph.r2cdocs::cdocs_roclet,devtag::dev_roclet


### PR DESCRIPTION
@moodymudskipper: This works for igraph to use devtag (and another roclet) in the standard "Document" menu command.

Do we want a blog post or an entry in the README? And `use_devtag()` could take care of that?