### PR TITLE
fledge: CRAN pre-release v2.1.1.9900

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: igraph
 Title: Network Analysis and Visualization
-Version: 2.1.1.9007
+Version: 2.1.1.9900
 Authors@R: c(
     person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0001-7098-9676")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,67 +1,20 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# igraph 2.1.1.9007
+# igraph 2.1.1.9900
 
-## Continuous integration
-
-- Remove Aviator.
-
-## doc
+## Documentation
 
 - Clarify what type of graph each community detection function supports.
 
 - Improve `read_graph` and `write_graph` documentation.
 
+- Improve `all_simple_paths()` documentation.
 
-# igraph 2.1.1.9006
-
-## Continuous integration
-
-- Install rgl from GitHub for Sanitizer runs (#1579).
-
-
-# igraph 2.1.1.9005
-
-## Chore
-
-- Configure the RStudio IDE to use the extra roclets (#1575).
-
-## Continuous integration
-
-- Work around rgl sanitizer failure (#1578).
-
-
-# igraph 2.1.1.9004
+- `cluster_optimal()` does support directed graphs.
 
 ## Bug fixes
 
 - Fix the incorrect handling of the `sample` parameter in `sample_motifs()` and ensure that the default `sample.size` is integer (#1568).
-
-
-# igraph 2.1.1.9003
-
-## doc
-
-- Improve `all_simple_paths()` documentation.
-
-
-# igraph 2.1.1.9002
-
-## doc
-
-- `cluster_optimal()` does support directed graphs.
-
-
-# igraph 2.1.1.9001
-
-## Chore
-
-- Update .Rbuildignore.
-
-
-# igraph 2.1.1.9000
-
-- Merge branch 'cran-2.1.1'.
 
 
 # igraph 2.1.1

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,42 +1,5 @@
-igraph 2.1.1
+igraph 2.1.1.9900
 
-## R CMD check results
+## Cran Repository Policy
 
-- [x] Checked locally, R 4.3.3
-- [x] Checked on CI system, R 4.4.1
-- [x] Checked on win-builder, R devel
-
-## Current CRAN check results
-
-- [x] Checked on 2024-10-18, problems found: https://cran.r-project.org/web/checks/check_results_igraph.html
-- [x] NOTE: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-linux-x86_64-fedora-clang, r-devel-linux-x86_64-fedora-gcc, r-devel-windows-x86_64
-     File ‘igraph/libs/igraph.so’:
-     Found non-API calls to R: ‘PRENV’, ‘R_PromiseExpr’
-     
-     Compiled code should not call non-API entry points in R.
-     
-     See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual,
-     and section ‘Moving into C API compliance’ for issues with the use of
-     non-API entry points.
-     
-     Fixed.
-- [x] WARN: r-devel-linux-x86_64-debian-gcc, r-devel-linux-x86_64-fedora-gcc, r-devel-windows-x86_64
-     Found the following significant warnings:
-     Warning: Obsolescent feature: Old-style character length at (1)
-     See ‘/home/hornik/tmp/R.check/r-devel-gcc/Work/PKGS/igraph.Rcheck/00install.out’ for details.
-     * used C compiler: ‘gcc-14 (Debian 14.2.0-6) 14.2.0’
-     * used C++ compiler: ‘g++-14 (Debian 14.2.0-6) 14.2.0’
-     
-     Fixed.
-- [x] other_issue: NA
-See: <https://www.stats.ox.ac.uk/pub/bdr/gcc/igraph.out>
-     
-     Fixed.
-- [x] other_issue: NA
-See: <https://www.stats.ox.ac.uk/pub/bdr/noSuggests/igraph.out>
-     
-     Fixed.
-- [x] other_issue: NA
-See: <https://raw.githubusercontent.com/kalibera/cran-checks/master/rchk/results/igraph.out>
-     
-     Fixed.
+- [x] Reviewed CRP last edited 2024-08-27.


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2024-11-25, problems found: https://cran.r-project.org/web/checks/check_results_igraph.html
- [ ] WARN: r-oldrel-windows-x86_64
     Found the following significant warnings:
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/winnt.h:8404:37: warning: ISO C++ forbids flexible array member 'Elements' [-Wpedantic]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/winnt.h:8667:22: warning: ISO C++ forbids flexible array member 'pEventLogRecords' [-Wpedantic]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/winnt.h:8673:13: warning: ISO C++ forbids flexible array member 'ulOffsets' [-Wpedantic]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/minwindef.h:196:3: warning: function declaration isn't a prototype [-Wstrict-prototypes]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/minwindef.h:197:3: warning: function declaration isn't a prototype [-Wstrict-prototypes]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/minwindef.h:198:3: warning: function declaration isn't a prototype [-Wstrict-prototypes]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/processthreadsapi.h:130:47: warning: ISO C does not allow extra ';' outside of a function [-Wpedantic]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/rpcndr.h:451:3: warning: function declaration isn't a prototype [-Wstrict-prototypes]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/urlmon.h:1333:24: warning: ISO C restricts enumerator values to range of 'int' [-Wpedantic]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/urlmon.h:1745:25: warning: ISO C restricts enumerator values to range of 'int' [-Wpedantic]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/winioctl.h:359:11: warning: ISO C forbids zero-size array 'SerialNumber' [-Wpedantic]
     See 'd:/Rcompile/CRANpkg/local/4.3/igraph.Rcheck/00install.out' for details.
     * used C compiler: 'gcc.exe (GCC) 12.3.0'
     * used C++ compil
- [ ] other_issue: NA
See: <https://www.stats.ox.ac.uk/pub/bdr/memtests/clang-UBSAN/igraph>
- [ ] other_issue: NA
See: <https://raw.githubusercontent.com/kalibera/cran-checks/master/rchk/results/igraph.out>

Check results at: https://cran.r-project.org/web/checks/check_results_igraph.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`