### PR TITLE
fledge: CRAN release v2.1.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: 'To cite package "igraph" in publications use:'
 type: software
 license: GPL-2.0-or-later
 title: 'igraph: Network Analysis and Visualization'
-version: 2.1.1
+version: 2.1.2
 identifiers:
 - type: doi
   value: 10.32614/CRAN.package.igraph
@@ -93,7 +93,7 @@ references:
   - family-names: Müller
     given-names: Kirill
   year: '2024'
-  notes: R package version 2.1.1
+  notes: R package version 2.1.2
   doi: 10.5281/zenodo.7682609
   url: https://CRAN.R-project.org/package=igraph
 - type: software

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: igraph
 Title: Network Analysis and Visualization
-Version: 2.1.1.9907
+Version: 2.1.2
 Authors@R: c(
     person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0001-7098-9676")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,19 +1,18 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# igraph 2.1.1.9907
-
-## Chore
-
-- Build-ignore rchk artifacts.
-
-
-# igraph 2.1.1.9906
+# igraph 2.1.2
 
 ## Bug fixes
 
 - `adjacent_vertices()` and `incident_edges()` are now correct if the `"return.vs.es"` option is `FALSE` (@stibu81, #1605, #1606).
 
 - Fix protection errors reported by rchk (#1592).
+
+- Fix the incorrect handling of the `sample` parameter in `sample_motifs()` and ensure that the default `sample.size` is integer (#1568).
+
+## Chore
+
+- Build-ignore rchk artifacts.
 
 ## Continuous integration
 
@@ -41,84 +40,6 @@
 
 - Tweak NEWS \[ci skip\].
 
-
-# igraph 2.1.1.9905
-
-## Continuous integration
-
-- Import from actions-sync, check carefully (#1600).
-
-- Remove covr, handled elsewhere.
-
-- Fix extra workflow.
-
-- Remove noise.
-
-- Sync workflows (#1589).
-
-## Documentation
-
-- Tweak NEWS \[ci skip\].
-
-
-# igraph 2.1.1.9904
-
-## Continuous integration
-
-- Import from actions-sync, check carefully (#1600).
-
-- Remove covr, handled elsewhere.
-
-- Fix extra workflow.
-
-- Remove noise.
-
-- Sync workflows (#1589).
-
-## Documentation
-
-- Tweak NEWS \[ci skip\].
-
-
-# igraph 2.1.1.9903
-
-## Continuous integration
-
-- Import from actions-sync, check carefully (#1600).
-
-- Remove covr, handled elsewhere.
-
-- Fix extra workflow.
-
-- Remove noise.
-
-- Sync workflows (#1589).
-
-
-# igraph 2.1.1.9902
-
-## Continuous integration
-
-- Remove covr, handled elsewhere.
-
-- Fix extra workflow.
-
-- Remove noise.
-
-- Sync workflows (#1589).
-
-
-# igraph 2.1.1.9901
-
-## Continuous integration
-
-- Sync workflows (#1589).
-
-
-# igraph 2.1.1.9900
-
-## Documentation
-
 - Clarify what type of graph each community detection function supports.
 
 - Improve `?read_graph` and `?write_graph` documentation.
@@ -126,10 +47,6 @@
 - Improve `all_simple_paths()` documentation.
 
 - `cluster_optimal()` does support directed graphs.
-
-## Bug fixes
-
-- Fix the incorrect handling of the `sample` parameter in `sample_motifs()` and ensure that the default `sample.size` is integer (#1568).
 
 
 # igraph 2.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,35 +10,7 @@
 
 - Fix the incorrect handling of the `sample` parameter in `sample_motifs()` and ensure that the default `sample.size` is integer (#1568).
 
-## Chore
-
-- Build-ignore rchk artifacts.
-
-## Continuous integration
-
-- Change `Makevars` only after installation of R.
-
-- Use GLPK on macOS.
-
-- Add required rgl version (#1584).
-
-- Install GLPK on macOS.
-
-- Bring back extra workflow.
-
-- Import from actions-sync, check carefully (#1600).
-
-- Remove covr, handled elsewhere.
-
-- Fix extra workflow.
-
-- Remove noise.
-
-- Sync workflows (#1589).
-
 ## Documentation
-
-- Tweak NEWS \[ci skip\].
 
 - Clarify what type of graph each community detection function supports.
 
@@ -47,6 +19,10 @@
 - Improve `all_simple_paths()` documentation.
 
 - `cluster_optimal()` does support directed graphs.
+
+## Testing
+
+- Test handling of `"return.vs.es"` in several functions (@stibu81, #1610).
 
 
 # igraph 2.1.1

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-igraph 2.1.1.9900
+igraph 2.1.2
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2024-12-01, problems found: https://cran.r-project.org/web/checks/check_results_igraph.html
- [ ] WARN: r-oldrel-windows-x86_64
     Found the following significant warnings:
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/winnt.h:8404:37: warning: ISO C++ forbids flexible array member 'Elements' [-Wpedantic]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/winnt.h:8667:22: warning: ISO C++ forbids flexible array member 'pEventLogRecords' [-Wpedantic]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/winnt.h:8673:13: warning: ISO C++ forbids flexible array member 'ulOffsets' [-Wpedantic]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/minwindef.h:196:3: warning: function declaration isn't a prototype [-Wstrict-prototypes]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/minwindef.h:197:3: warning: function declaration isn't a prototype [-Wstrict-prototypes]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/minwindef.h:198:3: warning: function declaration isn't a prototype [-Wstrict-prototypes]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/processthreadsapi.h:130:47: warning: ISO C does not allow extra ';' outside of a function [-Wpedantic]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/rpcndr.h:451:3: warning: function declaration isn't a prototype [-Wstrict-prototypes]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/urlmon.h:1333:24: warning: ISO C restricts enumerator values to range of 'int' [-Wpedantic]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/urlmon.h:1745:25: warning: ISO C restricts enumerator values to range of 'int' [-Wpedantic]
     D:/rtools43/usr/lib/mxe/usr/x86_64-w64-mingw32.static.posix/include/winioctl.h:359:11: warning: ISO C forbids zero-size array 'SerialNumber' [-Wpedantic]
     See 'd:/Rcompile/CRANpkg/local/4.3/igraph.Rcheck/00install.out' for details.
     * used C compiler: 'gcc.exe (GCC) 12.3.0'
     * used C++ compil
- [ ] other_issue: NA
See: <https://www.stats.ox.ac.uk/pub/bdr/memtests/clang-UBSAN/igraph>
- [ ] other_issue: NA
See: <https://raw.githubusercontent.com/kalibera/cran-checks/master/rchk/results/igraph.out>

Check results at: https://cran.r-project.org/web/checks/check_results_igraph.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`