### PR TITLE
fix: remove string matrix support from biadjacency matrix functions

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -857,7 +857,14 @@ get.incidence.dense <- function(graph, types, names, attr, call = rlang::caller_
     el[idx, ] <- el[idx, 2:1]
     # el[ ,1] only holds values 1..n1 and el[ ,2] values 1..n2
     # and we can populate the matrix
-    res[el] <- edge_attr(graph, attr)
+    value <- edge_attr(graph, attr)
+    if (!is.numeric(value) && !is.logical(value)) {
+      cli::cli_abort(
+        "Matrices must be either numeric or logical, and the edge attribute is not",
+        call = call
+      )
+    }
+    res[el] <- value
 
     if (names && "name" %in% vertex_attr_names(graph)) {
       rownames(res) <- V(graph)$name[which(!types)]
@@ -902,6 +909,12 @@ get.incidence.sparse <- function(graph, types, names, attr, call = rlang::caller
       cli::cli_abort("No such edge attribute", call = call)
     }
     value <- edge_attr(graph, name = attr)
+    if (!is.numeric(value) && !is.logical(value)) {
+      cli::cli_abort(
+        "Matrices must be either numeric or logical, and the edge attribute is not",
+        call = call
+      )
+    }
   } else {
     value <- rep(1, nrow(el))
   }


### PR DESCRIPTION
Fix #1542 
Fix #1540

@krlmlr, @maelle, @szhorvat: I took the extreme approach of hard deprecation. In my opinion, this is ok, because this should simply not be allowed and has produced an error for adjacency matrices for a while