### PR TITLE
fix: correct mapping of edge label properties in plots when loops are present

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -292,7 +292,8 @@ plot.igraph <- function(x,
       }
     }
 
-    loop <- function(x0, y0, cx = x0, cy = y0, color, angle = 0, label = NA,
+    loop <- function(x0, y0, cx = x0, cy = y0, color, angle = 0, label = NA, label.color,
+                     label.font, label.family, label.cex,
                      width = 1, arr = 2, lty = 1, arrow.size = arrow.size,
                      arr.w = arr.w, lab.x, lab.y, loopSize = loop.size) {
       rad <- angle
@@ -337,8 +338,8 @@ plot.igraph <- function(x,
         }
 
         text(lx, ly, label,
-          col = edge.label.color, font = edge.label.font,
-          family = edge.label.family, cex = edge.label.cex
+          col = label.color, font = label.font,
+          family = label.family, cex = label.cex
         )
       }
     }
@@ -371,10 +372,28 @@ plot.igraph <- function(x,
     if (length(arrow.size) > 1) {
       asize <- arrow.size[loops.e]
     }
+    lcol <- edge.label.color
+    if (length(lcol) > 1) {
+      lcol <- lcol[loops.e]
+    }
+    lfam <- edge.label.family
+    if (length(lfam) > 1) {
+      lfam <- lfam[loops.e]
+    }
+    lfon <- edge.label.font
+    if (length(lfon) > 1) {
+      lfon <- lfon[loops.e]
+    }
+    lcex <- edge.label.cex
+    if (length(lcex) > 1) {
+      lcex <- lcex[loops.e]
+    }
+
     xx0 <- layout[loops.v, 1] + cos(la) * vs
     yy0 <- layout[loops.v, 2] - sin(la) * vs
     mapply(loop, xx0, yy0,
-      color = ec, angle = -la, label = loop.labels, lty = lty,
+      color = ec, angle = -la, label = loop.labels,
+      label.color = lcol, label.family = lfam, label.font = lfon, label.cex = lcex, lty = lty,
       width = ew, arr = arr, arrow.size = asize, arr.w = arrow.width,
       lab.x = loop.labx, lab.y = loop.laby
     )
@@ -447,9 +466,27 @@ plot.igraph <- function(x,
     if (!is.null(elab.y)) {
       lc.y <- ifelse(is.na(elab.y), lc.y, elab.y)
     }
+
+    ecol <- edge.label.color
+    if (length(ecol) > 1) {
+      ecol <- ecol[nonloops.e]
+    }
+    efam <- edge.label.family
+    if (length(efam) > 1) {
+      efam <- efam[nonloops.e]
+    }
+    efon <- edge.label.font
+    if (length(efon) > 1) {
+      efon <- efon[nonloops.e]
+    }
+    ecex <- edge.label.cex
+    if (length(ecex) > 1) {
+      ecex <- ecex[nonloops.e]
+    }
+
     text(lc.x, lc.y,
-      labels = edge.labels, col = edge.label.color,
-      family = edge.label.family, font = edge.label.font, cex = edge.label.cex
+      labels = edge.labels, col = ecol,
+      family = efam, font = efon, cex = ecex
     )
   }
 

--- a/tests/testthat/_snaps/plot/loop-graph.svg
+++ b/tests/testthat/_snaps/plot/loop-graph.svg
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng=='>
+    <rect x='59.04' y='59.04' width='630.72' height='443.52' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTkuMDR8Njg5Ljc2fDU5LjA0fDUwMi41Ng==)'>
+<polygon points='197.72,89.79 202.30,87.59 206.69,85.67 210.89,84.01 214.90,82.60 218.72,81.43 222.35,80.49 225.78,79.77 229.03,79.25 232.08,78.92 234.95,78.77 237.62,78.80 240.10,78.98 242.40,79.31 244.50,79.77 246.40,80.35 248.12,81.05 249.65,81.84 250.99,82.73 252.13,83.68 253.09,84.71 253.85,85.78 254.42,86.90 254.81,88.04 255.00,89.21 255.00,90.38 254.81,91.54 254.42,92.69 253.85,93.80 253.09,94.88 252.13,95.90 250.99,96.86 249.65,97.74 248.12,98.54 246.40,99.23 244.50,99.82 242.40,100.28 240.10,100.61 237.62,100.79 234.95,100.81 232.08,100.66 229.03,100.34 225.78,99.82 222.35,99.09 218.72,98.15 214.90,96.98 210.89,95.57 206.69,93.91 202.30,91.99 197.72,89.79 ' style='stroke-width: 0.75; stroke: #00FF00; fill: none;' />
+<text x='255.02' y='91.78' text-anchor='middle' style='font-size: 12.00px; fill: #00FF00; font-family: sans;' textLength='30.69px' lengthAdjust='spacingAndGlyphs'>green</text>
+<line x1='193.52' y1='99.92' x2='364.13' y2='270.53' style='stroke-width: 0.75; stroke: #FF0000;' />
+<line x1='384.39' y1='290.79' x2='555.28' y2='461.68' style='stroke-width: 0.75; stroke: #0000FF;' />
+<text x='250.39' y='161.08' text-anchor='middle' style='font-size: 12.00px; fill: #FF0000; font-family: sans;' textLength='17.34px' lengthAdjust='spacingAndGlyphs'>red</text>
+<text x='441.35' y='352.04' text-anchor='middle' style='font-size: 12.00px; fill: #0000FF; font-family: sans;' textLength='22.69px' lengthAdjust='spacingAndGlyphs'>blue</text>
+<circle cx='183.39' cy='89.79' r='14.33' style='stroke-width: 0.75; fill: #E69F00;' />
+<circle cx='374.26' cy='280.66' r='14.33' style='stroke-width: 0.75; fill: #E69F00;' />
+<circle cx='565.41' cy='471.81' r='14.33' style='stroke-width: 0.75; fill: #E69F00;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='183.39' y='93.92' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='374.26' y='284.85' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='565.41' y='475.94' text-anchor='middle' style='font-size: 12.00px; fill: #00008B; font-family: sans;' textLength='6.67px' lengthAdjust='spacingAndGlyphs'>3</text>
+</g>
+</svg>

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -85,3 +85,27 @@ test_that("rglplot() works", {
   expect_silent(rglplot(g))
   expect_silent(rglplot(g, edge.label = letters[1:ecount(g)]))
 })
+
+test_that("label colors are correct when loops are present", {
+  # check that Bug 157 is fixed
+  skip_if_not_installed("vdiffr")
+  g <- make_graph(c(1, 2, 1, 1, 2, 3), directed = FALSE)
+  g$layout <- structure(
+    c(
+      1.17106961533433,
+      1.63885278868168,
+      2.10732892696401,
+      3.91718168529106,
+      2.87660789399794,
+      1.83449260993935
+    ),
+    dim = 3:2
+  )
+  cols <- c("red", "green", "blue")
+  vdiffr::expect_doppelganger(
+    "loop graph",
+    function() {
+      plot(g, edge.color = cols, edge.label.color = cols, edge.label = cols)
+    }
+  )
+})


### PR DESCRIPTION
Fix #157

``` r
library(igraph)
g <- make_graph(c(1, 2, 1, 1, 2, 3), directed = F)
cols <- c('red','green','blue')
plot(g, edge.color = cols, edge.label.color = cols, edge.label = cols)
```

![](https://i.imgur.com/hR9Eyhp.png)<!-- -->

Also fixed font, family and cex