### PR TITLE
fix: `adjacent_vertices()` and `incident_edges()` are now correct if the `"return.vs.es"` option is `FALSE`

### DIFF
--- a/R/interface.R
+++ b/R/interface.R
@@ -611,9 +611,9 @@ adjacent_vertices <- function(graph, v,
   on.exit(.Call(R_igraph_finalizer))
 
   res <- .Call(R_igraph_adjacent_vertices, graph, vv, mode)
+  res <- lapply(res, `+`, 1)
 
   if (igraph_opt("return.vs.es")) {
-    res <- lapply(res, `+`, 1)
     res <- lapply(res, unsafe_create_vs, graph = graph, verts = V(graph))
   }
 


### PR DESCRIPTION
fixes #1605

The problem is that in `adjacent_vertices()`, 1 is only added to the vertices if `return.vs.es` is `TRUE`.