### PR TITLE
docs: add author links

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -249,6 +249,10 @@ authors:
     href: "https://github.com/GroteGnoom"
   Kirill Müller:
     href: "https://krlmlr.info/"
+  David Schoch:
+    href: "https://mr.schochastics.net/"
+  Maëlle Salmon:
+    href: "https://masalmon.eu/"
 
 home:
   links:


### PR DESCRIPTION
@schochastics or should we use the cynkra/about links :thinking: 