### PR TITLE
refactor: forward `get.adjacency.dense()` to `get.adjacency.sparse()` if attributes are present (#1483)

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -211,13 +211,14 @@ get.adjacency.sparse <- function(graph, type = c("both", "upper", "lower"),
   if (!is.null(attr)) {
     attr <- as.character(attr)
     if (!attr %in% edge_attr_names(graph)) {
-      stop("no such edge attribute")
+      stop("no such edge attribute", call. = FALSE)
     }
     value <- edge_attr(graph, name = attr)
     if (!is.numeric(value) && !is.logical(value)) {
       stop(
         "Matrices must be either numeric or logical, ",
-        "and the edge attribute is not"
+        "and the edge attribute is not",
+        call. = FALSE
       )
     }
   } else {
@@ -334,7 +335,6 @@ as_adjacency_matrix <- function(graph, type = c("both", "upper", "lower"),
 as_adj <- function(graph, type = c("both", "upper", "lower"),
                    attr = NULL, edges = deprecated(), names = TRUE,
                    sparse = igraph_opt("sparsematrices")) {
-
   lifecycle::deprecate_soft("2.1.0", "as_adj()", "as_adjacency_matrix()")
 
   as_adjacency_matrix(
@@ -834,7 +834,7 @@ get.incidence.dense <- function(graph, types, names, attr) {
   } else {
     attr <- as.character(attr)
     if (!attr %in% edge_attr_names(graph)) {
-      stop("no such edge attribute")
+      stop("no such edge attribute", call. = FALSE)
     }
 
     vc <- vcount(graph)
@@ -871,12 +871,12 @@ get.incidence.dense <- function(graph, types, names, attr) {
 get.incidence.sparse <- function(graph, types, names, attr) {
   vc <- vcount(graph)
   if (length(types) != vc) {
-    stop("Invalid types vector")
+    stop("Invalid types vector", call. = FALSE)
   }
 
   el <- as_edgelist(graph, names = FALSE)
   if (any(types[el[, 1]] == types[el[, 2]])) {
-    stop("Invalid types vector, not a bipartite graph")
+    stop("Invalid types vector, not a bipartite graph", call. = FALSE)
   }
 
   n1 <- sum(!types)
@@ -896,7 +896,7 @@ get.incidence.sparse <- function(graph, types, names, attr) {
   if (!is.null(attr)) {
     attr <- as.character(attr)
     if (!attr %in% edge_attr_names(graph)) {
-      stop("no such edge attribute")
+      stop("no such edge attribute", call. = FALSE)
     }
     value <- edge_attr(graph, name = attr)
   } else {

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -187,6 +187,7 @@ get.adjacency.dense <- function(graph, type = c("both", "upper", "lower"),
       loops
     )
   } else {
+    # faster than a specialized implementation
     res <- as.matrix(get.adjacency.sparse(graph, type = type, attr = attr, names = names))
   }
 

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -188,7 +188,7 @@ get.adjacency.dense <- function(graph, type = c("both", "upper", "lower"),
     )
   } else {
     # faster than a specialized implementation
-    res <- as.matrix(get.adjacency.sparse(graph, type = type, attr = attr, names = names))
+    res <- as.matrix(get.adjacency.sparse(graph, type = type, attr = attr, names = names, call = rlang::caller_env()))
   }
 
   if (names && "name" %in% vertex_attr_names(graph)) {
@@ -198,7 +198,7 @@ get.adjacency.dense <- function(graph, type = c("both", "upper", "lower"),
 }
 
 get.adjacency.sparse <- function(graph, type = c("both", "upper", "lower"),
-                                 attr = NULL, names = TRUE) {
+                                 attr = NULL, names = TRUE, call = rlang::caller_env()) {
   ensure_igraph(graph)
 
   type <- igraph.match.arg(type)
@@ -211,14 +211,13 @@ get.adjacency.sparse <- function(graph, type = c("both", "upper", "lower"),
   if (!is.null(attr)) {
     attr <- as.character(attr)
     if (!attr %in% edge_attr_names(graph)) {
-      stop("no such edge attribute", call. = FALSE)
+      cli::cli_abort("no such edge attribute", call = call)
     }
     value <- edge_attr(graph, name = attr)
     if (!is.numeric(value) && !is.logical(value)) {
-      stop(
-        "Matrices must be either numeric or logical, ",
-        "and the edge attribute is not",
-        call. = FALSE
+      cli::cli_abort(
+        "Matrices must be either numeric or logical, and the edge attribute is not",
+        call = call
       )
     }
   } else {

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -211,7 +211,7 @@ get.adjacency.sparse <- function(graph, type = c("both", "upper", "lower"),
   if (!is.null(attr)) {
     attr <- as.character(attr)
     if (!attr %in% edge_attr_names(graph)) {
-      cli::cli_abort("no such edge attribute", call = call)
+      cli::cli_abort("No such edge attribute", call = call)
     }
     value <- edge_attr(graph, name = attr)
     if (!is.numeric(value) && !is.logical(value)) {
@@ -816,7 +816,7 @@ as_graphnel <- function(graph) {
   res
 }
 
-get.incidence.dense <- function(graph, types, names, attr) {
+get.incidence.dense <- function(graph, types, names, attr, call = rlang::caller_env()) {
   if (is.null(attr)) {
     on.exit(.Call(R_igraph_finalizer))
     ## Function call
@@ -833,7 +833,7 @@ get.incidence.dense <- function(graph, types, names, attr) {
   } else {
     attr <- as.character(attr)
     if (!attr %in% edge_attr_names(graph)) {
-      stop("no such edge attribute", call. = FALSE)
+      cli::cli_abort("No such edge attribute", call = call)
     }
 
     vc <- vcount(graph)
@@ -867,15 +867,15 @@ get.incidence.dense <- function(graph, types, names, attr) {
   }
 }
 
-get.incidence.sparse <- function(graph, types, names, attr) {
+get.incidence.sparse <- function(graph, types, names, attr, call = rlang::caller_env()) {
   vc <- vcount(graph)
   if (length(types) != vc) {
-    stop("Invalid types vector", call. = FALSE)
+    cli::cli_abort("Invalid types vector", call = call)
   }
 
   el <- as_edgelist(graph, names = FALSE)
   if (any(types[el[, 1]] == types[el[, 2]])) {
-    stop("Invalid types vector, not a bipartite graph", call. = FALSE)
+    cli::cli_abort("Invalid types vector, not a bipartite graph", call = call)
   }
 
   n1 <- sum(!types)
@@ -895,7 +895,7 @@ get.incidence.sparse <- function(graph, types, names, attr) {
   if (!is.null(attr)) {
     attr <- as.character(attr)
     if (!attr %in% edge_attr_names(graph)) {
-      stop("no such edge attribute", call. = FALSE)
+      cli::cli_abort("No such edge attribute", call = calls)
     }
     value <- edge_attr(graph, name = attr)
   } else {
@@ -968,7 +968,7 @@ as_biadjacency_matrix <- function(graph, types = NULL, attr = NULL,
   sparse <- as.logical(sparse)
 
   if (sparse) {
-    get.incidence.sparse(graph, types = types, names = names, attr = attr)
+    get.incidence.sparse(graph, types = types, names = names, attr = attr, call = rlang::caller_env())
   } else {
     get.incidence.dense(graph, types = types, names = names, attr = attr)
   }

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -899,7 +899,7 @@ get.incidence.sparse <- function(graph, types, names, attr, call = rlang::caller
   if (!is.null(attr)) {
     attr <- as.character(attr)
     if (!attr %in% edge_attr_names(graph)) {
-      cli::cli_abort("No such edge attribute", call = calls)
+      cli::cli_abort("No such edge attribute", call = call)
     }
     value <- edge_attr(graph, name = attr)
   } else {

--- a/tests/testthat/_snaps/conversion.md
+++ b/tests/testthat/_snaps/conversion.md
@@ -41,7 +41,7 @@
     Code
       as_adjacency_matrix(g, attr = "bla", sparse = FALSE)
     Condition
-      Error in `get.adjacency.dense()`:
+      Error in `get.adjacency.sparse()`:
       ! no such edge attribute
 
 ---
@@ -49,6 +49,6 @@
     Code
       as_adjacency_matrix(g, attr = "bla", sparse = FALSE)
     Condition
-      Error in `get.adjacency.dense()`:
+      Error in `get.adjacency.sparse()`:
       ! Matrices must be either numeric or logical, and the edge attribute is not
 

--- a/tests/testthat/_snaps/conversion.md
+++ b/tests/testthat/_snaps/conversion.md
@@ -25,7 +25,7 @@
     Code
       as_adjacency_matrix(g, attr = "bla")
     Condition
-      Error in `get.adjacency.sparse()`:
+      Error:
       ! no such edge attribute
 
 ---
@@ -33,7 +33,7 @@
     Code
       as_adjacency_matrix(g, attr = "bla")
     Condition
-      Error in `get.adjacency.sparse()`:
+      Error:
       ! Matrices must be either numeric or logical, and the edge attribute is not
 
 # as_adjacency_matrix() errors well -- dense
@@ -41,7 +41,7 @@
     Code
       as_adjacency_matrix(g, attr = "bla", sparse = FALSE)
     Condition
-      Error in `get.adjacency.sparse()`:
+      Error:
       ! no such edge attribute
 
 ---
@@ -49,6 +49,6 @@
     Code
       as_adjacency_matrix(g, attr = "bla", sparse = FALSE)
     Condition
-      Error in `get.adjacency.sparse()`:
+      Error:
       ! Matrices must be either numeric or logical, and the edge attribute is not
 

--- a/tests/testthat/_snaps/conversion.md
+++ b/tests/testthat/_snaps/conversion.md
@@ -26,7 +26,7 @@
       as_adjacency_matrix(g, attr = "bla")
     Condition
       Error in `as_adjacency_matrix()`:
-      ! no such edge attribute
+      ! No such edge attribute
 
 ---
 
@@ -42,7 +42,7 @@
       as_adjacency_matrix(g, attr = "bla", sparse = FALSE)
     Condition
       Error in `as_adjacency_matrix()`:
-      ! no such edge attribute
+      ! No such edge attribute
 
 ---
 

--- a/tests/testthat/_snaps/conversion.md
+++ b/tests/testthat/_snaps/conversion.md
@@ -25,7 +25,7 @@
     Code
       as_adjacency_matrix(g, attr = "bla")
     Condition
-      Error:
+      Error in `as_adjacency_matrix()`:
       ! no such edge attribute
 
 ---
@@ -33,7 +33,7 @@
     Code
       as_adjacency_matrix(g, attr = "bla")
     Condition
-      Error:
+      Error in `as_adjacency_matrix()`:
       ! Matrices must be either numeric or logical, and the edge attribute is not
 
 # as_adjacency_matrix() errors well -- dense
@@ -41,7 +41,7 @@
     Code
       as_adjacency_matrix(g, attr = "bla", sparse = FALSE)
     Condition
-      Error:
+      Error in `as_adjacency_matrix()`:
       ! no such edge attribute
 
 ---
@@ -49,6 +49,6 @@
     Code
       as_adjacency_matrix(g, attr = "bla", sparse = FALSE)
     Condition
-      Error:
+      Error in `as_adjacency_matrix()`:
       ! Matrices must be either numeric or logical, and the edge attribute is not
 

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -71,7 +71,7 @@ test_that("as_undirected() keeps attributes", {
 })
 
 test_that("as_adjacency_matrix() works -- sparse", {
-  g <- make_graph(c(1,2, 2,1, 2,2, 3,3, 3,3, 3,4, 4,2, 4,2, 4,2), directed = TRUE)
+  g <- make_graph(c(1, 2, 2, 1, 2, 2, 3, 3, 3, 3, 3, 4, 4, 2, 4, 2, 4, 2), directed = TRUE)
   basic_adj_matrix <- as_adjacency_matrix(g)
   expect_s4_class(basic_adj_matrix, "dgCMatrix")
   expected_matrix <- matrix(
@@ -93,17 +93,19 @@ test_that("as_adjacency_matrix() works -- sparse", {
   E(g)$weight <- c(1.2, 3.4, 2.7, 5.6, 6.0, 0.1, 6.1, 3.3, 4.3)
   weight_adj_matrix <- as_adjacency_matrix(g, attr = "weight")
   expect_s4_class(weight_adj_matrix, "dgCMatrix")
-  expect_equal(as.matrix(weight_adj_matrix),
+  expect_equal(
+    as.matrix(weight_adj_matrix),
     matrix(
       c(0, 3.4, 0, 0, 1.2, 2.7, 0, 13.7, 0, 0, 11.6, 0, 0, 0, 0.1, 0),
       nrow = 4L,
       ncol = 4L,
       dimnames = list(c("a", "b", "c", "d"), c("a", "b", "c", "d"))
-    ))
+    )
+  )
 })
 
 test_that("as_adjacency_matrix() works -- sparse + not both", {
-  dg <- make_graph(c(1,2, 2,1, 2,2, 3,3, 3,3, 3,4, 4,2, 4,2, 4,2), directed = TRUE)
+  dg <- make_graph(c(1, 2, 2, 1, 2, 2, 3, 3, 3, 3, 3, 4, 4, 2, 4, 2, 4, 2), directed = TRUE)
   g <- as_undirected(dg, mode = "each")
 
   lower_adj_matrix <- as_adjacency_matrix(g, type = "lower")
@@ -128,16 +130,15 @@ test_that("as_adjacency_matrix() works -- sparse + not both", {
 })
 
 test_that("as_adjacency_matrix() errors well -- sparse", {
-  g <- make_graph(c(1,2, 2,1, 2,2, 3,3, 3,3, 3,4, 4,2, 4,2, 4,2), directed = TRUE)
+  g <- make_graph(c(1, 2, 2, 1, 2, 2, 3, 3, 3, 3, 3, 4, 4, 2, 4, 2, 4, 2), directed = TRUE)
   expect_snapshot(as_adjacency_matrix(g, attr = "bla"), error = TRUE)
 
   E(g)$bla <- letters[1:ecount(g)]
   expect_snapshot(as_adjacency_matrix(g, attr = "bla"), error = TRUE)
-
 })
 
 test_that("as_adjacency_matrix() works -- sparse undirected", {
-  dg <- make_graph(c(1,2, 2,1, 2,2, 3,3, 3,3, 3,4, 4,2, 4,2, 4,2), directed = TRUE)
+  dg <- make_graph(c(1, 2, 2, 1, 2, 2, 3, 3, 3, 3, 3, 4, 4, 2, 4, 2, 4, 2), directed = TRUE)
   ug <- as_undirected(dg, mode = "each")
   adj_matrix <- as_adjacency_matrix(ug)
   expect_s4_class(adj_matrix, "dgCMatrix")
@@ -155,7 +156,7 @@ test_that("as_adjacency_matrix() works -- sparse undirected", {
 })
 
 test_that("as_adjacency_matrix() works -- dense", {
-  g <- make_graph(c(1,2, 2,1, 2,2, 3,3, 3,3, 3,4, 4,2, 4,2, 4,2), directed = TRUE)
+  g <- make_graph(c(1, 2, 2, 1, 2, 2, 3, 3, 3, 3, 3, 4, 4, 2, 4, 2, 4, 2), directed = TRUE)
 
   basic_adj_matrix <- as_adjacency_matrix(g, sparse = FALSE)
   expected_matrix <- matrix(
@@ -175,7 +176,11 @@ test_that("as_adjacency_matrix() works -- dense", {
   expect_equal(
     weight_adj_matrix,
     matrix(
-      c(0, 3.4, 0, 0, 1.2, 2.7, 0, 4.3, 0, 0, 6, 0, 0, 0, 0.1, 0),
+      c(0, 3.4, 0, 0, 1.2, 2.7, 0, 13.7, 0, 0, 11.6, 0, 0, 0, 0.1, 0),
+      # below is wrong test result due to a bug (#1551). Weights of ties
+      # between the same node pair should be aggregated and not only the last
+      # weight should be considered. The above is consistent with the sparse case
+      # c(0, 3.4, 0, 0, 1.2, 2.7, 0, 4.3, 0, 0, 6, 0, 0, 0, 0.1, 0),
       nrow = 4L,
       ncol = 4L,
       dimnames = list(c("a", "b", "c", "d"), c("a", "b", "c", "d"))
@@ -184,17 +189,16 @@ test_that("as_adjacency_matrix() works -- dense", {
 })
 
 test_that("as_adjacency_matrix() errors well -- dense", {
-  g <- make_graph(c(1,2, 2,1, 2,2, 3,3, 3,3, 3,4, 4,2, 4,2, 4,2), directed = TRUE)
+  g <- make_graph(c(1, 2, 2, 1, 2, 2, 3, 3, 3, 3, 3, 4, 4, 2, 4, 2, 4, 2), directed = TRUE)
   expect_snapshot(as_adjacency_matrix(g, attr = "bla", sparse = FALSE), error = TRUE)
 
   E(g)$bla <- letters[1:ecount(g)]
   expect_snapshot(as_adjacency_matrix(g, attr = "bla", sparse = FALSE), error = TRUE)
-
 })
 
 
 test_that("as_adjacency_matrix() works -- dense undirected", {
-  dg <- make_graph(c(1,2, 2,1, 2,2, 3,3, 3,3, 3,4, 4,2, 4,2, 4,2), directed = TRUE)
+  dg <- make_graph(c(1, 2, 2, 1, 2, 2, 3, 3, 3, 3, 3, 4, 4, 2, 4, 2, 4, 2), directed = TRUE)
   ug <- as_undirected(dg, mode = "each")
   # no different treatment than undirected if no attribute?!
   adj_matrix <- as_adjacency_matrix(ug, sparse = FALSE)
@@ -211,7 +215,11 @@ test_that("as_adjacency_matrix() works -- dense undirected", {
   expect_equal(
     weight_adj_matrix,
     matrix(
-      c(0, 3.4, 0, 0, 3.4, 2.7, 0, 4.3, 0, 0, 6, 0.1, 0, 4.3, 0.1, 0),
+      c(0, 4.6, 0, 0, 4.6, 2.7, 0, 13.7, 0, 0, 11.6, 0.1, 0, 13.7, 0.1, 0),
+      # below is wrong test result due to a bug (#1551). Weights of ties
+      # between the same node pair should be aggregated and not only the last
+      # weight should be considered. The above is consistent with the sparse case
+      # c(0, 3.4, 0, 0, 3.4, 2.7, 0, 4.3, 0, 0, 6, 0.1, 0, 4.3, 0.1, 0),
       nrow = 4L,
       ncol = 4L
     )
@@ -219,7 +227,7 @@ test_that("as_adjacency_matrix() works -- dense undirected", {
 })
 
 test_that("as_adjacency_matrix() works -- dense + not both", {
-  dg <- make_graph(c(1,2, 2,1, 2,2, 3,3, 3,3, 3,4, 4,2, 4,2, 4,2), directed = TRUE)
+  dg <- make_graph(c(1, 2, 2, 1, 2, 2, 3, 3, 3, 3, 3, 4, 4, 2, 4, 2, 4, 2), directed = TRUE)
   g <- as_undirected(dg, mode = "each")
   E(g)$attribute <- c(1.2, 3.4, 2.7, 5.6, 6.0, 0.1, 6.1, 3.3, 4.3)
 
@@ -233,13 +241,17 @@ test_that("as_adjacency_matrix() works -- dense + not both", {
   expect_equal(
     lower_adj_matrix,
     matrix(
-      c(0, 3.4, 0, 0, 0, 2.7, 0, 4.3, 0, 0, 6, 0.1, 0, 0, 0, 0),
+      c(0, 4.6, 0, 0, 0, 2.7, 0, 13.7, 0, 0, 11.6, 0.1, 0, 0, 0, 0),
+      # below is wrong test result due to a bug (#1551). Weights of ties
+      # between the same node pair should be aggregated and not only the last
+      # weight should be considered. The above is consistent with the sparse case
+      # c(0, 3.4, 0, 0, 0, 2.7, 0, 4.3, 0, 0, 6, 0.1, 0, 0, 0, 0),
       nrow = 4L,
       ncol = 4L
     )
   )
 
-  upper_adj_matrix  <- as_adjacency_matrix(
+  upper_adj_matrix <- as_adjacency_matrix(
     g,
     type = "upper",
     sparse = FALSE,
@@ -249,7 +261,11 @@ test_that("as_adjacency_matrix() works -- dense + not both", {
   expect_equal(
     upper_adj_matrix,
     matrix(
-      c(0, 0, 0, 0, 3.4, 2.7, 0, 0, 0, 0, 6, 0, 0, 4.3, 0.1, 0),
+      c(0, 0, 0, 0, 4.6, 2.7, 0, 0, 0, 0, 11.6, 0, 0, 13.7, 0.1, 0),
+      # below is wrong test result due to a bug (#1551). Weights of ties
+      # between the same node pair should be aggregated and not only the last
+      # weight should be considered. The above is consistent with the sparse case
+      # c(0, 0, 0, 0, 3.4, 2.7, 0, 0, 0, 0, 6, 0, 0, 4.3, 0.1, 0),
       nrow = 4L,
       ncol = 4L
     )

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -274,3 +274,26 @@ test_that("as_adjacency_matrix() works -- dense + not both", {
     )
   )
 })
+
+test_that("as_adjacency_matrix() works -- dense + weights", {
+  g <- make_full_graph(5, directed = FALSE)
+  E(g)$weight <- 1:10
+  mat <- matrix(0, 5, 5)
+  mat[lower.tri(mat)] <- 1:10
+  mat <- mat + t(mat)
+  A <- as_adjacency_matrix(g, attr = "weight", sparse = FALSE)
+  expect_equal(A, mat)
+})
+
+test_that("as_biadjacency_matrix() works -- dense + weights", {
+  g <- make_bipartite_graph(c(0, 1, 0, 1, 0, 0), c(1, 2, 2, 3, 3, 4))
+  E(g)$weight <- c(2, 4, 6)
+  A <- as_biadjacency_matrix(g, attr = "weight", sparse = FALSE)
+  mat <- matrix(
+    c(2, 4, 0, 0, 0, 6, 0, 0),
+    nrow = 4L,
+    ncol = 2L,
+    dimnames = list(c("1", "3", "5", "6"), c("2", "4"))
+  )
+  expect_equal(A, mat)
+})

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -202,6 +202,7 @@ test_that("as_adjacency_matrix() works -- dense undirected", {
   ug <- as_undirected(dg, mode = "each")
   # no different treatment than undirected if no attribute?!
   adj_matrix <- as_adjacency_matrix(ug, sparse = FALSE)
+  dimnames(adj_matrix) <- NULL
   expect_equal(
     adj_matrix,
     matrix(
@@ -212,6 +213,7 @@ test_that("as_adjacency_matrix() works -- dense undirected", {
 
   E(ug)$weight <- c(1.2, 3.4, 2.7, 5.6, 6.0, 0.1, 6.1, 3.3, 4.3)
   weight_adj_matrix <- as_adjacency_matrix(ug, sparse = FALSE, attr = "weight")
+  dimnames(weight_adj_matrix) <- NULL
   expect_equal(
     weight_adj_matrix,
     matrix(
@@ -237,6 +239,7 @@ test_that("as_adjacency_matrix() works -- dense + not both", {
     sparse = FALSE,
     attr = "attribute"
   )
+  dimnames(lower_adj_matrix) <- NULL
 
   expect_equal(
     lower_adj_matrix,
@@ -257,7 +260,7 @@ test_that("as_adjacency_matrix() works -- dense + not both", {
     sparse = FALSE,
     attr = "attribute"
   )
-
+  dimnames(upper_adj_matrix) <- NULL
   expect_equal(
     upper_adj_matrix,
     matrix(

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -295,5 +295,5 @@ test_that("as_biadjacency_matrix() works -- dense + weights", {
     ncol = 2L,
     dimnames = list(c("1", "3", "5", "6"), c("2", "4"))
   )
-  expect_equal(canonicalize_matrix(A), mat)
+  expect_equal(canonicalize_matrix(A), canonicalize_matrix(mat))
 })

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -282,7 +282,7 @@ test_that("as_adjacency_matrix() works -- dense + weights", {
   mat[lower.tri(mat)] <- 1:10
   mat <- mat + t(mat)
   A <- as_adjacency_matrix(g, attr = "weight", sparse = FALSE)
-  expect_equal(A, mat)
+  expect_equal(canonicalize_matrix(A), mat)
 })
 
 test_that("as_biadjacency_matrix() works -- dense + weights", {
@@ -295,5 +295,5 @@ test_that("as_biadjacency_matrix() works -- dense + weights", {
     ncol = 2L,
     dimnames = list(c("1", "3", "5", "6"), c("2", "4"))
   )
-  expect_equal(A, mat)
+  expect_equal(canonicalize_matrix(A), mat)
 })


### PR DESCRIPTION
This PR removes (nested) for loops for `get.adjacency.dense()` when `attr != NULL`

(cherry picked commits from #1518) 

