### PR TITLE
ci: Add workflow to check each commit

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,10 +29,6 @@ on:
         description: "Create a matrix of suggested dependencies"
         type: boolean
         default: false
-      concurrency-group:
-        description: "Concurrency group to support cancellation"
-        required: false
-        default: ""
   merge_group:
     types:
       - checks_requested
@@ -40,7 +36,7 @@ on:
     - cron: "10 0 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.concurrency-group || inputs.ref || github.head_ref || github.sha }}-${{ github.base_ref || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.ref || github.head_ref || github.sha }}-${{ github.base_ref || '' }}
   cancel-in-progress: true
 
 name: rcc

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,6 +29,10 @@ on:
         description: "Create a matrix of suggested dependencies"
         type: boolean
         default: false
+      concurrency-group:
+        description: "Concurrency group to support cancellation"
+        required: false
+        default: ""
   merge_group:
     types:
       - checks_requested
@@ -36,7 +40,7 @@ on:
     - cron: "10 0 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.ref || github.head_ref || github.sha }}-${{ github.base_ref || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.concurrency-group || inputs.ref || github.head_ref || github.sha }}-${{ github.base_ref || '' }}
   cancel-in-progress: true
 
 name: rcc

--- a/.github/workflows/each.yaml
+++ b/.github/workflows/each.yaml
@@ -38,7 +38,10 @@ jobs:
 
           # Run workflow for each commit where the status isn't "pending" or "success"
           for commit in $commits; do
+            echo $commit
+            gh api repos/${GITHUB_REPOSITORY}/commits/${commit}/status
             status=$(gh api repos/${GITHUB_REPOSITORY}/commits/${commit}/status | jq -r '.state')
+            echo $status
             if [[ $status != "pending" && $status != "success" ]]; then
               echo "Running rcc for commit $commit"
               gh workflow run rcc.yaml -f ref=$commit

--- a/.github/workflows/each.yaml
+++ b/.github/workflows/each.yaml
@@ -27,12 +27,21 @@ jobs:
           fetch-depth: 0
 
       - name: Enumerate all commits from the repository's main branch
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git remote -v
-          git fetch --all
           # Get name of main branch of repository
           # origin/HEAD isn't known here
           main=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
           commits=$(git log --pretty=format:"%H" origin/${main}.. --)
           echo $commits
+
+          # Run workflow for each commit where the status isn't "pending" or "success"
+          for commit in $commits; do
+            status=$(gh api repos/${GITHUB_REPOSITORY}/commits/${commit}/status | jq -r '.state')
+            if [[ $status != "pending" && $status != "success" ]]; then
+              echo "Running rcc for commit $commit"
+              gh workflow run rcc.yaml -f ref=$commit
+            fi
+          done
         shell: bash

--- a/.github/workflows/each.yaml
+++ b/.github/workflows/each.yaml
@@ -36,11 +36,12 @@ jobs:
           commits=$(git log --reverse --pretty=format:"%H" origin/${main}.. --)
           echo $commits
 
-          # Run workflow for each commit where the status isn't "pending" or "success"
+          # Run workflow for each commit where the status of the rcc workflow isn't "pending" or "success"
           for commit in $commits; do
             echo $commit
-            gh api repos/${GITHUB_REPOSITORY}/commits/${commit}/status
-            status=$(gh api repos/${GITHUB_REPOSITORY}/commits/${commit}/status | jq -r '.state')
+            gh api repos/{owner}/{repo}/commits/${commit}/statuses
+            # Get status of the workflow with the name "rcc"
+            status=$(gh api repos/{owner}/{repo}/commits/${commit}/status | jq -r '.state')
             echo $status
             if [[ $status != "pending" && $status != "success" ]]; then
               echo "Running rcc for commit $commit"

--- a/.github/workflows/each.yaml
+++ b/.github/workflows/each.yaml
@@ -39,11 +39,10 @@ jobs:
           # Run workflow for each commit where the status of the rcc workflow isn't "pending" or "success"
           for commit in $commits; do
             echo $commit
-            gh api repos/{owner}/{repo}/commits/${commit}/statuses
-            # Get status of the workflow with the name "rcc"
-            status=$(gh api repos/{owner}/{repo}/commits/${commit}/status | jq -r '.state')
+            # Get first status of the workflow with the name "rcc"
+            status=$(gh api repos/{owner}/{repo}/commits/${commit}/statuses | jq -r '.[] | select(.context == "rcc") | .state' | head -n 1)
             echo $status
-            if [[ $status != "pending" && $status != "success" ]]; then
+            if [[ "$status" != "pending" && "$status" != "success" ]]; then
               echo "Running rcc for commit $commit"
               gh workflow run rcc.yaml -f ref=$commit
             fi

--- a/.github/workflows/each.yaml
+++ b/.github/workflows/each.yaml
@@ -44,7 +44,7 @@ jobs:
             echo $status
             if [[ "$status" != "pending" && "$status" != "success" ]]; then
               echo "Running rcc for commit $commit"
-              gh workflow run rcc -f ref=$commit
+              gh workflow run rcc -f ref=$commit -r ${{ github.ref }}
             fi
           done
         shell: bash

--- a/.github/workflows/each.yaml
+++ b/.github/workflows/each.yaml
@@ -1,0 +1,38 @@
+# Helper workflow to trigger rcc for each commit on a branch
+
+on:
+  push:
+    branches:
+      - each-*
+
+name: rcc
+
+jobs:
+  rcc-smoke:
+    runs-on: ubuntu-24.04
+    outputs:
+      sha: ${{ steps.commit.outputs.sha }}
+      versions-matrix: ${{ steps.versions-matrix.outputs.matrix }}
+      dep-suggests-matrix: ${{ steps.dep-suggests-matrix.outputs.matrix }}
+
+    name: "Trigger rcc workflow for each commit"
+
+    # Begin custom: services
+    # End custom: services
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Enumerate all commits from the repository's main branch
+        run: |
+          git remote -v
+          git fetch --all
+          # Get name of main branch of repository
+          # origin/HEAD isn't known here
+          main=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
+          commits=$(git log --pretty=format:"%H" origin/${main}.. --)
+          echo $commits
+        shell: bash

--- a/.github/workflows/each.yaml
+++ b/.github/workflows/each.yaml
@@ -44,7 +44,7 @@ jobs:
             echo $status
             if [[ "$status" != "pending" && "$status" != "success" ]]; then
               echo "Running rcc for commit $commit"
-              gh workflow run rcc.yaml -f ref=$commit
+              gh workflow run rcc -f ref=$commit
             fi
           done
         shell: bash

--- a/.github/workflows/each.yaml
+++ b/.github/workflows/each.yaml
@@ -33,7 +33,7 @@ jobs:
           # Get name of main branch of repository
           # origin/HEAD isn't known here
           main=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
-          commits=$(git log --pretty=format:"%H" origin/${main}.. --)
+          commits=$(git log --reverse --pretty=format:"%H" origin/${main}.. --)
           echo $commits
 
           # Run workflow for each commit where the status isn't "pending" or "success"

--- a/.github/workflows/each.yaml
+++ b/.github/workflows/each.yaml
@@ -5,10 +5,10 @@ on:
     branches:
       - each-*
 
-name: rcc
+name: each-rcc
 
 jobs:
-  rcc-smoke:
+  each-rcc:
     runs-on: ubuntu-24.04
     outputs:
       sha: ${{ steps.commit.outputs.sha }}


### PR DESCRIPTION
For branches that start with `each-`, each commit is checked. Useful for checking how vendoring affects build and check results, commit by commit.