### PR TITLE
refactor: consolidate graph.incidence.* (#1483)

### DIFF
--- a/R/incidence.R
+++ b/R/incidence.R
@@ -46,7 +46,6 @@ process.sparse <- function(incidence, num_rows) {
 # Helper function to process dense matrices (matrix to edgelist)
 process.dense <- function(incidence, num_rows) {
   nz_ids <- which(incidence != 0, arr.ind = TRUE)
-  nz_ids <- nz_ids[order(nz_ids[, 1], nz_ids[, 2]), , drop = FALSE]
   el <- cbind(nz_ids, incidence[nz_ids])
   el[, 2] <- el[, 2] + num_rows
   el

--- a/R/incidence.R
+++ b/R/incidence.R
@@ -36,16 +36,9 @@ graph.incidence <- function(incidence, directed = FALSE, mode = c("all", "out", 
 ##
 ## -----------------------------------------------------------------
 
-# Helper function to process sparse matrices (matrix to edgelist)
-process.sparse <- function(incidence, num_rows) {
-  el <- mysummary(incidence)
-  # adjust indices for second column to create a second mode
-  el[, 2] <- el[, 2] + num_rows
-  as.matrix(el)
-}
 
 # adjust edgelist according to directionality of edges
-adjust.directionality <- function(el, mode, directed) {
+modify_edgelist <- function(el, mode, directed) {
   if (!directed || mode == "out") {
     # No adjustment needed
     return(el)
@@ -57,7 +50,7 @@ adjust.directionality <- function(el, mode, directed) {
   rbind(el, reversed_edges)
 }
 
-graph.incidence.build <- function(incidence, directed = FALSE, mode = "out",
+graph_incidence_build <- function(incidence, directed = FALSE, mode = "out",
                                   multiple = FALSE, weighted = NULL) {
   num_rows <- nrow(incidence)
   num_cols <- ncol(incidence)
@@ -82,10 +75,11 @@ graph.incidence.build <- function(incidence, directed = FALSE, mode = "out",
     incidence <- as(incidence, "dgCMatrix")
   }
 
-  # Process sparse matrix to edgelist
-  el <- process.sparse(incidence, num_rows)
-  # Adjust edgelist for directionality and mode
-  el <- adjust.directionality(el, mode, directed)
+  el <- mysummary(incidence)
+  el[, 2] <- el[, 2] + num_rows
+  el <- as.matrix(el)
+
+  el <- modify_edgelist(el, mode, directed)
 
   # Construct the graph object from processed edgelist
   if (!is.null(weighted)) {
@@ -202,7 +196,7 @@ graph_from_biadjacency_matrix <- function(incidence, directed = FALSE,
     }
   }
 
-  res <- graph.incidence.build(incidence,
+  res <- graph_incidence_build(incidence,
     directed = directed,
     mode = mode, multiple = multiple,
     weighted = weighted

--- a/R/incidence.R
+++ b/R/incidence.R
@@ -49,15 +49,15 @@ adjust.directionality <- function(el, mode, directed) {
   if (!directed || mode == "out") {
     # No adjustment needed
     return(el)
-  } else if (mode == "in") {
-    # Reverse the edges
-    el[, 1:2] <- el[, c(2, 1)]
-  } else if (mode %in% c("all", "total")) {
-    # Add reversed edges
-    reversed_edges <- el[, c(2, 1, 3)]
-    el <- rbind(el, reversed_edges)
   }
-  el
+  reversed_edges <- el[, c(2, 1, 3)]
+  if (mode == "in") {
+    return(reversed_edges)
+  }
+  if (mode %in% c("all", "total")) {
+    # Add reversed edges
+    rbind(el, reversed_edges)
+  }
 }
 
 graph.incidence.build <- function(incidence, directed = FALSE, mode = "out",

--- a/R/incidence.R
+++ b/R/incidence.R
@@ -39,16 +39,9 @@ graph.incidence <- function(incidence, directed = FALSE, mode = c("all", "out", 
 # Helper function to process sparse matrices (matrix to edgelist)
 process.sparse <- function(incidence, num_rows) {
   el <- mysummary(incidence)
+  # adjust indices for second column to create a second mode
   el[, 2] <- el[, 2] + num_rows
   as.matrix(el)
-}
-
-# Helper function to process dense matrices (matrix to edgelist)
-process.dense <- function(incidence, num_rows) {
-  nz_ids <- which(incidence != 0, arr.ind = TRUE)
-  el <- cbind(nz_ids, incidence[nz_ids])
-  el[, 2] <- el[, 2] + num_rows
-  el
 }
 
 # adjust edgelist according to directionality of edges
@@ -76,8 +69,8 @@ graph.incidence.build <- function(incidence, directed = FALSE, mode = "out",
     # General Sparse matrix processing
     el <- process.sparse(incidence, num_rows)
   } else if (!is.null(weighted)) {
-    # Dense weighted matrix processing
-    el <- process.dense(incidence, num_rows)
+    # Dense weighted matrix processing (convert to sparse matrix first)
+    el <- process.sparse(as(incidence, "dgCMatrix"), num_rows)
   } else {
     mode(incidence) <- "double"
     on.exit(.Call(R_igraph_finalizer))

--- a/R/incidence.R
+++ b/R/incidence.R
@@ -44,11 +44,11 @@ graph.incidence.sparse <- function(incidence, directed, mode, multiple,
   el[, 2] <- el[, 2] + n1
 
   if (!is.null(weighted)) {
-    if (!directed || mode == 1) {
+    if (!directed || mode == "out") {
       ## nothing do to
-    } else if (mode == 2) {
+    } else if (mode == "in") {
       el[, 1:2] <- el[, c(2, 1)]
-    } else if (mode == 3) {
+    } else if (mode %in% c("all", "total")) {
       reversed_el <- el[, c(2, 1, 3)]
       names(reversed_el) <- names(el)
       el <- rbind(el, reversed_el)
@@ -66,11 +66,11 @@ graph.incidence.sparse <- function(incidence, directed, mode, multiple,
       el[, 3] <- el[, 3] != 0
     }
 
-    if (!directed || mode == 1) {
+    if (!directed || mode == "out") {
       ## nothing do to
-    } else if (mode == 2) {
+    } else if (mode == "in") {
       el[, 1:2] <- el[, c(2, 1)]
-    } else if (mode == 3) {
+    } else if (mode %in% c("all", "total")) {
       el <- rbind(el, el[, c(2, 1, 3)])
     }
 
@@ -96,11 +96,11 @@ graph.incidence.dense <- function(incidence, directed, mode, multiple,
     # move from separate row/col indexing to 1..n1+n2 indexing
     el[, 2] <- el[, 2] + n1
 
-    if (!directed || mode == 1) {
+    if (!directed || mode == "out") {
       ## nothing do to
-    } else if (mode == 2) {
+    } else if (mode == "in") {
       el[, 1:2] <- el[, c(2, 1)]
-    } else if (mode == 3) {
+    } else if (mode %in% c("all", "total")) {
       reversed_el <- el[, c(2, 1, 3)]
       names(reversed_el) <- names(el)
       el <- rbind(el, reversed_el)
@@ -115,6 +115,12 @@ graph.incidence.dense <- function(incidence, directed, mode, multiple,
     mode(incidence) <- "double"
     on.exit(.Call(R_igraph_finalizer))
     ## Function call
+    mode <- switch(mode,
+      "out" = 1,
+      "in" = 2,
+      "all" = 3,
+      "total" = 3
+    )
     res <- .Call(R_igraph_biadjacency, incidence, directed, mode, multiple)
     res <- set_vertex_attr(res$graph, "type", value = res$types)
   }
@@ -191,12 +197,8 @@ graph_from_biadjacency_matrix <- function(incidence, directed = FALSE,
                                           add.names = NULL) {
   # Argument checks
   directed <- as.logical(directed)
-  mode <- switch(igraph.match.arg(mode),
-    "out" = 1,
-    "in" = 2,
-    "all" = 3,
-    "total" = 3
-  )
+  mode <- igraph.match.arg(mode)
+
   multiple <- as.logical(multiple)
 
   if (!is.null(weighted)) {

--- a/R/incidence.R
+++ b/R/incidence.R
@@ -90,6 +90,8 @@ graph.incidence.dense <- function(incidence, directed, mode, multiple,
     # create an edgelist from the nonzero entries of the
     # incidence matrix
     idx <- which(incidence != 0, arr.ind = TRUE)
+    # convert to row-first order
+    idx <- idx[order(idx[, 1], idx[, 2]), ]
     # add the value of the matrix. So a row is [s,t,incidence[s,t]]
     el <- cbind(idx, incidence[idx])
 

--- a/R/incidence.R
+++ b/R/incidence.R
@@ -54,10 +54,7 @@ adjust.directionality <- function(el, mode, directed) {
   if (mode == "in") {
     return(reversed_edges)
   }
-  if (mode %in% c("all", "total")) {
-    # Add reversed edges
-    rbind(el, reversed_edges)
-  }
+  rbind(el, reversed_edges)
 }
 
 graph.incidence.build <- function(incidence, directed = FALSE, mode = "out",

--- a/R/incidence.R
+++ b/R/incidence.R
@@ -44,7 +44,6 @@ graph.incidence.sparse <- function(incidence, directed, mode, multiple,
   el[, 2] <- el[, 2] + n1
 
   if (!is.null(weighted)) {
-
     if (!directed || mode == 1) {
       ## nothing do to
     } else if (mode == 2) {
@@ -85,13 +84,16 @@ graph.incidence.sparse <- function(incidence, directed, mode, multiple,
 graph.incidence.dense <- function(incidence, directed, mode, multiple,
                                   weighted) {
   if (!is.null(weighted)) {
-
     n1 <- nrow(incidence)
     n2 <- ncol(incidence)
 
+    # create an edgelist from the nonzero entries of the
+    # incidence matrix
     idx <- which(incidence != 0, arr.ind = TRUE)
+    # add the value of the matrix. So a row is [s,t,incidence[s,t]]
     el <- cbind(idx, incidence[idx])
 
+    # move from separate row/col indexing to 1..n1+n2 indexing
     el[, 2] <- el[, 2] + n1
 
     if (!directed || mode == 1) {
@@ -199,7 +201,6 @@ graph_from_biadjacency_matrix <- function(incidence, directed = FALSE,
 
   if (!is.null(weighted)) {
     if (is.logical(weighted) && weighted) {
-
       if (multiple) {
         cli::cli_abort(c(
           "{.arg multiple} and {.arg weighted} cannot be both {.code TRUE}.",

--- a/tests/testthat/_snaps/incidence.md
+++ b/tests/testthat/_snaps/incidence.md
@@ -16,7 +16,7 @@
       IGRAPH UNWB 8 7 -- 
       + attr: type (v/l), name (v/c), weight (e/n)
       + edges (vertex names):
-      [1] A--c A--d B--b B--c B--e C--b C--d
+      [1] B--b C--b A--c B--c A--d C--d B--e
 
 # graph_from_biadjacency_matrix() works -- dense + multiple
 


### PR DESCRIPTION
~~This PR removes (nested) for loops for `graph.incidence.dense()` when `weighted = TRUE`~~

~~(cherry picked commits from https://github.com/igraph/rigraph/pull/1518)~~

This PR removes `graph.incidence.sparse()` and `graph.incidence.dense()` and replaces it with a general `graph.incidence.build()` and more specialized helper functions.

