### PR TITLE
chore: require copyright assignment in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->
+
+<!-- The following text must be left intact and the box checked before the PR can be merged. -->
+
+- [ ] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.


### PR DESCRIPTION
See https://github.com/igraph/igraph/pull/2720

This is meant to apply to external contributors. Team members should feel free to delete the text when opening PRs.