### PR TITLE
fix: NA attribute values are replaced with default values for plotting

### DIFF
--- a/R/plot.common.R
+++ b/R/plot.common.R
@@ -502,13 +502,10 @@ i.parse.plot.params <- function(graph, params) {
       ## we don't have the parameter, check attributes first
       if (type == "vertex" && name %in% vertex_attr_names(graph)) {
         p[[type]][[name]] <- vertex_attr(graph, name)
-        return(ret())
       } else if (type == "edge" && name %in% edge_attr_names(graph)) {
         p[[type]][[name]] <- edge_attr(graph, name)
-        return(ret())
       } else if (type == "plot" && name %in% graph_attr_names(graph)) {
         p[[type]][[name]] <- graph_attr(graph, name)
-        return(ret())
       } else {
         ## no attributes either, check igraph parameters
         n <- paste(sep = "", type, ".", name)
@@ -522,6 +519,12 @@ i.parse.plot.params <- function(graph, params) {
         return(ret())
       }
     }
+    if (any(is.na(p[[type]][[name]]))) {
+      cli::cli_warn("{type} attribute {name} contains NAs. Replacing with default value {i.default.values[[type]][[name]]
+        }")
+      p[[type]][[name]][is.na(p[[type]][[name]])] <- i.default.values[[type]][[name]]
+    }
+    return(ret())
   }
 
   return(func)


### PR DESCRIPTION
fix #293 

Replaces NA values in attributes used for plotting with the default value and shows a warning

``` r
library(igraph)

schema <- make_empty_graph() + vertices("c", "p1", "p2", color = "green", shape = "rectangle", 
  size = 30, size2 = 30) + vertices("d", shape = "circle")
as_data_frame(schema,"vertices")
#>    name color     shape size size2
#> c     c green rectangle   30    30
#> p1   p1 green rectangle   30    30
#> p2   p2 green rectangle   30    30
#> d     d  <NA>    circle   NA    NA
plot(schema)
#> Warning: vertex attribute size contains NAs. Replacing with default value 15
#> Warning: vertex attribute color contains NAs. Replacing with default value 1
#> Warning: vertex attribute size contains NAs. Replacing with default value 15
#> Warning: vertex attribute size2 contains NAs. Replacing with default value 15
#> Warning: vertex attribute color contains NAs. Replacing with default value 1
#> Warning: vertex attribute size contains NAs. Replacing with default value 15
#> Warning: vertex attribute size2 contains NAs. Replacing with default value 15
#> Warning: vertex attribute color contains NAs. Replacing with default value 1
#> Warning: vertex attribute size contains NAs. Replacing with default value 15
#> Warning: vertex attribute size2 contains NAs. Replacing with default value 15
#> Warning: vertex attribute color contains NAs. Replacing with default value 1
#> Warning: vertex attribute size contains NAs. Replacing with default value 15
```

![](https://i.imgur.com/iPRbJng.png)<!-- -->

<sup>Created on 2025-02-20 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>