### PR TITLE
feat: rework is_bipartite to do an actual bipartivity check

### DIFF
--- a/R/attributes.R
+++ b/R/attributes.R
@@ -1006,6 +1006,8 @@ is_weighted <- function(graph) {
 #' @param graph The input graph
 #' @export
 is_bipartite <- function(graph) {
+  ensure_igraph(graph)
+
   has_type_attr <- "type" %in% vertex_attr_names(graph)
 
   bipartite_result <- bipartite_mapping(graph)

--- a/R/attributes.R
+++ b/R/attributes.R
@@ -1006,10 +1006,30 @@ is_weighted <- function(graph) {
 #' @param graph The input graph
 #' @export
 is_bipartite <- function(graph) {
-  ensure_igraph(graph)
+  has_type_attr <- "type" %in% vertex_attr_names(graph)
 
-  "type" %in% vertex_attr_names(graph)
+  bipartite_result <- bipartite_mapping(graph)
+
+  if (has_type_attr) {
+    if (!bipartite_result$res) {
+      cli::cli_warn("{.arg graph} has a type attribute but is not actually bipartite.")
+      FALSE
+    } else {
+      if (!all(bipartite_result$type == vertex_attr(graph, "type")) | !all(bipartite_result$type == !vertex_attr(graph, "type"))) {
+        cli::cli_warn("{.arg graph} is bipartite but has a wrong 'type' vertex attribute. You can correct it using:\n  {.code V(graph)$type <- bipartite_mapping(graph)$type}")
+      }
+      TRUE
+    }
+  } else {
+    if (bipartite_result$res) {
+      cli::cli_warn("{.arg graph} is bipartite but has no 'type' vertex attribute. You can add it using:\n  {.code V(graph)$type <- bipartite_mapping(graph)$type}")
+      TRUE
+    } else {
+      FALSE
+    }
+  }
 }
+
 
 #############
 

--- a/R/attributes.R
+++ b/R/attributes.R
@@ -1015,7 +1015,7 @@ is_bipartite <- function(graph) {
       cli::cli_warn("{.arg graph} has a type attribute but is not actually bipartite.")
       FALSE
     } else {
-      if (!all(bipartite_result$type == vertex_attr(graph, "type")) | !all(bipartite_result$type == !vertex_attr(graph, "type"))) {
+      if (!all(bipartite_result$type == vertex_attr(graph, "type")) & !all(bipartite_result$type == !vertex_attr(graph, "type"))) {
         cli::cli_warn("{.arg graph} is bipartite but has a wrong 'type' vertex attribute. You can correct it using:\n  {.code V(graph)$type <- bipartite_mapping(graph)$type}")
       }
       TRUE


### PR DESCRIPTION
Fix #709 
A suggestion how a reworked is_bipartite could look like that does not (or should not) break existing code. 

``` r
library(igraph)

#bipartite no type
is_bipartite(make_ring(10))
#> Warning: `graph` is bipartite but has no 'type' vertex attribute. You can add it using:
#> `V(graph)$type <- bipartite_mapping(graph)$type`
#> [1] TRUE

# not bipartite but type
g <- make_full_graph(4)
V(g)$type <- c(TRUE,TRUE,FALSE,FALSE)
is_bipartite(g)
#> Warning: `graph` has a type attribute but is not actually bipartite.
#> [1] FALSE

#bipartite and type
g <- make_ring(4)
V(g)$type <- c(TRUE,FALSE,TRUE,FALSE)
is_bipartite(g)
#> [1] TRUE

#bipartite wrong type
g <- make_ring(4)
V(g)$type <- c(TRUE,TRUE,FALSE,FALSE)
is_bipartite(g)
#> Warning: `graph` is bipartite but has a wrong 'type' vertex attribute. You can correct
#> it using: `V(graph)$type <- bipartite_mapping(graph)$type`
#> [1] TRUE
```

<sup>Created on 2025-02-28 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

@szhorvat, thoughts? 