### PR TITLE
test: Test handling of `"return.vs.es"` in several functions

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -448,6 +448,7 @@ references:
     email: dadler@dyncall.org
   year: '2024'
   doi: 10.32614/CRAN.package.rgl
+  version: '>= 1.3.14'
 - type: software
   title: rmarkdown
   abstract: 'rmarkdown: Dynamic Documents for R'

--- a/R/interface.R
+++ b/R/interface.R
@@ -654,9 +654,9 @@ incident_edges <- function(graph, v,
   on.exit(.Call(R_igraph_finalizer))
 
   res <- .Call(R_igraph_incident_edges, graph, vv, mode)
+  res <- lapply(res, `+`, 1)
 
   if (igraph_opt("return.vs.es")) {
-    res <- lapply(res, `+`, 1)
     res <- lapply(res, unsafe_create_es, graph = graph, es = E(graph))
   }
 

--- a/tests/testthat/test-get.adjlist.R
+++ b/tests/testthat/test-get.adjlist.R
@@ -31,3 +31,42 @@ test_that("as_adj_list works", {
     expect_equal(sort(el2[[i]]), sort(a), ignore_attr = TRUE)
   }
 })
+
+
+
+test_that("as_adj_list works when return.vs.es is FALSE", {
+  on.exit(try(igraph_options(old)), add = TRUE)
+  old <- igraph_options(return.vs.es = FALSE)
+
+  g <- sample_gnp(50, 2 / 50)
+  al <- as_adj_list(g)
+  g2 <- graph_from_adj_list(al, mode = "all")
+  expect_isomorphic(g, g2)
+  expect_true(graph.isomorphic.vf2(g, g2,
+    vertex.color1 = 1:vcount(g),
+    vertex.color2 = 1:vcount(g2)
+  )$iso)
+
+  ####
+
+  el <- as_adj_edge_list(g)
+  for (i in 1:vcount(g)) {
+    a <- E(g)[.inc(i)]
+    expect_equal(length(a), length(el[[i]]), ignore_attr = TRUE)
+    expect_equal(sort(el[[i]]), sort(a), ignore_attr = TRUE)
+  }
+
+  g <- sample_gnp(50, 4 / 50, directed = TRUE)
+  el1 <- as_adj_edge_list(g, mode = "out")
+  el2 <- as_adj_edge_list(g, mode = "in")
+  for (i in 1:vcount(g)) {
+    a <- E(g)[.from(i)]
+    expect_equal(length(a), length(el1[[i]]), ignore_attr = TRUE)
+    expect_equal(sort(el1[[i]]), sort(a), ignore_attr = TRUE)
+  }
+  for (i in 1:vcount(g)) {
+    a <- E(g)[.to(i)]
+    expect_equal(length(a), length(el2[[i]]), ignore_attr = TRUE)
+    expect_equal(sort(el2[[i]]), sort(a), ignore_attr = TRUE)
+  }
+})

--- a/tests/testthat/test-get.adjlist.R
+++ b/tests/testthat/test-get.adjlist.R
@@ -1,6 +1,7 @@
 test_that("as_adj_list works", {
   g <- sample_gnp(50, 2 / 50)
   al <- as_adj_list(g)
+  expect_s3_class(al[[1]], "igraph.vs")
   g2 <- graph_from_adj_list(al, mode = "all")
   expect_isomorphic(g, g2)
   expect_true(graph.isomorphic.vf2(g, g2,
@@ -11,6 +12,7 @@ test_that("as_adj_list works", {
   ####
 
   el <- as_adj_edge_list(g)
+  expect_s3_class(el[[1]], "igraph.es")
   for (i in 1:vcount(g)) {
     a <- E(g)[.inc(i)]
     expect_equal(length(a), length(el[[i]]), ignore_attr = TRUE)
@@ -40,6 +42,7 @@ test_that("as_adj_list works when return.vs.es is FALSE", {
 
   g <- sample_gnp(50, 2 / 50)
   al <- as_adj_list(g)
+  expect_s3_class(al[[1]], NA)
   g2 <- graph_from_adj_list(al, mode = "all")
   expect_isomorphic(g, g2)
   expect_true(graph.isomorphic.vf2(g, g2,

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -78,17 +78,78 @@ test_that("delete_vertices works", {
 test_that("neighbors works", {
   g <- sample_gnp(100, 20 / 100)
   al <- as_adj_list(g, mode = "all")
+  expect_s3_class(neighbors(g, v = 1, mode = "out"), "igraph.vs")
+  for (i in seq_along(al)) {
+    n <- neighbors(g, v = i, mode = "out")
+    expect_setequal(sort(n), al[[i]])
+  }
+
+  # test with return.vs.es = FALSE
+  on.exit(try(igraph_options(old)), add = TRUE)
+  old <- igraph_options(return.vs.es = FALSE)
+
+  al <- as_adj_list(g, mode = "all")
+  expect_s3_class(neighbors(g, v = 1, mode = "out"), NA)
   for (i in seq_along(al)) {
     n <- neighbors(g, v = i, mode = "out")
     expect_setequal(sort(n), al[[i]])
   }
 })
 
+
 test_that("neighbors prints an error for an empty input vector", {
   g <- make_tree(10)
   expect_error(neighbors(g, numeric()), "No vertex was specified")
 })
 
+
+test_that("adjacent_vertices works", {
+  g <- sample_gnp(100, 20 / 100)
+  al <- as_adj_list(g, mode = "all")
+  test_vertices <- c(1, 7, 38, 75, 99)
+  adj_vertices <- adjacent_vertices(g, v = test_vertices)
+  expect_s3_class(adj_vertices[[1]], "igraph.vs")
+  for (i in seq_along(test_vertices)) {
+    expect_setequal(adj_vertices[[i]], al[[test_vertices[i]]])
+  }
+
+  # test with return.vs.es = FALSE
+  on.exit(try(igraph_options(old)), add = TRUE)
+  old <- igraph_options(return.vs.es = FALSE)
+
+  al <- as_adj_list(g, mode = "all")
+  test_vertices <- c(1, 7, 38, 75, 99)
+  adj_vertices <- adjacent_vertices(g, v = test_vertices)
+  expect_s3_class(adj_vertices[[1]], NA)
+  for (i in seq_along(test_vertices)) {
+    expect_setequal(adj_vertices[[i]], al[[test_vertices[i]]])
+  }
+
+})
+
+
+test_that("incident_edges works", {
+  g <- sample_gnp(100, 20 / 100)
+  el <- as_adj_edge_list(g, mode = "all")
+  test_vertices <- c(1, 7, 38, 75, 99)
+  inc_edges <- incident_edges(g, v = test_vertices)
+  expect_s3_class(inc_edges[[1]], "igraph.es")
+  for (i in seq_along(test_vertices)) {
+    expect_setequal(inc_edges[[i]], el[[test_vertices[i]]])
+  }
+
+  # test with return.vs.es = FALSE
+  on.exit(try(igraph_options(old)), add = TRUE)
+  old <- igraph_options(return.vs.es = FALSE)
+
+  el <- as_adj_edge_list(g, mode = "all")
+  test_vertices <- c(1, 7, 38, 75, 99)
+  inc_edges <- incident_edges(g, v = test_vertices)
+  expect_s3_class(inc_edges[[1]], NA)
+  for (i in seq_along(test_vertices)) {
+    expect_setequal(inc_edges[[i]], el[[test_vertices[i]]])
+  }
+})
 
 test_that("delete_edges works", {
   g <- graph_from_literal(A:B:C - D:E:F, D - E - F)


### PR DESCRIPTION
This completes the fix of #1605 and adds tests.

Since the tests of `neighbors()` were based on `as_adj_list()`, I have extended the test of the latter to also run with `return.vs.es = FALSE`. I extended the tests of `neighbors()` and added tests for `adjacent_vertices()` and `incident_edges()`.

I found another small issue related to this one that I think is a mistake. But I am not entirely sure that it is, so I would like to have confirmation before I fix it: `as_adj_edge_list()` does not respect the setting `return.vs.es` and always returns `igraph.es` objects. Could someone please confirm that this is indeed not the expected behaviour. I could then fix this and update the pull request. Or should I open a new issue for this?