### PR TITLE
docs: add central note about experimental functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ See the [Installation FAQ](https://r.igraph.org/articles/installation-troublesho
 
 See the [igraph package's website](https://r.igraph.org/) for the complete manual.
 
+A good entry point is the "Get started" vignette, in [English](https://r.igraph.org/articles/igraph.html) or [Spanish](https://r.igraph.org/articles/igraph_ES.html).
+
+For an overview of igraph's functionality see the [reference index](https://r.igraph.org/reference/index.html).
+It includes [experimental functions](https://r.igraph.org/reference/index.html#experimental-functions) on which we especially welcome feedback 
+(but feedback on any function is appreciated)!
+
 ## Contributions
 
 Please read our

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -226,6 +226,9 @@ reference:
 - title: Versions
 - contents:
   - has_concept("versions")
+- title: Experimental functions
+  contents:
+  - has_lifecycle("experimental")
 - title: internal
   contents:
   - igraph-package


### PR DESCRIPTION
"Use lifecycle for all experimental functions, make a central note in the documentation." is part of the R Consortium proposal. 

Have we missed functions that should have the experimental badge? If so, how could I identify them?

Local preview:

![image](https://github.com/user-attachments/assets/b065d136-a5e8-4afa-b335-cb9ffe1a35ab)
