### PR TITLE
docs: update decription of `order` parameter of `ego()` and related functions

### DIFF
--- a/R/structural-properties.R
+++ b/R/structural-properties.R
@@ -1627,7 +1627,8 @@ neighborhood_size <- ego_size
 #' @aliases neighborhood ego_graph
 #' @aliases connect ego_size ego
 #' @param graph The input graph.
-#' @param order Integer giving the order of the neighborhood.
+#' @param order Integer giving the order of the neighborhood. Negative values
+#'   indicate an infinite order.
 #' @param nodes The vertices for which the calculation is performed.
 #' @param mode Character constant, it specifies how to use the direction of
 #'   the edges if a directed graph is analyzed. For \sQuote{out} only the


### PR DESCRIPTION
This PR makes the necessary doc updates after this C core PR: https://github.com/igraph/igraph/pull/2720

Merge this only after:

 - [x] the vendoring script is fixed and the C core change is lifted into R
 - [ ] the auto-formatter is fixed and docs can be properly regenerated
 - [ ] `document()` must first be run for the changes in this PR