### PR TITLE
fix: Duplicated arrowhead drawing

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -970,14 +970,14 @@ igraph.Arrows <-
       p.x2 <- rep(bx2, Rep)
       p.y2 <- rep(by2, Rep)
       ttheta <- rep(theta, Rep) + rep(deg.arr, lx)
-      r.arr <- rep(r.arr, lx)
+      r.arr.rep <- rep(r.arr, lx)
       if (open) {
-        lines((p.x2 + r.arr * cos(ttheta) / uin[1]),
-          (p.y2 + r.arr * sin(ttheta) / uin[2]),
+        lines((p.x2 + r.arr.rep * cos(ttheta) / uin[1]),
+          (p.y2 + r.arr.rep * sin(ttheta) / uin[2]),
           lwd = h.lwd, col = h.col.bo, lty = h.lty
         )
       } else {
-        polygon(p.x2 + r.arr * cos(ttheta) / uin[1], p.y2 + r.arr * sin(ttheta) / uin[2],
+        polygon(p.x2 + r.arr.rep * cos(ttheta) / uin[1], p.y2 + r.arr * sin(ttheta) / uin[2],
           col = h.col, lwd = h.lwd,
           border = h.col.bo, lty = h.lty
         )
@@ -1000,15 +1000,15 @@ igraph.Arrows <-
       p.x2 <- rep(x2, Rep)
       p.y2 <- rep(y2, Rep)
       ttheta <- rep(theta, Rep) + rep(deg.arr, lx)
-      r.arr <- rep(r.arr, lx)
+      r.arr.rep <- rep(r.arr, lx)
 
       if (open) {
-        lines((p.x2 + r.arr * cos(ttheta) / uin[1]),
-          (p.y2 + r.arr * sin(ttheta) / uin[2]),
+        lines((p.x2 + r.arr.rep * cos(ttheta) / uin[1]),
+          (p.y2 + r.arr.rep * sin(ttheta) / uin[2]),
           lwd = h.lwd, col = h.col.bo, lty = h.lty
         )
       } else {
-        polygon(p.x2 + r.arr * cos(ttheta) / uin[1], p.y2 + r.arr * sin(ttheta) / uin[2],
+        polygon(p.x2 + r.arr.rep * cos(ttheta) / uin[1], p.y2 + r.arr.rep * sin(ttheta) / uin[2],
           col = h.col, lwd = h.lwd,
           border = h.col.bo, lty = h.lty
         )


### PR DESCRIPTION
Fix #640 

``` r
library(igraph)
#> 
#> Attaching package: 'igraph'
#> The following objects are masked from 'package:stats':
#> 
#>     decompose, spectrum
#> The following object is masked from 'package:base':
#> 
#>     union
plot( 
  make_tree(4),
  edge.arrow.mode=1,
  edge.color=rgb(0,0,0,0.2)
)
```

![](https://i.imgur.com/rg53E4P.png)<!-- -->

``` r

plot( 
  make_tree(4),
  edge.arrow.mode=2,
  edge.color=rgb(0,0,0,0.2)
)
```

![](https://i.imgur.com/qxae4us.png)<!-- -->

``` r

plot( 
  make_tree(4),
  edge.arrow.mode=3,
  edge.color=rgb(0,0,0,0.2)
)
```

![](https://i.imgur.com/mJPxVp9.png)<!-- -->

<sup>Created on 2025-02-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>