### PR TITLE
feat: `get_edge_ids()` accepts data frames and matrices

### DIFF
--- a/R/interface.R
+++ b/R/interface.R
@@ -1,4 +1,3 @@
-
 #' Check whether a graph is directed
 #'
 #' @description
@@ -467,7 +466,7 @@ get.edges <- function(graph, es) {
   ends(graph, es, names = FALSE)
 }
 
-el_to_vec <- function(x, call = caller_env()) {
+el_to_vec <- function(x, call = rlang::caller_env()) {
   if (is.data.frame(x)) {
     c(rbind(x[[1]], x[[2]]))
   } else if (inherits(x, "matrix")) {
@@ -476,7 +475,7 @@ el_to_vec <- function(x, call = caller_env()) {
   } else if (is.vector(x)) {
     x
   } else {
-    cli::cli_abort("only two-column data.frames and matrices, and vectors are allowed for vp")
+    cli::cli_abort("only two-column data.frames and matrices, and vectors are allowed for vp", call = call)
   }
 }
 
@@ -559,7 +558,6 @@ get.edge.ids <- function(graph,
                          directed = TRUE,
                          error = FALSE,
                          multi = deprecated()) {
-
   if (lifecycle::is_present(multi)) {
     if (isTRUE(multi)) {
       lifecycle::deprecate_stop("2.0.0", "get.edge.ids(multi = )")

--- a/R/interface.R
+++ b/R/interface.R
@@ -475,18 +475,21 @@ el_to_vec <- function(x, call = rlang::caller_env()) {
     }
   } else if (inherits(x, "matrix")) {
     dimx <- dim(x)
-    if (identical(dimx, c(2L, 2L))) {
+    nrow <- dimx[[1]]
+    ncol <- dimx[[2]]
+    if (nrow == 2 && ncol == 2) {
       lifecycle::deprecate_stop(
         "2.1.5",
         "get_edge_ids(vp = 'is not allowed to be a 2 times 2 matrix')"
       )
-    } else if (dimx[1] == 2L) {
+    } else if (nrow == 2) {
       lifecycle::deprecate_warn(
         "2.1.5",
-        "get_edge_ids(vp = 'supplied as a matrix should be a n times 2 matrix, not 2 times n')"
+        "get_edge_ids(vp = 'supplied as a matrix should be a n times 2 matrix, not 2 times n')",
+        details = "either transpose the matrix with t() or convert it to a data.frame with two columns."
       )
       c(x)
-    } else if (dimx[2] == 2L) {
+    } else if (ncol == 2) {
       c(t(x))
     } else {
       cli::cli_abort("{.args vp} was supplied as a {dimx[1]} times {dimx[2]} matrix. Only n times 2 matrices are allowed")

--- a/R/interface.R
+++ b/R/interface.R
@@ -482,8 +482,9 @@ get.edges <- function(graph, es) {
 #' vertices.
 #'
 #' @param graph The input graph.
-#' @param vp The incident vertices, given as vertex ids or symbolic vertex
-#'   names. They are interpreted pairwise, i.e. the first and second are used for
+#' @param vp The incident vertices, given as a two-column data frame, two-column matrix,
+#'   or vector of vertex ids or symbolic vertex names.
+#'   For a vector, the values are interpreted pairwise, i.e. the first and second are used for
 #'   the first edge, the third and fourth for the second, etc.
 #' @param directed Logical scalar, whether to consider edge directions in
 #'   directed graphs. This argument is ignored for undirected graphs.

--- a/R/interface.R
+++ b/R/interface.R
@@ -467,6 +467,19 @@ get.edges <- function(graph, es) {
   ends(graph, es, names = FALSE)
 }
 
+el_to_vec <- function(x) {
+  if (is.data.frame(x)) {
+    c(rbind(x[[1]], x[[2]]))
+  } else if (inherits(x, "matrix")) {
+    # c(t(x[,1:2])) TODO: decide on deprecation note
+    x
+  } else if (is.vector(x)) {
+    x
+  } else {
+    cli::cli_abort("only two-column data.frames and matrices, and vectors are allowed for vp")
+  }
+}
+
 
 #' Find the edge ids based on the incident vertices of the edges
 #'
@@ -519,6 +532,8 @@ get_edge_ids <- function(graph,
                          directed = TRUE,
                          error = FALSE) {
   ensure_igraph(graph)
+
+  vp <- el_to_vec(vp)
 
   on.exit(.Call(R_igraph_finalizer))
   .Call(

--- a/R/interface.R
+++ b/R/interface.R
@@ -467,7 +467,7 @@ get.edges <- function(graph, es) {
   ends(graph, es, names = FALSE)
 }
 
-el_to_vec <- function(x) {
+el_to_vec <- function(x, call = caller_env()) {
   if (is.data.frame(x)) {
     c(rbind(x[[1]], x[[2]]))
   } else if (inherits(x, "matrix")) {

--- a/R/interface.R
+++ b/R/interface.R
@@ -475,7 +475,7 @@ el_to_vec <- function(x, call = rlang::caller_env()) {
   } else if (is.vector(x)) {
     x
   } else {
-    cli::cli_abort("only two-column data.frames and matrices, and vectors are allowed for vp", call = call)
+    cli::cli_abort("Only two-column data.frames and matrices, and vectors are allowed for {.args vp}", call = call)
   }
 }
 

--- a/tests/testthat/_snaps/interface.md
+++ b/tests/testthat/_snaps/interface.md
@@ -17,3 +17,19 @@
       Error:
       ! The `multi` argument of `get.edge.ids()` was deprecated in igraph 2.0.0 and is now defunct.
 
+# get_edge_id() errors correctly for wrong vp
+
+    Code
+      get_edge_ids(g, el_g)
+    Condition
+      Error:
+      ! Only two-column data.frames and matrices, and vectors are allowed for vp
+
+---
+
+    Code
+      get_edge_ids(g, df)
+    Condition
+      Error in `el_to_vec()`:
+      ! The columns of the data.frame are of different type (character and double)
+

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -217,8 +217,8 @@ test_that("get_edge_id() errors correctly for wrong vp", {
 
 test_that("get_edge_id() errors correctly for wrong matrices", {
   g <- make_full_graph(10)
-  mat <- matrix(c(1, 2, 3, 4), 2, 2)
+  mat <- matrix(c(1, 2, 3, 4), nrow = 2, ncol = 2)
   lifecycle::expect_defunct(get_edge_ids(g, mat))
-  mat <- matrix(c(1, 2, 1, 3, 1, 4), 2, 3)
+  mat <- matrix(c(1, 2, 1, 3, 1, 4), nrow = 2, ncol = 3)
   lifecycle::expect_deprecated(get_edge_ids(g, mat))
 })

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -124,7 +124,6 @@ test_that("adjacent_vertices works", {
   for (i in seq_along(test_vertices)) {
     expect_setequal(adj_vertices[[i]], al[[test_vertices[i]]])
   }
-
 })
 
 
@@ -156,18 +155,18 @@ test_that("delete_edges works", {
   g2 <- delete_edges(g, E(g, P = c("D", "E")))
 
   expected_matrix <- matrix(
-      c(
-        0, 0, 0, 1, 1, 1,
-        0, 0, 0, 1, 1, 1,
-        0, 0, 0, 1, 1, 1,
-        1, 1, 1, 0, 0, 0,
-        1, 1, 1, 0, 0, 1,
-        1, 1, 1, 0, 1, 0
-      ),
-      nrow = 6L,
-      ncol = 6L,
-      dimnames = list(c("A", "B", "C", "D", "E", "F"), c("A", "B", "C", "D", "E", "F"))
-    )
+    c(
+      0, 0, 0, 1, 1, 1,
+      0, 0, 0, 1, 1, 1,
+      0, 0, 0, 1, 1, 1,
+      1, 1, 1, 0, 0, 0,
+      1, 1, 1, 0, 0, 1,
+      1, 1, 1, 0, 1, 0
+    ),
+    nrow = 6L,
+    ncol = 6L,
+    dimnames = list(c("A", "B", "C", "D", "E", "F"), c("A", "B", "C", "D", "E", "F"))
+  )
 
   expect_equal(as.matrix(g2[]), expected_matrix)
 })
@@ -183,4 +182,18 @@ test_that("get.edge.ids() deprecation", {
   g <- make_empty_graph(10)
   expect_snapshot(get.edge.ids(g, 1:2))
   expect_snapshot(get.edge.ids(g, 1:2, multi = TRUE), error = TRUE)
+})
+
+test_that("get_edge_id() works with data frame", {
+  g <- make_full_graph(3, directed = FALSE)
+  el_df <- data.frame(from = c(1, 1), to = c(2, 3))
+  expect_equal(get_edge_ids(g, el_df), c(1, 2))
+})
+
+test_that("get_edge_id() errors correctly", {
+  g <- make_full_graph(3, directed = FALSE)
+  el_g <- make_empty_graph()
+  expect_error(get_edge_ids(g, el_g))
+  expect_error(get_edge_ids(g, NULL))
+  expect_error(get_edge_ids(g, NA))
 })

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -190,10 +190,35 @@ test_that("get_edge_id() works with data frame", {
   expect_equal(get_edge_ids(g, el_df), c(1, 2))
 })
 
-test_that("get_edge_id() errors correctly", {
+test_that("get_edge_id() works with matrices", {
+  g <- make_full_graph(10)
+  mat <- matrix(c(1, 2, 1, 3, 1, 4), 3, 2, byrow = TRUE)
+  expect_equal(get_edge_ids(g, mat), c(1, 2, 3))
+
+  mat <- matrix(c(1, 2), 1, 2)
+  expect_equal(get_edge_ids(g, mat), 1)
+})
+
+test_that("get_edge_id() errors correctly for wrong vp", {
   g <- make_full_graph(3, directed = FALSE)
   el_g <- make_empty_graph()
-  expect_error(get_edge_ids(g, el_g))
+  expect_snapshot(error = TRUE, {
+    get_edge_ids(g, el_g)
+  })
   expect_error(get_edge_ids(g, NULL))
   expect_error(get_edge_ids(g, NA))
+
+  V(g)$name <- letters[1:3]
+  df <- data.frame(from = c("a", "b"), to = c(1, 2))
+  expect_snapshot(error = TRUE, {
+    get_edge_ids(g, df)
+  })
+})
+
+test_that("get_edge_id() errors correctly for wrong matrices", {
+  g <- make_full_graph(10)
+  mat <- matrix(c(1, 2, 3, 4), 2, 2)
+  lifecycle::expect_defunct(get_edge_ids(g, mat))
+  mat <- matrix(c(1, 2, 1, 3, 1, 4), 2, 3)
+  lifecycle::expect_deprecated(get_edge_ids(g, mat))
 })


### PR DESCRIPTION
Also for `add_edges()` ?

The matrix case works already by accident, a two-row matrix will give the intended result. Should we soft-deprecate the matrix case to later support two-column matrices?

``` r
library(igraph)
set.seed(20250120)
g <- sample_gnp(20, 0.1)
g
#> IGRAPH dc0368b U--- 20 22 -- Erdos-Renyi (gnp) graph
#> + attr: name (g/c), type (g/c), loops (g/l), p (g/n)
#> + edges from dc0368b:
#>  [1]  1-- 3  1-- 5  3-- 8  7-- 8  5--11 10--11  2--12  3--14  5--14  1--15
#> [11] 10--15 11--15  4--16  6--16 12--16  1--17 15--17  3--18  4--18  8--19
#> [21] 11--19 12--19
x <- c(1, 3, 1, 5, 3, 8)
get_edge_ids(g, x)
#> [1] 1 2 3
m <- matrix(x, nrow = 2)
m
#>      [,1] [,2] [,3]
#> [1,]    1    1    3
#> [2,]    3    5    8
get_edge_ids(g, m)
#> [1] 1 2 3
```

<sup>Created on 2025-01-20 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

