### PR TITLE
fix: integer vectors are validated before transferring them to the C library

### DIFF
--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -3382,7 +3382,10 @@ igraph_error_t R_SEXP_to_vector_int_copy(SEXP sv, igraph_vector_int_t *v) {
   double *svv=REAL(sv);
   IGRAPH_CHECK(igraph_vector_int_init(v, n));
   for (igraph_integer_t i = 0; i<n; i++) {
-    VECTOR(*v)[i] = (igraph_integer_t)svv[i];
+    VECTOR(*v)[i] = (igraph_integer_t) svv[i];
+    if (VECTOR(*v)[i] != svv[i]) {
+      IGRAPH_ERRORF("The value %.17g is not representable as an integer.", IGRAPH_EINVAL, svv[i]);
+    }
   }
   return IGRAPH_SUCCESS;
 }


### PR DESCRIPTION
Effects of this change:

 - Fixes #1434 and eliminates a potential way to crash igraph
 - Potential small performance penalty. Probably inconsequential, but not measured.
 - This can potentially trigger an UBSan warning, and that's okay. The warning will only be triggered when passing invalid values. If this happens, the test suite or examples should be changed.
 - Values that were in the past blindly rounded are now checked. May cause revdepcheck failures.