### PR TITLE
perf: Faster single bracket querying of a graph

### DIFF
--- a/R/indexing.R
+++ b/R/indexing.R
@@ -169,24 +169,6 @@ get_submatrix <- function(x, i, j, attr = NULL, sparse = TRUE) {
   res
 }
 
-clean_indices <- function(x, indices) {
-  if (is.character(indices)) {
-    return(match(indices, V(x)$name))
-  }
-  if (is.logical(indices)) {
-    if (length(indices) != vcount(x)) {
-      indices <- which(rep(indices, length.out = vcount(x)))
-    } else {
-      indices <- which(indices)
-    }
-    return(indices)
-  }
-  if (all(indices < 0)) {
-    return(seq_len(vcount(x))[indices])
-  }
-  indices
-}
-
 #' Query and manipulate a graph as it were an adjacency matrix
 #'
 #' @details
@@ -328,10 +310,10 @@ clean_indices <- function(x, indices) {
 
   # convert logical, character or negative i/j to proper vertex ids
   if (!missing(i)) {
-    i <- clean_indices(x, i)
+    i <- as_igraph_vs(x, i)
   }
   if (!missing(j)) {
-    j <- clean_indices(x, j)
+    j <- as_igraph_vs(x, j)
   }
 
   if (missing(i) && missing(j)) {

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -53,7 +53,7 @@
 # - G[1:3,2,eid=TRUE]
 #               create an edge sequence
 
-get_adjacency_submatrix <- function(x, i, j, attr = NULL, sparse = TRUE) {
+get_adjacency_submatrix <- function(x, i, j, attr = NULL) {
   # If i or j is NULL, assume all nodes
   # if not NULL make sure to handle duplicates correctly
   if (missing(i)) {
@@ -90,16 +90,12 @@ get_adjacency_submatrix <- function(x, i, j, attr = NULL, sparse = TRUE) {
     dims = c(length(i), length(j))
   )
 
-  if (!sparse) {
-    res <- as.matrix(res)
-  }
-
   if ("name" %in% vertex_attr_names(x) && !is.null(dim(res))) {
     rownames(res) <- vertex_attr(x, "name", i)
     colnames(res) <- vertex_attr(x, "name", j)
   }
 
-  return(res[, , drop = FALSE])
+  res
 }
 
 
@@ -271,14 +267,20 @@ get_adjacency_submatrix <- function(x, i, j, attr = NULL, sparse = TRUE) {
     }
   }
 
-  sub_adjmat <- get_adjacency_submatrix(x, i = i, j = j, attr = attr, sparse = sparse)
+  sub_adjmat <- get_adjacency_submatrix(x, i = i, j = j, attr = attr)
   if (i_has_dupes) {
     sub_adjmat <- sub_adjmat[i_map, , drop = FALSE]
   }
   if (j_has_dupes) {
     sub_adjmat <- sub_adjmat[, j_map, drop = FALSE]
   }
-  sub_adjmat[, , drop = drop]
+
+  if (!sparse) {
+    as.matrix(sub_adjmat[, , drop = drop])
+  } else{
+    sub_adjmat[, , drop = drop]
+  } 
+  
 }
 
 #' Query and manipulate a graph as it were an adjacency list

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -69,16 +69,16 @@ get_adjacency_submatrix <- function(x, i, j, attr = NULL, sparse = TRUE) {
   from_id <- rep(i, i_degree)
   to_id <- unlist(adj)
 
-  edge_list <- cbind(from_id, to_id)
-  edge_list <- edge_list[edge_list[, 2] %in% j, , drop = FALSE]
+  edge_list <- data.frame(from = as.integer(from_id), to = as.integer(to_id))
+  edge_list <- edge_list[edge_list$to %in% j, ]
 
-  row_indices <- edge_list[, 1]
-  col_indices <- edge_list[, 2]
+  row_indices <- edge_list[[1]]
+  col_indices <- edge_list[[2]]
 
   values <- if (is.null(attr)) {
     1
   } else {
-    valid_edges <- get_edge_ids(x, c(t(edge_list)))
+    valid_edges <- get_edge_ids(x, edge_list)
     edge_attr(x, attr, valid_edges)
   }
 
@@ -230,7 +230,7 @@ get_adjacency_submatrix <- function(x, i, j, attr = NULL, sparse = TRUE) {
   ##################################################################
 
   if (!missing(from)) {
-    res <- get_edge_ids(x, rbind(from, to), error = FALSE)
+    res <- get_edge_ids(x, data.frame(from, to), error = FALSE)
     if (edges) {
       ## nop
     } else if (!is.null(attr)) {

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -55,7 +55,7 @@
 
 get_adjacency_submatrix <- function(x, i = NULL, j = NULL, attr = NULL, sparse = TRUE) {
   # If i or j is NULL, assume all nodes
-  #if not NULL make sure to handle duplicates correctly
+  # if not NULL make sure to handle duplicates correctly
   if (is.null(i)) {
     i <- i_unique <- i_map <- seq_len(vcount(x))
   } else {
@@ -71,7 +71,7 @@ get_adjacency_submatrix <- function(x, i = NULL, j = NULL, attr = NULL, sparse =
   }
 
   adj <- adjacent_vertices(x, i_unique, mode = "out")
-  i_degree <- purrr::map_int(adj, length)
+  i_degree <- map_int(adj, length)
 
   from_id <- rep(i_unique, i_degree)
   to_id <- unlist(adj)
@@ -218,9 +218,9 @@ get_adjacency_submatrix <- function(x, i = NULL, j = NULL, attr = NULL, sparse =
 #' @method [ igraph
 #' @export
 `[.igraph` <- function(x, i, j, ..., from, to,
-  sparse = igraph_opt("sparsematrices"),
-                       edges = FALSE, drop = TRUE,
-                       attr = if (is_weighted(x)) "weight" else NULL) {
+    sparse = igraph_opt("sparsematrices"),
+    edges = FALSE, drop = TRUE,
+    attr = if (is_weighted(x)) "weight" else NULL) {
   ################################################################
   ## Argument checks
   if ((!missing(from) || !missing(to)) &&
@@ -391,8 +391,8 @@ length.igraph <- function(x) {
 #' @family functions for manipulating graph structure
 #' @export
 `[<-.igraph` <- function(x, i, j, ..., from, to,
-  attr = if (is_weighted(x)) "weight" else NULL,
-                         value) {
+    attr = if (is_weighted(x)) "weight" else NULL,
+    value) {
   ## TODO: rewrite this in C to make it faster
 
   ################################################################
@@ -428,7 +428,7 @@ length.igraph <- function(x) {
 
   if (!missing(from)) {
     if (is.null(value) ||
-        (is.logical(value) && !value) ||
+      (is.logical(value) && !value) ||
       (is.null(attr) && is.numeric(value) && value == 0)) {
       ## Delete edges
       todel <- x[from = from, to = to, ..., edges = TRUE]
@@ -445,7 +445,7 @@ length.igraph <- function(x) {
       }
     }
   } else if (is.null(value) ||
-      (is.logical(value) && !value) ||
+    (is.logical(value) && !value) ||
     (is.null(attr) && is.numeric(value) && value == 0)) {
     ## Delete edges
     if (missing(i) && missing(j)) {
@@ -467,12 +467,12 @@ length.igraph <- function(x) {
       exe <- lapply(x[[i, j, ..., edges = TRUE]], as.vector)
       exv <- lapply(x[[i, j, ...]], as.vector)
       toadd <- unlist(lapply(seq_along(exv), function(idx) {
-          to <- setdiff(j, exv[[idx]])
-          if (length(to != 0)) {
-            rbind(i[idx], setdiff(j, exv[[idx]]))
-          } else {
-            numeric()
-          }
+        to <- setdiff(j, exv[[idx]])
+        if (length(to != 0)) {
+          rbind(i[idx], setdiff(j, exv[[idx]]))
+        } else {
+          numeric()
+        }
       }))
       ## Do the changes
       if (is.null(attr)) {

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -75,6 +75,7 @@ get_adjacency_submatrix <- function(x, i = NULL, j = NULL, attr = NULL, sparse =
 
   from_id <- rep(i_unique, i_degree)
   to_id <- unlist(adj)
+
   edge_list <- cbind(from_id, to_id)
   edge_list <- edge_list[edge_list[, 2] %in% j_unique, , drop = FALSE]
 
@@ -89,26 +90,19 @@ get_adjacency_submatrix <- function(x, i = NULL, j = NULL, attr = NULL, sparse =
     edge_attr(x, attr, valid_edges)
   }
 
-  # Construct sparse or dense result matrix
-  if (sparse) {
-    unique_res <- Matrix::sparseMatrix(
-      i = match(row_indices, i_unique),
-      j = match(col_indices, j_unique),
-      x = values,
-      dims = c(length(i_unique), length(j_unique))
-    )
-  } else {
-    unique_res <- matrix(0, nrow = length(i_unique), ncol = length(j_unique))
-    unique_res[
-      cbind(match(row_indices, i_unique), match(col_indices, j_unique))
-    ] <- values
-  }
+
+  unique_res <- Matrix::sparseMatrix(
+    i = match(row_indices, i_unique),
+    j = match(col_indices, j_unique),
+    x = values,
+    dims = c(length(i_unique), length(j_unique))
+  )
 
   # Expand to handle duplicated entries in i and j
-  res <- if (sparse) {
-    unique_res[i_map, j_map, drop = TRUE]
-  } else {
-    unique_res[i_map, j_map]
+  res <- unique_res[i_map, j_map, drop = TRUE]
+
+  if (!sparse) {
+    res <- as.matrix(res)
   }
 
   if ("name" %in% vertex_attr_names(x) && !is.null(dim(res))) {

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -322,3 +322,21 @@ test_that("[ handles all combinations of i and/or j", {
   expect_equal(canonicalize_matrix(g[, 4:7]), A[, 4:7])
   expect_equal(canonicalize_matrix(g[1:3, 4:7]), A[1:3, 4:7])
 })
+
+test_that("[ handles duplicated i/j well", {
+  A <- matrix(
+    rep(
+      c(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0),
+      c(
+        4L, 1L, 4L, 1L, 2L, 1L, 5L, 2L, 3L, 1L, 10L, 3L, 9L, 1L, 1L, 1L, 3L, 1L, 1L,
+        1L, 1L, 1L, 10L, 1L, 1L, 1L, 1L, 5L, 11L, 1L, 2L, 1L, 5L, 1L, 3L
+      )
+    ),
+    nrow = 10L,
+    ncol = 10L
+  )
+  g <- graph_from_adjacency_matrix(A, "directed")
+  expect_equal(canonicalize_matrix(g[c(1, 2, 2), ]), A[c(1, 2, 2), ])
+  expect_equal(canonicalize_matrix(g[, c(3, 3, 4, 4)]), A[, c(3, 3, 4, 4)])
+  expect_equal(canonicalize_matrix(g[c(1, 2, 2), c(3, 3, 4, 4)]), A[c(1, 2, 2), c(3, 3, 4, 4)])
+})

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -87,6 +87,7 @@ test_that("[ indexing works with weighted graphs", {
 })
 
 test_that("[ indexing works with weighted graphs and symbolic names", {
+  skip_if_not_installed("Matrix", minimum_version = "1.6.0")
   g <- make_test_weighted_tree()
 
   expect_equal(g["a", "b"], 2)

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -1,4 +1,5 @@
 test_that("[ indexing works", {
+  skip_if_not_installed("Matrix", minimum_version = "1.6.0")
   g <- make_tree(20)
   ## Are these vertices connected?
   expect_equal(g[1, 2], 1)
@@ -9,6 +10,7 @@ test_that("[ indexing works", {
 })
 
 test_that("[ indexing works with symbolic names", {
+  skip_if_not_installed("Matrix", minimum_version = "1.6.0")
   g <- make_test_named_tree()
 
   expect_equal(g["a", "b"], 1)
@@ -28,6 +30,7 @@ test_that("[ indexing works with symbolic names", {
 })
 
 test_that("[ indexing works with logical vectors", {
+  skip_if_not_installed("Matrix", minimum_version = "1.6.0")
   g <- make_test_named_tree()
 
   lres <- structure(
@@ -70,6 +73,7 @@ test_that("[ indexing works with negative indices", {
 })
 
 test_that("[ indexing works with weighted graphs", {
+  skip_if_not_installed("Matrix", minimum_version = "1.6.0")
   g <- make_test_weighted_tree()
 
   expect_equal(g[1, 2], 2)

--- a/tests/testthat/test-indexing.R
+++ b/tests/testthat/test-indexing.R
@@ -294,3 +294,31 @@ test_that("[[ handles from and to properly even if the graph has conflicting ver
   expect_true(is_igraph_vs(g[[1:3, 2:6]][[1]]))
   expect_true(is_igraph_vs(g[[from = 1:3, to = 2:6]][[1]]))
 })
+
+test_that("[ handles errors in input parameters well", {
+  g <- make_full_graph(10)
+  expect_error(g[from = 1, to = 1, i = 1, j = 1])
+  expect_error(g[from = 1])
+  expect_error(g[to = 1])
+  expect_error(g[from = NA, to = 2])
+  expect_error(g[from = 1, to = NA])
+  expect_error(g[from = 1, to = c(1, 2)])
+})
+
+test_that("[ handles all combinations of i and/or j", {
+  A <- matrix(
+    rep(
+      c(0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0),
+      c(
+        4L, 1L, 4L, 1L, 2L, 1L, 5L, 2L, 3L, 1L, 10L, 3L, 9L, 1L, 1L, 1L, 3L, 1L, 1L,
+        1L, 1L, 1L, 10L, 1L, 1L, 1L, 1L, 5L, 11L, 1L, 2L, 1L, 5L, 1L, 3L
+      )
+    ),
+    nrow = 10L,
+    ncol = 10L
+  )
+  g <- graph_from_adjacency_matrix(A, "directed")
+  expect_equal(canonicalize_matrix(g[1:3, ]), A[1:3, ])
+  expect_equal(canonicalize_matrix(g[, 4:7]), A[, 4:7])
+  expect_equal(canonicalize_matrix(g[1:3, 4:7]), A[1:3, 4:7])
+})


### PR DESCRIPTION
This PR refactors single bracket querying of a graph (`g[1:3,4:6]`) (closes #1465). 

### `[.igraph`
In the old version, the complete adjacency matrix was computed and then a subset created. The refactored function now builds the submatrix directly. This leads to a little speedup and a lower memory footprint.

``` r
set.seed(411)
g <- sample_gnp(5000,0.1)
bench::mark(
  check = FALSE,
  new = igraph:::get_adjacency_submatrix(g,1:100,1:100),
  old = as_adjacency_matrix(g)[1:100,1:100]
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new          1.84ms   1.94ms    452.      4.26MB     24.0
#> 2 old         61.36ms 118.39ms      9.11   210.4MB     38.3

bench::mark(
  check = FALSE,
  new = igraph:::get_adjacency_submatrix(g,i = 1:100,j = 1:100,sparse = FALSE),
  old = as_adjacency_matrix(g,sparse = FALSE)[1:100,1:100]
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new          1.69ms   1.81ms     462.     3.31MB     5.99
#> 2 old         59.95ms   61.1ms      16.0  190.81MB    16.0

E(g)$weight <- runif(ecount(g))
bench::mark(
  check = FALSE,
  new = igraph:::get_adjacency_submatrix(g,1:100,1:100),
  old = as_adjacency_matrix(g)[1:100,1:100]
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new          1.88ms   1.99ms     451.      3.2MB     7.98
#> 2 old         55.34ms  62.09ms      14.5   209.7MB    23.6

bench::mark(
  check = FALSE,
  new = igraph:::get_adjacency_submatrix(g,i = 1:100,j = 1:100,sparse = FALSE),
  old = as_adjacency_matrix(g,sparse = FALSE)[1:100,1:100]
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 new           1.7ms    1.8ms     432.     3.31MB     8.00
#> 2 old          56.7ms   57.8ms      13.8  190.81MB    13.8
```

<sup>Created on 2025-01-18 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

