### PR TITLE
fix: Recycling of logical vectors when indexing into edge/vertex selectors now throws an error

### DIFF
--- a/R/iterators.R
+++ b/R/iterators.R
@@ -676,6 +676,10 @@ simple_vs_index <- function(x, i, na_ok = FALSE) {
       if (is.null(ii)) {
         return(NULL)
       }
+      if (is.logical(ii) && length(ii) != length(x)) {
+        cli::cli_abort("Error: Logical index length does not match the number of vertices. Recycling is not allowed.")
+      }
+
       ii <- simple_vs_index(x, ii, na_ok)
       attr(ii, "env") <- attr(x, "env")
       attr(ii, "graph") <- attr(x, "graph")
@@ -991,6 +995,10 @@ simple_es_index <- function(x, i, na_ok = FALSE) {
       if (is.null(ii)) {
         return(NULL)
       }
+      if (is.logical(ii) && length(ii) != length(x)) {
+        cli::cli_abort("Error: Logical index length does not match the number of edges. Recycling is not allowed.")
+      }
+
       ii <- simple_es_index(x, ii)
       attr(ii, "env") <- attr(x, "env")
       attr(ii, "graph") <- attr(x, "graph")

--- a/R/iterators.R
+++ b/R/iterators.R
@@ -676,7 +676,7 @@ simple_vs_index <- function(x, i, na_ok = FALSE) {
       if (is.null(ii)) {
         return(NULL)
       }
-      if (is.logical(ii) && length(ii) != length(x)) {
+      if (is.logical(ii) && (length(ii) != length(x) && length(ii) != 1)) {
         cli::cli_abort("Error: Logical index length does not match the number of vertices. Recycling is not allowed.")
       }
 
@@ -995,7 +995,10 @@ simple_es_index <- function(x, i, na_ok = FALSE) {
       if (is.null(ii)) {
         return(NULL)
       }
-      if (is.logical(ii) && length(ii) != length(x)) {
+      if (is.logical(ii) && (length(ii) != length(x) && length(ii) != 1)) {
+        print(ii)
+        print(length(ii))
+        print(length(x))
         cli::cli_abort("Error: Logical index length does not match the number of edges. Recycling is not allowed.")
       }
 

--- a/R/iterators.R
+++ b/R/iterators.R
@@ -996,9 +996,6 @@ simple_es_index <- function(x, i, na_ok = FALSE) {
         return(NULL)
       }
       if (is.logical(ii) && (length(ii) != length(x) && length(ii) != 1)) {
-        print(ii)
-        print(length(ii))
-        print(length(x))
         cli::cli_abort("Error: Logical index length does not match the number of edges. Recycling is not allowed.")
       }
 

--- a/tests/testthat/_snaps/iterators.md
+++ b/tests/testthat/_snaps/iterators.md
@@ -104,10 +104,6 @@
 
     Code
       E(g)[c(TRUE, FALSE)]
-    Output
-      [1]  TRUE FALSE
-      [1] 2
-      [1] 5
     Condition
       Error in `FUN()`:
       ! Error: Logical index length does not match the number of edges. Recycling is not allowed.

--- a/tests/testthat/_snaps/iterators.md
+++ b/tests/testthat/_snaps/iterators.md
@@ -92,3 +92,23 @@
       + 10/? edges (deleted) (vertex names):
        [1] a|b b|c c|d d|e e|f f|g g|h h|i i|j a|j
 
+# logical indices are not recycled
+
+    Code
+      V(g)[c(TRUE, FALSE)]
+    Condition
+      Error in `FUN()`:
+      ! Error: Logical index length does not match the number of vertices. Recycling is not allowed.
+
+---
+
+    Code
+      E(g)[c(TRUE, FALSE)]
+    Output
+      [1]  TRUE FALSE
+      [1] 2
+      [1] 5
+    Condition
+      Error in `FUN()`:
+      ! Error: Logical index length does not match the number of edges. Recycling is not allowed.
+

--- a/tests/testthat/test-iterators.R
+++ b/tests/testthat/test-iterators.R
@@ -440,3 +440,10 @@ test_that("edge indexes are stored as raw numbers", {
   expect_identical(E(g)$id, as.numeric(1:3))
   expect_error(induced_subgraph(g, 1:2), NA)
 })
+
+test_that("logical indices are not recycled", {
+  # https://github.com/igraph/rigraph/issues/848
+  g <- make_ring(5)
+  expect_snapshot(V(g)[c(TRUE, FALSE)], error = TRUE)
+  expect_snapshot(E(g)[c(TRUE, FALSE)], error = TRUE)
+})


### PR DESCRIPTION
Fix #848 

Did not remove recycling for length 1 vectors because that still makes sense in my opinion

``` r
pkgload::load_all("~/git/R_packages/rigraph/")
#> ℹ Loading igraph
g <- make_ring(5)
V(g)[c(TRUE, FALSE)]
#> Error in `FUN()`:
#> ! Error: Logical index length does not match the number of vertices.
#>   Recycling is not allowed.
E(g)[c(TRUE, FALSE)]
#> Error in `FUN()`:
#> ! Error: Logical index length does not match the number of edges.
#>   Recycling is not allowed.

V(g)[TRUE]
#> + 5/5 vertices, from bafeef3:
#> [1] 1 2 3 4 5
E(g)[FALSE]
#> + 0/5 edges from bafeef3:
```

<sup>Created on 2025-03-03 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>