### PR TITLE
chore!: stricter deprecation of non-functional parameters of `layout_with_kk()` and `layout_with_fr()`

### DIFF
--- a/R/layout.R
+++ b/R/layout.R
@@ -1269,16 +1269,16 @@ layout_with_fr <- function(graph, coords = NULL, dim = 2,
   if (!is.null(minz)) minz <- as.numeric(minz)
   if (!is.null(maxz)) maxz <- as.numeric(maxz)
   if (lifecycle::is_present(coolexp)) {
-    lifecycle::deprecate_warn("0.8.0", "layout_with_fr(coolexp = )")
+    lifecycle::deprecate_stop("0.8.0", "layout_with_fr(coolexp = )")
   }
   if (lifecycle::is_present(maxdelta)) {
-    lifecycle::deprecate_warn("0.8.0", "layout_with_fr(maxdelta = )")
+    lifecycle::deprecate_stop("0.8.0", "layout_with_fr(maxdelta = )")
   }
   if (lifecycle::is_present(area)) {
-    lifecycle::deprecate_warn("0.8.0", "layout_with_fr(area = )")
+    lifecycle::deprecate_stop("0.8.0", "layout_with_fr(area = )")
   }
   if (lifecycle::is_present(repulserad)) {
-    lifecycle::deprecate_warn("0.8.0", "layout_with_fr(repulserad = )")
+    lifecycle::deprecate_stop("0.8.0", "layout_with_fr(repulserad = )")
   }
 
   on.exit(.Call(R_igraph_finalizer))
@@ -1568,16 +1568,16 @@ layout_with_kk <- function(graph, coords = NULL, dim = 2,
   if (!is.null(maxz)) maxz <- as.numeric(maxz)
 
   if (lifecycle::is_present(niter)) {
-    lifecycle::deprecate_warn("0.8.0", "layout_with_kk(niter = )")
+    lifecycle::deprecate_stop("0.8.0", "layout_with_kk(niter = )")
   }
   if (lifecycle::is_present(sigma)) {
-    lifecycle::deprecate_warn("0.8.0", "layout_with_kk(sigma = )")
+    lifecycle::deprecate_stop("0.8.0", "layout_with_kk(sigma = )")
   }
   if (lifecycle::is_present(initemp)) {
-    lifecycle::deprecate_warn("0.8.0", "layout_with_kk(initemp = )")
+    lifecycle::deprecate_stop("0.8.0", "layout_with_kk(initemp = )")
   }
   if (lifecycle::is_present(coolexp)) {
-    lifecycle::deprecate_warn("0.8.0", "layout_with_kk(coolexp = )")
+    lifecycle::deprecate_stop("0.8.0", "layout_with_kk(coolexp = )")
   }
 
   on.exit(.Call(R_igraph_finalizer))

--- a/tests/testthat/_snaps/layout.md
+++ b/tests/testthat/_snaps/layout.md
@@ -4,14 +4,8 @@
       l <- layout_with_fr(g, niter = 50, start.temp = sqrt(10) / 10, coolexp = 1,
       maxdelta = 1, area = 1, repulserad = 1)
     Condition
-      Warning:
-      The `coolexp` argument of `layout_with_fr()` is deprecated as of igraph 0.8.0.
-      Warning:
-      The `maxdelta` argument of `layout_with_fr()` is deprecated as of igraph 0.8.0.
-      Warning:
-      The `area` argument of `layout_with_fr()` is deprecated as of igraph 0.8.0.
-      Warning:
-      The `repulserad` argument of `layout_with_fr()` is deprecated as of igraph 0.8.0.
+      Error:
+      ! The `coolexp` argument of `layout_with_fr()` was deprecated in igraph 0.8.0 and is now defunct.
 
 # layout_with_kk() deprecated arguments
 
@@ -19,12 +13,6 @@
       l <- layout_with_kk(g, maxiter = 50, coords = layout_in_circle(g), niter = 1,
       sigma = 1, initemp = 1, coolexp = 1)
     Condition
-      Warning:
-      The `niter` argument of `layout_with_kk()` is deprecated as of igraph 0.8.0.
-      Warning:
-      The `sigma` argument of `layout_with_kk()` is deprecated as of igraph 0.8.0.
-      Warning:
-      The `initemp` argument of `layout_with_kk()` is deprecated as of igraph 0.8.0.
-      Warning:
-      The `coolexp` argument of `layout_with_kk()` is deprecated as of igraph 0.8.0.
+      Error:
+      ! The `niter` argument of `layout_with_kk()` was deprecated in igraph 0.8.0 and is now defunct.
 

--- a/tests/testthat/test-layout.R
+++ b/tests/testthat/test-layout.R
@@ -17,7 +17,7 @@ test_that("layout_with_fr() works", {
 test_that("layout_with_fr() deprecated argument", {
   rlang::local_options(lifecycle_verbosity = "warning")
   g <- make_ring(10)
-  expect_snapshot(
+  expect_snapshot(error = TRUE, {
     l <- layout_with_fr(
       g,
       niter = 50,
@@ -27,7 +27,7 @@ test_that("layout_with_fr() deprecated argument", {
       area = 1,
       repulserad = 1
     )
-  )
+  })
 
 })
 
@@ -205,7 +205,7 @@ test_that("Kamada-Kawai layout generator works", {
 
 test_that("layout_with_kk() deprecated arguments", {
   g <- make_ring(10)
-  expect_snapshot(
+  expect_snapshot(error = TRUE, {
     l <- layout_with_kk(
       g,
       maxiter = 50,
@@ -215,7 +215,7 @@ test_that("layout_with_kk() deprecated arguments", {
       initemp = 1,
       coolexp = 1
     )
-  )
+  })
 
 })
 


### PR DESCRIPTION
…with_kk()` and `layout_with_fr()`

Fix #1108

This does not remove them completely yet but since they're in the lifecycle system, and we plan to advance deprecation over time, we can then close the issue.

@krlmlr could you please run revdeps on this? Thank you!