### PR TITLE
docs: link to replacements of deprecated functions

### DIFF
--- a/R/adjacency.R
+++ b/R/adjacency.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.adjacency()` was renamed to [`graph_from_adjacency_matrix()`] to create a more
+#' `graph.adjacency()` was renamed to [graph_from_adjacency_matrix()] to create a more
 #' consistent API.
 #' @inheritParams graph_from_adjacency_matrix
 #' @keywords internal

--- a/R/adjacency.R
+++ b/R/adjacency.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.adjacency()` was renamed to `graph_from_adjacency_matrix()` to create a more
+#' `graph.adjacency()` was renamed to [`graph_from_adjacency_matrix()`] to create a more
 #' consistent API.
 #' @inheritParams graph_from_adjacency_matrix
 #' @keywords internal

--- a/R/assortativity.R
+++ b/R/assortativity.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `assortativity.nominal()` was renamed to [`assortativity_nominal()`] to create a more
+#' `assortativity.nominal()` was renamed to [assortativity_nominal()] to create a more
 #' consistent API.
 #' @inheritParams assortativity_nominal
 #' @keywords internal
@@ -18,7 +18,7 @@ assortativity.nominal <- function(graph, types, directed = TRUE, normalized = TR
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `assortativity.degree()` was renamed to [`assortativity_degree()`] to create a more
+#' `assortativity.degree()` was renamed to [assortativity_degree()] to create a more
 #' consistent API.
 #' @inheritParams assortativity_degree
 #' @keywords internal

--- a/R/assortativity.R
+++ b/R/assortativity.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `assortativity.nominal()` was renamed to `assortativity_nominal()` to create a more
+#' `assortativity.nominal()` was renamed to [`assortativity_nominal()`] to create a more
 #' consistent API.
 #' @inheritParams assortativity_nominal
 #' @keywords internal
@@ -18,7 +18,7 @@ assortativity.nominal <- function(graph, types, directed = TRUE, normalized = TR
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `assortativity.degree()` was renamed to `assortativity_degree()` to create a more
+#' `assortativity.degree()` was renamed to [`assortativity_degree()`] to create a more
 #' consistent API.
 #' @inheritParams assortativity_degree
 #' @keywords internal

--- a/R/attributes.R
+++ b/R/attributes.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `set.vertex.attribute()` was renamed to [`set_vertex_attr()`] to create a more
+#' `set.vertex.attribute()` was renamed to [set_vertex_attr()] to create a more
 #' consistent API.
 #' @inheritParams set_vertex_attr
 #' @keywords internal
@@ -23,7 +23,7 @@ set.vertex.attribute <- function(graph, name, index = V(graph), value) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `set.graph.attribute()` was renamed to [`set_graph_attr()`] to create a more
+#' `set.graph.attribute()` was renamed to [set_graph_attr()] to create a more
 #' consistent API.
 #' @inheritParams set_graph_attr
 #' @keywords internal
@@ -43,7 +43,7 @@ set.graph.attribute <- function(graph, name, value) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `set.edge.attribute()` was renamed to [`set_edge_attr()`] to create a more
+#' `set.edge.attribute()` was renamed to [set_edge_attr()] to create a more
 #' consistent API.
 #' @inheritParams set_edge_attr
 #' @keywords internal
@@ -59,7 +59,7 @@ set.edge.attribute <- function(graph, name, index = E(graph), value) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `remove.vertex.attribute()` was renamed to [`delete_vertex_attr()`] to create a more
+#' `remove.vertex.attribute()` was renamed to [delete_vertex_attr()] to create a more
 #' consistent API.
 #' @inheritParams delete_vertex_attr
 #' @keywords internal
@@ -79,7 +79,7 @@ remove.vertex.attribute <- function(graph, name) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `remove.graph.attribute()` was renamed to [`delete_graph_attr()`] to create a more
+#' `remove.graph.attribute()` was renamed to [delete_graph_attr()] to create a more
 #' consistent API.
 #' @inheritParams delete_graph_attr
 #' @keywords internal
@@ -99,7 +99,7 @@ remove.graph.attribute <- function(graph, name) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `remove.edge.attribute()` was renamed to [`delete_edge_attr()`] to create a more
+#' `remove.edge.attribute()` was renamed to [delete_edge_attr()] to create a more
 #' consistent API.
 #' @inheritParams delete_edge_attr
 #' @keywords internal
@@ -119,7 +119,7 @@ remove.edge.attribute <- function(graph, name) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `list.vertex.attributes()` was renamed to [`vertex_attr_names()`] to create a more
+#' `list.vertex.attributes()` was renamed to [vertex_attr_names()] to create a more
 #' consistent API.
 #' @inheritParams vertex_attr_names
 #' @keywords internal
@@ -139,7 +139,7 @@ list.vertex.attributes <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `list.graph.attributes()` was renamed to [`graph_attr_names()`] to create a more
+#' `list.graph.attributes()` was renamed to [graph_attr_names()] to create a more
 #' consistent API.
 #' @inheritParams graph_attr_names
 #' @keywords internal
@@ -159,7 +159,7 @@ list.graph.attributes <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `list.edge.attributes()` was renamed to [`edge_attr_names()`] to create a more
+#' `list.edge.attributes()` was renamed to [edge_attr_names()] to create a more
 #' consistent API.
 #' @inheritParams edge_attr_names
 #' @keywords internal
@@ -179,7 +179,7 @@ list.edge.attributes <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.weighted()` was renamed to [`is_weighted()`] to create a more
+#' `is.weighted()` was renamed to [is_weighted()] to create a more
 #' consistent API.
 #' @inheritParams is_weighted
 #' @keywords internal
@@ -195,7 +195,7 @@ is.weighted <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.named()` was renamed to [`is_named()`] to create a more
+#' `is.named()` was renamed to [is_named()] to create a more
 #' consistent API.
 #' @inheritParams is_named
 #' @keywords internal
@@ -211,7 +211,7 @@ is.named <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.bipartite()` was renamed to [`is_bipartite()`] to create a more
+#' `is.bipartite()` was renamed to [is_bipartite()] to create a more
 #' consistent API.
 #' @inheritParams is_bipartite
 #' @keywords internal
@@ -227,7 +227,7 @@ is.bipartite <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.vertex.attribute()` was renamed to [`vertex_attr()`] to create a more
+#' `get.vertex.attribute()` was renamed to [vertex_attr()] to create a more
 #' consistent API.
 #' @inheritParams vertex_attr
 #' @keywords internal
@@ -243,7 +243,7 @@ get.vertex.attribute <- function(graph, name, index = V(graph)) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.graph.attribute()` was renamed to [`graph_attr()`] to create a more
+#' `get.graph.attribute()` was renamed to [graph_attr()] to create a more
 #' consistent API.
 #' @inheritParams graph_attr
 #' @keywords internal
@@ -259,7 +259,7 @@ get.graph.attribute <- function(graph, name) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.edge.attribute()` was renamed to [`edge_attr()`] to create a more
+#' `get.edge.attribute()` was renamed to [edge_attr()] to create a more
 #' consistent API.
 #' @inheritParams edge_attr
 #' @keywords internal

--- a/R/attributes.R
+++ b/R/attributes.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `set.vertex.attribute()` was renamed to `set_vertex_attr()` to create a more
+#' `set.vertex.attribute()` was renamed to [`set_vertex_attr()`] to create a more
 #' consistent API.
 #' @inheritParams set_vertex_attr
 #' @keywords internal
@@ -23,7 +23,7 @@ set.vertex.attribute <- function(graph, name, index = V(graph), value) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `set.graph.attribute()` was renamed to `set_graph_attr()` to create a more
+#' `set.graph.attribute()` was renamed to [`set_graph_attr()`] to create a more
 #' consistent API.
 #' @inheritParams set_graph_attr
 #' @keywords internal
@@ -43,7 +43,7 @@ set.graph.attribute <- function(graph, name, value) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `set.edge.attribute()` was renamed to `set_edge_attr()` to create a more
+#' `set.edge.attribute()` was renamed to [`set_edge_attr()`] to create a more
 #' consistent API.
 #' @inheritParams set_edge_attr
 #' @keywords internal
@@ -59,7 +59,7 @@ set.edge.attribute <- function(graph, name, index = E(graph), value) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `remove.vertex.attribute()` was renamed to `delete_vertex_attr()` to create a more
+#' `remove.vertex.attribute()` was renamed to [`delete_vertex_attr()`] to create a more
 #' consistent API.
 #' @inheritParams delete_vertex_attr
 #' @keywords internal
@@ -79,7 +79,7 @@ remove.vertex.attribute <- function(graph, name) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `remove.graph.attribute()` was renamed to `delete_graph_attr()` to create a more
+#' `remove.graph.attribute()` was renamed to [`delete_graph_attr()`] to create a more
 #' consistent API.
 #' @inheritParams delete_graph_attr
 #' @keywords internal
@@ -99,7 +99,7 @@ remove.graph.attribute <- function(graph, name) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `remove.edge.attribute()` was renamed to `delete_edge_attr()` to create a more
+#' `remove.edge.attribute()` was renamed to [`delete_edge_attr()`] to create a more
 #' consistent API.
 #' @inheritParams delete_edge_attr
 #' @keywords internal
@@ -119,7 +119,7 @@ remove.edge.attribute <- function(graph, name) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `list.vertex.attributes()` was renamed to `vertex_attr_names()` to create a more
+#' `list.vertex.attributes()` was renamed to [`vertex_attr_names()`] to create a more
 #' consistent API.
 #' @inheritParams vertex_attr_names
 #' @keywords internal
@@ -139,7 +139,7 @@ list.vertex.attributes <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `list.graph.attributes()` was renamed to `graph_attr_names()` to create a more
+#' `list.graph.attributes()` was renamed to [`graph_attr_names()`] to create a more
 #' consistent API.
 #' @inheritParams graph_attr_names
 #' @keywords internal
@@ -159,7 +159,7 @@ list.graph.attributes <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `list.edge.attributes()` was renamed to `edge_attr_names()` to create a more
+#' `list.edge.attributes()` was renamed to [`edge_attr_names()`] to create a more
 #' consistent API.
 #' @inheritParams edge_attr_names
 #' @keywords internal
@@ -179,7 +179,7 @@ list.edge.attributes <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.weighted()` was renamed to `is_weighted()` to create a more
+#' `is.weighted()` was renamed to [`is_weighted()`] to create a more
 #' consistent API.
 #' @inheritParams is_weighted
 #' @keywords internal
@@ -195,7 +195,7 @@ is.weighted <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.named()` was renamed to `is_named()` to create a more
+#' `is.named()` was renamed to [`is_named()`] to create a more
 #' consistent API.
 #' @inheritParams is_named
 #' @keywords internal
@@ -211,7 +211,7 @@ is.named <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.bipartite()` was renamed to `is_bipartite()` to create a more
+#' `is.bipartite()` was renamed to [`is_bipartite()`] to create a more
 #' consistent API.
 #' @inheritParams is_bipartite
 #' @keywords internal
@@ -227,7 +227,7 @@ is.bipartite <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.vertex.attribute()` was renamed to `vertex_attr()` to create a more
+#' `get.vertex.attribute()` was renamed to [`vertex_attr()`] to create a more
 #' consistent API.
 #' @inheritParams vertex_attr
 #' @keywords internal
@@ -243,7 +243,7 @@ get.vertex.attribute <- function(graph, name, index = V(graph)) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.graph.attribute()` was renamed to `graph_attr()` to create a more
+#' `get.graph.attribute()` was renamed to [`graph_attr()`] to create a more
 #' consistent API.
 #' @inheritParams graph_attr
 #' @keywords internal
@@ -259,7 +259,7 @@ get.graph.attribute <- function(graph, name) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.edge.attribute()` was renamed to `edge_attr()` to create a more
+#' `get.edge.attribute()` was renamed to [`edge_attr()`] to create a more
 #' consistent API.
 #' @inheritParams edge_attr
 #' @keywords internal

--- a/R/basic.R
+++ b/R/basic.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.igraph()` was renamed to [`is_igraph()`] to create a more
+#' `is.igraph()` was renamed to [is_igraph()] to create a more
 #' consistent API.
 #' @inheritParams is_igraph
 #' @keywords internal

--- a/R/basic.R
+++ b/R/basic.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.igraph()` was renamed to `is_igraph()` to create a more
+#' `is.igraph()` was renamed to [`is_igraph()`] to create a more
 #' consistent API.
 #' @inheritParams is_igraph
 #' @keywords internal

--- a/R/bipartite.R
+++ b/R/bipartite.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `bipartite.projection.size()` was renamed to `bipartite_projection_size()` to create a more
+#' `bipartite.projection.size()` was renamed to [`bipartite_projection_size()`] to create a more
 #' consistent API.
 #' @inheritParams bipartite_projection_size
 #' @keywords internal
@@ -18,7 +18,7 @@ bipartite.projection.size <- function(graph, types = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `bipartite.projection()` was renamed to `bipartite_projection()` to create a more
+#' `bipartite.projection()` was renamed to [`bipartite_projection()`] to create a more
 #' consistent API.
 #' @inheritParams bipartite_projection
 #' @keywords internal
@@ -33,7 +33,7 @@ bipartite.projection <- function(graph, types = NULL, multiplicity = TRUE, probe
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `bipartite.mapping()` was renamed to `bipartite_mapping()` to create a more
+#' `bipartite.mapping()` was renamed to [`bipartite_mapping()`] to create a more
 #' consistent API.
 #' @inheritParams bipartite_mapping
 #' @keywords internal

--- a/R/bipartite.R
+++ b/R/bipartite.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `bipartite.projection.size()` was renamed to [`bipartite_projection_size()`] to create a more
+#' `bipartite.projection.size()` was renamed to [bipartite_projection_size()] to create a more
 #' consistent API.
 #' @inheritParams bipartite_projection_size
 #' @keywords internal
@@ -18,7 +18,7 @@ bipartite.projection.size <- function(graph, types = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `bipartite.projection()` was renamed to [`bipartite_projection()`] to create a more
+#' `bipartite.projection()` was renamed to [bipartite_projection()] to create a more
 #' consistent API.
 #' @inheritParams bipartite_projection
 #' @keywords internal
@@ -33,7 +33,7 @@ bipartite.projection <- function(graph, types = NULL, multiplicity = TRUE, probe
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `bipartite.mapping()` was renamed to [`bipartite_mapping()`] to create a more
+#' `bipartite.mapping()` was renamed to [bipartite_mapping()] to create a more
 #' consistent API.
 #' @inheritParams bipartite_mapping
 #' @keywords internal

--- a/R/centrality.R
+++ b/R/centrality.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `subgraph.centrality()` was renamed to [`subgraph_centrality()`] to create a more
+#' `subgraph.centrality()` was renamed to [subgraph_centrality()] to create a more
 #' consistent API.
 #' @inheritParams subgraph_centrality
 #' @keywords internal
@@ -18,7 +18,7 @@ subgraph.centrality <- function(graph, diag = FALSE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `page.rank()` was renamed to [`page_rank()`] to create a more
+#' `page.rank()` was renamed to [page_rank()] to create a more
 #' consistent API.
 #' @inheritParams page_rank
 #' @keywords internal
@@ -33,7 +33,7 @@ page.rank <- function(graph, algo = c("prpack", "arpack"), vids = V(graph), dire
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hub.score()` was renamed to [`hub_score()`] to create a more
+#' `hub.score()` was renamed to [hub_score()] to create a more
 #' consistent API.
 #' @inheritParams hub_score
 #' @keywords internal
@@ -48,7 +48,7 @@ hub.score <- function(graph, scale = TRUE, weights = NULL, options = arpack_defa
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `authority.score()` was renamed to [`authority_score()`] to create a more
+#' `authority.score()` was renamed to [authority_score()] to create a more
 #' consistent API.
 #' @inheritParams authority_score
 #' @keywords internal
@@ -63,7 +63,7 @@ authority.score <- function(graph, scale = TRUE, weights = NULL, options = arpac
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.strength()` was renamed to [`strength()`] to create a more
+#' `graph.strength()` was renamed to [strength()] to create a more
 #' consistent API.
 #' @inheritParams strength
 #' @keywords internal
@@ -78,7 +78,7 @@ graph.strength <- function(graph, vids = V(graph), mode = c("all", "out", "in", 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.eigen()` was renamed to [`spectrum()`] to create a more
+#' `graph.eigen()` was renamed to [spectrum()] to create a more
 #' consistent API.
 #' @inheritParams spectrum
 #' @keywords internal
@@ -93,7 +93,7 @@ graph.eigen <- function(graph, algorithm = c("arpack", "auto", "lapack", "comp_a
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.diversity()` was renamed to [`diversity()`] to create a more
+#' `graph.diversity()` was renamed to [diversity()] to create a more
 #' consistent API.
 #' @inheritParams diversity
 #' @keywords internal
@@ -108,7 +108,7 @@ graph.diversity <- function(graph, weights = NULL, vids = V(graph)) { # nocov st
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `evcent()` was renamed to [`eigen_centrality()`] to create a more
+#' `evcent()` was renamed to [eigen_centrality()] to create a more
 #' consistent API.
 #' @inheritParams eigen_centrality
 #' @keywords internal
@@ -123,7 +123,7 @@ evcent <- function(graph, directed = FALSE, scale = TRUE, weights = NULL, option
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `edge.betweenness()` was renamed to [`edge_betweenness()`] to create a more
+#' `edge.betweenness()` was renamed to [edge_betweenness()] to create a more
 #' consistent API.
 #' @inheritParams edge_betweenness
 #' @keywords internal
@@ -138,7 +138,7 @@ edge.betweenness <- function(graph, e = E(graph), directed = TRUE, weights = NUL
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `bonpow()` was renamed to [`power_centrality()`] to create a more
+#' `bonpow()` was renamed to [power_centrality()] to create a more
 #' consistent API.
 #' @inheritParams power_centrality
 #' @keywords internal
@@ -153,7 +153,7 @@ bonpow <- function(graph, nodes = V(graph), loops = FALSE, exponent = 1, rescale
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `alpha.centrality()` was renamed to [`alpha_centrality()`] to create a more
+#' `alpha.centrality()` was renamed to [alpha_centrality()] to create a more
 #' consistent API.
 #' @inheritParams alpha_centrality
 #' @keywords internal
@@ -188,7 +188,7 @@ alpha.centrality <- function(graph, nodes = V(graph), alpha = 1, loops = FALSE, 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' Use [`betweenness()`] with the `cutoff` argument instead.
+#' Use [betweenness()] with the `cutoff` argument instead.
 #' @param vids The vertices for which the vertex betweenness estimation will be
 #'   calculated.
 #' @inheritParams betweenness
@@ -351,7 +351,7 @@ edge_betweenness <- function(graph, e = E(graph),
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' Use [`edge_betweenness()`] with the `cutoff` argument instead.
+#' Use [edge_betweenness()] with the `cutoff` argument instead.
 #' @inheritParams edge_betweenness
 #' @keywords internal
 #' @export
@@ -467,7 +467,7 @@ closeness <- function(graph, vids = V(graph),
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' Use [`closeness()`] with the `cutoff` argument instead.
+#' Use [closeness()] with the `cutoff` argument instead.
 #' @inheritParams closeness
 #' @keywords internal
 #' @export

--- a/R/centrality.R
+++ b/R/centrality.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `subgraph.centrality()` was renamed to `subgraph_centrality()` to create a more
+#' `subgraph.centrality()` was renamed to [`subgraph_centrality()`] to create a more
 #' consistent API.
 #' @inheritParams subgraph_centrality
 #' @keywords internal
@@ -18,7 +18,7 @@ subgraph.centrality <- function(graph, diag = FALSE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `page.rank()` was renamed to `page_rank()` to create a more
+#' `page.rank()` was renamed to [`page_rank()`] to create a more
 #' consistent API.
 #' @inheritParams page_rank
 #' @keywords internal
@@ -33,7 +33,7 @@ page.rank <- function(graph, algo = c("prpack", "arpack"), vids = V(graph), dire
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hub.score()` was renamed to `hub_score()` to create a more
+#' `hub.score()` was renamed to [`hub_score()`] to create a more
 #' consistent API.
 #' @inheritParams hub_score
 #' @keywords internal
@@ -48,7 +48,7 @@ hub.score <- function(graph, scale = TRUE, weights = NULL, options = arpack_defa
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `authority.score()` was renamed to `authority_score()` to create a more
+#' `authority.score()` was renamed to [`authority_score()`] to create a more
 #' consistent API.
 #' @inheritParams authority_score
 #' @keywords internal
@@ -63,7 +63,7 @@ authority.score <- function(graph, scale = TRUE, weights = NULL, options = arpac
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.strength()` was renamed to `strength()` to create a more
+#' `graph.strength()` was renamed to [`strength()`] to create a more
 #' consistent API.
 #' @inheritParams strength
 #' @keywords internal
@@ -78,7 +78,7 @@ graph.strength <- function(graph, vids = V(graph), mode = c("all", "out", "in", 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.eigen()` was renamed to `spectrum()` to create a more
+#' `graph.eigen()` was renamed to [`spectrum()`] to create a more
 #' consistent API.
 #' @inheritParams spectrum
 #' @keywords internal
@@ -93,7 +93,7 @@ graph.eigen <- function(graph, algorithm = c("arpack", "auto", "lapack", "comp_a
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.diversity()` was renamed to `diversity()` to create a more
+#' `graph.diversity()` was renamed to [`diversity()`] to create a more
 #' consistent API.
 #' @inheritParams diversity
 #' @keywords internal
@@ -108,7 +108,7 @@ graph.diversity <- function(graph, weights = NULL, vids = V(graph)) { # nocov st
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `evcent()` was renamed to `eigen_centrality()` to create a more
+#' `evcent()` was renamed to [`eigen_centrality()`] to create a more
 #' consistent API.
 #' @inheritParams eigen_centrality
 #' @keywords internal
@@ -123,7 +123,7 @@ evcent <- function(graph, directed = FALSE, scale = TRUE, weights = NULL, option
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `edge.betweenness()` was renamed to `edge_betweenness()` to create a more
+#' `edge.betweenness()` was renamed to [`edge_betweenness()`] to create a more
 #' consistent API.
 #' @inheritParams edge_betweenness
 #' @keywords internal
@@ -138,7 +138,7 @@ edge.betweenness <- function(graph, e = E(graph), directed = TRUE, weights = NUL
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `bonpow()` was renamed to `power_centrality()` to create a more
+#' `bonpow()` was renamed to [`power_centrality()`] to create a more
 #' consistent API.
 #' @inheritParams power_centrality
 #' @keywords internal
@@ -153,7 +153,7 @@ bonpow <- function(graph, nodes = V(graph), loops = FALSE, exponent = 1, rescale
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `alpha.centrality()` was renamed to `alpha_centrality()` to create a more
+#' `alpha.centrality()` was renamed to [`alpha_centrality()`] to create a more
 #' consistent API.
 #' @inheritParams alpha_centrality
 #' @keywords internal

--- a/R/centralization.R
+++ b/R/centralization.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralize.scores()` was renamed to `centralize()` to create a more
+#' `centralize.scores()` was renamed to [`centralize()`] to create a more
 #' consistent API.
 #' @inheritParams centralize
 #' @keywords internal
@@ -18,7 +18,7 @@ centralize.scores <- function(scores, theoretical.max = 0, normalized = TRUE) { 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.evcent.tmax()` was renamed to `centr_eigen_tmax()` to create a more
+#' `centralization.evcent.tmax()` was renamed to [`centr_eigen_tmax()`] to create a more
 #' consistent API.
 #' @inheritParams centr_eigen_tmax
 #' @keywords internal
@@ -33,7 +33,7 @@ centralization.evcent.tmax <- function(graph = NULL, nodes = 0, directed = FALSE
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.evcent()` was renamed to `centr_eigen()` to create a more
+#' `centralization.evcent()` was renamed to [`centr_eigen()`] to create a more
 #' consistent API.
 #' @inheritParams centr_eigen
 #' @keywords internal
@@ -48,7 +48,7 @@ centralization.evcent <- function(graph, directed = FALSE, scale = TRUE, options
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.degree.tmax()` was renamed to `centr_degree_tmax()` to create a more
+#' `centralization.degree.tmax()` was renamed to [`centr_degree_tmax()`] to create a more
 #' consistent API.
 #' @inheritParams centr_degree_tmax
 #' @keywords internal
@@ -63,7 +63,7 @@ centralization.degree.tmax <- function(graph = NULL, nodes = 0, mode = c("all", 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.degree()` was renamed to `centr_degree()` to create a more
+#' `centralization.degree()` was renamed to [`centr_degree()`] to create a more
 #' consistent API.
 #' @inheritParams centr_degree
 #' @keywords internal
@@ -78,7 +78,7 @@ centralization.degree <- function(graph, mode = c("all", "out", "in", "total"), 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.closeness.tmax()` was renamed to `centr_clo_tmax()` to create a more
+#' `centralization.closeness.tmax()` was renamed to [`centr_clo_tmax()`] to create a more
 #' consistent API.
 #' @inheritParams centr_clo_tmax
 #' @keywords internal
@@ -93,7 +93,7 @@ centralization.closeness.tmax <- function(graph = NULL, nodes = 0, mode = c("out
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.closeness()` was renamed to `centr_clo()` to create a more
+#' `centralization.closeness()` was renamed to [`centr_clo()`] to create a more
 #' consistent API.
 #' @inheritParams centr_clo
 #' @keywords internal
@@ -108,7 +108,7 @@ centralization.closeness <- function(graph, mode = c("out", "in", "all", "total"
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.betweenness.tmax()` was renamed to `centr_betw_tmax()` to create a more
+#' `centralization.betweenness.tmax()` was renamed to [`centr_betw_tmax()`] to create a more
 #' consistent API.
 #' @inheritParams centr_betw_tmax
 #' @keywords internal
@@ -123,7 +123,7 @@ centralization.betweenness.tmax <- function(graph = NULL, nodes = 0, directed = 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.betweenness()` was renamed to `centr_betw()` to create a more
+#' `centralization.betweenness()` was renamed to [`centr_betw()`] to create a more
 #' consistent API.
 #' @inheritParams centr_betw
 #' @keywords internal

--- a/R/centralization.R
+++ b/R/centralization.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralize.scores()` was renamed to [`centralize()`] to create a more
+#' `centralize.scores()` was renamed to [centralize()] to create a more
 #' consistent API.
 #' @inheritParams centralize
 #' @keywords internal
@@ -18,7 +18,7 @@ centralize.scores <- function(scores, theoretical.max = 0, normalized = TRUE) { 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.evcent.tmax()` was renamed to [`centr_eigen_tmax()`] to create a more
+#' `centralization.evcent.tmax()` was renamed to [centr_eigen_tmax()] to create a more
 #' consistent API.
 #' @inheritParams centr_eigen_tmax
 #' @keywords internal
@@ -33,7 +33,7 @@ centralization.evcent.tmax <- function(graph = NULL, nodes = 0, directed = FALSE
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.evcent()` was renamed to [`centr_eigen()`] to create a more
+#' `centralization.evcent()` was renamed to [centr_eigen()] to create a more
 #' consistent API.
 #' @inheritParams centr_eigen
 #' @keywords internal
@@ -48,7 +48,7 @@ centralization.evcent <- function(graph, directed = FALSE, scale = TRUE, options
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.degree.tmax()` was renamed to [`centr_degree_tmax()`] to create a more
+#' `centralization.degree.tmax()` was renamed to [centr_degree_tmax()] to create a more
 #' consistent API.
 #' @inheritParams centr_degree_tmax
 #' @keywords internal
@@ -63,7 +63,7 @@ centralization.degree.tmax <- function(graph = NULL, nodes = 0, mode = c("all", 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.degree()` was renamed to [`centr_degree()`] to create a more
+#' `centralization.degree()` was renamed to [centr_degree()] to create a more
 #' consistent API.
 #' @inheritParams centr_degree
 #' @keywords internal
@@ -78,7 +78,7 @@ centralization.degree <- function(graph, mode = c("all", "out", "in", "total"), 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.closeness.tmax()` was renamed to [`centr_clo_tmax()`] to create a more
+#' `centralization.closeness.tmax()` was renamed to [centr_clo_tmax()] to create a more
 #' consistent API.
 #' @inheritParams centr_clo_tmax
 #' @keywords internal
@@ -93,7 +93,7 @@ centralization.closeness.tmax <- function(graph = NULL, nodes = 0, mode = c("out
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.closeness()` was renamed to [`centr_clo()`] to create a more
+#' `centralization.closeness()` was renamed to [centr_clo()] to create a more
 #' consistent API.
 #' @inheritParams centr_clo
 #' @keywords internal
@@ -108,7 +108,7 @@ centralization.closeness <- function(graph, mode = c("out", "in", "all", "total"
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.betweenness.tmax()` was renamed to [`centr_betw_tmax()`] to create a more
+#' `centralization.betweenness.tmax()` was renamed to [centr_betw_tmax()] to create a more
 #' consistent API.
 #' @inheritParams centr_betw_tmax
 #' @keywords internal
@@ -123,7 +123,7 @@ centralization.betweenness.tmax <- function(graph = NULL, nodes = 0, directed = 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `centralization.betweenness()` was renamed to [`centr_betw()`] to create a more
+#' `centralization.betweenness()` was renamed to [centr_betw()] to create a more
 #' consistent API.
 #' @inheritParams centr_betw
 #' @keywords internal

--- a/R/cliques.R
+++ b/R/cliques.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maximal.independent.vertex.sets()` was renamed to [`max_ivs()`] to create a more
+#' `maximal.independent.vertex.sets()` was renamed to [max_ivs()] to create a more
 #' consistent API.
 #' @inheritParams max_ivs
 #' @keywords internal
@@ -18,7 +18,7 @@ maximal.independent.vertex.sets <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maximal.cliques.count()` was renamed to [`count_max_cliques()`] to create a more
+#' `maximal.cliques.count()` was renamed to [count_max_cliques()] to create a more
 #' consistent API.
 #' @inheritParams count_max_cliques
 #' @keywords internal
@@ -33,7 +33,7 @@ maximal.cliques.count <- function(graph, min = NULL, max = NULL, subset = NULL) 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maximal.cliques()` was renamed to [`max_cliques()`] to create a more
+#' `maximal.cliques()` was renamed to [max_cliques()] to create a more
 #' consistent API.
 #' @inheritParams max_cliques
 #' @keywords internal
@@ -48,7 +48,7 @@ maximal.cliques <- function(graph, min = NULL, max = NULL, subset = NULL, file =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `largest.independent.vertex.sets()` was renamed to [`largest_ivs()`] to create a more
+#' `largest.independent.vertex.sets()` was renamed to [largest_ivs()] to create a more
 #' consistent API.
 #' @inheritParams largest_ivs
 #' @keywords internal
@@ -63,7 +63,7 @@ largest.independent.vertex.sets <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `largest.cliques()` was renamed to [`largest_cliques()`] to create a more
+#' `largest.cliques()` was renamed to [largest_cliques()] to create a more
 #' consistent API.
 #' @inheritParams largest_cliques
 #' @keywords internal
@@ -78,7 +78,7 @@ largest.cliques <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `independent.vertex.sets()` was renamed to [`ivs()`] to create a more
+#' `independent.vertex.sets()` was renamed to [ivs()] to create a more
 #' consistent API.
 #' @inheritParams ivs
 #' @keywords internal
@@ -93,7 +93,7 @@ independent.vertex.sets <- function(graph, min = NULL, max = NULL) { # nocov sta
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `independence.number()` was renamed to [`ivs_size()`] to create a more
+#' `independence.number()` was renamed to [ivs_size()] to create a more
 #' consistent API.
 #' @inheritParams ivs_size
 #' @keywords internal
@@ -108,7 +108,7 @@ independence.number <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `clique.number()` was renamed to [`clique_num()`] to create a more
+#' `clique.number()` was renamed to [clique_num()] to create a more
 #' consistent API.
 #' @inheritParams clique_num
 #' @keywords internal
@@ -174,7 +174,7 @@ clique.number <- function(graph) { # nocov start
 #'   `NULL` means no limit.
 #' @return `cliques()`, `largest_cliques()` and `clique_num()`
 #'   return a list containing numeric vectors of vertex ids. Each list element is
-#'   a clique, i.e. a vertex sequence of class [`igraph.vs()`][V].
+#'   a clique, i.e. a vertex sequence of class [igraph.vs()][V].
 #'
 #'   `max_cliques()` returns `NULL`, invisibly, if its `file`
 #'   argument is not `NULL`. The output is written to the specified file in
@@ -343,7 +343,7 @@ clique_num <- clique_number_impl
 #'   or only the maximal ones (`TRUE`).
 #' @return `weighted_cliques()` and `largest_weighted_cliques()` return a
 #'   list containing numeric vectors of vertex IDs. Each list element is a weighted
-#'   clique, i.e. a vertex sequence of class [`igraph.vs()`][V].
+#'   clique, i.e. a vertex sequence of class [igraph.vs()][V].
 #'
 #'   `weighted_clique_num()` returns an integer scalar.
 #'
@@ -499,7 +499,7 @@ max_ivs <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maximal_ivs()` was renamed to [`max_ivs()`] to create a more
+#' `maximal_ivs()` was renamed to [max_ivs()] to create a more
 #' consistent API.
 #' @export
 #' @inheritParams max_ivs

--- a/R/cliques.R
+++ b/R/cliques.R
@@ -174,7 +174,7 @@ clique.number <- function(graph) { # nocov start
 #'   `NULL` means no limit.
 #' @return `cliques()`, `largest_cliques()` and `clique_num()`
 #'   return a list containing numeric vectors of vertex ids. Each list element is
-#'   a clique, i.e. a vertex sequence of class [igraph.vs()][V].
+#'   a clique, i.e. a vertex sequence of class [igraph.vs][V].
 #'
 #'   `max_cliques()` returns `NULL`, invisibly, if its `file`
 #'   argument is not `NULL`. The output is written to the specified file in
@@ -343,7 +343,7 @@ clique_num <- clique_number_impl
 #'   or only the maximal ones (`TRUE`).
 #' @return `weighted_cliques()` and `largest_weighted_cliques()` return a
 #'   list containing numeric vectors of vertex IDs. Each list element is a weighted
-#'   clique, i.e. a vertex sequence of class [igraph.vs()][V].
+#'   clique, i.e. a vertex sequence of class [igraph.vs][V].
 #'
 #'   `weighted_clique_num()` returns an integer scalar.
 #'

--- a/R/cliques.R
+++ b/R/cliques.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maximal.independent.vertex.sets()` was renamed to `max_ivs()` to create a more
+#' `maximal.independent.vertex.sets()` was renamed to [`max_ivs()`] to create a more
 #' consistent API.
 #' @inheritParams max_ivs
 #' @keywords internal
@@ -18,7 +18,7 @@ maximal.independent.vertex.sets <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maximal.cliques.count()` was renamed to `count_max_cliques()` to create a more
+#' `maximal.cliques.count()` was renamed to [`count_max_cliques()`] to create a more
 #' consistent API.
 #' @inheritParams count_max_cliques
 #' @keywords internal
@@ -33,7 +33,7 @@ maximal.cliques.count <- function(graph, min = NULL, max = NULL, subset = NULL) 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maximal.cliques()` was renamed to `max_cliques()` to create a more
+#' `maximal.cliques()` was renamed to [`max_cliques()`] to create a more
 #' consistent API.
 #' @inheritParams max_cliques
 #' @keywords internal
@@ -48,7 +48,7 @@ maximal.cliques <- function(graph, min = NULL, max = NULL, subset = NULL, file =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `largest.independent.vertex.sets()` was renamed to `largest_ivs()` to create a more
+#' `largest.independent.vertex.sets()` was renamed to [`largest_ivs()`] to create a more
 #' consistent API.
 #' @inheritParams largest_ivs
 #' @keywords internal
@@ -63,7 +63,7 @@ largest.independent.vertex.sets <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `largest.cliques()` was renamed to `largest_cliques()` to create a more
+#' `largest.cliques()` was renamed to [`largest_cliques()`] to create a more
 #' consistent API.
 #' @inheritParams largest_cliques
 #' @keywords internal
@@ -78,7 +78,7 @@ largest.cliques <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `independent.vertex.sets()` was renamed to `ivs()` to create a more
+#' `independent.vertex.sets()` was renamed to [`ivs()`] to create a more
 #' consistent API.
 #' @inheritParams ivs
 #' @keywords internal
@@ -93,7 +93,7 @@ independent.vertex.sets <- function(graph, min = NULL, max = NULL) { # nocov sta
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `independence.number()` was renamed to `ivs_size()` to create a more
+#' `independence.number()` was renamed to [`ivs_size()`] to create a more
 #' consistent API.
 #' @inheritParams ivs_size
 #' @keywords internal
@@ -108,7 +108,7 @@ independence.number <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `clique.number()` was renamed to `clique_num()` to create a more
+#' `clique.number()` was renamed to [`clique_num()`] to create a more
 #' consistent API.
 #' @inheritParams clique_num
 #' @keywords internal
@@ -499,7 +499,7 @@ max_ivs <- function(graph) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maximal_ivs()` was renamed to `max_ivs()` to create a more
+#' `maximal_ivs()` was renamed to [`max_ivs()`] to create a more
 #' consistent API.
 #' @export
 #' @inheritParams max_ivs

--- a/R/cohesive.blocks.R
+++ b/R/cohesive.blocks.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `exportPajek()` was renamed to [`export_pajek()`] to create a more
+#' `exportPajek()` was renamed to [export_pajek()] to create a more
 #' consistent API.
 #' @inheritParams export_pajek
 #' @keywords internal
@@ -18,7 +18,7 @@ exportPajek <- function(blocks, graph, file, project.file = TRUE) { # nocov star
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `plotHierarchy()` was renamed to [`plot_hierarchy()`] to create a more
+#' `plotHierarchy()` was renamed to [plot_hierarchy()] to create a more
 #' consistent API.
 #' @inheritParams plot_hierarchy
 #' @keywords internal
@@ -33,7 +33,7 @@ plotHierarchy <- function(blocks, layout = layout_as_tree(hierarchy(blocks), roo
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maxcohesion()` was renamed to [`max_cohesion()`] to create a more
+#' `maxcohesion()` was renamed to [max_cohesion()] to create a more
 #' consistent API.
 #' @inheritParams max_cohesion
 #' @keywords internal
@@ -48,7 +48,7 @@ maxcohesion <- function(blocks) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.cohesion()` was renamed to [`cohesion()`] to create a more
+#' `graph.cohesion()` was renamed to [cohesion()] to create a more
 #' consistent API.
 #' @param x x
 #' @param ... passed to `cohesion()`
@@ -64,7 +64,7 @@ graph.cohesion <- function(x, ...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `cohesive.blocks()` was renamed to [`cohesive_blocks()`] to create a more
+#' `cohesive.blocks()` was renamed to [cohesive_blocks()] to create a more
 #' consistent API.
 #' @inheritParams cohesive_blocks
 #' @keywords internal
@@ -79,7 +79,7 @@ cohesive.blocks <- function(graph, labels = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `blockGraphs()` was renamed to [`graphs_from_cohesive_blocks()`] to create a more
+#' `blockGraphs()` was renamed to [graphs_from_cohesive_blocks()] to create a more
 #' consistent API.
 #' @inheritParams graphs_from_cohesive_blocks
 #' @keywords internal

--- a/R/cohesive.blocks.R
+++ b/R/cohesive.blocks.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `exportPajek()` was renamed to `export_pajek()` to create a more
+#' `exportPajek()` was renamed to [`export_pajek()`] to create a more
 #' consistent API.
 #' @inheritParams export_pajek
 #' @keywords internal
@@ -18,7 +18,7 @@ exportPajek <- function(blocks, graph, file, project.file = TRUE) { # nocov star
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `plotHierarchy()` was renamed to `plot_hierarchy()` to create a more
+#' `plotHierarchy()` was renamed to [`plot_hierarchy()`] to create a more
 #' consistent API.
 #' @inheritParams plot_hierarchy
 #' @keywords internal
@@ -33,7 +33,7 @@ plotHierarchy <- function(blocks, layout = layout_as_tree(hierarchy(blocks), roo
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maxcohesion()` was renamed to `max_cohesion()` to create a more
+#' `maxcohesion()` was renamed to [`max_cohesion()`] to create a more
 #' consistent API.
 #' @inheritParams max_cohesion
 #' @keywords internal
@@ -48,7 +48,7 @@ maxcohesion <- function(blocks) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.cohesion()` was renamed to `cohesion()` to create a more
+#' `graph.cohesion()` was renamed to [`cohesion()`] to create a more
 #' consistent API.
 #' @param x x
 #' @param ... passed to `cohesion()`
@@ -64,7 +64,7 @@ graph.cohesion <- function(x, ...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `cohesive.blocks()` was renamed to `cohesive_blocks()` to create a more
+#' `cohesive.blocks()` was renamed to [`cohesive_blocks()`] to create a more
 #' consistent API.
 #' @inheritParams cohesive_blocks
 #' @keywords internal
@@ -79,7 +79,7 @@ cohesive.blocks <- function(graph, labels = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `blockGraphs()` was renamed to `graphs_from_cohesive_blocks()` to create a more
+#' `blockGraphs()` was renamed to [`graphs_from_cohesive_blocks()`] to create a more
 #' consistent API.
 #' @inheritParams graphs_from_cohesive_blocks
 #' @keywords internal

--- a/R/community.R
+++ b/R/community.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `create.communities()` was renamed to `make_clusters()` to create a more
+#' `create.communities()` was renamed to [`make_clusters()`] to create a more
 #' consistent API.
 #' @inheritParams make_clusters
 #' @keywords internal
@@ -18,7 +18,7 @@ create.communities <- function(graph, membership = NULL, algorithm = NULL, merge
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `walktrap.community()` was renamed to `cluster_walktrap()` to create a more
+#' `walktrap.community()` was renamed to [`cluster_walktrap()`] to create a more
 #' consistent API.
 #' @inheritParams cluster_walktrap
 #' @keywords internal
@@ -33,7 +33,7 @@ walktrap.community <- function(graph, weights = NULL, steps = 4, merges = TRUE, 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `spinglass.community()` was renamed to `cluster_spinglass()` to create a more
+#' `spinglass.community()` was renamed to [`cluster_spinglass()`] to create a more
 #' consistent API.
 #' @inheritParams cluster_spinglass
 #' @keywords internal
@@ -48,7 +48,7 @@ spinglass.community <- function(graph, weights = NULL, vertex = NULL, spins = 25
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `showtrace()` was renamed to `show_trace()` to create a more
+#' `showtrace()` was renamed to [`show_trace()`] to create a more
 #' consistent API.
 #' @inheritParams show_trace
 #' @keywords internal
@@ -63,7 +63,7 @@ showtrace <- function(communities) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `optimal.community()` was renamed to `cluster_optimal()` to create a more
+#' `optimal.community()` was renamed to [`cluster_optimal()`] to create a more
 #' consistent API.
 #' @inheritParams cluster_optimal
 #' @keywords internal
@@ -78,7 +78,7 @@ optimal.community <- function(graph, weights = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `multilevel.community()` was renamed to `cluster_louvain()` to create a more
+#' `multilevel.community()` was renamed to [`cluster_louvain()`] to create a more
 #' consistent API.
 #' @inheritParams cluster_louvain
 #' @keywords internal
@@ -93,7 +93,7 @@ multilevel.community <- function(graph, weights = NULL, resolution = 1) { # noco
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `mod.matrix()` was renamed to `modularity_matrix()` to create a more
+#' `mod.matrix()` was renamed to [`modularity_matrix()`] to create a more
 #' consistent API.
 #' @inheritParams modularity_matrix
 #' @keywords internal
@@ -108,7 +108,7 @@ mod.matrix <- function(graph, membership, weights = NULL, resolution = 1, direct
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `leading.eigenvector.community()` was renamed to `cluster_leading_eigen()` to create a more
+#' `leading.eigenvector.community()` was renamed to [`cluster_leading_eigen()`] to create a more
 #' consistent API.
 #' @inheritParams cluster_leading_eigen
 #' @keywords internal
@@ -123,7 +123,7 @@ leading.eigenvector.community <- function(graph, steps = -1, weights = NULL, sta
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `label.propagation.community()` was renamed to `cluster_label_prop()` to create a more
+#' `label.propagation.community()` was renamed to [`cluster_label_prop()`] to create a more
 #' consistent API.
 #' @inheritParams cluster_label_prop
 #' @keywords internal
@@ -138,7 +138,7 @@ label.propagation.community <- function(graph, weights = NULL, ..., mode = c("ou
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.hierarchical()` was renamed to `is_hierarchical()` to create a more
+#' `is.hierarchical()` was renamed to [`is_hierarchical()`] to create a more
 #' consistent API.
 #' @inheritParams is_hierarchical
 #' @keywords internal
@@ -153,7 +153,7 @@ is.hierarchical <- function(communities) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `infomap.community()` was renamed to `cluster_infomap()` to create a more
+#' `infomap.community()` was renamed to [`cluster_infomap()`] to create a more
 #' consistent API.
 #' @inheritParams cluster_infomap
 #' @keywords internal
@@ -168,7 +168,7 @@ infomap.community <- function(graph, e.weights = NULL, v.weights = NULL, nb.tria
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `fastgreedy.community()` was renamed to `cluster_fast_greedy()` to create a more
+#' `fastgreedy.community()` was renamed to [`cluster_fast_greedy()`] to create a more
 #' consistent API.
 #' @inheritParams cluster_fast_greedy
 #' @keywords internal
@@ -183,7 +183,7 @@ fastgreedy.community <- function(graph, merges = TRUE, modularity = TRUE, member
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `edge.betweenness.community()` was renamed to `cluster_edge_betweenness()` to create a more
+#' `edge.betweenness.community()` was renamed to [`cluster_edge_betweenness()`] to create a more
 #' consistent API.
 #' @inheritParams cluster_edge_betweenness
 #' @keywords internal
@@ -198,7 +198,7 @@ edge.betweenness.community <- function(graph, weights = NULL, directed = TRUE, e
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `dendPlot()` was renamed to `plot_dendrogram()` to create a more
+#' `dendPlot()` was renamed to [`plot_dendrogram()`] to create a more
 #' consistent API.
 #' @inheritParams plot_dendrogram
 #' @keywords internal
@@ -213,7 +213,7 @@ dendPlot <- function(x, mode = igraph_opt("dend.plot.type"), ...) { # nocov star
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `cutat()` was renamed to `cut_at()` to create a more
+#' `cutat()` was renamed to [`cut_at()`] to create a more
 #' consistent API.
 #' @inheritParams cut_at
 #' @keywords internal
@@ -228,7 +228,7 @@ cutat <- function(communities, no, steps) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `contract.vertices()` was renamed to `contract()` to create a more
+#' `contract.vertices()` was renamed to [`contract()`] to create a more
 #' consistent API.
 #' @inheritParams contract
 #' @keywords internal
@@ -243,7 +243,7 @@ contract.vertices <- function(graph, mapping, vertex.attr.comb = igraph_opt("ver
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `code.length()` was renamed to `code_len()` to create a more
+#' `code.length()` was renamed to [`code_len()`] to create a more
 #' consistent API.
 #' @inheritParams code_len
 #' @keywords internal

--- a/R/community.R
+++ b/R/community.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `create.communities()` was renamed to [`make_clusters()`] to create a more
+#' `create.communities()` was renamed to [make_clusters()] to create a more
 #' consistent API.
 #' @inheritParams make_clusters
 #' @keywords internal
@@ -18,7 +18,7 @@ create.communities <- function(graph, membership = NULL, algorithm = NULL, merge
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `walktrap.community()` was renamed to [`cluster_walktrap()`] to create a more
+#' `walktrap.community()` was renamed to [cluster_walktrap()] to create a more
 #' consistent API.
 #' @inheritParams cluster_walktrap
 #' @keywords internal
@@ -33,7 +33,7 @@ walktrap.community <- function(graph, weights = NULL, steps = 4, merges = TRUE, 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `spinglass.community()` was renamed to [`cluster_spinglass()`] to create a more
+#' `spinglass.community()` was renamed to [cluster_spinglass()] to create a more
 #' consistent API.
 #' @inheritParams cluster_spinglass
 #' @keywords internal
@@ -48,7 +48,7 @@ spinglass.community <- function(graph, weights = NULL, vertex = NULL, spins = 25
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `showtrace()` was renamed to [`show_trace()`] to create a more
+#' `showtrace()` was renamed to [show_trace()] to create a more
 #' consistent API.
 #' @inheritParams show_trace
 #' @keywords internal
@@ -63,7 +63,7 @@ showtrace <- function(communities) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `optimal.community()` was renamed to [`cluster_optimal()`] to create a more
+#' `optimal.community()` was renamed to [cluster_optimal()] to create a more
 #' consistent API.
 #' @inheritParams cluster_optimal
 #' @keywords internal
@@ -78,7 +78,7 @@ optimal.community <- function(graph, weights = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `multilevel.community()` was renamed to [`cluster_louvain()`] to create a more
+#' `multilevel.community()` was renamed to [cluster_louvain()] to create a more
 #' consistent API.
 #' @inheritParams cluster_louvain
 #' @keywords internal
@@ -93,7 +93,7 @@ multilevel.community <- function(graph, weights = NULL, resolution = 1) { # noco
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `mod.matrix()` was renamed to [`modularity_matrix()`] to create a more
+#' `mod.matrix()` was renamed to [modularity_matrix()] to create a more
 #' consistent API.
 #' @inheritParams modularity_matrix
 #' @keywords internal
@@ -108,7 +108,7 @@ mod.matrix <- function(graph, membership, weights = NULL, resolution = 1, direct
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `leading.eigenvector.community()` was renamed to [`cluster_leading_eigen()`] to create a more
+#' `leading.eigenvector.community()` was renamed to [cluster_leading_eigen()] to create a more
 #' consistent API.
 #' @inheritParams cluster_leading_eigen
 #' @keywords internal
@@ -123,7 +123,7 @@ leading.eigenvector.community <- function(graph, steps = -1, weights = NULL, sta
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `label.propagation.community()` was renamed to [`cluster_label_prop()`] to create a more
+#' `label.propagation.community()` was renamed to [cluster_label_prop()] to create a more
 #' consistent API.
 #' @inheritParams cluster_label_prop
 #' @keywords internal
@@ -138,7 +138,7 @@ label.propagation.community <- function(graph, weights = NULL, ..., mode = c("ou
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.hierarchical()` was renamed to [`is_hierarchical()`] to create a more
+#' `is.hierarchical()` was renamed to [is_hierarchical()] to create a more
 #' consistent API.
 #' @inheritParams is_hierarchical
 #' @keywords internal
@@ -153,7 +153,7 @@ is.hierarchical <- function(communities) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `infomap.community()` was renamed to [`cluster_infomap()`] to create a more
+#' `infomap.community()` was renamed to [cluster_infomap()] to create a more
 #' consistent API.
 #' @inheritParams cluster_infomap
 #' @keywords internal
@@ -168,7 +168,7 @@ infomap.community <- function(graph, e.weights = NULL, v.weights = NULL, nb.tria
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `fastgreedy.community()` was renamed to [`cluster_fast_greedy()`] to create a more
+#' `fastgreedy.community()` was renamed to [cluster_fast_greedy()] to create a more
 #' consistent API.
 #' @inheritParams cluster_fast_greedy
 #' @keywords internal
@@ -183,7 +183,7 @@ fastgreedy.community <- function(graph, merges = TRUE, modularity = TRUE, member
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `edge.betweenness.community()` was renamed to [`cluster_edge_betweenness()`] to create a more
+#' `edge.betweenness.community()` was renamed to [cluster_edge_betweenness()] to create a more
 #' consistent API.
 #' @inheritParams cluster_edge_betweenness
 #' @keywords internal
@@ -198,7 +198,7 @@ edge.betweenness.community <- function(graph, weights = NULL, directed = TRUE, e
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `dendPlot()` was renamed to [`plot_dendrogram()`] to create a more
+#' `dendPlot()` was renamed to [plot_dendrogram()] to create a more
 #' consistent API.
 #' @inheritParams plot_dendrogram
 #' @keywords internal
@@ -213,7 +213,7 @@ dendPlot <- function(x, mode = igraph_opt("dend.plot.type"), ...) { # nocov star
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `cutat()` was renamed to [`cut_at()`] to create a more
+#' `cutat()` was renamed to [cut_at()] to create a more
 #' consistent API.
 #' @inheritParams cut_at
 #' @keywords internal
@@ -228,7 +228,7 @@ cutat <- function(communities, no, steps) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `contract.vertices()` was renamed to [`contract()`] to create a more
+#' `contract.vertices()` was renamed to [contract()] to create a more
 #' consistent API.
 #' @inheritParams contract
 #' @keywords internal
@@ -243,7 +243,7 @@ contract.vertices <- function(graph, mapping, vertex.attr.comb = igraph_opt("ver
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `code.length()` was renamed to [`code_len()`] to create a more
+#' `code.length()` was renamed to [code_len()] to create a more
 #' consistent API.
 #' @inheritParams code_len
 #' @keywords internal

--- a/R/components.R
+++ b/R/components.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `no.clusters()` was renamed to `count_components()` to create a more
+#' `no.clusters()` was renamed to [`count_components()`] to create a more
 #' consistent API.
 #' @inheritParams count_components
 #' @keywords internal
@@ -18,7 +18,7 @@ no.clusters <- function(graph, mode = c("weak", "strong")) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `decompose.graph()` was renamed to `decompose()` to create a more
+#' `decompose.graph()` was renamed to [`decompose()`] to create a more
 #' consistent API.
 #' @inheritParams decompose
 #' @keywords internal
@@ -33,7 +33,7 @@ decompose.graph <- function(graph, mode = c("weak", "strong"), max.comps = NA, m
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `cluster.distribution()` was renamed to `component_distribution()` to create a more
+#' `cluster.distribution()` was renamed to [`component_distribution()`] to create a more
 #' consistent API.
 #' @inheritParams component_distribution
 #' @keywords internal
@@ -48,7 +48,7 @@ cluster.distribution <- function(graph, cumulative = FALSE, mul.size = FALSE, ..
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `biconnected.components()` was renamed to `biconnected_components()` to create a more
+#' `biconnected.components()` was renamed to [`biconnected_components()`] to create a more
 #' consistent API.
 #' @inheritParams biconnected_components
 #' @keywords internal
@@ -63,7 +63,7 @@ biconnected.components <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `articulation.points()` was renamed to `articulation_points()` to create a more
+#' `articulation.points()` was renamed to [`articulation_points()`] to create a more
 #' consistent API.
 #' @inheritParams articulation_points
 #' @keywords internal

--- a/R/components.R
+++ b/R/components.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `no.clusters()` was renamed to [`count_components()`] to create a more
+#' `no.clusters()` was renamed to [count_components()] to create a more
 #' consistent API.
 #' @inheritParams count_components
 #' @keywords internal
@@ -18,7 +18,7 @@ no.clusters <- function(graph, mode = c("weak", "strong")) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `decompose.graph()` was renamed to [`decompose()`] to create a more
+#' `decompose.graph()` was renamed to [decompose()] to create a more
 #' consistent API.
 #' @inheritParams decompose
 #' @keywords internal
@@ -33,7 +33,7 @@ decompose.graph <- function(graph, mode = c("weak", "strong"), max.comps = NA, m
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `cluster.distribution()` was renamed to [`component_distribution()`] to create a more
+#' `cluster.distribution()` was renamed to [component_distribution()] to create a more
 #' consistent API.
 #' @inheritParams component_distribution
 #' @keywords internal
@@ -48,7 +48,7 @@ cluster.distribution <- function(graph, cumulative = FALSE, mul.size = FALSE, ..
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `biconnected.components()` was renamed to [`biconnected_components()`] to create a more
+#' `biconnected.components()` was renamed to [biconnected_components()] to create a more
 #' consistent API.
 #' @inheritParams biconnected_components
 #' @keywords internal
@@ -63,7 +63,7 @@ biconnected.components <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `articulation.points()` was renamed to [`articulation_points()`] to create a more
+#' `articulation.points()` was renamed to [articulation_points()] to create a more
 #' consistent API.
 #' @inheritParams articulation_points
 #' @keywords internal

--- a/R/console.R
+++ b/R/console.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.console()` was renamed to [`console()`] to create a more
+#' `igraph.console()` was renamed to [console()] to create a more
 #' consistent API.
 #'
 #' @keywords internal

--- a/R/console.R
+++ b/R/console.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.console()` was renamed to `console()` to create a more
+#' `igraph.console()` was renamed to [`console()`] to create a more
 #' consistent API.
 #'
 #' @keywords internal

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.to.graphNEL()` was renamed to [`as_graphnel()`] to create a more
+#' `igraph.to.graphNEL()` was renamed to [as_graphnel()] to create a more
 #' consistent API.
 #' @inheritParams as_graphnel
 #' @keywords internal
@@ -18,7 +18,7 @@ igraph.to.graphNEL <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.from.graphNEL()` was renamed to [`graph_from_graphnel()`] to create a more
+#' `igraph.from.graphNEL()` was renamed to [graph_from_graphnel()] to create a more
 #' consistent API.
 #' @inheritParams graph_from_graphnel
 #' @keywords internal
@@ -33,7 +33,7 @@ igraph.from.graphNEL <- function(graphNEL, name = TRUE, weight = TRUE, unlist.at
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.adjlist()` was renamed to [`graph_from_adj_list()`] to create a more
+#' `graph.adjlist()` was renamed to [graph_from_adj_list()] to create a more
 #' consistent API.
 #' @inheritParams graph_from_adj_list
 #' @keywords internal
@@ -48,7 +48,7 @@ graph.adjlist <- function(adjlist, mode = c("out", "in", "all", "total"), duplic
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.incidence()` was renamed to [`as_biadjacency_matrix()`] to create a more
+#' `get.incidence()` was renamed to [as_biadjacency_matrix()] to create a more
 #' consistent API.
 #' @inheritParams as_biadjacency_matrix
 #' @keywords internal
@@ -63,7 +63,7 @@ get.incidence <- function(graph, types = NULL, attr = NULL, names = TRUE, sparse
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.edgelist()` was renamed to [`as_edgelist()`] to create a more
+#' `get.edgelist()` was renamed to [as_edgelist()] to create a more
 #' consistent API.
 #' @inheritParams as_edgelist
 #' @keywords internal
@@ -78,7 +78,7 @@ get.edgelist <- function(graph, names = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.data.frame()` was renamed to [`as_data_frame()`] to create a more
+#' `get.data.frame()` was renamed to [as_data_frame()] to create a more
 #' consistent API.
 #' @inheritParams as_data_frame
 #' @keywords internal
@@ -93,7 +93,7 @@ get.data.frame <- function(x, what = c("edges", "vertices", "both")) { # nocov s
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.adjacency()` was renamed to [`as_adjacency_matrix()`] to create a more
+#' `get.adjacency()` was renamed to [as_adjacency_matrix()] to create a more
 #' consistent API.
 #' @inheritParams as_adjacency_matrix
 #' @keywords internal
@@ -108,7 +108,7 @@ get.adjacency <- function(graph, type = c("both", "upper", "lower"), attr = NULL
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.adjlist()` was renamed to [`as_adj_list()`] to create a more
+#' `get.adjlist()` was renamed to [as_adj_list()] to create a more
 #' consistent API.
 #' @inheritParams as_adj_list
 #' @keywords internal
@@ -123,7 +123,7 @@ get.adjlist <- function(graph, mode = c("all", "out", "in", "total"), loops = c(
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.adjedgelist()` was renamed to [`as_adj_edge_list()`] to create a more
+#' `get.adjedgelist()` was renamed to [as_adj_edge_list()] to create a more
 #' consistent API.
 #' @inheritParams as_adj_edge_list
 #' @keywords internal
@@ -995,7 +995,7 @@ as_biadjacency_matrix <- function(graph, types = NULL, attr = NULL,
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `as_incidence_matrix()` was renamed to [`as_biadjacency_matrix()`] to create a more
+#' `as_incidence_matrix()` was renamed to [as_biadjacency_matrix()] to create a more
 #' consistent API.
 #' @inheritParams as_biadjacency_matrix
 #' @keywords internal
@@ -1205,7 +1205,7 @@ as.matrix.igraph <- function(x, matrix.type = c("adjacency", "edgelist"), ...) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `as.directed()` was renamed to [`as_directed()`] to create a more
+#' `as.directed()` was renamed to [as_directed()] to create a more
 #' consistent API.
 #' @inheritParams as_directed
 #' @keywords internal
@@ -1220,7 +1220,7 @@ as.directed <- function(graph, mode = c("mutual", "arbitrary", "random", "acycli
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `as.undirected()` was renamed to [`as_undirected()`] to create a more
+#' `as.undirected()` was renamed to [as_undirected()] to create a more
 #' consistent API.
 #' @inheritParams as_undirected
 #' @keywords internal
@@ -1237,7 +1237,7 @@ as.undirected <- function(graph,
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.edgelist()` was renamed to [`graph_from_edgelist()`] to create a more
+#' `graph.edgelist()` was renamed to [graph_from_edgelist()] to create a more
 #' consistent API.
 #' @inheritParams graph_from_edgelist
 #' @keywords internal
@@ -1252,7 +1252,7 @@ graph.edgelist <- function(el, directed = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.data.frame()` was renamed to [`graph_from_data_frame()`] to create a more
+#' `graph.data.frame()` was renamed to [graph_from_data_frame()] to create a more
 #' consistent API.
 #' @inheritParams graph_from_data_frame
 #' @keywords internal

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.to.graphNEL()` was renamed to `as_graphnel()` to create a more
+#' `igraph.to.graphNEL()` was renamed to [`as_graphnel()`] to create a more
 #' consistent API.
 #' @inheritParams as_graphnel
 #' @keywords internal
@@ -18,7 +18,7 @@ igraph.to.graphNEL <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.from.graphNEL()` was renamed to `graph_from_graphnel()` to create a more
+#' `igraph.from.graphNEL()` was renamed to [`graph_from_graphnel()`] to create a more
 #' consistent API.
 #' @inheritParams graph_from_graphnel
 #' @keywords internal
@@ -33,7 +33,7 @@ igraph.from.graphNEL <- function(graphNEL, name = TRUE, weight = TRUE, unlist.at
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.adjlist()` was renamed to `graph_from_adj_list()` to create a more
+#' `graph.adjlist()` was renamed to [`graph_from_adj_list()`] to create a more
 #' consistent API.
 #' @inheritParams graph_from_adj_list
 #' @keywords internal
@@ -48,7 +48,7 @@ graph.adjlist <- function(adjlist, mode = c("out", "in", "all", "total"), duplic
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.incidence()` was renamed to `as_biadjacency_matrix()` to create a more
+#' `get.incidence()` was renamed to [`as_biadjacency_matrix()`] to create a more
 #' consistent API.
 #' @inheritParams as_biadjacency_matrix
 #' @keywords internal
@@ -63,7 +63,7 @@ get.incidence <- function(graph, types = NULL, attr = NULL, names = TRUE, sparse
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.edgelist()` was renamed to `as_edgelist()` to create a more
+#' `get.edgelist()` was renamed to [`as_edgelist()`] to create a more
 #' consistent API.
 #' @inheritParams as_edgelist
 #' @keywords internal
@@ -78,7 +78,7 @@ get.edgelist <- function(graph, names = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.data.frame()` was renamed to `as_data_frame()` to create a more
+#' `get.data.frame()` was renamed to [`as_data_frame()`] to create a more
 #' consistent API.
 #' @inheritParams as_data_frame
 #' @keywords internal
@@ -93,7 +93,7 @@ get.data.frame <- function(x, what = c("edges", "vertices", "both")) { # nocov s
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.adjacency()` was renamed to `as_adjacency_matrix()` to create a more
+#' `get.adjacency()` was renamed to [`as_adjacency_matrix()`] to create a more
 #' consistent API.
 #' @inheritParams as_adjacency_matrix
 #' @keywords internal
@@ -108,7 +108,7 @@ get.adjacency <- function(graph, type = c("both", "upper", "lower"), attr = NULL
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.adjlist()` was renamed to `as_adj_list()` to create a more
+#' `get.adjlist()` was renamed to [`as_adj_list()`] to create a more
 #' consistent API.
 #' @inheritParams as_adj_list
 #' @keywords internal
@@ -123,7 +123,7 @@ get.adjlist <- function(graph, mode = c("all", "out", "in", "total"), loops = c(
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.adjedgelist()` was renamed to `as_adj_edge_list()` to create a more
+#' `get.adjedgelist()` was renamed to [`as_adj_edge_list()`] to create a more
 #' consistent API.
 #' @inheritParams as_adj_edge_list
 #' @keywords internal
@@ -995,7 +995,7 @@ as_biadjacency_matrix <- function(graph, types = NULL, attr = NULL,
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `as_incidence_matrix()` was renamed to `as_biadjacency_matrix()` to create a more
+#' `as_incidence_matrix()` was renamed to [`as_biadjacency_matrix()`] to create a more
 #' consistent API.
 #' @inheritParams as_biadjacency_matrix
 #' @keywords internal
@@ -1205,7 +1205,7 @@ as.matrix.igraph <- function(x, matrix.type = c("adjacency", "edgelist"), ...) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `as.directed()` was renamed to `as_directed()` to create a more
+#' `as.directed()` was renamed to [`as_directed()`] to create a more
 #' consistent API.
 #' @inheritParams as_directed
 #' @keywords internal
@@ -1220,7 +1220,7 @@ as.directed <- function(graph, mode = c("mutual", "arbitrary", "random", "acycli
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `as.undirected()` was renamed to `as_undirected()` to create a more
+#' `as.undirected()` was renamed to [`as_undirected()`] to create a more
 #' consistent API.
 #' @inheritParams as_undirected
 #' @keywords internal
@@ -1237,7 +1237,7 @@ as.undirected <- function(graph,
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.edgelist()` was renamed to `graph_from_edgelist()` to create a more
+#' `graph.edgelist()` was renamed to [`graph_from_edgelist()`] to create a more
 #' consistent API.
 #' @inheritParams graph_from_edgelist
 #' @keywords internal
@@ -1252,7 +1252,7 @@ graph.edgelist <- function(el, directed = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.data.frame()` was renamed to `graph_from_data_frame()` to create a more
+#' `graph.data.frame()` was renamed to [`graph_from_data_frame()`] to create a more
 #' consistent API.
 #' @inheritParams graph_from_data_frame
 #' @keywords internal

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -1174,7 +1174,7 @@ as_long_data_frame <- function(graph) {
 #' [as_adjacency_matrix()] or [as_edgelist()]
 #' depending on the value of `matrix.type`.
 #'
-#' @param x object of class igraph, the network
+#' @param x object of class `igraph`, the network
 #' @param matrix.type character, type of matrix to return, currently "adjacency"
 #'   or "edgelist" are supported
 #' @param \dots other arguments to/from other methods

--- a/R/decomposition.R
+++ b/R/decomposition.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.chordal()` was renamed to [`is_chordal()`] to create a more
+#' `is.chordal()` was renamed to [is_chordal()] to create a more
 #' consistent API.
 #' @inheritParams is_chordal
 #' @keywords internal

--- a/R/decomposition.R
+++ b/R/decomposition.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.chordal()` was renamed to `is_chordal()` to create a more
+#' `is.chordal()` was renamed to [`is_chordal()`] to create a more
 #' consistent API.
 #' @inheritParams is_chordal
 #' @keywords internal

--- a/R/degseq.R
+++ b/R/degseq.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.graphical.degree.sequence()` was renamed to `is_graphical()` to create a more
+#' `is.graphical.degree.sequence()` was renamed to [`is_graphical()`] to create a more
 #' consistent API.
 #' @inheritParams is_graphical
 #' @keywords internal
@@ -18,7 +18,7 @@ is.graphical.degree.sequence <- function(out.deg, in.deg = NULL, allowed.edge.ty
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.degree.sequence()` was renamed to `is_degseq()` to create a more
+#' `is.degree.sequence()` was renamed to [`is_degseq()`] to create a more
 #' consistent API.
 #' @inheritParams is_degseq
 #' @keywords internal

--- a/R/degseq.R
+++ b/R/degseq.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.graphical.degree.sequence()` was renamed to [`is_graphical()`] to create a more
+#' `is.graphical.degree.sequence()` was renamed to [is_graphical()] to create a more
 #' consistent API.
 #' @inheritParams is_graphical
 #' @keywords internal
@@ -18,7 +18,7 @@ is.graphical.degree.sequence <- function(out.deg, in.deg = NULL, allowed.edge.ty
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.degree.sequence()` was renamed to [`is_degseq()`] to create a more
+#' `is.degree.sequence()` was renamed to [is_degseq()] to create a more
 #' consistent API.
 #' @inheritParams is_degseq
 #' @keywords internal

--- a/R/demo.R
+++ b/R/demo.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraphdemo()` was renamed to [`igraph_demo()`] to create a more
+#' `igraphdemo()` was renamed to [igraph_demo()] to create a more
 #' consistent API.
 #' @inheritParams igraph_demo
 #' @keywords internal

--- a/R/demo.R
+++ b/R/demo.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraphdemo()` was renamed to `igraph_demo()` to create a more
+#' `igraphdemo()` was renamed to [`igraph_demo()`] to create a more
 #' consistent API.
 #' @inheritParams igraph_demo
 #' @keywords internal

--- a/R/fit.R
+++ b/R/fit.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `power.law.fit()` was renamed to `fit_power_law()` to create a more
+#' `power.law.fit()` was renamed to [`fit_power_law()`] to create a more
 #' consistent API.
 #' @inheritParams fit_power_law
 #' @keywords internal

--- a/R/fit.R
+++ b/R/fit.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `power.law.fit()` was renamed to [`fit_power_law()`] to create a more
+#' `power.law.fit()` was renamed to [fit_power_law()] to create a more
 #' consistent API.
 #' @inheritParams fit_power_law
 #' @keywords internal

--- a/R/flow.R
+++ b/R/flow.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `vertex.disjoint.paths()` was renamed to [`vertex_disjoint_paths()`] to create a more
+#' `vertex.disjoint.paths()` was renamed to [vertex_disjoint_paths()] to create a more
 #' consistent API.
 #' @inheritParams vertex_disjoint_paths
 #' @keywords internal
@@ -18,7 +18,7 @@ vertex.disjoint.paths <- function(graph, source = NULL, target = NULL) { # nocov
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `vertex.connectivity()` was renamed to [`vertex_connectivity()`] to create a more
+#' `vertex.connectivity()` was renamed to [vertex_connectivity()] to create a more
 #' consistent API.
 #' @inheritParams vertex_connectivity
 #' @keywords internal
@@ -33,7 +33,7 @@ vertex.connectivity <- function(graph, source = NULL, target = NULL, checks = TR
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `stMincuts()` was renamed to [`st_min_cuts()`] to create a more
+#' `stMincuts()` was renamed to [st_min_cuts()] to create a more
 #' consistent API.
 #' @inheritParams st_min_cuts
 #' @keywords internal
@@ -48,7 +48,7 @@ stMincuts <- function(graph, source, target, capacity = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `stCuts()` was renamed to [`st_cuts()`] to create a more
+#' `stCuts()` was renamed to [st_cuts()] to create a more
 #' consistent API.
 #' @inheritParams st_cuts
 #' @keywords internal
@@ -63,7 +63,7 @@ stCuts <- function(graph, source, target) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `minimum.size.separators()` was renamed to [`min_separators()`] to create a more
+#' `minimum.size.separators()` was renamed to [min_separators()] to create a more
 #' consistent API.
 #' @inheritParams min_separators
 #' @keywords internal
@@ -78,7 +78,7 @@ minimum.size.separators <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `minimal.st.separators()` was renamed to [`min_st_separators()`] to create a more
+#' `minimal.st.separators()` was renamed to [min_st_separators()] to create a more
 #' consistent API.
 #' @inheritParams min_st_separators
 #' @keywords internal
@@ -93,7 +93,7 @@ minimal.st.separators <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.separator()` was renamed to [`is_separator()`] to create a more
+#' `is.separator()` was renamed to [is_separator()] to create a more
 #' consistent API.
 #' @inheritParams is_separator
 #' @keywords internal
@@ -108,7 +108,7 @@ is.separator <- function(graph, candidate) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.minimal.separator()` was renamed to [`is_min_separator()`] to create a more
+#' `is.minimal.separator()` was renamed to [is_min_separator()] to create a more
 #' consistent API.
 #' @inheritParams is_min_separator
 #' @keywords internal
@@ -123,7 +123,7 @@ is.minimal.separator <- function(graph, candidate) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.mincut()` was renamed to [`min_cut()`] to create a more
+#' `graph.mincut()` was renamed to [min_cut()] to create a more
 #' consistent API.
 #' @inheritParams min_cut
 #' @keywords internal
@@ -138,7 +138,7 @@ graph.mincut <- function(graph, source = NULL, target = NULL, capacity = NULL, v
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.maxflow()` was renamed to [`max_flow()`] to create a more
+#' `graph.maxflow()` was renamed to [max_flow()] to create a more
 #' consistent API.
 #' @inheritParams max_flow
 #' @keywords internal
@@ -153,7 +153,7 @@ graph.maxflow <- function(graph, source, target, capacity = NULL) { # nocov star
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.adhesion()` was renamed to [`adhesion()`] to create a more
+#' `graph.adhesion()` was renamed to [adhesion()] to create a more
 #' consistent API.
 #' @inheritParams adhesion
 #' @keywords internal
@@ -168,7 +168,7 @@ graph.adhesion <- function(graph, checks = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `edge.disjoint.paths()` was renamed to [`edge_connectivity()`] to create a more
+#' `edge.disjoint.paths()` was renamed to [edge_connectivity()] to create a more
 #' consistent API.
 #' @inheritParams edge_connectivity
 #' @keywords internal
@@ -183,7 +183,7 @@ edge.disjoint.paths <- function(graph, source = NULL, target = NULL, checks = TR
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `edge.connectivity()` was renamed to [`edge_connectivity()`] to create a more
+#' `edge.connectivity()` was renamed to [edge_connectivity()] to create a more
 #' consistent API.
 #' @inheritParams edge_connectivity
 #' @keywords internal
@@ -198,7 +198,7 @@ edge.connectivity <- function(graph, source = NULL, target = NULL, checks = TRUE
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `dominator.tree()` was renamed to [`dominator_tree()`] to create a more
+#' `dominator.tree()` was renamed to [dominator_tree()] to create a more
 #' consistent API.
 #' @inheritParams dominator_tree
 #' @keywords internal

--- a/R/flow.R
+++ b/R/flow.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `vertex.disjoint.paths()` was renamed to `vertex_disjoint_paths()` to create a more
+#' `vertex.disjoint.paths()` was renamed to [`vertex_disjoint_paths()`] to create a more
 #' consistent API.
 #' @inheritParams vertex_disjoint_paths
 #' @keywords internal
@@ -18,7 +18,7 @@ vertex.disjoint.paths <- function(graph, source = NULL, target = NULL) { # nocov
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `vertex.connectivity()` was renamed to `vertex_connectivity()` to create a more
+#' `vertex.connectivity()` was renamed to [`vertex_connectivity()`] to create a more
 #' consistent API.
 #' @inheritParams vertex_connectivity
 #' @keywords internal
@@ -33,7 +33,7 @@ vertex.connectivity <- function(graph, source = NULL, target = NULL, checks = TR
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `stMincuts()` was renamed to `st_min_cuts()` to create a more
+#' `stMincuts()` was renamed to [`st_min_cuts()`] to create a more
 #' consistent API.
 #' @inheritParams st_min_cuts
 #' @keywords internal
@@ -48,7 +48,7 @@ stMincuts <- function(graph, source, target, capacity = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `stCuts()` was renamed to `st_cuts()` to create a more
+#' `stCuts()` was renamed to [`st_cuts()`] to create a more
 #' consistent API.
 #' @inheritParams st_cuts
 #' @keywords internal
@@ -63,7 +63,7 @@ stCuts <- function(graph, source, target) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `minimum.size.separators()` was renamed to `min_separators()` to create a more
+#' `minimum.size.separators()` was renamed to [`min_separators()`] to create a more
 #' consistent API.
 #' @inheritParams min_separators
 #' @keywords internal
@@ -78,7 +78,7 @@ minimum.size.separators <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `minimal.st.separators()` was renamed to `min_st_separators()` to create a more
+#' `minimal.st.separators()` was renamed to [`min_st_separators()`] to create a more
 #' consistent API.
 #' @inheritParams min_st_separators
 #' @keywords internal
@@ -93,7 +93,7 @@ minimal.st.separators <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.separator()` was renamed to `is_separator()` to create a more
+#' `is.separator()` was renamed to [`is_separator()`] to create a more
 #' consistent API.
 #' @inheritParams is_separator
 #' @keywords internal
@@ -108,7 +108,7 @@ is.separator <- function(graph, candidate) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.minimal.separator()` was renamed to `is_min_separator()` to create a more
+#' `is.minimal.separator()` was renamed to [`is_min_separator()`] to create a more
 #' consistent API.
 #' @inheritParams is_min_separator
 #' @keywords internal
@@ -123,7 +123,7 @@ is.minimal.separator <- function(graph, candidate) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.mincut()` was renamed to `min_cut()` to create a more
+#' `graph.mincut()` was renamed to [`min_cut()`] to create a more
 #' consistent API.
 #' @inheritParams min_cut
 #' @keywords internal
@@ -138,7 +138,7 @@ graph.mincut <- function(graph, source = NULL, target = NULL, capacity = NULL, v
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.maxflow()` was renamed to `max_flow()` to create a more
+#' `graph.maxflow()` was renamed to [`max_flow()`] to create a more
 #' consistent API.
 #' @inheritParams max_flow
 #' @keywords internal
@@ -153,7 +153,7 @@ graph.maxflow <- function(graph, source, target, capacity = NULL) { # nocov star
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.adhesion()` was renamed to `adhesion()` to create a more
+#' `graph.adhesion()` was renamed to [`adhesion()`] to create a more
 #' consistent API.
 #' @inheritParams adhesion
 #' @keywords internal
@@ -168,7 +168,7 @@ graph.adhesion <- function(graph, checks = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `edge.disjoint.paths()` was renamed to `edge_connectivity()` to create a more
+#' `edge.disjoint.paths()` was renamed to [`edge_connectivity()`] to create a more
 #' consistent API.
 #' @inheritParams edge_connectivity
 #' @keywords internal
@@ -183,7 +183,7 @@ edge.disjoint.paths <- function(graph, source = NULL, target = NULL, checks = TR
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `edge.connectivity()` was renamed to `edge_connectivity()` to create a more
+#' `edge.connectivity()` was renamed to [`edge_connectivity()`] to create a more
 #' consistent API.
 #' @inheritParams edge_connectivity
 #' @keywords internal
@@ -198,7 +198,7 @@ edge.connectivity <- function(graph, source = NULL, target = NULL, checks = TRUE
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `dominator.tree()` was renamed to `dominator_tree()` to create a more
+#' `dominator.tree()` was renamed to [`dominator_tree()`] to create a more
 #' consistent API.
 #' @inheritParams dominator_tree
 #' @keywords internal

--- a/R/foreign.R
+++ b/R/foreign.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `write.graph()` was renamed to [`write_graph()`] to create a more
+#' `write.graph()` was renamed to [write_graph()] to create a more
 #' consistent API.
 #' @inheritParams write_graph
 #' @keywords internal
@@ -18,7 +18,7 @@ write.graph <- function(graph, file, format = c("edgelist", "pajek", "ncol", "lg
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `read.graph()` was renamed to [`read_graph()`] to create a more
+#' `read.graph()` was renamed to [read_graph()] to create a more
 #' consistent API.
 #' @inheritParams read_graph
 #' @keywords internal
@@ -33,7 +33,7 @@ read.graph <- function(file, format = c("edgelist", "pajek", "ncol", "lgl", "gra
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.graphdb()` was renamed to [`graph_from_graphdb()`] to create a more
+#' `graph.graphdb()` was renamed to [graph_from_graphdb()] to create a more
 #' consistent API.
 #' @inheritParams graph_from_graphdb
 #' @keywords internal

--- a/R/foreign.R
+++ b/R/foreign.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `write.graph()` was renamed to `write_graph()` to create a more
+#' `write.graph()` was renamed to [`write_graph()`] to create a more
 #' consistent API.
 #' @inheritParams write_graph
 #' @keywords internal
@@ -18,7 +18,7 @@ write.graph <- function(graph, file, format = c("edgelist", "pajek", "ncol", "lg
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `read.graph()` was renamed to `read_graph()` to create a more
+#' `read.graph()` was renamed to [`read_graph()`] to create a more
 #' consistent API.
 #' @inheritParams read_graph
 #' @keywords internal
@@ -33,7 +33,7 @@ read.graph <- function(file, format = c("edgelist", "pajek", "ncol", "lgl", "gra
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.graphdb()` was renamed to `graph_from_graphdb()` to create a more
+#' `graph.graphdb()` was renamed to [`graph_from_graphdb()`] to create a more
 #' consistent API.
 #' @inheritParams graph_from_graphdb
 #' @keywords internal

--- a/R/games.R
+++ b/R/games.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `watts.strogatz.game()` was renamed to `sample_smallworld()` to create a more
+#' `watts.strogatz.game()` was renamed to [`sample_smallworld()`] to create a more
 #' consistent API.
 #' @inheritParams sample_smallworld
 #' @keywords internal
@@ -18,7 +18,7 @@ watts.strogatz.game <- function(dim, size, nei, p, loops = FALSE, multiple = FAL
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `static.power.law.game()` was renamed to `sample_fitness_pl()` to create a more
+#' `static.power.law.game()` was renamed to [`sample_fitness_pl()`] to create a more
 #' consistent API.
 #' @inheritParams sample_fitness_pl
 #' @keywords internal
@@ -33,7 +33,7 @@ static.power.law.game <- function(no.of.nodes, no.of.edges, exponent.out, expone
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `static.fitness.game()` was renamed to `sample_fitness()` to create a more
+#' `static.fitness.game()` was renamed to [`sample_fitness()`] to create a more
 #' consistent API.
 #' @inheritParams sample_fitness
 #' @keywords internal
@@ -48,7 +48,7 @@ static.fitness.game <- function(no.of.edges, fitness.out, fitness.in = NULL, loo
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `sbm.game()` was renamed to `sample_sbm()` to create a more
+#' `sbm.game()` was renamed to [`sample_sbm()`] to create a more
 #' consistent API.
 #' @inheritParams sample_sbm
 #' @keywords internal
@@ -63,7 +63,7 @@ sbm.game <- function(n, pref.matrix, block.sizes, directed = FALSE, loops = FALS
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `preference.game()` was renamed to `sample_pref()` to create a more
+#' `preference.game()` was renamed to [`sample_pref()`] to create a more
 #' consistent API.
 #' @inheritParams sample_pref
 #' @keywords internal
@@ -78,7 +78,7 @@ preference.game <- function(nodes, types, type.dist = rep(1, types), fixed.sizes
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `lastcit.game()` was renamed to `sample_last_cit()` to create a more
+#' `lastcit.game()` was renamed to [`sample_last_cit()`] to create a more
 #' consistent API.
 #' @inheritParams sample_last_cit
 #' @keywords internal
@@ -93,7 +93,7 @@ lastcit.game <- function(n, edges = 1, agebins = n / 7100, pref = (1:(agebins + 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `k.regular.game()` was renamed to `sample_k_regular()` to create a more
+#' `k.regular.game()` was renamed to [`sample_k_regular()`] to create a more
 #' consistent API.
 #' @inheritParams sample_k_regular
 #' @keywords internal
@@ -108,7 +108,7 @@ k.regular.game <- function(no.of.nodes, k, directed = FALSE, multiple = FALSE) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `interconnected.islands.game()` was renamed to `sample_islands()` to create a more
+#' `interconnected.islands.game()` was renamed to [`sample_islands()`] to create a more
 #' consistent API.
 #' @inheritParams sample_islands
 #' @keywords internal
@@ -123,7 +123,7 @@ interconnected.islands.game <- function(islands.n, islands.size, islands.pin, n.
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `grg.game()` was renamed to `sample_grg()` to create a more
+#' `grg.game()` was renamed to [`sample_grg()`] to create a more
 #' consistent API.
 #' @inheritParams sample_grg
 #' @keywords internal
@@ -138,7 +138,7 @@ grg.game <- function(nodes, radius, torus = FALSE, coords = FALSE) { # nocov sta
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `growing.random.game()` was renamed to `sample_growing()` to create a more
+#' `growing.random.game()` was renamed to [`sample_growing()`] to create a more
 #' consistent API.
 #' @inheritParams sample_growing
 #' @keywords internal
@@ -153,7 +153,7 @@ growing.random.game <- function(n, m = 1, directed = TRUE, citation = FALSE) { #
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `forest.fire.game()` was renamed to `sample_forestfire()` to create a more
+#' `forest.fire.game()` was renamed to [`sample_forestfire()`] to create a more
 #' consistent API.
 #' @inheritParams sample_forestfire
 #' @keywords internal
@@ -168,7 +168,7 @@ forest.fire.game <- function(nodes, fw.prob, bw.factor = 1, ambs = 1, directed =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `establishment.game()` was renamed to `sample_traits()` to create a more
+#' `establishment.game()` was renamed to [`sample_traits()`] to create a more
 #' consistent API.
 #' @inheritParams sample_traits
 #' @keywords internal
@@ -183,7 +183,7 @@ establishment.game <- function(nodes, types, k = 1, type.dist = rep(1, types), p
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `degree.sequence.game()` was renamed to `sample_degseq()` to create a more
+#' `degree.sequence.game()` was renamed to [`sample_degseq()`] to create a more
 #' consistent API.
 #' @inheritParams sample_degseq
 #' @keywords internal
@@ -198,7 +198,7 @@ degree.sequence.game <- function(out.deg, in.deg = NULL, method = c("simple", "v
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `connect.neighborhood()` was renamed to `connect()` to create a more
+#' `connect.neighborhood()` was renamed to [`connect()`] to create a more
 #' consistent API.
 #' @inheritParams connect
 #' @keywords internal
@@ -213,7 +213,7 @@ connect.neighborhood <- function(graph, order, mode = c("all", "out", "in", "tot
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `citing.cited.type.game()` was renamed to `sample_cit_cit_types()` to create a more
+#' `citing.cited.type.game()` was renamed to [`sample_cit_cit_types()`] to create a more
 #' consistent API.
 #' @inheritParams sample_cit_cit_types
 #' @keywords internal
@@ -228,7 +228,7 @@ citing.cited.type.game <- function(n, edges = 1, types = rep(0, n), pref = matri
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `cited.type.game()` was renamed to `sample_cit_types()` to create a more
+#' `cited.type.game()` was renamed to [`sample_cit_types()`] to create a more
 #' consistent API.
 #' @inheritParams sample_cit_types
 #' @keywords internal
@@ -243,7 +243,7 @@ cited.type.game <- function(n, edges = 1, types = rep(0, n), pref = rep(1, lengt
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `callaway.traits.game()` was renamed to `sample_traits_callaway()` to create a more
+#' `callaway.traits.game()` was renamed to [`sample_traits_callaway()`] to create a more
 #' consistent API.
 #' @inheritParams sample_traits_callaway
 #' @keywords internal
@@ -258,7 +258,7 @@ callaway.traits.game <- function(nodes, types, edge.per.step = 1, type.dist = re
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `bipartite.random.game()` was renamed to `sample_bipartite()` to create a more
+#' `bipartite.random.game()` was renamed to [`sample_bipartite()`] to create a more
 #' consistent API.
 #' @inheritParams sample_bipartite
 #' @keywords internal
@@ -276,7 +276,7 @@ bipartite.random.game <- function(n1, n2, type = c("gnp", "gnm"), p, m, directed
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `barabasi.game()` was renamed to `sample_pa()` to create a more
+#' `barabasi.game()` was renamed to [`sample_pa()`] to create a more
 #' consistent API.
 #' @inheritParams sample_pa
 #' @keywords internal
@@ -291,7 +291,7 @@ barabasi.game <- function(n, power = 1, m = NULL, out.dist = NULL, out.seq = NUL
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `ba.game()` was renamed to `sample_pa()` to create a more
+#' `ba.game()` was renamed to [`sample_pa()`] to create a more
 #' consistent API.
 #' @inheritParams sample_pa
 #' @keywords internal
@@ -306,7 +306,7 @@ ba.game <- function(n, power = 1, m = NULL, out.dist = NULL, out.seq = NULL, out
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `asymmetric.preference.game()` was renamed to `sample_asym_pref()` to create a more
+#' `asymmetric.preference.game()` was renamed to [`sample_asym_pref()`] to create a more
 #' consistent API.
 #' @inheritParams sample_asym_pref
 #' @keywords internal
@@ -321,7 +321,7 @@ asymmetric.preference.game <- function(nodes, types, type.dist.matrix = matrix(1
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `aging.barabasi.game()` was renamed to `sample_pa_age()` to create a more
+#' `aging.barabasi.game()` was renamed to [`sample_pa_age()`] to create a more
 #' consistent API.
 #' @inheritParams sample_pa_age
 #' @keywords internal
@@ -336,7 +336,7 @@ aging.barabasi.game <- function(n, pa.exp, aging.exp, m = NULL, aging.bin = 300,
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `aging.ba.game()` was renamed to `sample_pa_age()` to create a more
+#' `aging.ba.game()` was renamed to [`sample_pa_age()`] to create a more
 #' consistent API.
 #' @inheritParams sample_pa_age
 #' @keywords internal
@@ -351,7 +351,7 @@ aging.ba.game <- function(n, pa.exp, aging.exp, m = NULL, aging.bin = 300, out.d
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `aging.prefatt.game()` was renamed to `sample_pa_age()` to create a more
+#' `aging.prefatt.game()` was renamed to [`sample_pa_age()`] to create a more
 #' consistent API.
 #' @inheritParams sample_pa_age
 #' @keywords internal

--- a/R/games.R
+++ b/R/games.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `watts.strogatz.game()` was renamed to [`sample_smallworld()`] to create a more
+#' `watts.strogatz.game()` was renamed to [sample_smallworld()] to create a more
 #' consistent API.
 #' @inheritParams sample_smallworld
 #' @keywords internal
@@ -18,7 +18,7 @@ watts.strogatz.game <- function(dim, size, nei, p, loops = FALSE, multiple = FAL
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `static.power.law.game()` was renamed to [`sample_fitness_pl()`] to create a more
+#' `static.power.law.game()` was renamed to [sample_fitness_pl()] to create a more
 #' consistent API.
 #' @inheritParams sample_fitness_pl
 #' @keywords internal
@@ -33,7 +33,7 @@ static.power.law.game <- function(no.of.nodes, no.of.edges, exponent.out, expone
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `static.fitness.game()` was renamed to [`sample_fitness()`] to create a more
+#' `static.fitness.game()` was renamed to [sample_fitness()] to create a more
 #' consistent API.
 #' @inheritParams sample_fitness
 #' @keywords internal
@@ -48,7 +48,7 @@ static.fitness.game <- function(no.of.edges, fitness.out, fitness.in = NULL, loo
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `sbm.game()` was renamed to [`sample_sbm()`] to create a more
+#' `sbm.game()` was renamed to [sample_sbm()] to create a more
 #' consistent API.
 #' @inheritParams sample_sbm
 #' @keywords internal
@@ -63,7 +63,7 @@ sbm.game <- function(n, pref.matrix, block.sizes, directed = FALSE, loops = FALS
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `preference.game()` was renamed to [`sample_pref()`] to create a more
+#' `preference.game()` was renamed to [sample_pref()] to create a more
 #' consistent API.
 #' @inheritParams sample_pref
 #' @keywords internal
@@ -78,7 +78,7 @@ preference.game <- function(nodes, types, type.dist = rep(1, types), fixed.sizes
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `lastcit.game()` was renamed to [`sample_last_cit()`] to create a more
+#' `lastcit.game()` was renamed to [sample_last_cit()] to create a more
 #' consistent API.
 #' @inheritParams sample_last_cit
 #' @keywords internal
@@ -93,7 +93,7 @@ lastcit.game <- function(n, edges = 1, agebins = n / 7100, pref = (1:(agebins + 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `k.regular.game()` was renamed to [`sample_k_regular()`] to create a more
+#' `k.regular.game()` was renamed to [sample_k_regular()] to create a more
 #' consistent API.
 #' @inheritParams sample_k_regular
 #' @keywords internal
@@ -108,7 +108,7 @@ k.regular.game <- function(no.of.nodes, k, directed = FALSE, multiple = FALSE) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `interconnected.islands.game()` was renamed to [`sample_islands()`] to create a more
+#' `interconnected.islands.game()` was renamed to [sample_islands()] to create a more
 #' consistent API.
 #' @inheritParams sample_islands
 #' @keywords internal
@@ -123,7 +123,7 @@ interconnected.islands.game <- function(islands.n, islands.size, islands.pin, n.
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `grg.game()` was renamed to [`sample_grg()`] to create a more
+#' `grg.game()` was renamed to [sample_grg()] to create a more
 #' consistent API.
 #' @inheritParams sample_grg
 #' @keywords internal
@@ -138,7 +138,7 @@ grg.game <- function(nodes, radius, torus = FALSE, coords = FALSE) { # nocov sta
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `growing.random.game()` was renamed to [`sample_growing()`] to create a more
+#' `growing.random.game()` was renamed to [sample_growing()] to create a more
 #' consistent API.
 #' @inheritParams sample_growing
 #' @keywords internal
@@ -153,7 +153,7 @@ growing.random.game <- function(n, m = 1, directed = TRUE, citation = FALSE) { #
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `forest.fire.game()` was renamed to [`sample_forestfire()`] to create a more
+#' `forest.fire.game()` was renamed to [sample_forestfire()] to create a more
 #' consistent API.
 #' @inheritParams sample_forestfire
 #' @keywords internal
@@ -168,7 +168,7 @@ forest.fire.game <- function(nodes, fw.prob, bw.factor = 1, ambs = 1, directed =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `establishment.game()` was renamed to [`sample_traits()`] to create a more
+#' `establishment.game()` was renamed to [sample_traits()] to create a more
 #' consistent API.
 #' @inheritParams sample_traits
 #' @keywords internal
@@ -183,7 +183,7 @@ establishment.game <- function(nodes, types, k = 1, type.dist = rep(1, types), p
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `degree.sequence.game()` was renamed to [`sample_degseq()`] to create a more
+#' `degree.sequence.game()` was renamed to [sample_degseq()] to create a more
 #' consistent API.
 #' @inheritParams sample_degseq
 #' @keywords internal
@@ -198,7 +198,7 @@ degree.sequence.game <- function(out.deg, in.deg = NULL, method = c("simple", "v
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `connect.neighborhood()` was renamed to [`connect()`] to create a more
+#' `connect.neighborhood()` was renamed to [connect()] to create a more
 #' consistent API.
 #' @inheritParams connect
 #' @keywords internal
@@ -213,7 +213,7 @@ connect.neighborhood <- function(graph, order, mode = c("all", "out", "in", "tot
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `citing.cited.type.game()` was renamed to [`sample_cit_cit_types()`] to create a more
+#' `citing.cited.type.game()` was renamed to [sample_cit_cit_types()] to create a more
 #' consistent API.
 #' @inheritParams sample_cit_cit_types
 #' @keywords internal
@@ -228,7 +228,7 @@ citing.cited.type.game <- function(n, edges = 1, types = rep(0, n), pref = matri
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `cited.type.game()` was renamed to [`sample_cit_types()`] to create a more
+#' `cited.type.game()` was renamed to [sample_cit_types()] to create a more
 #' consistent API.
 #' @inheritParams sample_cit_types
 #' @keywords internal
@@ -243,7 +243,7 @@ cited.type.game <- function(n, edges = 1, types = rep(0, n), pref = rep(1, lengt
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `callaway.traits.game()` was renamed to [`sample_traits_callaway()`] to create a more
+#' `callaway.traits.game()` was renamed to [sample_traits_callaway()] to create a more
 #' consistent API.
 #' @inheritParams sample_traits_callaway
 #' @keywords internal
@@ -258,7 +258,7 @@ callaway.traits.game <- function(nodes, types, edge.per.step = 1, type.dist = re
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `bipartite.random.game()` was renamed to [`sample_bipartite()`] to create a more
+#' `bipartite.random.game()` was renamed to [sample_bipartite()] to create a more
 #' consistent API.
 #' @inheritParams sample_bipartite
 #' @keywords internal
@@ -276,7 +276,7 @@ bipartite.random.game <- function(n1, n2, type = c("gnp", "gnm"), p, m, directed
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `barabasi.game()` was renamed to [`sample_pa()`] to create a more
+#' `barabasi.game()` was renamed to [sample_pa()] to create a more
 #' consistent API.
 #' @inheritParams sample_pa
 #' @keywords internal
@@ -291,7 +291,7 @@ barabasi.game <- function(n, power = 1, m = NULL, out.dist = NULL, out.seq = NUL
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `ba.game()` was renamed to [`sample_pa()`] to create a more
+#' `ba.game()` was renamed to [sample_pa()] to create a more
 #' consistent API.
 #' @inheritParams sample_pa
 #' @keywords internal
@@ -306,7 +306,7 @@ ba.game <- function(n, power = 1, m = NULL, out.dist = NULL, out.seq = NULL, out
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `asymmetric.preference.game()` was renamed to [`sample_asym_pref()`] to create a more
+#' `asymmetric.preference.game()` was renamed to [sample_asym_pref()] to create a more
 #' consistent API.
 #' @inheritParams sample_asym_pref
 #' @keywords internal
@@ -321,7 +321,7 @@ asymmetric.preference.game <- function(nodes, types, type.dist.matrix = matrix(1
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `aging.barabasi.game()` was renamed to [`sample_pa_age()`] to create a more
+#' `aging.barabasi.game()` was renamed to [sample_pa_age()] to create a more
 #' consistent API.
 #' @inheritParams sample_pa_age
 #' @keywords internal
@@ -336,7 +336,7 @@ aging.barabasi.game <- function(n, pa.exp, aging.exp, m = NULL, aging.bin = 300,
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `aging.ba.game()` was renamed to [`sample_pa_age()`] to create a more
+#' `aging.ba.game()` was renamed to [sample_pa_age()] to create a more
 #' consistent API.
 #' @inheritParams sample_pa_age
 #' @keywords internal
@@ -351,7 +351,7 @@ aging.ba.game <- function(n, pa.exp, aging.exp, m = NULL, aging.bin = 300, out.d
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `aging.prefatt.game()` was renamed to [`sample_pa_age()`] to create a more
+#' `aging.prefatt.game()` was renamed to [sample_pa_age()] to create a more
 #' consistent API.
 #' @inheritParams sample_pa_age
 #' @keywords internal
@@ -1707,7 +1707,7 @@ cit_cit_types <- function(...) constructor_spec(sample_cit_cit_types, ...)
 #' Bipartite random graphs
 #'
 #' `r lifecycle::badge("deprecated")` Generate bipartite graphs using the Erdős-Rényi model.
-#' Use [`sample_bipartite_gnm()`] and [`sample_bipartite_gnp()`] instead.
+#' Use [sample_bipartite_gnm()] and [sample_bipartite_gnp()] instead.
 #'
 #' @param n1 Integer scalar, the number of bottom vertices.
 #' @param n2 Integer scalar, the number of top vertices.

--- a/R/glet.R
+++ b/R/glet.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graphlets.project()` was renamed to `graphlet_proj()` to create a more
+#' `graphlets.project()` was renamed to [`graphlet_proj()`] to create a more
 #' consistent API.
 #' @inheritParams graphlet_proj
 #' @keywords internal
@@ -18,7 +18,7 @@ graphlets.project <- function(graph, weights = NULL, cliques, niter = 1000, Mu =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graphlets.candidate.basis()` was renamed to `graphlet_basis()` to create a more
+#' `graphlets.candidate.basis()` was renamed to [`graphlet_basis()`] to create a more
 #' consistent API.
 #' @inheritParams graphlet_basis
 #' @keywords internal

--- a/R/glet.R
+++ b/R/glet.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graphlets.project()` was renamed to [`graphlet_proj()`] to create a more
+#' `graphlets.project()` was renamed to [graphlet_proj()] to create a more
 #' consistent API.
 #' @inheritParams graphlet_proj
 #' @keywords internal
@@ -18,7 +18,7 @@ graphlets.project <- function(graph, weights = NULL, cliques, niter = 1000, Mu =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graphlets.candidate.basis()` was renamed to [`graphlet_basis()`] to create a more
+#' `graphlets.candidate.basis()` was renamed to [graphlet_basis()] to create a more
 #' consistent API.
 #' @inheritParams graphlet_basis
 #' @keywords internal

--- a/R/hrg.R
+++ b/R/hrg.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hrg.predict()` was renamed to `predict_edges()` to create a more
+#' `hrg.predict()` was renamed to [`predict_edges()`] to create a more
 #' consistent API.
 #' @inheritParams predict_edges
 #' @keywords internal
@@ -18,7 +18,7 @@ hrg.predict <- function(graph, hrg = NULL, start = FALSE, num.samples = 10000, n
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hrg.fit()` was renamed to `fit_hrg()` to create a more
+#' `hrg.fit()` was renamed to [`fit_hrg()`] to create a more
 #' consistent API.
 #' @inheritParams fit_hrg
 #' @keywords internal
@@ -33,7 +33,7 @@ hrg.fit <- function(graph, hrg = NULL, start = FALSE, steps = 0) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hrg.game()` was renamed to `sample_hrg()` to create a more
+#' `hrg.game()` was renamed to [`sample_hrg()`] to create a more
 #' consistent API.
 #' @inheritParams sample_hrg
 #' @keywords internal
@@ -48,7 +48,7 @@ hrg.game <- function(hrg) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hrg.dendrogram()` was renamed to `hrg_tree()` to create a more
+#' `hrg.dendrogram()` was renamed to [`hrg_tree()`] to create a more
 #' consistent API.
 #' @inheritParams hrg_tree
 #' @keywords internal
@@ -63,7 +63,7 @@ hrg.dendrogram <- function(hrg) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hrg.create()` was renamed to `hrg()` to create a more
+#' `hrg.create()` was renamed to [`hrg()`] to create a more
 #' consistent API.
 #' @inheritParams hrg
 #' @keywords internal
@@ -78,7 +78,7 @@ hrg.create <- function(graph, prob) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hrg.consensus()` was renamed to `consensus_tree()` to create a more
+#' `hrg.consensus()` was renamed to [`consensus_tree()`] to create a more
 #' consistent API.
 #' @inheritParams consensus_tree
 #' @keywords internal

--- a/R/hrg.R
+++ b/R/hrg.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hrg.predict()` was renamed to [`predict_edges()`] to create a more
+#' `hrg.predict()` was renamed to [predict_edges()] to create a more
 #' consistent API.
 #' @inheritParams predict_edges
 #' @keywords internal
@@ -18,7 +18,7 @@ hrg.predict <- function(graph, hrg = NULL, start = FALSE, num.samples = 10000, n
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hrg.fit()` was renamed to [`fit_hrg()`] to create a more
+#' `hrg.fit()` was renamed to [fit_hrg()] to create a more
 #' consistent API.
 #' @inheritParams fit_hrg
 #' @keywords internal
@@ -33,7 +33,7 @@ hrg.fit <- function(graph, hrg = NULL, start = FALSE, steps = 0) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hrg.game()` was renamed to [`sample_hrg()`] to create a more
+#' `hrg.game()` was renamed to [sample_hrg()] to create a more
 #' consistent API.
 #' @inheritParams sample_hrg
 #' @keywords internal
@@ -48,7 +48,7 @@ hrg.game <- function(hrg) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hrg.dendrogram()` was renamed to [`hrg_tree()`] to create a more
+#' `hrg.dendrogram()` was renamed to [hrg_tree()] to create a more
 #' consistent API.
 #' @inheritParams hrg_tree
 #' @keywords internal
@@ -63,7 +63,7 @@ hrg.dendrogram <- function(hrg) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hrg.create()` was renamed to [`hrg()`] to create a more
+#' `hrg.create()` was renamed to [hrg()] to create a more
 #' consistent API.
 #' @inheritParams hrg
 #' @keywords internal
@@ -78,7 +78,7 @@ hrg.create <- function(graph, prob) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `hrg.consensus()` was renamed to [`consensus_tree()`] to create a more
+#' `hrg.consensus()` was renamed to [consensus_tree()] to create a more
 #' consistent API.
 #' @inheritParams consensus_tree
 #' @keywords internal

--- a/R/incidence.R
+++ b/R/incidence.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.incidence()` was renamed to [`graph_from_biadjacency_matrix()`] to create a more
+#' `graph.incidence()` was renamed to [graph_from_biadjacency_matrix()] to create a more
 #' consistent API.
 #' @inheritParams graph_from_biadjacency_matrix
 #' @keywords internal
@@ -228,7 +228,7 @@ graph_from_biadjacency_matrix <- function(incidence, directed = FALSE,
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph_from_incidence_matrix()` was renamed to [`graph_from_biadjacency_matrix()`] to create a more
+#' `graph_from_incidence_matrix()` was renamed to [graph_from_biadjacency_matrix()] to create a more
 #' consistent API.
 #' @inheritParams graph_from_biadjacency_matrix
 #' @keywords internal
@@ -246,7 +246,7 @@ from_incidence_matrix <- function(...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph_from_incidence_matrix()` was renamed to [`graph_from_biadjacency_matrix()`] to create a more
+#' `graph_from_incidence_matrix()` was renamed to [graph_from_biadjacency_matrix()] to create a more
 #' consistent API.
 #' @inheritParams graph_from_biadjacency_matrix
 #' @keywords internal

--- a/R/incidence.R
+++ b/R/incidence.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.incidence()` was renamed to `graph_from_biadjacency_matrix()` to create a more
+#' `graph.incidence()` was renamed to [`graph_from_biadjacency_matrix()`] to create a more
 #' consistent API.
 #' @inheritParams graph_from_biadjacency_matrix
 #' @keywords internal
@@ -228,7 +228,7 @@ graph_from_biadjacency_matrix <- function(incidence, directed = FALSE,
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph_from_incidence_matrix()` was renamed to `graph_from_biadjacency_matrix()` to create a more
+#' `graph_from_incidence_matrix()` was renamed to [`graph_from_biadjacency_matrix()`] to create a more
 #' consistent API.
 #' @inheritParams graph_from_biadjacency_matrix
 #' @keywords internal
@@ -246,7 +246,7 @@ from_incidence_matrix <- function(...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph_from_incidence_matrix()` was renamed to `graph_from_biadjacency_matrix()` to create a more
+#' `graph_from_incidence_matrix()` was renamed to [`graph_from_biadjacency_matrix()`] to create a more
 #' consistent API.
 #' @inheritParams graph_from_biadjacency_matrix
 #' @keywords internal

--- a/R/interface.R
+++ b/R/interface.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.directed()` was renamed to `is_directed()` to create a more
+#' `is.directed()` was renamed to [`is_directed()`] to create a more
 #' consistent API.
 #' @inheritParams is_directed
 #' @keywords internal
@@ -18,7 +18,7 @@ is.directed <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `delete.vertices()` was renamed to `delete_vertices()` to create a more
+#' `delete.vertices()` was renamed to [`delete_vertices()`] to create a more
 #' consistent API.
 #' @inheritParams delete_vertices
 #' @keywords internal
@@ -33,7 +33,7 @@ delete.vertices <- function(graph, v) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `delete.edges()` was renamed to `delete_edges()` to create a more
+#' `delete.edges()` was renamed to [`delete_edges()`] to create a more
 #' consistent API.
 #' @inheritParams delete_edges
 #' @keywords internal
@@ -48,7 +48,7 @@ delete.edges <- function(graph, edges) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `add.vertices()` was renamed to `add_vertices()` to create a more
+#' `add.vertices()` was renamed to [`add_vertices()`] to create a more
 #' consistent API.
 #' @inheritParams add_vertices
 #' @keywords internal
@@ -63,7 +63,7 @@ add.vertices <- function(graph, nv, ..., attr = list()) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `add.edges()` was renamed to `add_edges()` to create a more
+#' `add.edges()` was renamed to [`add_edges()`] to create a more
 #' consistent API.
 #' @inheritParams add_edges
 #' @keywords internal
@@ -568,7 +568,7 @@ get_edge_ids <- function(graph,
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.edge.ids()` was renamed to `get_edge_ids()` to create a more
+#' `get.edge.ids()` was renamed to [`get_edge_ids()`] to create a more
 #' consistent API.
 #' @inheritParams get_edge_ids
 #' @param multi

--- a/R/interface.R
+++ b/R/interface.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.directed()` was renamed to [`is_directed()`] to create a more
+#' `is.directed()` was renamed to [is_directed()] to create a more
 #' consistent API.
 #' @inheritParams is_directed
 #' @keywords internal
@@ -18,7 +18,7 @@ is.directed <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `delete.vertices()` was renamed to [`delete_vertices()`] to create a more
+#' `delete.vertices()` was renamed to [delete_vertices()] to create a more
 #' consistent API.
 #' @inheritParams delete_vertices
 #' @keywords internal
@@ -33,7 +33,7 @@ delete.vertices <- function(graph, v) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `delete.edges()` was renamed to [`delete_edges()`] to create a more
+#' `delete.edges()` was renamed to [delete_edges()] to create a more
 #' consistent API.
 #' @inheritParams delete_edges
 #' @keywords internal
@@ -48,7 +48,7 @@ delete.edges <- function(graph, edges) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `add.vertices()` was renamed to [`add_vertices()`] to create a more
+#' `add.vertices()` was renamed to [add_vertices()] to create a more
 #' consistent API.
 #' @inheritParams add_vertices
 #' @keywords internal
@@ -63,7 +63,7 @@ add.vertices <- function(graph, nv, ..., attr = list()) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `add.edges()` was renamed to [`add_edges()`] to create a more
+#' `add.edges()` was renamed to [add_edges()] to create a more
 #' consistent API.
 #' @inheritParams add_edges
 #' @keywords internal
@@ -568,7 +568,7 @@ get_edge_ids <- function(graph,
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.edge.ids()` was renamed to [`get_edge_ids()`] to create a more
+#' `get.edge.ids()` was renamed to [get_edge_ids()] to create a more
 #' consistent API.
 #' @inheritParams get_edge_ids
 #' @param multi

--- a/R/layout.R
+++ b/R/layout.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `piecewise.layout()` was renamed to `layout_components()` to create a more
+#' `piecewise.layout()` was renamed to [`layout_components()`] to create a more
 #' consistent API.
 #' @inheritParams layout_components
 #' @keywords internal
@@ -18,7 +18,7 @@ piecewise.layout <- function(graph, layout = layout_with_kk, ...) { # nocov star
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.sugiyama()` was renamed to `layout_with_sugiyama()` to create a more
+#' `layout.sugiyama()` was renamed to [`layout_with_sugiyama()`] to create a more
 #' consistent API.
 #' @inheritParams layout_with_sugiyama
 #' @keywords internal
@@ -33,7 +33,7 @@ layout.sugiyama <- function(graph, layers = NULL, hgap = 1, vgap = 1, maxiter = 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.star()` was renamed to `layout_as_star()` to create a more
+#' `layout.star()` was renamed to [`layout_as_star()`] to create a more
 #' consistent API.
 #' @inheritParams layout_as_star
 #' @keywords internal
@@ -48,7 +48,7 @@ layout.star <- function(graph, center = V(graph)[1], order = NULL) { # nocov sta
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.norm()` was renamed to `norm_coords()` to create a more
+#' `layout.norm()` was renamed to [`norm_coords()`] to create a more
 #' consistent API.
 #' @inheritParams norm_coords
 #' @keywords internal
@@ -63,7 +63,7 @@ layout.norm <- function(layout, xmin = -1, xmax = 1, ymin = -1, ymax = 1, zmin =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.merge()` was renamed to `merge_coords()` to create a more
+#' `layout.merge()` was renamed to [`merge_coords()`] to create a more
 #' consistent API.
 #' @inheritParams merge_coords
 #' @keywords internal
@@ -78,7 +78,7 @@ layout.merge <- function(graphs, layouts, method = "dla") { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.mds()` was renamed to `layout_with_mds()` to create a more
+#' `layout.mds()` was renamed to [`layout_with_mds()`] to create a more
 #' consistent API.
 #' @inheritParams layout_with_mds
 #' @keywords internal
@@ -93,7 +93,7 @@ layout.mds <- function(graph, dist = NULL, dim = 2, options = arpack_defaults())
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.grid()` was renamed to `layout_on_grid()` to create a more
+#' `layout.grid()` was renamed to [`layout_on_grid()`] to create a more
 #' consistent API.
 #' @inheritParams layout_on_grid
 #' @keywords internal
@@ -108,7 +108,7 @@ layout.grid <- function(graph, width = 0, height = 0, dim = 2) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.graphopt()` was renamed to `layout_with_graphopt()` to create a more
+#' `layout.graphopt()` was renamed to [`layout_with_graphopt()`] to create a more
 #' consistent API.
 #' @inheritParams layout_with_graphopt
 #' @keywords internal
@@ -123,7 +123,7 @@ layout.graphopt <- function(graph, start = NULL, niter = 500, charge = 0.001, ma
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.gem()` was renamed to `layout_with_gem()` to create a more
+#' `layout.gem()` was renamed to [`layout_with_gem()`] to create a more
 #' consistent API.
 #' @inheritParams layout_with_gem
 #' @keywords internal
@@ -138,7 +138,7 @@ layout.gem <- function(graph, coords = NULL, maxiter = 40 * vcount(graph)^2, tem
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.davidson.harel()` was renamed to `layout_with_dh()` to create a more
+#' `layout.davidson.harel()` was renamed to [`layout_with_dh()`] to create a more
 #' consistent API.
 #' @inheritParams layout_with_dh
 #' @keywords internal
@@ -153,7 +153,7 @@ layout.davidson.harel <- function(graph, coords = NULL, maxiter = 10, fineiter =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.bipartite()` was renamed to `layout_as_bipartite()` to create a more
+#' `layout.bipartite()` was renamed to [`layout_as_bipartite()`] to create a more
 #' consistent API.
 #' @inheritParams layout_as_bipartite
 #' @keywords internal
@@ -168,7 +168,7 @@ layout.bipartite <- function(graph, types = NULL, hgap = 1, vgap = 1, maxiter = 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.auto()` was renamed to `layout_nicely()` to create a more
+#' `layout.auto()` was renamed to [`layout_nicely()`] to create a more
 #' consistent API.
 #' @inheritParams layout_nicely
 #' @keywords internal
@@ -638,7 +638,7 @@ as_tree <- function(...) layout_spec(layout_as_tree, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.reingold.tilford()` was renamed to `layout_as_tree()` to create a more
+#' `layout.reingold.tilford()` was renamed to [`layout_as_tree()`] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -699,7 +699,7 @@ in_circle <- function(...) layout_spec(layout_in_circle, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.circle()` was renamed to `layout_in_circle()` to create a more
+#' `layout.circle()` was renamed to [`layout_in_circle()`] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -929,7 +929,7 @@ on_sphere <- function(...) layout_spec(layout_on_sphere, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.sphere()` was renamed to `layout_on_sphere()` to create a more
+#' `layout.sphere()` was renamed to [`layout_on_sphere()`] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -982,7 +982,7 @@ randomly <- function(...) layout_spec(layout_randomly, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.random()` was renamed to `layout_randomly()` to create a more
+#' `layout.random()` was renamed to [`layout_randomly()`] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -1306,7 +1306,7 @@ with_fr <- function(...) layout_spec(layout_with_fr, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.fruchterman.reingold()` was renamed to `layout_with_fr()` to create a more
+#' `layout.fruchterman.reingold()` was renamed to [`layout_with_fr()`] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -1608,7 +1608,7 @@ with_kk <- function(...) layout_spec(layout_with_kk, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.kamada.kawai()` was renamed to `layout_with_kk()` to create a more
+#' `layout.kamada.kawai()` was renamed to [`layout_with_kk()`] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -1679,7 +1679,7 @@ with_lgl <- function(...) layout_spec(layout_with_lgl, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.lgl()` was renamed to `layout_with_lgl()` to create a more
+#' `layout.lgl()` was renamed to [`layout_with_lgl()`] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -2301,7 +2301,7 @@ layout.fruchterman.reingold.grid <- function(graph, ...) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.drl()` was renamed to `layout_with_drl()` to create a more
+#' `layout.drl()` was renamed to [`layout_with_drl()`] to create a more
 #' consistent API.
 #' @inheritParams layout_with_drl
 #' @keywords internal

--- a/R/layout.R
+++ b/R/layout.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `piecewise.layout()` was renamed to [`layout_components()`] to create a more
+#' `piecewise.layout()` was renamed to [layout_components()] to create a more
 #' consistent API.
 #' @inheritParams layout_components
 #' @keywords internal
@@ -18,7 +18,7 @@ piecewise.layout <- function(graph, layout = layout_with_kk, ...) { # nocov star
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.sugiyama()` was renamed to [`layout_with_sugiyama()`] to create a more
+#' `layout.sugiyama()` was renamed to [layout_with_sugiyama()] to create a more
 #' consistent API.
 #' @inheritParams layout_with_sugiyama
 #' @keywords internal
@@ -33,7 +33,7 @@ layout.sugiyama <- function(graph, layers = NULL, hgap = 1, vgap = 1, maxiter = 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.star()` was renamed to [`layout_as_star()`] to create a more
+#' `layout.star()` was renamed to [layout_as_star()] to create a more
 #' consistent API.
 #' @inheritParams layout_as_star
 #' @keywords internal
@@ -48,7 +48,7 @@ layout.star <- function(graph, center = V(graph)[1], order = NULL) { # nocov sta
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.norm()` was renamed to [`norm_coords()`] to create a more
+#' `layout.norm()` was renamed to [norm_coords()] to create a more
 #' consistent API.
 #' @inheritParams norm_coords
 #' @keywords internal
@@ -63,7 +63,7 @@ layout.norm <- function(layout, xmin = -1, xmax = 1, ymin = -1, ymax = 1, zmin =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.merge()` was renamed to [`merge_coords()`] to create a more
+#' `layout.merge()` was renamed to [merge_coords()] to create a more
 #' consistent API.
 #' @inheritParams merge_coords
 #' @keywords internal
@@ -78,7 +78,7 @@ layout.merge <- function(graphs, layouts, method = "dla") { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.mds()` was renamed to [`layout_with_mds()`] to create a more
+#' `layout.mds()` was renamed to [layout_with_mds()] to create a more
 #' consistent API.
 #' @inheritParams layout_with_mds
 #' @keywords internal
@@ -93,7 +93,7 @@ layout.mds <- function(graph, dist = NULL, dim = 2, options = arpack_defaults())
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.grid()` was renamed to [`layout_on_grid()`] to create a more
+#' `layout.grid()` was renamed to [layout_on_grid()] to create a more
 #' consistent API.
 #' @inheritParams layout_on_grid
 #' @keywords internal
@@ -108,7 +108,7 @@ layout.grid <- function(graph, width = 0, height = 0, dim = 2) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.graphopt()` was renamed to [`layout_with_graphopt()`] to create a more
+#' `layout.graphopt()` was renamed to [layout_with_graphopt()] to create a more
 #' consistent API.
 #' @inheritParams layout_with_graphopt
 #' @keywords internal
@@ -123,7 +123,7 @@ layout.graphopt <- function(graph, start = NULL, niter = 500, charge = 0.001, ma
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.gem()` was renamed to [`layout_with_gem()`] to create a more
+#' `layout.gem()` was renamed to [layout_with_gem()] to create a more
 #' consistent API.
 #' @inheritParams layout_with_gem
 #' @keywords internal
@@ -138,7 +138,7 @@ layout.gem <- function(graph, coords = NULL, maxiter = 40 * vcount(graph)^2, tem
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.davidson.harel()` was renamed to [`layout_with_dh()`] to create a more
+#' `layout.davidson.harel()` was renamed to [layout_with_dh()] to create a more
 #' consistent API.
 #' @inheritParams layout_with_dh
 #' @keywords internal
@@ -153,7 +153,7 @@ layout.davidson.harel <- function(graph, coords = NULL, maxiter = 10, fineiter =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.bipartite()` was renamed to [`layout_as_bipartite()`] to create a more
+#' `layout.bipartite()` was renamed to [layout_as_bipartite()] to create a more
 #' consistent API.
 #' @inheritParams layout_as_bipartite
 #' @keywords internal
@@ -168,7 +168,7 @@ layout.bipartite <- function(graph, types = NULL, hgap = 1, vgap = 1, maxiter = 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.auto()` was renamed to [`layout_nicely()`] to create a more
+#' `layout.auto()` was renamed to [layout_nicely()] to create a more
 #' consistent API.
 #' @inheritParams layout_nicely
 #' @keywords internal
@@ -638,7 +638,7 @@ as_tree <- function(...) layout_spec(layout_as_tree, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.reingold.tilford()` was renamed to [`layout_as_tree()`] to create a more
+#' `layout.reingold.tilford()` was renamed to [layout_as_tree()] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -699,7 +699,7 @@ in_circle <- function(...) layout_spec(layout_in_circle, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.circle()` was renamed to [`layout_in_circle()`] to create a more
+#' `layout.circle()` was renamed to [layout_in_circle()] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -929,7 +929,7 @@ on_sphere <- function(...) layout_spec(layout_on_sphere, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.sphere()` was renamed to [`layout_on_sphere()`] to create a more
+#' `layout.sphere()` was renamed to [layout_on_sphere()] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -982,7 +982,7 @@ randomly <- function(...) layout_spec(layout_randomly, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.random()` was renamed to [`layout_randomly()`] to create a more
+#' `layout.random()` was renamed to [layout_randomly()] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -1306,7 +1306,7 @@ with_fr <- function(...) layout_spec(layout_with_fr, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.fruchterman.reingold()` was renamed to [`layout_with_fr()`] to create a more
+#' `layout.fruchterman.reingold()` was renamed to [layout_with_fr()] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -1608,7 +1608,7 @@ with_kk <- function(...) layout_spec(layout_with_kk, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.kamada.kawai()` was renamed to [`layout_with_kk()`] to create a more
+#' `layout.kamada.kawai()` was renamed to [layout_with_kk()] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -1679,7 +1679,7 @@ with_lgl <- function(...) layout_spec(layout_with_lgl, ...)
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.lgl()` was renamed to [`layout_with_lgl()`] to create a more
+#' `layout.lgl()` was renamed to [layout_with_lgl()] to create a more
 #' consistent API.
 #' @param ... Passed to the new layout functions.
 #' @param params Passed to the new layout functions as arguments.
@@ -2260,7 +2260,7 @@ layout.spring <- function(graph, ...) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' Now it calls the Fruchterman-Reingold layout [`layout_with_fr()`].
+#' Now it calls the Fruchterman-Reingold layout [layout_with_fr()].
 #'
 #' @param graph Input graph.
 #' @param ... Extra arguments are ignored.
@@ -2279,7 +2279,7 @@ layout.svd <- function(graph, ...) {
 #' `r lifecycle::badge("deprecated")`
 #'
 #'
-#' Now it calls the Fruchterman-Reingold layout [`layout_with_fr()`].
+#' Now it calls the Fruchterman-Reingold layout [layout_with_fr()].
 #'
 #' @param graph Input graph.
 #' @param ... Extra arguments are ignored.
@@ -2301,7 +2301,7 @@ layout.fruchterman.reingold.grid <- function(graph, ...) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `layout.drl()` was renamed to [`layout_with_drl()`] to create a more
+#' `layout.drl()` was renamed to [layout_with_drl()] to create a more
 #' consistent API.
 #' @inheritParams layout_with_drl
 #' @keywords internal

--- a/R/make.R
+++ b/R/make.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph()` was renamed to `make_graph()` to create a more
+#' `graph()` was renamed to [`make_graph()`] to create a more
 #' consistent API.
 #' @inheritParams make_graph
 #' @keywords internal
@@ -96,7 +96,7 @@ graph <- function(edges, ..., n = max(edges), isolates = NULL, directed = TRUE, 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.famous()` was renamed to `make_graph()` to create a more
+#' `graph.famous()` was renamed to [`make_graph()`] to create a more
 #' consistent API.
 #' @inheritParams make_graph
 #' @keywords internal
@@ -189,7 +189,7 @@ graph.famous <- function(edges, ..., n = max(edges), isolates = NULL, directed =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `line.graph()` was renamed to `make_line_graph()` to create a more
+#' `line.graph()` was renamed to [`make_line_graph()`] to create a more
 #' consistent API.
 #' @inheritParams make_line_graph
 #' @keywords internal
@@ -211,7 +211,7 @@ line.graph <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.ring()` was renamed to `make_ring()` to create a more
+#' `graph.ring()` was renamed to [`make_ring()`] to create a more
 #' consistent API.
 #' @inheritParams make_ring
 #' @keywords internal
@@ -236,7 +236,7 @@ graph.ring <- function(n, directed = FALSE, mutual = FALSE, circular = TRUE) { #
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.tree()` was renamed to `make_tree()` to create a more
+#' `graph.tree()` was renamed to [`make_tree()`] to create a more
 #' consistent API.
 #' @inheritParams make_tree
 #' @keywords internal
@@ -268,7 +268,7 @@ graph.tree <- function(n, children = 2, mode = c("out", "in", "undirected")) { #
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.star()` was renamed to `make_star()` to create a more
+#' `graph.star()` was renamed to [`make_star()`] to create a more
 #' consistent API.
 #' @inheritParams make_star
 #' @keywords internal
@@ -305,7 +305,7 @@ graph.star <- function(n, mode = c("in", "out", "mutual", "undirected"), center 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.lcf()` was renamed to `graph_from_lcf()` to create a more
+#' `graph.lcf()` was renamed to [`graph_from_lcf()`] to create a more
 #' consistent API.
 #' @inheritParams graph_from_lcf
 #' @keywords internal
@@ -333,7 +333,7 @@ graph.lcf <- function(n, shifts, repeats = 1) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.lattice()` was renamed to `make_lattice()` to create a more
+#' `graph.lattice()` was renamed to [`make_lattice()`] to create a more
 #' consistent API.
 #' @inheritParams make_lattice
 #' @keywords internal
@@ -385,7 +385,7 @@ graph.lattice <- function(dimvector = NULL, length = NULL, dim = NULL, nei = 1, 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.kautz()` was renamed to `make_kautz_graph()` to create a more
+#' `graph.kautz()` was renamed to [`make_kautz_graph()`] to create a more
 #' consistent API.
 #' @inheritParams make_kautz_graph
 #' @keywords internal
@@ -407,7 +407,7 @@ graph.kautz <- function(m, n) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.full.citation()` was renamed to `make_full_citation_graph()` to create a more
+#' `graph.full.citation()` was renamed to [`make_full_citation_graph()`] to create a more
 #' consistent API.
 #' @inheritParams make_full_citation_graph
 #' @keywords internal
@@ -431,7 +431,7 @@ graph.full.citation <- function(n, directed = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.full.bipartite()` was renamed to `make_full_bipartite_graph()` to create a more
+#' `graph.full.bipartite()` was renamed to [`make_full_bipartite_graph()`] to create a more
 #' consistent API.
 #' @inheritParams make_full_bipartite_graph
 #' @keywords internal
@@ -464,7 +464,7 @@ graph.full.bipartite <- function(n1, n2, directed = FALSE, mode = c("all", "out"
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.full()` was renamed to `make_full_graph()` to create a more
+#' `graph.full()` was renamed to [`make_full_graph()`] to create a more
 #' consistent API.
 #' @inheritParams make_full_graph
 #' @keywords internal
@@ -488,7 +488,7 @@ graph.full <- function(n, directed = FALSE, loops = FALSE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.formula()` was renamed to `graph_from_literal()` to create a more
+#' `graph.formula()` was renamed to [`graph_from_literal()`] to create a more
 #' consistent API.
 #' @inheritParams graph_from_literal
 #' @keywords internal
@@ -504,7 +504,7 @@ graph.formula <- function(..., simplify = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.extended.chordal.ring()` was renamed to `make_chordal_ring()` to create a more
+#' `graph.extended.chordal.ring()` was renamed to [`make_chordal_ring()`] to create a more
 #' consistent API.
 #' @inheritParams make_chordal_ring
 #' @keywords internal
@@ -528,7 +528,7 @@ graph.extended.chordal.ring <- function(n, w, directed = FALSE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.empty()` was renamed to `make_empty_graph()` to create a more
+#' `graph.empty()` was renamed to [`make_empty_graph()`] to create a more
 #' consistent API.
 #' @inheritParams make_empty_graph
 #' @keywords internal
@@ -551,7 +551,7 @@ graph.empty <- function(n = 0, directed = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.de.bruijn()` was renamed to `make_de_bruijn_graph()` to create a more
+#' `graph.de.bruijn()` was renamed to [`make_de_bruijn_graph()`] to create a more
 #' consistent API.
 #' @inheritParams make_de_bruijn_graph
 #' @keywords internal
@@ -573,7 +573,7 @@ graph.de.bruijn <- function(m, n) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.bipartite()` was renamed to `make_bipartite_graph()` to create a more
+#' `graph.bipartite()` was renamed to [`make_bipartite_graph()`] to create a more
 #' consistent API.
 #' @inheritParams make_bipartite_graph
 #' @keywords internal
@@ -612,7 +612,7 @@ graph.bipartite <- function(types, edges, directed = FALSE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.atlas()` was renamed to `graph_from_atlas()` to create a more
+#' `graph.atlas()` was renamed to [`graph_from_atlas()`] to create a more
 #' consistent API.
 #' @inheritParams graph_from_atlas
 #' @keywords internal

--- a/R/make.R
+++ b/R/make.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph()` was renamed to [`make_graph()`] to create a more
+#' `graph()` was renamed to [make_graph()] to create a more
 #' consistent API.
 #' @inheritParams make_graph
 #' @keywords internal
@@ -96,7 +96,7 @@ graph <- function(edges, ..., n = max(edges), isolates = NULL, directed = TRUE, 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.famous()` was renamed to [`make_graph()`] to create a more
+#' `graph.famous()` was renamed to [make_graph()] to create a more
 #' consistent API.
 #' @inheritParams make_graph
 #' @keywords internal
@@ -189,7 +189,7 @@ graph.famous <- function(edges, ..., n = max(edges), isolates = NULL, directed =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `line.graph()` was renamed to [`make_line_graph()`] to create a more
+#' `line.graph()` was renamed to [make_line_graph()] to create a more
 #' consistent API.
 #' @inheritParams make_line_graph
 #' @keywords internal
@@ -211,7 +211,7 @@ line.graph <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.ring()` was renamed to [`make_ring()`] to create a more
+#' `graph.ring()` was renamed to [make_ring()] to create a more
 #' consistent API.
 #' @inheritParams make_ring
 #' @keywords internal
@@ -236,7 +236,7 @@ graph.ring <- function(n, directed = FALSE, mutual = FALSE, circular = TRUE) { #
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.tree()` was renamed to [`make_tree()`] to create a more
+#' `graph.tree()` was renamed to [make_tree()] to create a more
 #' consistent API.
 #' @inheritParams make_tree
 #' @keywords internal
@@ -268,7 +268,7 @@ graph.tree <- function(n, children = 2, mode = c("out", "in", "undirected")) { #
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.star()` was renamed to [`make_star()`] to create a more
+#' `graph.star()` was renamed to [make_star()] to create a more
 #' consistent API.
 #' @inheritParams make_star
 #' @keywords internal
@@ -305,7 +305,7 @@ graph.star <- function(n, mode = c("in", "out", "mutual", "undirected"), center 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.lcf()` was renamed to [`graph_from_lcf()`] to create a more
+#' `graph.lcf()` was renamed to [graph_from_lcf()] to create a more
 #' consistent API.
 #' @inheritParams graph_from_lcf
 #' @keywords internal
@@ -333,7 +333,7 @@ graph.lcf <- function(n, shifts, repeats = 1) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.lattice()` was renamed to [`make_lattice()`] to create a more
+#' `graph.lattice()` was renamed to [make_lattice()] to create a more
 #' consistent API.
 #' @inheritParams make_lattice
 #' @keywords internal
@@ -385,7 +385,7 @@ graph.lattice <- function(dimvector = NULL, length = NULL, dim = NULL, nei = 1, 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.kautz()` was renamed to [`make_kautz_graph()`] to create a more
+#' `graph.kautz()` was renamed to [make_kautz_graph()] to create a more
 #' consistent API.
 #' @inheritParams make_kautz_graph
 #' @keywords internal
@@ -407,7 +407,7 @@ graph.kautz <- function(m, n) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.full.citation()` was renamed to [`make_full_citation_graph()`] to create a more
+#' `graph.full.citation()` was renamed to [make_full_citation_graph()] to create a more
 #' consistent API.
 #' @inheritParams make_full_citation_graph
 #' @keywords internal
@@ -431,7 +431,7 @@ graph.full.citation <- function(n, directed = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.full.bipartite()` was renamed to [`make_full_bipartite_graph()`] to create a more
+#' `graph.full.bipartite()` was renamed to [make_full_bipartite_graph()] to create a more
 #' consistent API.
 #' @inheritParams make_full_bipartite_graph
 #' @keywords internal
@@ -464,7 +464,7 @@ graph.full.bipartite <- function(n1, n2, directed = FALSE, mode = c("all", "out"
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.full()` was renamed to [`make_full_graph()`] to create a more
+#' `graph.full()` was renamed to [make_full_graph()] to create a more
 #' consistent API.
 #' @inheritParams make_full_graph
 #' @keywords internal
@@ -488,7 +488,7 @@ graph.full <- function(n, directed = FALSE, loops = FALSE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.formula()` was renamed to [`graph_from_literal()`] to create a more
+#' `graph.formula()` was renamed to [graph_from_literal()] to create a more
 #' consistent API.
 #' @inheritParams graph_from_literal
 #' @keywords internal
@@ -504,7 +504,7 @@ graph.formula <- function(..., simplify = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.extended.chordal.ring()` was renamed to [`make_chordal_ring()`] to create a more
+#' `graph.extended.chordal.ring()` was renamed to [make_chordal_ring()] to create a more
 #' consistent API.
 #' @inheritParams make_chordal_ring
 #' @keywords internal
@@ -528,7 +528,7 @@ graph.extended.chordal.ring <- function(n, w, directed = FALSE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.empty()` was renamed to [`make_empty_graph()`] to create a more
+#' `graph.empty()` was renamed to [make_empty_graph()] to create a more
 #' consistent API.
 #' @inheritParams make_empty_graph
 #' @keywords internal
@@ -551,7 +551,7 @@ graph.empty <- function(n = 0, directed = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.de.bruijn()` was renamed to [`make_de_bruijn_graph()`] to create a more
+#' `graph.de.bruijn()` was renamed to [make_de_bruijn_graph()] to create a more
 #' consistent API.
 #' @inheritParams make_de_bruijn_graph
 #' @keywords internal
@@ -573,7 +573,7 @@ graph.de.bruijn <- function(m, n) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.bipartite()` was renamed to [`make_bipartite_graph()`] to create a more
+#' `graph.bipartite()` was renamed to [make_bipartite_graph()] to create a more
 #' consistent API.
 #' @inheritParams make_bipartite_graph
 #' @keywords internal
@@ -612,7 +612,7 @@ graph.bipartite <- function(types, edges, directed = FALSE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.atlas()` was renamed to [`graph_from_atlas()`] to create a more
+#' `graph.atlas()` was renamed to [graph_from_atlas()] to create a more
 #' consistent API.
 #' @inheritParams graph_from_atlas
 #' @keywords internal

--- a/R/minimum.spanning.tree.R
+++ b/R/minimum.spanning.tree.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `minimum.spanning.tree()` was renamed to `mst()` to create a more
+#' `minimum.spanning.tree()` was renamed to [`mst()`] to create a more
 #' consistent API.
 #' @inheritParams mst
 #' @keywords internal

--- a/R/minimum.spanning.tree.R
+++ b/R/minimum.spanning.tree.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `minimum.spanning.tree()` was renamed to [`mst()`] to create a more
+#' `minimum.spanning.tree()` was renamed to [mst()] to create a more
 #' consistent API.
 #' @inheritParams mst
 #' @keywords internal

--- a/R/motifs.R
+++ b/R/motifs.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `triad.census()` was renamed to [`triad_census()`] to create a more
+#' `triad.census()` was renamed to [triad_census()] to create a more
 #' consistent API.
 #' @inheritParams triad_census
 #' @keywords internal
@@ -18,7 +18,7 @@ triad.census <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.motifs.no()` was renamed to [`count_motifs()`] to create a more
+#' `graph.motifs.no()` was renamed to [count_motifs()] to create a more
 #' consistent API.
 #' @inheritParams count_motifs
 #' @keywords internal
@@ -34,7 +34,7 @@ graph.motifs.no <- function(graph, size = 3, cut.prob = rep(0, size)) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.motifs.est()` was renamed to [`sample_motifs()`] to create a more
+#' `graph.motifs.est()` was renamed to [sample_motifs()] to create a more
 #' consistent API.
 #' @param cut.prob Numeric vector giving the probabilities that the search
 #'   graph is cut at a certain level. Its length should be the same as the size
@@ -53,7 +53,7 @@ graph.motifs.est <- function(graph, size = 3, cut.prob = rep(0, size), sample.si
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.motifs()` was renamed to [`motifs()`] to create a more
+#' `graph.motifs()` was renamed to [motifs()] to create a more
 #' consistent API.
 #' @param cut.prob Numeric vector giving the probabilities that the search
 #'   graph is cut at a certain level. Its length should be the same as the size
@@ -72,7 +72,7 @@ graph.motifs <- function(graph, size = 3, cut.prob = rep(0, size)) { # nocov sta
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `dyad.census()` was renamed to [`dyad_census()`] to create a more
+#' `dyad.census()` was renamed to [dyad_census()] to create a more
 #' consistent API.
 #' @inheritParams dyad_census
 #' @keywords internal

--- a/R/motifs.R
+++ b/R/motifs.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `triad.census()` was renamed to `triad_census()` to create a more
+#' `triad.census()` was renamed to [`triad_census()`] to create a more
 #' consistent API.
 #' @inheritParams triad_census
 #' @keywords internal
@@ -18,7 +18,7 @@ triad.census <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.motifs.no()` was renamed to `count_motifs()` to create a more
+#' `graph.motifs.no()` was renamed to [`count_motifs()`] to create a more
 #' consistent API.
 #' @inheritParams count_motifs
 #' @keywords internal
@@ -34,7 +34,7 @@ graph.motifs.no <- function(graph, size = 3, cut.prob = rep(0, size)) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.motifs.est()` was renamed to `sample_motifs()` to create a more
+#' `graph.motifs.est()` was renamed to [`sample_motifs()`] to create a more
 #' consistent API.
 #' @param cut.prob Numeric vector giving the probabilities that the search
 #'   graph is cut at a certain level. Its length should be the same as the size
@@ -53,7 +53,7 @@ graph.motifs.est <- function(graph, size = 3, cut.prob = rep(0, size), sample.si
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.motifs()` was renamed to `motifs()` to create a more
+#' `graph.motifs()` was renamed to [`motifs()`] to create a more
 #' consistent API.
 #' @param cut.prob Numeric vector giving the probabilities that the search
 #'   graph is cut at a certain level. Its length should be the same as the size
@@ -72,7 +72,7 @@ graph.motifs <- function(graph, size = 3, cut.prob = rep(0, size)) { # nocov sta
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `dyad.census()` was renamed to `dyad_census()` to create a more
+#' `dyad.census()` was renamed to [`dyad_census()`] to create a more
 #' consistent API.
 #' @inheritParams dyad_census
 #' @keywords internal

--- a/R/operators.R
+++ b/R/operators.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.intersection()` was renamed to [`intersection()`] to create a more
+#' `graph.intersection()` was renamed to [intersection()] to create a more
 #' consistent API.
 #' @inheritParams intersection
 #' @keywords internal
@@ -18,7 +18,7 @@ graph.intersection <- function(...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.union()` was renamed to [`union.igraph()`] to create a more
+#' `graph.union()` was renamed to [union.igraph()] to create a more
 #' consistent API.
 #' @inheritParams union.igraph
 #' @keywords internal
@@ -33,7 +33,7 @@ graph.union <- function(..., byname = "auto") { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.difference()` was renamed to [`difference()`] to create a more
+#' `graph.difference()` was renamed to [difference()] to create a more
 #' consistent API.
 #' @inheritParams difference
 #' @keywords internal
@@ -48,7 +48,7 @@ graph.difference <- function(...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.disjoint.union()` was renamed to [`disjoint_union()`] to create a more
+#' `graph.disjoint.union()` was renamed to [disjoint_union()] to create a more
 #' consistent API.
 #' @inheritParams disjoint_union
 #' @keywords internal
@@ -63,7 +63,7 @@ graph.disjoint.union <- function(...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.compose()` was renamed to [`compose()`] to create a more
+#' `graph.compose()` was renamed to [compose()] to create a more
 #' consistent API.
 #' @inheritParams compose
 #' @keywords internal
@@ -78,7 +78,7 @@ graph.compose <- function(g1, g2, byname = "auto") { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.complementer()` was renamed to [`complementer()`] to create a more
+#' `graph.complementer()` was renamed to [complementer()] to create a more
 #' consistent API.
 #' @inheritParams complementer
 #' @keywords internal

--- a/R/operators.R
+++ b/R/operators.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.intersection()` was renamed to `intersection()` to create a more
+#' `graph.intersection()` was renamed to [`intersection()`] to create a more
 #' consistent API.
 #' @inheritParams intersection
 #' @keywords internal
@@ -18,7 +18,7 @@ graph.intersection <- function(...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.union()` was renamed to `union.igraph()` to create a more
+#' `graph.union()` was renamed to [`union.igraph()`] to create a more
 #' consistent API.
 #' @inheritParams union.igraph
 #' @keywords internal
@@ -33,7 +33,7 @@ graph.union <- function(..., byname = "auto") { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.difference()` was renamed to `difference()` to create a more
+#' `graph.difference()` was renamed to [`difference()`] to create a more
 #' consistent API.
 #' @inheritParams difference
 #' @keywords internal
@@ -48,7 +48,7 @@ graph.difference <- function(...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.disjoint.union()` was renamed to `disjoint_union()` to create a more
+#' `graph.disjoint.union()` was renamed to [`disjoint_union()`] to create a more
 #' consistent API.
 #' @inheritParams disjoint_union
 #' @keywords internal
@@ -63,7 +63,7 @@ graph.disjoint.union <- function(...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.compose()` was renamed to `compose()` to create a more
+#' `graph.compose()` was renamed to [`compose()`] to create a more
 #' consistent API.
 #' @inheritParams compose
 #' @keywords internal
@@ -78,7 +78,7 @@ graph.compose <- function(g1, g2, byname = "auto") { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.complementer()` was renamed to `complementer()` to create a more
+#' `graph.complementer()` was renamed to [`complementer()`] to create a more
 #' consistent API.
 #' @inheritParams complementer
 #' @keywords internal

--- a/R/other.R
+++ b/R/other.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `running.mean()` was renamed to `running_mean()` to create a more
+#' `running.mean()` was renamed to [`running_mean()`] to create a more
 #' consistent API.
 #' @inheritParams running_mean
 #' @keywords internal
@@ -18,7 +18,7 @@ running.mean <- function(v, binwidth) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.sample()` was renamed to `sample_seq()` to create a more
+#' `igraph.sample()` was renamed to [`sample_seq()`] to create a more
 #' consistent API.
 #' @inheritParams sample_seq
 #' @keywords internal
@@ -33,7 +33,7 @@ igraph.sample <- function(low, high, length) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `convex.hull()` was renamed to `convex_hull()` to create a more
+#' `convex.hull()` was renamed to [`convex_hull()`] to create a more
 #' consistent API.
 #' @inheritParams convex_hull
 #' @keywords internal

--- a/R/other.R
+++ b/R/other.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `running.mean()` was renamed to [`running_mean()`] to create a more
+#' `running.mean()` was renamed to [running_mean()] to create a more
 #' consistent API.
 #' @inheritParams running_mean
 #' @keywords internal
@@ -18,7 +18,7 @@ running.mean <- function(v, binwidth) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.sample()` was renamed to [`sample_seq()`] to create a more
+#' `igraph.sample()` was renamed to [sample_seq()] to create a more
 #' consistent API.
 #' @inheritParams sample_seq
 #' @keywords internal
@@ -33,7 +33,7 @@ igraph.sample <- function(low, high, length) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `convex.hull()` was renamed to [`convex_hull()`] to create a more
+#' `convex.hull()` was renamed to [convex_hull()] to create a more
 #' consistent API.
 #' @inheritParams convex_hull
 #' @keywords internal

--- a/R/par.R
+++ b/R/par.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.options()` was renamed to [`igraph_options()`] to create a more
+#' `igraph.options()` was renamed to [igraph_options()] to create a more
 #' consistent API.
 #' @inheritParams igraph_options
 #' @keywords internal
@@ -18,7 +18,7 @@ igraph.options <- function(...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `getIgraphOpt()` was renamed to [`igraph_opt()`] to create a more
+#' `getIgraphOpt()` was renamed to [igraph_opt()] to create a more
 #' consistent API.
 #' @inheritParams igraph_opt
 #' @keywords internal

--- a/R/par.R
+++ b/R/par.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.options()` was renamed to `igraph_options()` to create a more
+#' `igraph.options()` was renamed to [`igraph_options()`] to create a more
 #' consistent API.
 #' @inheritParams igraph_options
 #' @keywords internal
@@ -18,7 +18,7 @@ igraph.options <- function(...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `getIgraphOpt()` was renamed to `igraph_opt()` to create a more
+#' `getIgraphOpt()` was renamed to [`igraph_opt()`] to create a more
 #' consistent API.
 #' @inheritParams igraph_opt
 #' @keywords internal

--- a/R/paths.R
+++ b/R/paths.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `path.length.hist()` was renamed to [`distance_table()`] to create a more
+#' `path.length.hist()` was renamed to [distance_table()] to create a more
 #' consistent API.
 #' @inheritParams distance_table
 #' @keywords internal
@@ -18,7 +18,7 @@ path.length.hist <- function(graph, directed = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maximum.cardinality.search()` was renamed to [`max_cardinality()`] to create a more
+#' `maximum.cardinality.search()` was renamed to [max_cardinality()] to create a more
 #' consistent API.
 #' @inheritParams max_cardinality
 #' @keywords internal
@@ -33,7 +33,7 @@ maximum.cardinality.search <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.dag()` was renamed to [`is_dag()`] to create a more
+#' `is.dag()` was renamed to [is_dag()] to create a more
 #' consistent API.
 #' @inheritParams is_dag
 #' @keywords internal

--- a/R/paths.R
+++ b/R/paths.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `path.length.hist()` was renamed to `distance_table()` to create a more
+#' `path.length.hist()` was renamed to [`distance_table()`] to create a more
 #' consistent API.
 #' @inheritParams distance_table
 #' @keywords internal
@@ -18,7 +18,7 @@ path.length.hist <- function(graph, directed = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maximum.cardinality.search()` was renamed to `max_cardinality()` to create a more
+#' `maximum.cardinality.search()` was renamed to [`max_cardinality()`] to create a more
 #' consistent API.
 #' @inheritParams max_cardinality
 #' @keywords internal
@@ -33,7 +33,7 @@ maximum.cardinality.search <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.dag()` was renamed to `is_dag()` to create a more
+#' `is.dag()` was renamed to [`is_dag()`] to create a more
 #' consistent API.
 #' @inheritParams is_dag
 #' @keywords internal

--- a/R/plot.common.R
+++ b/R/plot.common.R
@@ -449,7 +449,7 @@ NULL
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `autocurve.edges()` was renamed to [`curve_multiple()`] to create a more
+#' `autocurve.edges()` was renamed to [curve_multiple()] to create a more
 #' consistent API.
 #' @inheritParams curve_multiple
 #' @keywords internal

--- a/R/plot.common.R
+++ b/R/plot.common.R
@@ -449,7 +449,7 @@ NULL
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `autocurve.edges()` was renamed to `curve_multiple()` to create a more
+#' `autocurve.edges()` was renamed to [`curve_multiple()`] to create a more
 #' consistent API.
 #' @inheritParams curve_multiple
 #' @keywords internal

--- a/R/plot.shapes.R
+++ b/R/plot.shapes.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.shape.noplot()` was renamed to [`shape_noplot()`] to create a more
+#' `igraph.shape.noplot()` was renamed to [shape_noplot()] to create a more
 #' consistent API.
 #' @inheritParams shape_noplot
 #' @keywords internal
@@ -18,7 +18,7 @@ igraph.shape.noplot <- function(coords, v = NULL, params) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.shape.noclip()` was renamed to [`shape_noclip()`] to create a more
+#' `igraph.shape.noclip()` was renamed to [shape_noclip()] to create a more
 #' consistent API.
 #' @inheritParams shape_noclip
 #' @keywords internal
@@ -33,7 +33,7 @@ igraph.shape.noclip <- function(coords, el, params, end = c("both", "from", "to"
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `vertex.shapes()` was renamed to [`shapes()`] to create a more
+#' `vertex.shapes()` was renamed to [shapes()] to create a more
 #' consistent API.
 #' @inheritParams shapes
 #' @keywords internal
@@ -48,7 +48,7 @@ vertex.shapes <- function(shape = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `add.vertex.shape()` was renamed to [`add_shape()`] to create a more
+#' `add.vertex.shape()` was renamed to [add_shape()] to create a more
 #' consistent API.
 #' @inheritParams add_shape
 #' @keywords internal

--- a/R/plot.shapes.R
+++ b/R/plot.shapes.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.shape.noplot()` was renamed to `shape_noplot()` to create a more
+#' `igraph.shape.noplot()` was renamed to [`shape_noplot()`] to create a more
 #' consistent API.
 #' @inheritParams shape_noplot
 #' @keywords internal
@@ -18,7 +18,7 @@ igraph.shape.noplot <- function(coords, v = NULL, params) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.shape.noclip()` was renamed to `shape_noclip()` to create a more
+#' `igraph.shape.noclip()` was renamed to [`shape_noclip()`] to create a more
 #' consistent API.
 #' @inheritParams shape_noclip
 #' @keywords internal
@@ -33,7 +33,7 @@ igraph.shape.noclip <- function(coords, el, params, end = c("both", "from", "to"
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `vertex.shapes()` was renamed to `shapes()` to create a more
+#' `vertex.shapes()` was renamed to [`shapes()`] to create a more
 #' consistent API.
 #' @inheritParams shapes
 #' @keywords internal
@@ -48,7 +48,7 @@ vertex.shapes <- function(shape = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `add.vertex.shape()` was renamed to `add_shape()` to create a more
+#' `add.vertex.shape()` was renamed to [`add_shape()`] to create a more
 #' consistent API.
 #' @inheritParams add_shape
 #' @keywords internal

--- a/R/similarity.R
+++ b/R/similarity.R
@@ -75,7 +75,7 @@ similarity <- function(graph, vids = V(graph),
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' Please use [`similarity()`] with `method = "jaccard"` instead.
+#' Please use [similarity()] with `method = "jaccard"` instead.
 #' @inheritParams similarity
 #' @keywords internal
 #' @export
@@ -104,7 +104,7 @@ similarity.jaccard <- function(graph,
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' Please use [`similarity()`] with `method = "dice"` instead.
+#' Please use [similarity()] with `method = "dice"` instead.
 #' @inheritParams similarity
 #' @keywords internal
 #' @export
@@ -133,7 +133,7 @@ similarity.dice <- function(graph,
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' Please use [`similarity()`] with `method = "invlogweighted"` instead.
+#' Please use [similarity()] with `method = "invlogweighted"` instead.
 #' @inheritParams similarity
 #' @keywords internal
 #' @export

--- a/R/simple.R
+++ b/R/simple.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.simple()` was renamed to [`is_simple()`] to create a more
+#' `is.simple()` was renamed to [is_simple()] to create a more
 #' consistent API.
 #' @inheritParams is_simple
 #' @keywords internal

--- a/R/simple.R
+++ b/R/simple.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.simple()` was renamed to `is_simple()` to create a more
+#' `is.simple()` was renamed to [`is_simple()`] to create a more
 #' consistent API.
 #' @inheritParams is_simple
 #' @keywords internal

--- a/R/stochastic_matrix.R
+++ b/R/stochastic_matrix.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.stochastic()` was renamed to `stochastic_matrix()` to create a more
+#' `get.stochastic()` was renamed to [`stochastic_matrix()`] to create a more
 #' consistent API.
 #' @inheritParams stochastic_matrix
 #' @keywords internal

--- a/R/stochastic_matrix.R
+++ b/R/stochastic_matrix.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.stochastic()` was renamed to [`stochastic_matrix()`] to create a more
+#' `get.stochastic()` was renamed to [stochastic_matrix()] to create a more
 #' consistent API.
 #' @inheritParams stochastic_matrix
 #' @keywords internal

--- a/R/structural-properties.R
+++ b/R/structural-properties.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.shortest.paths()` was renamed to [`shortest_paths()`] to create a more
+#' `get.shortest.paths()` was renamed to [shortest_paths()] to create a more
 #' consistent API.
 #' @inheritParams shortest_paths
 #' @keywords internal
@@ -18,7 +18,7 @@ get.shortest.paths <- function(graph, from, to = V(graph), mode = c("out", "all"
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.all.shortest.paths()` was renamed to [`all_shortest_paths()`] to create a more
+#' `get.all.shortest.paths()` was renamed to [all_shortest_paths()] to create a more
 #' consistent API.
 #' @inheritParams all_shortest_paths
 #' @keywords internal
@@ -33,7 +33,7 @@ get.all.shortest.paths <- function(graph, from, to = V(graph), mode = c("out", "
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.diameter()` was renamed to [`get_diameter()`] to create a more
+#' `get.diameter()` was renamed to [get_diameter()] to create a more
 #' consistent API.
 #' @inheritParams get_diameter
 #' @keywords internal
@@ -48,7 +48,7 @@ get.diameter <- function(graph, directed = TRUE, unconnected = TRUE, weights = N
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `unfold.tree()` was renamed to [`unfold_tree()`] to create a more
+#' `unfold.tree()` was renamed to [unfold_tree()] to create a more
 #' consistent API.
 #' @inheritParams unfold_tree
 #' @keywords internal
@@ -63,7 +63,7 @@ unfold.tree <- function(graph, mode = c("all", "out", "in", "total"), roots) { #
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `topological.sort()` was renamed to [`topo_sort()`] to create a more
+#' `topological.sort()` was renamed to [topo_sort()] to create a more
 #' consistent API.
 #' @inheritParams topo_sort
 #' @keywords internal
@@ -78,7 +78,7 @@ topological.sort <- function(graph, mode = c("out", "all", "in")) { # nocov star
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `shortest.paths()` was renamed to [`distances()`] to create a more
+#' `shortest.paths()` was renamed to [distances()] to create a more
 #' consistent API.
 #' @inheritParams distances
 #' @keywords internal
@@ -95,7 +95,7 @@ shortest.paths <- function(graph, v = V(graph), to = V(graph), mode = c("all", "
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `neighborhood.size()` was renamed to [`ego_size()`] to create a more
+#' `neighborhood.size()` was renamed to [ego_size()] to create a more
 #' consistent API.
 #' @inheritParams ego_size
 #' @keywords internal
@@ -110,7 +110,7 @@ neighborhood.size <- function(graph, order = 1, nodes = V(graph), mode = c("all"
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maximum.bipartite.matching()` was renamed to [`max_bipartite_match()`] to create a more
+#' `maximum.bipartite.matching()` was renamed to [max_bipartite_match()] to create a more
 #' consistent API.
 #' @inheritParams max_bipartite_match
 #' @keywords internal
@@ -125,7 +125,7 @@ maximum.bipartite.matching <- function(graph, types = NULL, weights = NULL, eps 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.mutual()` was renamed to [`which_mutual()`] to create a more
+#' `is.mutual()` was renamed to [which_mutual()] to create a more
 #' consistent API.
 #' @inheritParams which_mutual
 #' @keywords internal
@@ -140,7 +140,7 @@ is.mutual <- function(graph, eids = E(graph), loops = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.multiple()` was renamed to [`which_multiple()`] to create a more
+#' `is.multiple()` was renamed to [which_multiple()] to create a more
 #' consistent API.
 #' @inheritParams which_multiple
 #' @keywords internal
@@ -155,7 +155,7 @@ is.multiple <- function(graph, eids = E(graph)) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.maximal.matching()` was renamed to [`is_max_matching()`] to create a more
+#' `is.maximal.matching()` was renamed to [is_max_matching()] to create a more
 #' consistent API.
 #' @inheritParams is_max_matching
 #' @keywords internal
@@ -170,7 +170,7 @@ is.maximal.matching <- function(graph, matching, types = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.matching()` was renamed to [`is_matching()`] to create a more
+#' `is.matching()` was renamed to [is_matching()] to create a more
 #' consistent API.
 #' @inheritParams is_matching
 #' @keywords internal
@@ -185,7 +185,7 @@ is.matching <- function(graph, matching, types = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.loop()` was renamed to [`which_loop()`] to create a more
+#' `is.loop()` was renamed to [which_loop()] to create a more
 #' consistent API.
 #' @inheritParams which_loop
 #' @keywords internal
@@ -200,7 +200,7 @@ is.loop <- function(graph, eids = E(graph)) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.connected()` was renamed to [`is_connected()`] to create a more
+#' `is.connected()` was renamed to [is_connected()] to create a more
 #' consistent API.
 #' @inheritParams is_connected
 #' @keywords internal
@@ -215,7 +215,7 @@ is.connected <- function(graph, mode = c("weak", "strong")) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `induced.subgraph()` was renamed to [`induced_subgraph()`] to create a more
+#' `induced.subgraph()` was renamed to [induced_subgraph()] to create a more
 #' consistent API.
 #' @inheritParams induced_subgraph
 #' @keywords internal
@@ -230,7 +230,7 @@ induced.subgraph <- function(graph, vids, impl = c("auto", "copy_and_delete", "c
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `has.multiple()` was renamed to [`any_multiple()`] to create a more
+#' `has.multiple()` was renamed to [any_multiple()] to create a more
 #' consistent API.
 #' @inheritParams any_multiple
 #' @keywords internal
@@ -245,7 +245,7 @@ has.multiple <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.neighborhood()` was renamed to [`make_ego_graph()`] to create a more
+#' `graph.neighborhood()` was renamed to [make_ego_graph()] to create a more
 #' consistent API.
 #' @inheritParams make_ego_graph
 #' @keywords internal
@@ -260,7 +260,7 @@ graph.neighborhood <- function(graph, order = 1, nodes = V(graph), mode = c("all
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.laplacian()` was renamed to [`laplacian_matrix()`] to create a more
+#' `graph.laplacian()` was renamed to [laplacian_matrix()] to create a more
 #' consistent API.
 #' @inheritParams laplacian_matrix
 #' @keywords internal
@@ -275,7 +275,7 @@ graph.laplacian <- function(graph, normalized = FALSE, weights = NULL, sparse = 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.knn()` was renamed to [`knn()`] to create a more
+#' `graph.knn()` was renamed to [knn()] to create a more
 #' consistent API.
 #' @inheritParams knn
 #' @keywords internal
@@ -290,7 +290,7 @@ graph.knn <- function(graph, vids = V(graph), mode = c("all", "out", "in", "tota
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.dfs()` was renamed to [`dfs()`] to create a more
+#' `graph.dfs()` was renamed to [dfs()] to create a more
 #' consistent API.
 #' @param father Logical scalar, whether to return the father of the vertices.
 #' @inheritParams dfs
@@ -306,7 +306,7 @@ graph.dfs <- function(graph, root, mode = c("out", "in", "all", "total"), unreac
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.density()` was renamed to [`edge_density()`] to create a more
+#' `graph.density()` was renamed to [edge_density()] to create a more
 #' consistent API.
 #' @inheritParams edge_density
 #' @keywords internal
@@ -321,7 +321,7 @@ graph.density <- function(graph, loops = FALSE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.coreness()` was renamed to [`coreness()`] to create a more
+#' `graph.coreness()` was renamed to [coreness()] to create a more
 #' consistent API.
 #' @inheritParams coreness
 #' @keywords internal
@@ -336,7 +336,7 @@ graph.coreness <- function(graph, mode = c("all", "out", "in")) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.bfs()` was renamed to [`bfs()`] to create a more
+#' `graph.bfs()` was renamed to [bfs()] to create a more
 #' consistent API.
 #' @inheritParams bfs
 #' @param father Logical scalar, whether to return the father of the vertices.
@@ -352,7 +352,7 @@ graph.bfs <- function(graph, root, mode = c("out", "in", "all", "total"), unreac
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `farthest.nodes()` was renamed to [`farthest_vertices()`] to create a more
+#' `farthest.nodes()` was renamed to [farthest_vertices()] to create a more
 #' consistent API.
 #' @inheritParams farthest_vertices
 #' @keywords internal
@@ -367,7 +367,7 @@ farthest.nodes <- function(graph, directed = TRUE, unconnected = TRUE, weights =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `degree.distribution()` was renamed to [`degree_distribution()`] to create a more
+#' `degree.distribution()` was renamed to [degree_distribution()] to create a more
 #' consistent API.
 #' @inheritParams degree_distribution
 #' @keywords internal
@@ -382,7 +382,7 @@ degree.distribution <- function(graph, cumulative = FALSE, ...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `count.multiple()` was renamed to [`count_multiple()`] to create a more
+#' `count.multiple()` was renamed to [count_multiple()] to create a more
 #' consistent API.
 #' @inheritParams count_multiple
 #' @keywords internal
@@ -397,7 +397,7 @@ count.multiple <- function(graph, eids = E(graph)) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `clusters()` was renamed to [`components()`] to create a more
+#' `clusters()` was renamed to [components()] to create a more
 #' consistent API.
 #' @inheritParams components
 #' @keywords internal
@@ -412,7 +412,7 @@ clusters <- function(graph, mode = c("weak", "strong")) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `average.path.length()` was renamed to [`mean_distance()`] to create a more
+#' `average.path.length()` was renamed to [mean_distance()] to create a more
 #' consistent API.
 #' @inheritParams mean_distance
 #' @keywords internal
@@ -1249,7 +1249,7 @@ subgraph_from_edges <- function(graph, eids, delete.vertices = TRUE) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `subgraph.edges()` was renamed to [`subgraph_from_edges()`] to create a more
+#' `subgraph.edges()` was renamed to [subgraph_from_edges()] to create a more
 #' consistent API.
 #' @inheritParams subgraph_from_edges
 #' @keywords internal

--- a/R/structural-properties.R
+++ b/R/structural-properties.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.shortest.paths()` was renamed to `shortest_paths()` to create a more
+#' `get.shortest.paths()` was renamed to [`shortest_paths()`] to create a more
 #' consistent API.
 #' @inheritParams shortest_paths
 #' @keywords internal
@@ -18,7 +18,7 @@ get.shortest.paths <- function(graph, from, to = V(graph), mode = c("out", "all"
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.all.shortest.paths()` was renamed to `all_shortest_paths()` to create a more
+#' `get.all.shortest.paths()` was renamed to [`all_shortest_paths()`] to create a more
 #' consistent API.
 #' @inheritParams all_shortest_paths
 #' @keywords internal
@@ -33,7 +33,7 @@ get.all.shortest.paths <- function(graph, from, to = V(graph), mode = c("out", "
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `get.diameter()` was renamed to `get_diameter()` to create a more
+#' `get.diameter()` was renamed to [`get_diameter()`] to create a more
 #' consistent API.
 #' @inheritParams get_diameter
 #' @keywords internal
@@ -48,7 +48,7 @@ get.diameter <- function(graph, directed = TRUE, unconnected = TRUE, weights = N
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `unfold.tree()` was renamed to `unfold_tree()` to create a more
+#' `unfold.tree()` was renamed to [`unfold_tree()`] to create a more
 #' consistent API.
 #' @inheritParams unfold_tree
 #' @keywords internal
@@ -63,7 +63,7 @@ unfold.tree <- function(graph, mode = c("all", "out", "in", "total"), roots) { #
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `topological.sort()` was renamed to `topo_sort()` to create a more
+#' `topological.sort()` was renamed to [`topo_sort()`] to create a more
 #' consistent API.
 #' @inheritParams topo_sort
 #' @keywords internal
@@ -78,7 +78,7 @@ topological.sort <- function(graph, mode = c("out", "all", "in")) { # nocov star
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `shortest.paths()` was renamed to `distances()` to create a more
+#' `shortest.paths()` was renamed to [`distances()`] to create a more
 #' consistent API.
 #' @inheritParams distances
 #' @keywords internal
@@ -95,7 +95,7 @@ shortest.paths <- function(graph, v = V(graph), to = V(graph), mode = c("all", "
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `neighborhood.size()` was renamed to `ego_size()` to create a more
+#' `neighborhood.size()` was renamed to [`ego_size()`] to create a more
 #' consistent API.
 #' @inheritParams ego_size
 #' @keywords internal
@@ -110,7 +110,7 @@ neighborhood.size <- function(graph, order = 1, nodes = V(graph), mode = c("all"
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `maximum.bipartite.matching()` was renamed to `max_bipartite_match()` to create a more
+#' `maximum.bipartite.matching()` was renamed to [`max_bipartite_match()`] to create a more
 #' consistent API.
 #' @inheritParams max_bipartite_match
 #' @keywords internal
@@ -125,7 +125,7 @@ maximum.bipartite.matching <- function(graph, types = NULL, weights = NULL, eps 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.mutual()` was renamed to `which_mutual()` to create a more
+#' `is.mutual()` was renamed to [`which_mutual()`] to create a more
 #' consistent API.
 #' @inheritParams which_mutual
 #' @keywords internal
@@ -140,7 +140,7 @@ is.mutual <- function(graph, eids = E(graph), loops = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.multiple()` was renamed to `which_multiple()` to create a more
+#' `is.multiple()` was renamed to [`which_multiple()`] to create a more
 #' consistent API.
 #' @inheritParams which_multiple
 #' @keywords internal
@@ -155,7 +155,7 @@ is.multiple <- function(graph, eids = E(graph)) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.maximal.matching()` was renamed to `is_max_matching()` to create a more
+#' `is.maximal.matching()` was renamed to [`is_max_matching()`] to create a more
 #' consistent API.
 #' @inheritParams is_max_matching
 #' @keywords internal
@@ -170,7 +170,7 @@ is.maximal.matching <- function(graph, matching, types = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.matching()` was renamed to `is_matching()` to create a more
+#' `is.matching()` was renamed to [`is_matching()`] to create a more
 #' consistent API.
 #' @inheritParams is_matching
 #' @keywords internal
@@ -185,7 +185,7 @@ is.matching <- function(graph, matching, types = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.loop()` was renamed to `which_loop()` to create a more
+#' `is.loop()` was renamed to [`which_loop()`] to create a more
 #' consistent API.
 #' @inheritParams which_loop
 #' @keywords internal
@@ -200,7 +200,7 @@ is.loop <- function(graph, eids = E(graph)) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `is.connected()` was renamed to `is_connected()` to create a more
+#' `is.connected()` was renamed to [`is_connected()`] to create a more
 #' consistent API.
 #' @inheritParams is_connected
 #' @keywords internal
@@ -215,7 +215,7 @@ is.connected <- function(graph, mode = c("weak", "strong")) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `induced.subgraph()` was renamed to `induced_subgraph()` to create a more
+#' `induced.subgraph()` was renamed to [`induced_subgraph()`] to create a more
 #' consistent API.
 #' @inheritParams induced_subgraph
 #' @keywords internal
@@ -230,7 +230,7 @@ induced.subgraph <- function(graph, vids, impl = c("auto", "copy_and_delete", "c
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `has.multiple()` was renamed to `any_multiple()` to create a more
+#' `has.multiple()` was renamed to [`any_multiple()`] to create a more
 #' consistent API.
 #' @inheritParams any_multiple
 #' @keywords internal
@@ -245,7 +245,7 @@ has.multiple <- function(graph) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.neighborhood()` was renamed to `make_ego_graph()` to create a more
+#' `graph.neighborhood()` was renamed to [`make_ego_graph()`] to create a more
 #' consistent API.
 #' @inheritParams make_ego_graph
 #' @keywords internal
@@ -260,7 +260,7 @@ graph.neighborhood <- function(graph, order = 1, nodes = V(graph), mode = c("all
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.laplacian()` was renamed to `laplacian_matrix()` to create a more
+#' `graph.laplacian()` was renamed to [`laplacian_matrix()`] to create a more
 #' consistent API.
 #' @inheritParams laplacian_matrix
 #' @keywords internal
@@ -275,7 +275,7 @@ graph.laplacian <- function(graph, normalized = FALSE, weights = NULL, sparse = 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.knn()` was renamed to `knn()` to create a more
+#' `graph.knn()` was renamed to [`knn()`] to create a more
 #' consistent API.
 #' @inheritParams knn
 #' @keywords internal
@@ -290,7 +290,7 @@ graph.knn <- function(graph, vids = V(graph), mode = c("all", "out", "in", "tota
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.dfs()` was renamed to `dfs()` to create a more
+#' `graph.dfs()` was renamed to [`dfs()`] to create a more
 #' consistent API.
 #' @param father Logical scalar, whether to return the father of the vertices.
 #' @inheritParams dfs
@@ -306,7 +306,7 @@ graph.dfs <- function(graph, root, mode = c("out", "in", "all", "total"), unreac
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.density()` was renamed to `edge_density()` to create a more
+#' `graph.density()` was renamed to [`edge_density()`] to create a more
 #' consistent API.
 #' @inheritParams edge_density
 #' @keywords internal
@@ -321,7 +321,7 @@ graph.density <- function(graph, loops = FALSE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.coreness()` was renamed to `coreness()` to create a more
+#' `graph.coreness()` was renamed to [`coreness()`] to create a more
 #' consistent API.
 #' @inheritParams coreness
 #' @keywords internal
@@ -336,7 +336,7 @@ graph.coreness <- function(graph, mode = c("all", "out", "in")) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.bfs()` was renamed to `bfs()` to create a more
+#' `graph.bfs()` was renamed to [`bfs()`] to create a more
 #' consistent API.
 #' @inheritParams bfs
 #' @param father Logical scalar, whether to return the father of the vertices.
@@ -352,7 +352,7 @@ graph.bfs <- function(graph, root, mode = c("out", "in", "all", "total"), unreac
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `farthest.nodes()` was renamed to `farthest_vertices()` to create a more
+#' `farthest.nodes()` was renamed to [`farthest_vertices()`] to create a more
 #' consistent API.
 #' @inheritParams farthest_vertices
 #' @keywords internal
@@ -367,7 +367,7 @@ farthest.nodes <- function(graph, directed = TRUE, unconnected = TRUE, weights =
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `degree.distribution()` was renamed to `degree_distribution()` to create a more
+#' `degree.distribution()` was renamed to [`degree_distribution()`] to create a more
 #' consistent API.
 #' @inheritParams degree_distribution
 #' @keywords internal
@@ -382,7 +382,7 @@ degree.distribution <- function(graph, cumulative = FALSE, ...) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `count.multiple()` was renamed to `count_multiple()` to create a more
+#' `count.multiple()` was renamed to [`count_multiple()`] to create a more
 #' consistent API.
 #' @inheritParams count_multiple
 #' @keywords internal
@@ -397,7 +397,7 @@ count.multiple <- function(graph, eids = E(graph)) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `clusters()` was renamed to `components()` to create a more
+#' `clusters()` was renamed to [`components()`] to create a more
 #' consistent API.
 #' @inheritParams components
 #' @keywords internal
@@ -412,7 +412,7 @@ clusters <- function(graph, mode = c("weak", "strong")) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `average.path.length()` was renamed to `mean_distance()` to create a more
+#' `average.path.length()` was renamed to [`mean_distance()`] to create a more
 #' consistent API.
 #' @inheritParams mean_distance
 #' @keywords internal
@@ -1249,7 +1249,7 @@ subgraph_from_edges <- function(graph, eids, delete.vertices = TRUE) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `subgraph.edges()` was renamed to `subgraph_from_edges()` to create a more
+#' `subgraph.edges()` was renamed to [`subgraph_from_edges()`] to create a more
 #' consistent API.
 #' @inheritParams subgraph_from_edges
 #' @keywords internal

--- a/R/structure.info.R
+++ b/R/structure.info.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `are.connected()` was renamed to [`are_adjacent()`] to create a more
+#' `are.connected()` was renamed to [are_adjacent()] to create a more
 #' consistent API.
 #' @inheritParams are_adjacent
 #' @keywords internal

--- a/R/structure.info.R
+++ b/R/structure.info.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `are.connected()` was renamed to `are_adjacent()` to create a more
+#' `are.connected()` was renamed to [`are_adjacent()`] to create a more
 #' consistent API.
 #' @inheritParams are_adjacent
 #' @keywords internal

--- a/R/tkplot.R
+++ b/R/tkplot.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.setcoords()` was renamed to [`tk_set_coords()`] to create a more
+#' `tkplot.setcoords()` was renamed to [tk_set_coords()] to create a more
 #' consistent API.
 #' @inheritParams tk_set_coords
 #' @keywords internal
@@ -18,7 +18,7 @@ tkplot.setcoords <- function(tkp.id, coords) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.rotate()` was renamed to [`tk_rotate()`] to create a more
+#' `tkplot.rotate()` was renamed to [tk_rotate()] to create a more
 #' consistent API.
 #' @inheritParams tk_rotate
 #' @keywords internal
@@ -33,7 +33,7 @@ tkplot.rotate <- function(tkp.id, degree = NULL, rad = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.reshape()` was renamed to [`tk_reshape()`] to create a more
+#' `tkplot.reshape()` was renamed to [tk_reshape()] to create a more
 #' consistent API.
 #' @inheritParams tk_reshape
 #' @keywords internal
@@ -48,7 +48,7 @@ tkplot.reshape <- function(tkp.id, newlayout, ..., params) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.off()` was renamed to [`tk_off()`] to create a more
+#' `tkplot.off()` was renamed to [tk_off()] to create a more
 #' consistent API.
 #'
 #' @keywords internal
@@ -63,7 +63,7 @@ tkplot.off <- function() { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.getcoords()` was renamed to [`tk_coords()`] to create a more
+#' `tkplot.getcoords()` was renamed to [tk_coords()] to create a more
 #' consistent API.
 #' @inheritParams tk_coords
 #' @keywords internal
@@ -78,7 +78,7 @@ tkplot.getcoords <- function(tkp.id, norm = FALSE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.fit.to.screen()` was renamed to [`tk_fit()`] to create a more
+#' `tkplot.fit.to.screen()` was renamed to [tk_fit()] to create a more
 #' consistent API.
 #' @inheritParams tk_fit
 #' @keywords internal
@@ -93,7 +93,7 @@ tkplot.fit.to.screen <- function(tkp.id, width = NULL, height = NULL) { # nocov 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.export.postscript()` was renamed to [`tk_postscript()`] to create a more
+#' `tkplot.export.postscript()` was renamed to [tk_postscript()] to create a more
 #' consistent API.
 #' @inheritParams tk_postscript
 #' @keywords internal
@@ -108,7 +108,7 @@ tkplot.export.postscript <- function(tkp.id) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.close()` was renamed to [`tk_close()`] to create a more
+#' `tkplot.close()` was renamed to [tk_close()] to create a more
 #' consistent API.
 #' @inheritParams tk_close
 #' @keywords internal
@@ -123,7 +123,7 @@ tkplot.close <- function(tkp.id, window.close = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.center()` was renamed to [`tk_center()`] to create a more
+#' `tkplot.center()` was renamed to [tk_center()] to create a more
 #' consistent API.
 #' @inheritParams tk_center
 #' @keywords internal
@@ -138,7 +138,7 @@ tkplot.center <- function(tkp.id) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.canvas()` was renamed to [`tk_canvas()`] to create a more
+#' `tkplot.canvas()` was renamed to [tk_canvas()] to create a more
 #' consistent API.
 #' @inheritParams tk_canvas
 #' @keywords internal

--- a/R/tkplot.R
+++ b/R/tkplot.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.setcoords()` was renamed to `tk_set_coords()` to create a more
+#' `tkplot.setcoords()` was renamed to [`tk_set_coords()`] to create a more
 #' consistent API.
 #' @inheritParams tk_set_coords
 #' @keywords internal
@@ -18,7 +18,7 @@ tkplot.setcoords <- function(tkp.id, coords) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.rotate()` was renamed to `tk_rotate()` to create a more
+#' `tkplot.rotate()` was renamed to [`tk_rotate()`] to create a more
 #' consistent API.
 #' @inheritParams tk_rotate
 #' @keywords internal
@@ -33,7 +33,7 @@ tkplot.rotate <- function(tkp.id, degree = NULL, rad = NULL) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.reshape()` was renamed to `tk_reshape()` to create a more
+#' `tkplot.reshape()` was renamed to [`tk_reshape()`] to create a more
 #' consistent API.
 #' @inheritParams tk_reshape
 #' @keywords internal
@@ -48,7 +48,7 @@ tkplot.reshape <- function(tkp.id, newlayout, ..., params) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.off()` was renamed to `tk_off()` to create a more
+#' `tkplot.off()` was renamed to [`tk_off()`] to create a more
 #' consistent API.
 #'
 #' @keywords internal
@@ -63,7 +63,7 @@ tkplot.off <- function() { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.getcoords()` was renamed to `tk_coords()` to create a more
+#' `tkplot.getcoords()` was renamed to [`tk_coords()`] to create a more
 #' consistent API.
 #' @inheritParams tk_coords
 #' @keywords internal
@@ -78,7 +78,7 @@ tkplot.getcoords <- function(tkp.id, norm = FALSE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.fit.to.screen()` was renamed to `tk_fit()` to create a more
+#' `tkplot.fit.to.screen()` was renamed to [`tk_fit()`] to create a more
 #' consistent API.
 #' @inheritParams tk_fit
 #' @keywords internal
@@ -93,7 +93,7 @@ tkplot.fit.to.screen <- function(tkp.id, width = NULL, height = NULL) { # nocov 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.export.postscript()` was renamed to `tk_postscript()` to create a more
+#' `tkplot.export.postscript()` was renamed to [`tk_postscript()`] to create a more
 #' consistent API.
 #' @inheritParams tk_postscript
 #' @keywords internal
@@ -108,7 +108,7 @@ tkplot.export.postscript <- function(tkp.id) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.close()` was renamed to `tk_close()` to create a more
+#' `tkplot.close()` was renamed to [`tk_close()`] to create a more
 #' consistent API.
 #' @inheritParams tk_close
 #' @keywords internal
@@ -123,7 +123,7 @@ tkplot.close <- function(tkp.id, window.close = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.center()` was renamed to `tk_center()` to create a more
+#' `tkplot.center()` was renamed to [`tk_center()`] to create a more
 #' consistent API.
 #' @inheritParams tk_center
 #' @keywords internal
@@ -138,7 +138,7 @@ tkplot.center <- function(tkp.id) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `tkplot.canvas()` was renamed to `tk_canvas()` to create a more
+#' `tkplot.canvas()` was renamed to [`tk_canvas()`] to create a more
 #' consistent API.
 #' @inheritParams tk_canvas
 #' @keywords internal

--- a/R/topology.R
+++ b/R/topology.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `permute.vertices()` was renamed to [`permute()`] to create a more
+#' `permute.vertices()` was renamed to [permute()] to create a more
 #' consistent API.
 #' @inheritParams permute
 #' @keywords internal
@@ -18,7 +18,7 @@ permute.vertices <- function(graph, permutation) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.isocreate()` was renamed to [`graph_from_isomorphism_class()`] to create a more
+#' `graph.isocreate()` was renamed to [graph_from_isomorphism_class()] to create a more
 #' consistent API.
 #' @inheritParams graph_from_isomorphism_class
 #' @keywords internal
@@ -33,7 +33,7 @@ graph.isocreate <- function(size, number, directed = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.automorphisms()` was renamed to [`count_automorphisms()`] to create a more
+#' `graph.automorphisms()` was renamed to [count_automorphisms()] to create a more
 #' consistent API.
 #' @inheritParams count_automorphisms
 #' @keywords internal
@@ -48,7 +48,7 @@ graph.automorphisms <- function(graph, colors = NULL, sh = c("fm", "f", "fs", "f
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `canonical.permutation()` was renamed to [`canonical_permutation()`] to create a more
+#' `canonical.permutation()` was renamed to [canonical_permutation()] to create a more
 #' consistent API.
 #' @inheritParams canonical_permutation
 #' @keywords internal
@@ -63,7 +63,7 @@ canonical.permutation <- function(graph, colors = NULL, sh = c("fm", "f", "fs", 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `automorphisms()` was renamed to [`count_automorphisms()`] to create a more
+#' `automorphisms()` was renamed to [count_automorphisms()] to create a more
 #' consistent API.
 #' @inheritParams count_automorphisms
 #' @keywords internal

--- a/R/topology.R
+++ b/R/topology.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `permute.vertices()` was renamed to `permute()` to create a more
+#' `permute.vertices()` was renamed to [`permute()`] to create a more
 #' consistent API.
 #' @inheritParams permute
 #' @keywords internal
@@ -18,7 +18,7 @@ permute.vertices <- function(graph, permutation) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.isocreate()` was renamed to `graph_from_isomorphism_class()` to create a more
+#' `graph.isocreate()` was renamed to [`graph_from_isomorphism_class()`] to create a more
 #' consistent API.
 #' @inheritParams graph_from_isomorphism_class
 #' @keywords internal
@@ -33,7 +33,7 @@ graph.isocreate <- function(size, number, directed = TRUE) { # nocov start
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `graph.automorphisms()` was renamed to `count_automorphisms()` to create a more
+#' `graph.automorphisms()` was renamed to [`count_automorphisms()`] to create a more
 #' consistent API.
 #' @inheritParams count_automorphisms
 #' @keywords internal
@@ -48,7 +48,7 @@ graph.automorphisms <- function(graph, colors = NULL, sh = c("fm", "f", "fs", "f
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `canonical.permutation()` was renamed to `canonical_permutation()` to create a more
+#' `canonical.permutation()` was renamed to [`canonical_permutation()`] to create a more
 #' consistent API.
 #' @inheritParams canonical_permutation
 #' @keywords internal
@@ -63,7 +63,7 @@ canonical.permutation <- function(graph, colors = NULL, sh = c("fm", "f", "fs", 
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `automorphisms()` was renamed to `count_automorphisms()` to create a more
+#' `automorphisms()` was renamed to [`count_automorphisms()`] to create a more
 #' consistent API.
 #' @inheritParams count_automorphisms
 #' @keywords internal

--- a/R/triangles.R
+++ b/R/triangles.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `adjacent.triangles()` was renamed to `count_triangles()` to create a more
+#' `adjacent.triangles()` was renamed to [`count_triangles()`] to create a more
 #' consistent API.
 #' @inheritParams count_triangles
 #' @keywords internal

--- a/R/triangles.R
+++ b/R/triangles.R
@@ -3,7 +3,7 @@
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `adjacent.triangles()` was renamed to [`count_triangles()`] to create a more
+#' `adjacent.triangles()` was renamed to [count_triangles()] to create a more
 #' consistent API.
 #' @inheritParams count_triangles
 #' @keywords internal

--- a/R/versions.R
+++ b/R/versions.R
@@ -195,7 +195,7 @@ clear_native_ptr <- function(g) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.version()` was renamed to [`igraph_version()`] to create a more
+#' `igraph.version()` was renamed to [igraph_version()] to create a more
 #' consistent API.
 #'
 #' @keywords internal

--- a/R/versions.R
+++ b/R/versions.R
@@ -195,7 +195,7 @@ clear_native_ptr <- function(g) {
 #' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' `igraph.version()` was renamed to `igraph_version()` to create a more
+#' `igraph.version()` was renamed to [`igraph_version()`] to create a more
 #' consistent API.
 #'
 #' @keywords internal

--- a/man/add.edges.Rd
+++ b/man/add.edges.Rd
@@ -23,7 +23,7 @@ below.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{add.edges()} was renamed to \code{add_edges()} to create a more
+\code{add.edges()} was renamed to \code{\link[=add_edges]{add_edges()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/add.vertex.shape.Rd
+++ b/man/add.vertex.shape.Rd
@@ -31,7 +31,7 @@ a prefix \sQuote{\code{plot.}}. See Details below.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{add.vertex.shape()} was renamed to \code{add_shape()} to create a more
+\code{add.vertex.shape()} was renamed to \code{\link[=add_shape]{add_shape()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/add.vertices.Rd
+++ b/man/add.vertices.Rd
@@ -22,7 +22,7 @@ below.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{add.vertices()} was renamed to \code{add_vertices()} to create a more
+\code{add.vertices()} was renamed to \code{\link[=add_vertices]{add_vertices()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/adjacent.triangles.Rd
+++ b/man/adjacent.triangles.Rd
@@ -17,7 +17,7 @@ named graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{adjacent.triangles()} was renamed to \code{count_triangles()} to create a more
+\code{adjacent.triangles()} was renamed to \code{\link[=count_triangles]{count_triangles()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/aging.ba.game.Rd
+++ b/man/aging.ba.game.Rd
@@ -68,7 +68,7 @@ attachment. See also details below.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{aging.ba.game()} was renamed to \code{sample_pa_age()} to create a more
+\code{aging.ba.game()} was renamed to \code{\link[=sample_pa_age]{sample_pa_age()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/aging.barabasi.game.Rd
+++ b/man/aging.barabasi.game.Rd
@@ -68,7 +68,7 @@ attachment. See also details below.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{aging.barabasi.game()} was renamed to \code{sample_pa_age()} to create a more
+\code{aging.barabasi.game()} was renamed to \code{\link[=sample_pa_age]{sample_pa_age()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/aging.prefatt.game.Rd
+++ b/man/aging.prefatt.game.Rd
@@ -68,7 +68,7 @@ attachment. See also details below.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{aging.prefatt.game()} was renamed to \code{sample_pa_age()} to create a more
+\code{aging.prefatt.game()} was renamed to \code{\link[=sample_pa_age]{sample_pa_age()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/alpha.centrality.Rd
+++ b/man/alpha.centrality.Rd
@@ -51,7 +51,7 @@ support}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{alpha.centrality()} was renamed to \code{alpha_centrality()} to create a more
+\code{alpha.centrality()} was renamed to \code{\link[=alpha_centrality]{alpha_centrality()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/are.connected.Rd
+++ b/man/are.connected.Rd
@@ -16,7 +16,7 @@ are.connected(graph, v1, v2)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{are.connected()} was renamed to \code{are_adjacent()} to create a more
+\code{are.connected()} was renamed to \code{\link[=are_adjacent]{are_adjacent()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/articulation.points.Rd
+++ b/man/articulation.points.Rd
@@ -13,7 +13,7 @@ it is directed.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{articulation.points()} was renamed to \code{articulation_points()} to create a more
+\code{articulation.points()} was renamed to \code{\link[=articulation_points]{articulation_points()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/as.directed.Rd
+++ b/man/as.directed.Rd
@@ -17,7 +17,7 @@ as.directed(graph, mode = c("mutual", "arbitrary", "random", "acyclic"))
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{as.directed()} was renamed to \code{as_directed()} to create a more
+\code{as.directed()} was renamed to \code{\link[=as_directed]{as_directed()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/as.matrix.igraph.Rd
+++ b/man/as.matrix.igraph.Rd
@@ -7,7 +7,7 @@
 \method{as.matrix}{igraph}(x, matrix.type = c("adjacency", "edgelist"), ...)
 }
 \arguments{
-\item{x}{object of class igraph, the network}
+\item{x}{object of class \code{igraph}, the network}
 
 \item{matrix.type}{character, type of matrix to return, currently "adjacency"
 or "edgelist" are supported}

--- a/man/as.undirected.Rd
+++ b/man/as.undirected.Rd
@@ -27,7 +27,7 @@ this.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{as.undirected()} was renamed to \code{as_undirected()} to create a more
+\code{as.undirected()} was renamed to \code{\link[=as_undirected]{as_undirected()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/as_incidence_matrix.Rd
+++ b/man/as_incidence_matrix.Rd
@@ -9,7 +9,7 @@ as_incidence_matrix(...)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{as_incidence_matrix()} was renamed to \code{as_biadjacency_matrix()} to create a more
+\code{as_incidence_matrix()} was renamed to \code{\link[=as_biadjacency_matrix]{as_biadjacency_matrix()}} to create a more
 consistent API.
 }
 \details{

--- a/man/assortativity.degree.Rd
+++ b/man/assortativity.degree.Rd
@@ -20,7 +20,7 @@ graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{assortativity.degree()} was renamed to \code{assortativity_degree()} to create a more
+\code{assortativity.degree()} was renamed to \code{\link[=assortativity_degree]{assortativity_degree()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/assortativity.nominal.Rd
+++ b/man/assortativity.nominal.Rd
@@ -29,7 +29,7 @@ values at the two ends of edges.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{assortativity.nominal()} was renamed to \code{assortativity_nominal()} to create a more
+\code{assortativity.nominal()} was renamed to \code{\link[=assortativity_nominal]{assortativity_nominal()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/asymmetric.preference.game.Rd
+++ b/man/asymmetric.preference.game.Rd
@@ -29,7 +29,7 @@ an undirected graph, it must be symmetric.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{asymmetric.preference.game()} was renamed to \code{sample_asym_pref()} to create a more
+\code{asymmetric.preference.game()} was renamed to \code{\link[=sample_asym_pref]{sample_asym_pref()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/authority.score.Rd
+++ b/man/authority.score.Rd
@@ -31,7 +31,7 @@ selected by the surfer.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{authority.score()} was renamed to \code{authority_score()} to create a more
+\code{authority.score()} was renamed to \code{\link[=authority_score]{authority_score()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/autocurve.edges.Rd
+++ b/man/autocurve.edges.Rd
@@ -15,7 +15,7 @@ curvature between \code{-start} and \code{start}, spaced equally.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{autocurve.edges()} was renamed to \code{curve_multiple()} to create a more
+\code{autocurve.edges()} was renamed to \code{\link[=curve_multiple]{curve_multiple()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/automorphisms.Rd
+++ b/man/automorphisms.Rd
@@ -31,7 +31,7 @@ smallest maximally non-trivially connected non-singleton cell.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{automorphisms()} was renamed to \code{count_automorphisms()} to create a more
+\code{automorphisms()} was renamed to \code{\link[=count_automorphisms]{count_automorphisms()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/average.path.length.Rd
+++ b/man/average.path.length.Rd
@@ -38,7 +38,7 @@ the result when this parameter is set to \code{TRUE}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{average.path.length()} was renamed to \code{mean_distance()} to create a more
+\code{average.path.length()} was renamed to \code{\link[=mean_distance]{mean_distance()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/ba.game.Rd
+++ b/man/ba.game.Rd
@@ -67,7 +67,7 @@ contain the out degrees of the new vertices only, not the ones in the
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{ba.game()} was renamed to \code{sample_pa()} to create a more
+\code{ba.game()} was renamed to \code{\link[=sample_pa]{sample_pa()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/barabasi.game.Rd
+++ b/man/barabasi.game.Rd
@@ -67,7 +67,7 @@ contain the out degrees of the new vertices only, not the ones in the
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{barabasi.game()} was renamed to \code{sample_pa()} to create a more
+\code{barabasi.game()} was renamed to \code{\link[=sample_pa]{sample_pa()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/biconnected.components.Rd
+++ b/man/biconnected.components.Rd
@@ -13,7 +13,7 @@ it is directed.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{biconnected.components()} was renamed to \code{biconnected_components()} to create a more
+\code{biconnected.components()} was renamed to \code{\link[=biconnected_components]{biconnected_components()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/bipartite.mapping.Rd
+++ b/man/bipartite.mapping.Rd
@@ -12,7 +12,7 @@ bipartite.mapping(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{bipartite.mapping()} was renamed to \code{bipartite_mapping()} to create a more
+\code{bipartite.mapping()} was renamed to \code{\link[=bipartite_mapping]{bipartite_mapping()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/bipartite.projection.Rd
+++ b/man/bipartite.projection.Rd
@@ -45,7 +45,7 @@ default it will be removed.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{bipartite.projection()} was renamed to \code{bipartite_projection()} to create a more
+\code{bipartite.projection()} was renamed to \code{\link[=bipartite_projection]{bipartite_projection()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/bipartite.projection.size.Rd
+++ b/man/bipartite.projection.size.Rd
@@ -17,7 +17,7 @@ graph has no \sQuote{\code{type}} vertex attribute.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{bipartite.projection.size()} was renamed to \code{bipartite_projection_size()} to create a more
+\code{bipartite.projection.size()} was renamed to \code{\link[=bipartite_projection_size]{bipartite_projection_size()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/bipartite.random.game.Rd
+++ b/man/bipartite.random.game.Rd
@@ -42,7 +42,7 @@ is ignored for undirected graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{bipartite.random.game()} was renamed to \code{sample_bipartite()} to create a more
+\code{bipartite.random.game()} was renamed to \code{\link[=sample_bipartite]{sample_bipartite()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/blockGraphs.Rd
+++ b/man/blockGraphs.Rd
@@ -18,7 +18,7 @@ argument.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{blockGraphs()} was renamed to \code{graphs_from_cohesive_blocks()} to create a more
+\code{blockGraphs()} was renamed to \code{\link[=graphs_from_cohesive_blocks]{graphs_from_cohesive_blocks()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/bonpow.Rd
+++ b/man/bonpow.Rd
@@ -40,7 +40,7 @@ support}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{bonpow()} was renamed to \code{power_centrality()} to create a more
+\code{bonpow()} was renamed to \code{\link[=power_centrality]{power_centrality()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/callaway.traits.game.Rd
+++ b/man/callaway.traits.game.Rd
@@ -31,7 +31,7 @@ types. These should be probabilities, i.e. numbers between zero and one.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{callaway.traits.game()} was renamed to \code{sample_traits_callaway()} to create a more
+\code{callaway.traits.game()} was renamed to \code{\link[=sample_traits_callaway]{sample_traits_callaway()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/canonical.permutation.Rd
+++ b/man/canonical.permutation.Rd
@@ -26,7 +26,7 @@ for possible values.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{canonical.permutation()} was renamed to \code{canonical_permutation()} to create a more
+\code{canonical.permutation()} was renamed to \code{\link[=canonical_permutation]{canonical_permutation()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/centralization.betweenness.Rd
+++ b/man/centralization.betweenness.Rd
@@ -18,7 +18,7 @@ centrality score by dividing by the theoretical maximum.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{centralization.betweenness()} was renamed to \code{centr_betw()} to create a more
+\code{centralization.betweenness()} was renamed to \code{\link[=centr_betw]{centr_betw()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/centralization.betweenness.tmax.Rd
+++ b/man/centralization.betweenness.tmax.Rd
@@ -20,7 +20,7 @@ given.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{centralization.betweenness.tmax()} was renamed to \code{centr_betw_tmax()} to create a more
+\code{centralization.betweenness.tmax()} was renamed to \code{\link[=centr_betw_tmax]{centr_betw_tmax()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/centralization.closeness.Rd
+++ b/man/centralization.closeness.Rd
@@ -22,7 +22,7 @@ centrality score by dividing by the theoretical maximum.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{centralization.closeness()} was renamed to \code{centr_clo()} to create a more
+\code{centralization.closeness()} was renamed to \code{\link[=centr_clo]{centr_clo()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/centralization.closeness.tmax.Rd
+++ b/man/centralization.closeness.tmax.Rd
@@ -23,7 +23,7 @@ given.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{centralization.closeness.tmax()} was renamed to \code{centr_clo_tmax()} to create a more
+\code{centralization.closeness.tmax()} was renamed to \code{\link[=centr_clo_tmax]{centr_clo_tmax()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/centralization.degree.Rd
+++ b/man/centralization.degree.Rd
@@ -26,7 +26,7 @@ centrality score by dividing by the theoretical maximum.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{centralization.degree()} was renamed to \code{centr_degree()} to create a more
+\code{centralization.degree()} was renamed to \code{\link[=centr_degree]{centr_degree()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/centralization.degree.tmax.Rd
+++ b/man/centralization.degree.tmax.Rd
@@ -25,7 +25,7 @@ calculating the degree.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{centralization.degree.tmax()} was renamed to \code{centr_degree_tmax()} to create a more
+\code{centralization.degree.tmax()} was renamed to \code{\link[=centr_degree_tmax]{centr_degree_tmax()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/centralization.evcent.Rd
+++ b/man/centralization.evcent.Rd
@@ -30,7 +30,7 @@ centrality score by dividing by the theoretical maximum.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{centralization.evcent()} was renamed to \code{centr_eigen()} to create a more
+\code{centralization.evcent()} was renamed to \code{\link[=centr_eigen]{centr_eigen()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/centralization.evcent.tmax.Rd
+++ b/man/centralization.evcent.tmax.Rd
@@ -27,7 +27,7 @@ eigenvector centralization requires normalized eigenvector centrality scores.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{centralization.evcent.tmax()} was renamed to \code{centr_eigen_tmax()} to create a more
+\code{centralization.evcent.tmax()} was renamed to \code{\link[=centr_eigen_tmax]{centr_eigen_tmax()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/centralize.scores.Rd
+++ b/man/centralize.scores.Rd
@@ -20,7 +20,7 @@ centrality score by dividing by the supplied theoretical maximum.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{centralize.scores()} was renamed to \code{centralize()} to create a more
+\code{centralize.scores()} was renamed to \code{\link[=centralize]{centralize()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/cited.type.game.Rd
+++ b/man/cited.type.game.Rd
@@ -33,7 +33,7 @@ graph as a vertex attribute called \sQuote{\code{type}}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{cited.type.game()} was renamed to \code{sample_cit_types()} to create a more
+\code{cited.type.game()} was renamed to \code{\link[=sample_cit_types]{sample_cit_types()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/citing.cited.type.game.Rd
+++ b/man/citing.cited.type.game.Rd
@@ -33,7 +33,7 @@ graph as a vertex attribute called \sQuote{\code{type}}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{citing.cited.type.game()} was renamed to \code{sample_cit_cit_types()} to create a more
+\code{citing.cited.type.game()} was renamed to \code{\link[=sample_cit_cit_types]{sample_cit_cit_types()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/clique.number.Rd
+++ b/man/clique.number.Rd
@@ -12,7 +12,7 @@ clique.number(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{clique.number()} was renamed to \code{clique_num()} to create a more
+\code{clique.number()} was renamed to \code{\link[=clique_num]{clique_num()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/cliques.Rd
+++ b/man/cliques.Rd
@@ -67,7 +67,7 @@ or only the maximal ones (\code{TRUE}).}
 \value{
 \code{cliques()}, \code{largest_cliques()} and \code{clique_num()}
 return a list containing numeric vectors of vertex ids. Each list element is
-a clique, i.e. a vertex sequence of class \code{\link[=V]{igraph.vs()}}.
+a clique, i.e. a vertex sequence of class \link[=V]{igraph.vs}.
 
 \code{max_cliques()} returns \code{NULL}, invisibly, if its \code{file}
 argument is not \code{NULL}. The output is written to the specified file in

--- a/man/cluster.distribution.Rd
+++ b/man/cluster.distribution.Rd
@@ -21,7 +21,7 @@ by the cluster sizes.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{cluster.distribution()} was renamed to \code{component_distribution()} to create a more
+\code{cluster.distribution()} was renamed to \code{\link[=component_distribution]{component_distribution()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/clusters.Rd
+++ b/man/clusters.Rd
@@ -16,7 +16,7 @@ connected components to search. It is ignored for undirected graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{clusters()} was renamed to \code{components()} to create a more
+\code{clusters()} was renamed to \code{\link[=components]{components()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/code.length.Rd
+++ b/man/code.length.Rd
@@ -9,7 +9,7 @@ code.length(communities)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{code.length()} was renamed to \code{code_len()} to create a more
+\code{code.length()} was renamed to \code{\link[=code_len]{code_len()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/cohesive.blocks.Rd
+++ b/man/cohesive.blocks.Rd
@@ -22,7 +22,7 @@ cohesive blocks.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{cohesive.blocks()} was renamed to \code{cohesive_blocks()} to create a more
+\code{cohesive.blocks()} was renamed to \code{\link[=cohesive_blocks]{cohesive_blocks()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/connect.neighborhood.Rd
+++ b/man/connect.neighborhood.Rd
@@ -23,7 +23,7 @@ argument is ignored for undirected graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{connect.neighborhood()} was renamed to \code{connect()} to create a more
+\code{connect.neighborhood()} was renamed to \code{\link[=connect]{connect()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/contract.vertices.Rd
+++ b/man/contract.vertices.Rd
@@ -23,7 +23,7 @@ the new graph. Please see \code{\link[=attribute.combination]{attribute.combinat
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{contract.vertices()} was renamed to \code{contract()} to create a more
+\code{contract.vertices()} was renamed to \code{\link[=contract]{contract()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/convex.hull.Rd
+++ b/man/convex.hull.Rd
@@ -12,7 +12,7 @@ convex.hull(data)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{convex.hull()} was renamed to \code{convex_hull()} to create a more
+\code{convex.hull()} was renamed to \code{\link[=convex_hull]{convex_hull()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/count.multiple.Rd
+++ b/man/count.multiple.Rd
@@ -15,7 +15,7 @@ all edges in the graph.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{count.multiple()} was renamed to \code{count_multiple()} to create a more
+\code{count.multiple()} was renamed to \code{\link[=count_multiple]{count_multiple()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/create.communities.Rd
+++ b/man/create.communities.Rd
@@ -32,7 +32,7 @@ modularity values is calculated automatically.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{create.communities()} was renamed to \code{make_clusters()} to create a more
+\code{create.communities()} was renamed to \code{\link[=make_clusters]{make_clusters()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/cutat.Rd
+++ b/man/cutat.Rd
@@ -17,7 +17,7 @@ communities. Exactly one of \code{no} and \code{steps} must be supplied.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{cutat()} was renamed to \code{cut_at()} to create a more
+\code{cutat()} was renamed to \code{\link[=cut_at]{cut_at()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/decompose.graph.Rd
+++ b/man/decompose.graph.Rd
@@ -31,7 +31,7 @@ isolate vertices.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{decompose.graph()} was renamed to \code{decompose()} to create a more
+\code{decompose.graph()} was renamed to \code{\link[=decompose]{decompose()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/degree.distribution.Rd
+++ b/man/degree.distribution.Rd
@@ -17,7 +17,7 @@ be calculated.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{degree.distribution()} was renamed to \code{degree_distribution()} to create a more
+\code{degree.distribution()} was renamed to \code{\link[=degree_distribution]{degree_distribution()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/degree.sequence.game.Rd
+++ b/man/degree.sequence.game.Rd
@@ -24,7 +24,7 @@ should be even. For directed graphs its sum should be the same as the sum of
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{degree.sequence.game()} was renamed to \code{sample_degseq()} to create a more
+\code{degree.sequence.game()} was renamed to \code{\link[=sample_degseq]{sample_degseq()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/delete.edges.Rd
+++ b/man/delete.edges.Rd
@@ -17,7 +17,7 @@ containing the IDs or names of the source and target vertices, separated by
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{delete.edges()} was renamed to \code{delete_edges()} to create a more
+\code{delete.edges()} was renamed to \code{\link[=delete_edges]{delete_edges()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/delete.vertices.Rd
+++ b/man/delete.vertices.Rd
@@ -14,7 +14,7 @@ delete.vertices(graph, v)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{delete.vertices()} was renamed to \code{delete_vertices()} to create a more
+\code{delete.vertices()} was renamed to \code{\link[=delete_vertices]{delete_vertices()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/dendPlot.Rd
+++ b/man/dendPlot.Rd
@@ -18,7 +18,7 @@ function.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{dendPlot()} was renamed to \code{plot_dendrogram()} to create a more
+\code{dendPlot()} was renamed to \code{\link[=plot_dendrogram]{plot_dendrogram()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/dominator.tree.Rd
+++ b/man/dominator.tree.Rd
@@ -21,7 +21,7 @@ the original one in the input graph.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{dominator.tree()} was renamed to \code{dominator_tree()} to create a more
+\code{dominator.tree()} was renamed to \code{\link[=dominator_tree]{dominator_tree()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/dyad.census.Rd
+++ b/man/dyad.census.Rd
@@ -12,7 +12,7 @@ dyad.census(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{dyad.census()} was renamed to \code{dyad_census()} to create a more
+\code{dyad.census()} was renamed to \code{\link[=dyad_census]{dyad_census()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/edge.betweenness.Rd
+++ b/man/edge.betweenness.Rd
@@ -31,7 +31,7 @@ betweenness. If negative, then there is no such limit.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{edge.betweenness()} was renamed to \code{edge_betweenness()} to create a more
+\code{edge.betweenness()} was renamed to \code{\link[=edge_betweenness]{edge_betweenness()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/edge.betweenness.community.Rd
+++ b/man/edge.betweenness.community.Rd
@@ -59,7 +59,7 @@ vector corresponding to the highest possible modularity score.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{edge.betweenness.community()} was renamed to \code{cluster_edge_betweenness()} to create a more
+\code{edge.betweenness.community()} was renamed to \code{\link[=cluster_edge_betweenness]{cluster_edge_betweenness()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/edge.connectivity.Rd
+++ b/man/edge.connectivity.Rd
@@ -26,7 +26,7 @@ thanks Peter.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{edge.connectivity()} was renamed to \code{edge_connectivity()} to create a more
+\code{edge.connectivity()} was renamed to \code{\link[=edge_connectivity]{edge_connectivity()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/edge.disjoint.paths.Rd
+++ b/man/edge.disjoint.paths.Rd
@@ -26,7 +26,7 @@ thanks Peter.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{edge.disjoint.paths()} was renamed to \code{edge_connectivity()} to create a more
+\code{edge.disjoint.paths()} was renamed to \code{\link[=edge_connectivity]{edge_connectivity()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/establishment.game.Rd
+++ b/man/establishment.game.Rd
@@ -31,7 +31,7 @@ types. These should be probabilities, i.e. numbers between zero and one.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{establishment.game()} was renamed to \code{sample_traits()} to create a more
+\code{establishment.game()} was renamed to \code{\link[=sample_traits]{sample_traits()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/evcent.Rd
+++ b/man/evcent.Rd
@@ -39,7 +39,7 @@ weights spread the centrality better.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{evcent()} was renamed to \code{eigen_centrality()} to create a more
+\code{evcent()} was renamed to \code{\link[=eigen_centrality]{eigen_centrality()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/exportPajek.Rd
+++ b/man/exportPajek.Rd
@@ -34,7 +34,7 @@ See details below.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{exportPajek()} was renamed to \code{export_pajek()} to create a more
+\code{exportPajek()} was renamed to \code{\link[=export_pajek]{export_pajek()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/farthest.nodes.Rd
+++ b/man/farthest.nodes.Rd
@@ -25,7 +25,7 @@ used by default.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{farthest.nodes()} was renamed to \code{farthest_vertices()} to create a more
+\code{farthest.nodes()} was renamed to \code{\link[=farthest_vertices]{farthest_vertices()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/fastgreedy.community.Rd
+++ b/man/fastgreedy.community.Rd
@@ -36,7 +36,7 @@ edge weight means a stronger connection for this function.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{fastgreedy.community()} was renamed to \code{cluster_fast_greedy()} to create a more
+\code{fastgreedy.community()} was renamed to \code{\link[=cluster_fast_greedy]{cluster_fast_greedy()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/forest.fire.game.Rd
+++ b/man/forest.fire.game.Rd
@@ -21,7 +21,7 @@ probability is calculated as \code{bw.factor*fw.prob}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{forest.fire.game()} was renamed to \code{sample_forestfire()} to create a more
+\code{forest.fire.game()} was renamed to \code{\link[=sample_forestfire]{sample_forestfire()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/from_incidence_matrix.Rd
+++ b/man/from_incidence_matrix.Rd
@@ -9,7 +9,7 @@ from_incidence_matrix(...)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph_from_incidence_matrix()} was renamed to \code{graph_from_biadjacency_matrix()} to create a more
+\code{graph_from_incidence_matrix()} was renamed to \code{\link[=graph_from_biadjacency_matrix]{graph_from_biadjacency_matrix()}} to create a more
 consistent API.
 }
 \details{

--- a/man/get.adjacency.Rd
+++ b/man/get.adjacency.Rd
@@ -49,7 +49,7 @@ matrices.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.adjacency()} was renamed to \code{as_adjacency_matrix()} to create a more
+\code{get.adjacency()} was renamed to \code{\link[=as_adjacency_matrix]{as_adjacency_matrix()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/get.adjedgelist.Rd
+++ b/man/get.adjedgelist.Rd
@@ -25,7 +25,7 @@ is not allowed for directed graphs and will be replaced with \code{"once"}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.adjedgelist()} was renamed to \code{as_adj_edge_list()} to create a more
+\code{get.adjedgelist()} was renamed to \code{\link[=as_adj_edge_list]{as_adj_edge_list()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/get.adjlist.Rd
+++ b/man/get.adjlist.Rd
@@ -29,7 +29,7 @@ of each set of parallel edges.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.adjlist()} was renamed to \code{as_adj_list()} to create a more
+\code{get.adjlist()} was renamed to \code{\link[=as_adj_list]{as_adj_list()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/get.all.shortest.paths.Rd
+++ b/man/get.all.shortest.paths.Rd
@@ -40,7 +40,7 @@ of a path is the sum of the weights of its constituent edges.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.all.shortest.paths()} was renamed to \code{all_shortest_paths()} to create a more
+\code{get.all.shortest.paths()} was renamed to \code{\link[=all_shortest_paths]{all_shortest_paths()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/get.data.frame.Rd
+++ b/man/get.data.frame.Rd
@@ -15,7 +15,7 @@ edges, or both. The default is \sQuote{edges}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.data.frame()} was renamed to \code{as_data_frame()} to create a more
+\code{get.data.frame()} was renamed to \code{\link[=as_data_frame]{as_data_frame()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/get.diameter.Rd
+++ b/man/get.diameter.Rd
@@ -25,7 +25,7 @@ used by default.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.diameter()} was renamed to \code{get_diameter()} to create a more
+\code{get.diameter()} was renamed to \code{\link[=get_diameter]{get_diameter()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/get.edge.attribute.Rd
+++ b/man/get.edge.attribute.Rd
@@ -18,7 +18,7 @@ for a subset of edges.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.edge.attribute()} was renamed to \code{edge_attr()} to create a more
+\code{get.edge.attribute()} was renamed to \code{\link[=edge_attr]{edge_attr()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/get.edge.ids.Rd
+++ b/man/get.edge.ids.Rd
@@ -26,7 +26,7 @@ returned for the non-existant edge(s).}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.edge.ids()} was renamed to \code{get_edge_ids()} to create a more
+\code{get.edge.ids()} was renamed to \code{\link[=get_edge_ids]{get_edge_ids()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/get.edgelist.Rd
+++ b/man/get.edgelist.Rd
@@ -16,7 +16,7 @@ vertex ids.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.edgelist()} was renamed to \code{as_edgelist()} to create a more
+\code{get.edgelist()} was renamed to \code{\link[=as_edgelist]{as_edgelist()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/get.graph.attribute.Rd
+++ b/man/get.graph.attribute.Rd
@@ -15,7 +15,7 @@ attributes are returned in a list.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.graph.attribute()} was renamed to \code{graph_attr()} to create a more
+\code{get.graph.attribute()} was renamed to \code{\link[=graph_attr]{graph_attr()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/get.incidence.Rd
+++ b/man/get.incidence.Rd
@@ -32,7 +32,7 @@ created, you will need the \code{Matrix} package for this.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.incidence()} was renamed to \code{as_biadjacency_matrix()} to create a more
+\code{get.incidence()} was renamed to \code{\link[=as_biadjacency_matrix]{as_biadjacency_matrix()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/get.shortest.paths.Rd
+++ b/man/get.shortest.paths.Rd
@@ -76,7 +76,7 @@ used, regardless of this argument.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.shortest.paths()} was renamed to \code{shortest_paths()} to create a more
+\code{get.shortest.paths()} was renamed to \code{\link[=shortest_paths]{shortest_paths()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/get.stochastic.Rd
+++ b/man/get.stochastic.Rd
@@ -22,7 +22,7 @@ sum up to one; otherwise it is the columns.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.stochastic()} was renamed to \code{stochastic_matrix()} to create a more
+\code{get.stochastic()} was renamed to \code{\link[=stochastic_matrix]{stochastic_matrix()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/get.vertex.attribute.Rd
+++ b/man/get.vertex.attribute.Rd
@@ -18,7 +18,7 @@ for these vertices.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{get.vertex.attribute()} was renamed to \code{vertex_attr()} to create a more
+\code{get.vertex.attribute()} was renamed to \code{\link[=vertex_attr]{vertex_attr()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/getIgraphOpt.Rd
+++ b/man/getIgraphOpt.Rd
@@ -16,7 +16,7 @@ whether it is set and setting it separately if not.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{getIgraphOpt()} was renamed to \code{igraph_opt()} to create a more
+\code{getIgraphOpt()} was renamed to \code{\link[=igraph_opt]{igraph_opt()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.Rd
+++ b/man/graph.Rd
@@ -55,7 +55,7 @@ Do not give both of them.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph()} was renamed to \code{make_graph()} to create a more
+\code{graph()} was renamed to \code{\link[=make_graph]{make_graph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.adhesion.Rd
+++ b/man/graph.adhesion.Rd
@@ -20,7 +20,7 @@ thanks Peter.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.adhesion()} was renamed to \code{adhesion()} to create a more
+\code{graph.adhesion()} was renamed to \code{\link[=adhesion]{adhesion()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.adjacency.Rd
+++ b/man/graph.adjacency.Rd
@@ -51,7 +51,7 @@ former is ignored.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.adjacency()} was renamed to \code{graph_from_adjacency_matrix()} to create a more
+\code{graph.adjacency()} was renamed to \code{\link[=graph_from_adjacency_matrix]{graph_from_adjacency_matrix()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.adjlist.Rd
+++ b/man/graph.adjlist.Rd
@@ -27,7 +27,7 @@ This argument is ignored if \code{mode} is \code{out} or \verb{in}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.adjlist()} was renamed to \code{graph_from_adj_list()} to create a more
+\code{graph.adjlist()} was renamed to \code{\link[=graph_from_adj_list]{graph_from_adj_list()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.atlas.Rd
+++ b/man/graph.atlas.Rd
@@ -12,7 +12,7 @@ graph.atlas(n)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.atlas()} was renamed to \code{graph_from_atlas()} to create a more
+\code{graph.atlas()} was renamed to \code{\link[=graph_from_atlas]{graph_from_atlas()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.automorphisms.Rd
+++ b/man/graph.automorphisms.Rd
@@ -31,7 +31,7 @@ smallest maximally non-trivially connected non-singleton cell.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.automorphisms()} was renamed to \code{count_automorphisms()} to create a more
+\code{graph.automorphisms()} was renamed to \code{\link[=count_automorphisms]{count_automorphisms()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.bfs.Rd
+++ b/man/graph.bfs.Rd
@@ -70,7 +70,7 @@ from igraph 1.3.0; use \code{mode} instead.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.bfs()} was renamed to \code{bfs()} to create a more
+\code{graph.bfs()} was renamed to \code{\link[=bfs]{bfs()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.bipartite.Rd
+++ b/man/graph.bipartite.Rd
@@ -24,7 +24,7 @@ bipartite graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.bipartite()} was renamed to \code{make_bipartite_graph()} to create a more
+\code{graph.bipartite()} was renamed to \code{\link[=make_bipartite_graph]{make_bipartite_graph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.cohesion.Rd
+++ b/man/graph.cohesion.Rd
@@ -14,7 +14,7 @@ graph.cohesion(x, ...)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.cohesion()} was renamed to \code{cohesion()} to create a more
+\code{graph.cohesion()} was renamed to \code{\link[=cohesion]{cohesion()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.complementer.Rd
+++ b/man/graph.complementer.Rd
@@ -14,7 +14,7 @@ graph.complementer(graph, loops = FALSE)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.complementer()} was renamed to \code{complementer()} to create a more
+\code{graph.complementer()} was renamed to \code{\link[=complementer]{complementer()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.compose.Rd
+++ b/man/graph.compose.Rd
@@ -20,7 +20,7 @@ but not both graphs are named.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.compose()} was renamed to \code{compose()} to create a more
+\code{graph.compose()} was renamed to \code{\link[=compose]{compose()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.coreness.Rd
+++ b/man/graph.coreness.Rd
@@ -17,7 +17,7 @@ argument is ignored for undirected graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.coreness()} was renamed to \code{coreness()} to create a more
+\code{graph.coreness()} was renamed to \code{\link[=coreness]{coreness()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.data.frame.Rd
+++ b/man/graph.data.frame.Rd
@@ -21,7 +21,7 @@ with \code{as.data.frame}, if not \code{NULL}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.data.frame()} was renamed to \code{graph_from_data_frame()} to create a more
+\code{graph.data.frame()} was renamed to \code{\link[=graph_from_data_frame]{graph_from_data_frame()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.de.bruijn.Rd
+++ b/man/graph.de.bruijn.Rd
@@ -14,7 +14,7 @@ graph.de.bruijn(m, n)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.de.bruijn()} was renamed to \code{make_de_bruijn_graph()} to create a more
+\code{graph.de.bruijn()} was renamed to \code{\link[=make_de_bruijn_graph]{make_de_bruijn_graph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.density.Rd
+++ b/man/graph.density.Rd
@@ -17,7 +17,7 @@ the result will not be meaningful.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.density()} was renamed to \code{edge_density()} to create a more
+\code{graph.density()} was renamed to \code{\link[=edge_density]{edge_density()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.dfs.Rd
+++ b/man/graph.dfs.Rd
@@ -63,7 +63,7 @@ algorithm. See details below.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.dfs()} was renamed to \code{dfs()} to create a more
+\code{graph.dfs()} was renamed to \code{\link[=dfs]{dfs()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.difference.Rd
+++ b/man/graph.difference.Rd
@@ -13,7 +13,7 @@ the function that implements \code{difference()}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.difference()} was renamed to \code{difference()} to create a more
+\code{graph.difference()} was renamed to \code{\link[=difference]{difference()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.disjoint.union.Rd
+++ b/man/graph.disjoint.union.Rd
@@ -12,7 +12,7 @@ graph.disjoint.union(...)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.disjoint.union()} was renamed to \code{disjoint_union()} to create a more
+\code{graph.disjoint.union()} was renamed to \code{\link[=disjoint_union]{disjoint_union()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.diversity.Rd
+++ b/man/graph.diversity.Rd
@@ -18,7 +18,7 @@ that this measure is not defined for unweighted graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.diversity()} was renamed to \code{diversity()} to create a more
+\code{graph.diversity()} was renamed to \code{\link[=diversity]{diversity()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.edgelist.Rd
+++ b/man/graph.edgelist.Rd
@@ -14,7 +14,7 @@ graph.edgelist(el, directed = TRUE)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.edgelist()} was renamed to \code{graph_from_edgelist()} to create a more
+\code{graph.edgelist()} was renamed to \code{\link[=graph_from_edgelist]{graph_from_edgelist()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.eigen.Rd
+++ b/man/graph.eigen.Rd
@@ -27,7 +27,7 @@ the corresponding eigenvector is calculated.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.eigen()} was renamed to \code{spectrum()} to create a more
+\code{graph.eigen()} was renamed to \code{\link[=spectrum]{spectrum()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.empty.Rd
+++ b/man/graph.empty.Rd
@@ -14,7 +14,7 @@ graph.empty(n = 0, directed = TRUE)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.empty()} was renamed to \code{make_empty_graph()} to create a more
+\code{graph.empty()} was renamed to \code{\link[=make_empty_graph]{make_empty_graph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.extended.chordal.ring.Rd
+++ b/man/graph.extended.chordal.ring.Rd
@@ -17,7 +17,7 @@ details below.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.extended.chordal.ring()} was renamed to \code{make_chordal_ring()} to create a more
+\code{graph.extended.chordal.ring()} was renamed to \code{\link[=make_chordal_ring]{make_chordal_ring()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.famous.Rd
+++ b/man/graph.famous.Rd
@@ -55,7 +55,7 @@ Do not give both of them.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.famous()} was renamed to \code{make_graph()} to create a more
+\code{graph.famous()} was renamed to \code{\link[=make_graph]{make_graph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.formula.Rd
+++ b/man/graph.formula.Rd
@@ -18,7 +18,7 @@ multiple edges are removed.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.formula()} was renamed to \code{graph_from_literal()} to create a more
+\code{graph.formula()} was renamed to \code{\link[=graph_from_literal]{graph_from_literal()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.full.Rd
+++ b/man/graph.full.Rd
@@ -16,7 +16,7 @@ graph.full(n, directed = FALSE, loops = FALSE)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.full()} was renamed to \code{make_full_graph()} to create a more
+\code{graph.full()} was renamed to \code{\link[=make_full_graph]{make_full_graph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.full.bipartite.Rd
+++ b/man/graph.full.bipartite.Rd
@@ -22,7 +22,7 @@ ignored for undirected graphs.x}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.full.bipartite()} was renamed to \code{make_full_bipartite_graph()} to create a more
+\code{graph.full.bipartite()} was renamed to \code{\link[=make_full_bipartite_graph]{make_full_bipartite_graph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.full.citation.Rd
+++ b/man/graph.full.citation.Rd
@@ -14,7 +14,7 @@ graph.full.citation(n, directed = TRUE)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.full.citation()} was renamed to \code{make_full_citation_graph()} to create a more
+\code{graph.full.citation()} was renamed to \code{\link[=make_full_citation_graph]{make_full_citation_graph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.graphdb.Rd
+++ b/man/graph.graphdb.Rd
@@ -50,7 +50,7 @@ suffix is added to the filename.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.graphdb()} was renamed to \code{graph_from_graphdb()} to create a more
+\code{graph.graphdb()} was renamed to \code{\link[=graph_from_graphdb]{graph_from_graphdb()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.incidence.Rd
+++ b/man/graph.incidence.Rd
@@ -50,7 +50,7 @@ type) will be added.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.incidence()} was renamed to \code{graph_from_biadjacency_matrix()} to create a more
+\code{graph.incidence()} was renamed to \code{\link[=graph_from_biadjacency_matrix]{graph_from_biadjacency_matrix()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.intersection.Rd
+++ b/man/graph.intersection.Rd
@@ -13,7 +13,7 @@ the function that implements \code{intersection()}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.intersection()} was renamed to \code{intersection()} to create a more
+\code{graph.intersection()} was renamed to \code{\link[=intersection]{intersection()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.isocreate.Rd
+++ b/man/graph.isocreate.Rd
@@ -16,7 +16,7 @@ graph.isocreate(size, number, directed = TRUE)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.isocreate()} was renamed to \code{graph_from_isomorphism_class()} to create a more
+\code{graph.isocreate()} was renamed to \code{\link[=graph_from_isomorphism_class]{graph_from_isomorphism_class()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.kautz.Rd
+++ b/man/graph.kautz.Rd
@@ -14,7 +14,7 @@ graph.kautz(m, n)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.kautz()} was renamed to \code{make_kautz_graph()} to create a more
+\code{graph.kautz()} was renamed to \code{\link[=make_kautz_graph]{make_kautz_graph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.knn.Rd
+++ b/man/graph.knn.Rd
@@ -39,7 +39,7 @@ Weights are are used to calculate a weighted degree (also called
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.knn()} was renamed to \code{knn()} to create a more
+\code{graph.knn()} was renamed to \code{\link[=knn]{knn()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.laplacian.Rd
+++ b/man/graph.laplacian.Rd
@@ -28,7 +28,7 @@ matrix. The \code{Matrix} package is required for sparse matrices.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.laplacian()} was renamed to \code{laplacian_matrix()} to create a more
+\code{graph.laplacian()} was renamed to \code{\link[=laplacian_matrix]{laplacian_matrix()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.lattice.Rd
+++ b/man/graph.lattice.Rd
@@ -41,7 +41,7 @@ be extended to boolean vector with dimvector length.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.lattice()} was renamed to \code{make_lattice()} to create a more
+\code{graph.lattice()} was renamed to \code{\link[=make_lattice]{make_lattice()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.lcf.Rd
+++ b/man/graph.lcf.Rd
@@ -16,7 +16,7 @@ graph.lcf(n, shifts, repeats = 1)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.lcf()} was renamed to \code{graph_from_lcf()} to create a more
+\code{graph.lcf()} was renamed to \code{\link[=graph_from_lcf]{graph_from_lcf()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.maxflow.Rd
+++ b/man/graph.maxflow.Rd
@@ -20,7 +20,7 @@ Note that the \code{weight} edge attribute is not used by this function.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.maxflow()} was renamed to \code{max_flow()} to create a more
+\code{graph.maxflow()} was renamed to \code{\link[=max_flow]{max_flow()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.mincut.Rd
+++ b/man/graph.mincut.Rd
@@ -29,7 +29,7 @@ partitions are also returned.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.mincut()} was renamed to \code{min_cut()} to create a more
+\code{graph.mincut()} was renamed to \code{\link[=min_cut]{min_cut()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.motifs.Rd
+++ b/man/graph.motifs.Rd
@@ -20,7 +20,7 @@ If \verb{rep(0, size))}, the default, no cuts are made.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.motifs()} was renamed to \code{motifs()} to create a more
+\code{graph.motifs()} was renamed to \code{\link[=motifs]{motifs()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.motifs.est.Rd
+++ b/man/graph.motifs.est.Rd
@@ -33,7 +33,7 @@ starting point for finding motifs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.motifs.est()} was renamed to \code{sample_motifs()} to create a more
+\code{graph.motifs.est()} was renamed to \code{\link[=sample_motifs]{sample_motifs()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.motifs.no.Rd
+++ b/man/graph.motifs.no.Rd
@@ -19,7 +19,7 @@ If \code{NULL}, the default, no cuts are made.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.motifs.no()} was renamed to \code{count_motifs()} to create a more
+\code{graph.motifs.no()} was renamed to \code{\link[=count_motifs]{count_motifs()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.neighborhood.Rd
+++ b/man/graph.neighborhood.Rd
@@ -33,7 +33,7 @@ argument is ignored for undirected graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.neighborhood()} was renamed to \code{make_ego_graph()} to create a more
+\code{graph.neighborhood()} was renamed to \code{\link[=make_ego_graph]{make_ego_graph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.ring.Rd
+++ b/man/graph.ring.Rd
@@ -21,7 +21,7 @@ vertex has one child.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.ring()} was renamed to \code{make_ring()} to create a more
+\code{graph.ring()} was renamed to \code{\link[=make_ring]{make_ring()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.star.Rd
+++ b/man/graph.star.Rd
@@ -20,7 +20,7 @@ are undirected.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.star()} was renamed to \code{make_star()} to create a more
+\code{graph.star()} was renamed to \code{\link[=make_star]{make_star()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.strength.Rd
+++ b/man/graph.strength.Rd
@@ -32,7 +32,7 @@ attribute, then this is used by default. If the graph does not have a
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.strength()} was renamed to \code{strength()} to create a more
+\code{graph.strength()} was renamed to \code{\link[=strength]{strength()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.tree.Rd
+++ b/man/graph.tree.Rd
@@ -21,7 +21,7 @@ graph.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.tree()} was renamed to \code{make_tree()} to create a more
+\code{graph.tree()} was renamed to \code{\link[=make_tree]{make_tree()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph.union.Rd
+++ b/man/graph.union.Rd
@@ -18,7 +18,7 @@ graphs are named.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph.union()} was renamed to \code{union.igraph()} to create a more
+\code{graph.union()} was renamed to \code{\link[=union.igraph]{union.igraph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graph_from_incidence_matrix.Rd
+++ b/man/graph_from_incidence_matrix.Rd
@@ -9,7 +9,7 @@ graph_from_incidence_matrix(...)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graph_from_incidence_matrix()} was renamed to \code{graph_from_biadjacency_matrix()} to create a more
+\code{graph_from_incidence_matrix()} was renamed to \code{\link[=graph_from_biadjacency_matrix]{graph_from_biadjacency_matrix()}} to create a more
 consistent API.
 }
 \details{

--- a/man/graphlets.candidate.basis.Rd
+++ b/man/graphlets.candidate.basis.Rd
@@ -17,7 +17,7 @@ attribute is used.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graphlets.candidate.basis()} was renamed to \code{graphlet_basis()} to create a more
+\code{graphlets.candidate.basis()} was renamed to \code{\link[=graphlet_basis]{graphlet_basis()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/graphlets.project.Rd
+++ b/man/graphlets.project.Rd
@@ -30,7 +30,7 @@ projection.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{graphlets.project()} was renamed to \code{graphlet_proj()} to create a more
+\code{graphlets.project()} was renamed to \code{\link[=graphlet_proj]{graphlet_proj()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/grg.game.Rd
+++ b/man/grg.game.Rd
@@ -20,7 +20,7 @@ as vertex attributes called \sQuote{\code{x}} and \sQuote{\code{y}}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{grg.game()} was renamed to \code{sample_grg()} to create a more
+\code{grg.game()} was renamed to \code{\link[=sample_grg]{sample_grg()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/growing.random.game.Rd
+++ b/man/growing.random.game.Rd
@@ -19,7 +19,7 @@ each time step the added edges are originating from the new vertex.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{growing.random.game()} was renamed to \code{sample_growing()} to create a more
+\code{growing.random.game()} was renamed to \code{\link[=sample_growing]{sample_growing()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/has.multiple.Rd
+++ b/man/has.multiple.Rd
@@ -12,7 +12,7 @@ has.multiple(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{has.multiple()} was renamed to \code{any_multiple()} to create a more
+\code{has.multiple()} was renamed to \code{\link[=any_multiple]{any_multiple()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/hrg.consensus.Rd
+++ b/man/hrg.consensus.Rd
@@ -23,7 +23,7 @@ missing edge prediction.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{hrg.consensus()} was renamed to \code{consensus_tree()} to create a more
+\code{hrg.consensus()} was renamed to \code{\link[=consensus_tree]{consensus_tree()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/hrg.create.Rd
+++ b/man/hrg.create.Rd
@@ -15,7 +15,7 @@ vertex ids.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{hrg.create()} was renamed to \code{hrg()} to create a more
+\code{hrg.create()} was renamed to \code{\link[=hrg]{hrg()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/hrg.dendrogram.Rd
+++ b/man/hrg.dendrogram.Rd
@@ -12,7 +12,7 @@ hrg.dendrogram(hrg)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{hrg.dendrogram()} was renamed to \code{hrg_tree()} to create a more
+\code{hrg.dendrogram()} was renamed to \code{\link[=hrg_tree]{hrg_tree()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/hrg.fit.Rd
+++ b/man/hrg.fit.Rd
@@ -23,7 +23,7 @@ MCMC procedure is performed until convergence.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{hrg.fit()} was renamed to \code{fit_hrg()} to create a more
+\code{hrg.fit()} was renamed to \code{\link[=fit_hrg]{fit_hrg()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/hrg.game.Rd
+++ b/man/hrg.game.Rd
@@ -12,7 +12,7 @@ hrg.game(hrg)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{hrg.game()} was renamed to \code{sample_hrg()} to create a more
+\code{hrg.game()} was renamed to \code{\link[=sample_hrg]{sample_hrg()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/hrg.predict.Rd
+++ b/man/hrg.predict.Rd
@@ -33,7 +33,7 @@ number for a more accurate prediction.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{hrg.predict()} was renamed to \code{predict_edges()} to create a more
+\code{hrg.predict()} was renamed to \code{\link[=predict_edges]{predict_edges()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/hub.score.Rd
+++ b/man/hub.score.Rd
@@ -26,7 +26,7 @@ selected by the surfer.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{hub.score()} was renamed to \code{hub_score()} to create a more
+\code{hub.score()} was renamed to \code{\link[=hub_score]{hub_score()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/igraph.console.Rd
+++ b/man/igraph.console.Rd
@@ -9,7 +9,7 @@ igraph.console()
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{igraph.console()} was renamed to \code{console()} to create a more
+\code{igraph.console()} was renamed to \code{\link[=console]{console()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/igraph.from.graphNEL.Rd
+++ b/man/igraph.from.graphNEL.Rd
@@ -24,7 +24,7 @@ whenever possible, before adding them to the igraph graph.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{igraph.from.graphNEL()} was renamed to \code{graph_from_graphnel()} to create a more
+\code{igraph.from.graphNEL()} was renamed to \code{\link[=graph_from_graphnel]{graph_from_graphnel()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/igraph.options.Rd
+++ b/man/igraph.options.Rd
@@ -14,7 +14,7 @@ given. See the Value and Details sections for explanation.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{igraph.options()} was renamed to \code{igraph_options()} to create a more
+\code{igraph.options()} was renamed to \code{\link[=igraph_options]{igraph_options()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/igraph.sample.Rd
+++ b/man/igraph.sample.Rd
@@ -16,7 +16,7 @@ igraph.sample(low, high, length)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{igraph.sample()} was renamed to \code{sample_seq()} to create a more
+\code{igraph.sample()} was renamed to \code{\link[=sample_seq]{sample_seq()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/igraph.shape.noclip.Rd
+++ b/man/igraph.shape.noclip.Rd
@@ -9,7 +9,7 @@ igraph.shape.noclip(coords, el, params, end = c("both", "from", "to"))
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{igraph.shape.noclip()} was renamed to \code{shape_noclip()} to create a more
+\code{igraph.shape.noclip()} was renamed to \code{\link[=shape_noclip]{shape_noclip()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/igraph.shape.noplot.Rd
+++ b/man/igraph.shape.noplot.Rd
@@ -9,7 +9,7 @@ igraph.shape.noplot(coords, v = NULL, params)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{igraph.shape.noplot()} was renamed to \code{shape_noplot()} to create a more
+\code{igraph.shape.noplot()} was renamed to \code{\link[=shape_noplot]{shape_noplot()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/igraph.to.graphNEL.Rd
+++ b/man/igraph.to.graphNEL.Rd
@@ -12,7 +12,7 @@ igraph.to.graphNEL(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{igraph.to.graphNEL()} was renamed to \code{as_graphnel()} to create a more
+\code{igraph.to.graphNEL()} was renamed to \code{\link[=as_graphnel]{as_graphnel()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/igraph.version.Rd
+++ b/man/igraph.version.Rd
@@ -9,7 +9,7 @@ igraph.version()
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{igraph.version()} was renamed to \code{igraph_version()} to create a more
+\code{igraph.version()} was renamed to \code{\link[=igraph_version]{igraph_version()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/igraphdemo.Rd
+++ b/man/igraphdemo.Rd
@@ -13,7 +13,7 @@ Otherwise it should be either a filename or the name of an igraph demo.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{igraphdemo()} was renamed to \code{igraph_demo()} to create a more
+\code{igraphdemo()} was renamed to \code{\link[=igraph_demo]{igraph_demo()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/independence.number.Rd
+++ b/man/independence.number.Rd
@@ -12,7 +12,7 @@ independence.number(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{independence.number()} was renamed to \code{ivs_size()} to create a more
+\code{independence.number()} was renamed to \code{\link[=ivs_size]{ivs_size()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/independent.vertex.sets.Rd
+++ b/man/independent.vertex.sets.Rd
@@ -18,7 +18,7 @@ vertex sets to find. \code{NULL} means no limit.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{independent.vertex.sets()} was renamed to \code{ivs()} to create a more
+\code{independent.vertex.sets()} was renamed to \code{\link[=ivs]{ivs()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/induced.subgraph.Rd
+++ b/man/induced.subgraph.Rd
@@ -28,7 +28,7 @@ result graph.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{induced.subgraph()} was renamed to \code{induced_subgraph()} to create a more
+\code{induced.subgraph()} was renamed to \code{\link[=induced_subgraph]{induced_subgraph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/infomap.community.Rd
+++ b/man/infomap.community.Rd
@@ -37,7 +37,7 @@ of the detected community structure.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{infomap.community()} was renamed to \code{cluster_infomap()} to create a more
+\code{infomap.community()} was renamed to \code{\link[=cluster_infomap]{cluster_infomap()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/interconnected.islands.game.Rd
+++ b/man/interconnected.islands.game.Rd
@@ -19,7 +19,7 @@ island.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{interconnected.islands.game()} was renamed to \code{sample_islands()} to create a more
+\code{interconnected.islands.game()} was renamed to \code{\link[=sample_islands]{sample_islands()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.bipartite.Rd
+++ b/man/is.bipartite.Rd
@@ -12,7 +12,7 @@ is.bipartite(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.bipartite()} was renamed to \code{is_bipartite()} to create a more
+\code{is.bipartite()} was renamed to \code{\link[=is_bipartite]{is_bipartite()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.chordal.Rd
+++ b/man/is.chordal.Rd
@@ -32,7 +32,7 @@ that is given..}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.chordal()} was renamed to \code{is_chordal()} to create a more
+\code{is.chordal()} was renamed to \code{\link[=is_chordal]{is_chordal()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.connected.Rd
+++ b/man/is.connected.Rd
@@ -16,7 +16,7 @@ connected components to search. It is ignored for undirected graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.connected()} was renamed to \code{is_connected()} to create a more
+\code{is.connected()} was renamed to \code{\link[=is_connected]{is_connected()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.dag.Rd
+++ b/man/is.dag.Rd
@@ -13,7 +13,7 @@ is.dag(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.dag()} was renamed to \code{is_dag()} to create a more
+\code{is.dag()} was renamed to \code{\link[=is_dag]{is_dag()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.degree.sequence.Rd
+++ b/man/is.degree.sequence.Rd
@@ -16,7 +16,7 @@ should be \code{NULL}. For directed graphs it specifies the in-degrees.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.degree.sequence()} was renamed to \code{is_degseq()} to create a more
+\code{is.degree.sequence()} was renamed to \code{\link[=is_degseq]{is_degseq()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.directed.Rd
+++ b/man/is.directed.Rd
@@ -12,7 +12,7 @@ is.directed(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.directed()} was renamed to \code{is_directed()} to create a more
+\code{is.directed()} was renamed to \code{\link[=is_directed]{is_directed()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.graphical.degree.sequence.Rd
+++ b/man/is.graphical.degree.sequence.Rd
@@ -27,7 +27,7 @@ allowed.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.graphical.degree.sequence()} was renamed to \code{is_graphical()} to create a more
+\code{is.graphical.degree.sequence()} was renamed to \code{\link[=is_graphical]{is_graphical()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.hierarchical.Rd
+++ b/man/is.hierarchical.Rd
@@ -9,7 +9,7 @@ is.hierarchical(communities)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.hierarchical()} was renamed to \code{is_hierarchical()} to create a more
+\code{is.hierarchical()} was renamed to \code{\link[=is_hierarchical]{is_hierarchical()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.igraph.Rd
+++ b/man/is.igraph.Rd
@@ -12,7 +12,7 @@ is.igraph(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.igraph()} was renamed to \code{is_igraph()} to create a more
+\code{is.igraph()} was renamed to \code{\link[=is_igraph]{is_igraph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.loop.Rd
+++ b/man/is.loop.Rd
@@ -15,7 +15,7 @@ all edges in the graph.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.loop()} was renamed to \code{which_loop()} to create a more
+\code{is.loop()} was renamed to \code{\link[=which_loop]{which_loop()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.matching.Rd
+++ b/man/is.matching.Rd
@@ -20,7 +20,7 @@ are taken from the \sQuote{\code{type}} vertex attribute, if present.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.matching()} was renamed to \code{is_matching()} to create a more
+\code{is.matching()} was renamed to \code{\link[=is_matching]{is_matching()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.maximal.matching.Rd
+++ b/man/is.maximal.matching.Rd
@@ -20,7 +20,7 @@ are taken from the \sQuote{\code{type}} vertex attribute, if present.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.maximal.matching()} was renamed to \code{is_max_matching()} to create a more
+\code{is.maximal.matching()} was renamed to \code{\link[=is_max_matching]{is_max_matching()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.minimal.separator.Rd
+++ b/man/is.minimal.separator.Rd
@@ -16,7 +16,7 @@ separator.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.minimal.separator()} was renamed to \code{is_min_separator()} to create a more
+\code{is.minimal.separator()} was renamed to \code{\link[=is_min_separator]{is_min_separator()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.multiple.Rd
+++ b/man/is.multiple.Rd
@@ -15,7 +15,7 @@ all edges in the graph.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.multiple()} was renamed to \code{which_multiple()} to create a more
+\code{is.multiple()} was renamed to \code{\link[=which_multiple]{which_multiple()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.mutual.Rd
+++ b/man/is.mutual.Rd
@@ -17,7 +17,7 @@ includes all edges in the order of their ids.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.mutual()} was renamed to \code{which_mutual()} to create a more
+\code{is.mutual()} was renamed to \code{\link[=which_mutual]{which_mutual()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.named.Rd
+++ b/man/is.named.Rd
@@ -12,7 +12,7 @@ is.named(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.named()} was renamed to \code{is_named()} to create a more
+\code{is.named()} was renamed to \code{\link[=is_named]{is_named()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.separator.Rd
+++ b/man/is.separator.Rd
@@ -16,7 +16,7 @@ separator.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.separator()} was renamed to \code{is_separator()} to create a more
+\code{is.separator()} was renamed to \code{\link[=is_separator]{is_separator()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.simple.Rd
+++ b/man/is.simple.Rd
@@ -12,7 +12,7 @@ is.simple(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.simple()} was renamed to \code{is_simple()} to create a more
+\code{is.simple()} was renamed to \code{\link[=is_simple]{is_simple()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/is.weighted.Rd
+++ b/man/is.weighted.Rd
@@ -12,7 +12,7 @@ is.weighted(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{is.weighted()} was renamed to \code{is_weighted()} to create a more
+\code{is.weighted()} was renamed to \code{\link[=is_weighted]{is_weighted()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/k.regular.game.Rd
+++ b/man/k.regular.game.Rd
@@ -20,7 +20,7 @@ out-degree and in-degree in a directed graph.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{k.regular.game()} was renamed to \code{sample_k_regular()} to create a more
+\code{k.regular.game()} was renamed to \code{\link[=sample_k_regular]{sample_k_regular()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/label.propagation.community.Rd
+++ b/man/label.propagation.community.Rd
@@ -47,7 +47,7 @@ will be ignored. Also note that vertices without labels cannot be fixed.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{label.propagation.community()} was renamed to \code{cluster_label_prop()} to create a more
+\code{label.propagation.community()} was renamed to \code{\link[=cluster_label_prop]{cluster_label_prop()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/largest.cliques.Rd
+++ b/man/largest.cliques.Rd
@@ -12,7 +12,7 @@ largest.cliques(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{largest.cliques()} was renamed to \code{largest_cliques()} to create a more
+\code{largest.cliques()} was renamed to \code{\link[=largest_cliques]{largest_cliques()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/largest.independent.vertex.sets.Rd
+++ b/man/largest.independent.vertex.sets.Rd
@@ -12,7 +12,7 @@ largest.independent.vertex.sets(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{largest.independent.vertex.sets()} was renamed to \code{largest_ivs()} to create a more
+\code{largest.independent.vertex.sets()} was renamed to \code{\link[=largest_ivs]{largest_ivs()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/lastcit.game.Rd
+++ b/man/lastcit.game.Rd
@@ -28,7 +28,7 @@ probabilities for the different vertex types.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{lastcit.game()} was renamed to \code{sample_last_cit()} to create a more
+\code{lastcit.game()} was renamed to \code{\link[=sample_last_cit]{sample_last_cit()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.auto.Rd
+++ b/man/layout.auto.Rd
@@ -18,7 +18,7 @@ the real layout function. For \code{nicely()} all argument are passed to
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.auto()} was renamed to \code{layout_nicely()} to create a more
+\code{layout.auto()} was renamed to \code{\link[=layout_nicely]{layout_nicely()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.bipartite.Rd
+++ b/man/layout.bipartite.Rd
@@ -27,7 +27,7 @@ you have too many edge crossings, increase this.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.bipartite()} was renamed to \code{layout_as_bipartite()} to create a more
+\code{layout.bipartite()} was renamed to \code{\link[=layout_as_bipartite]{layout_as_bipartite()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.circle.Rd
+++ b/man/layout.circle.Rd
@@ -14,7 +14,7 @@ layout.circle(..., params = list())
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.circle()} was renamed to \code{layout_in_circle()} to create a more
+\code{layout.circle()} was renamed to \code{\link[=layout_in_circle]{layout_in_circle()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.davidson.harel.Rd
+++ b/man/layout.davidson.harel.Rd
@@ -49,7 +49,7 @@ the energy function.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.davidson.harel()} was renamed to \code{layout_with_dh()} to create a more
+\code{layout.davidson.harel()} was renamed to \code{\link[=layout_with_dh]{layout_with_dh()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.drl.Rd
+++ b/man/layout.drl.Rd
@@ -41,7 +41,7 @@ significantly longer to compute.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.drl()} was renamed to \code{layout_with_drl()} to create a more
+\code{layout.drl()} was renamed to \code{\link[=layout_with_drl]{layout_with_drl()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.fruchterman.reingold.Rd
+++ b/man/layout.fruchterman.reingold.Rd
@@ -14,7 +14,7 @@ layout.fruchterman.reingold(..., params = list())
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.fruchterman.reingold()} was renamed to \code{layout_with_fr()} to create a more
+\code{layout.fruchterman.reingold()} was renamed to \code{\link[=layout_with_fr]{layout_with_fr()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.gem.Rd
+++ b/man/layout.gem.Rd
@@ -38,7 +38,7 @@ default is the square root of the number of vertices.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.gem()} was renamed to \code{layout_with_gem()} to create a more
+\code{layout.gem()} was renamed to \code{\link[=layout_with_gem]{layout_with_gem()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.graphopt.Rd
+++ b/man/layout.graphopt.Rd
@@ -46,7 +46,7 @@ movement allowed in a single step along a single axis. The default value is
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.graphopt()} was renamed to \code{layout_with_graphopt()} to create a more
+\code{layout.graphopt()} was renamed to \code{\link[=layout_with_graphopt]{layout_with_graphopt()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.grid.Rd
+++ b/man/layout.grid.Rd
@@ -23,7 +23,7 @@ determinted automatically.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.grid()} was renamed to \code{layout_on_grid()} to create a more
+\code{layout.grid()} was renamed to \code{\link[=layout_on_grid]{layout_on_grid()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.kamada.kawai.Rd
+++ b/man/layout.kamada.kawai.Rd
@@ -14,7 +14,7 @@ layout.kamada.kawai(..., params = list())
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.kamada.kawai()} was renamed to \code{layout_with_kk()} to create a more
+\code{layout.kamada.kawai()} was renamed to \code{\link[=layout_with_kk]{layout_with_kk()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.lgl.Rd
+++ b/man/layout.lgl.Rd
@@ -14,7 +14,7 @@ layout.lgl(..., params = list())
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.lgl()} was renamed to \code{layout_with_lgl()} to create a more
+\code{layout.lgl()} was renamed to \code{\link[=layout_with_lgl]{layout_with_lgl()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.mds.Rd
+++ b/man/layout.mds.Rd
@@ -23,7 +23,7 @@ solving the eigenproblem}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.mds()} was renamed to \code{layout_with_mds()} to create a more
+\code{layout.mds()} was renamed to \code{\link[=layout_with_mds]{layout_with_mds()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.merge.Rd
+++ b/man/layout.merge.Rd
@@ -17,7 +17,7 @@ layout.merge(graphs, layouts, method = "dla")
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.merge()} was renamed to \code{merge_coords()} to create a more
+\code{layout.merge()} was renamed to \code{\link[=merge_coords]{merge_coords()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.norm.Rd
+++ b/man/layout.norm.Rd
@@ -30,7 +30,7 @@ are \code{NULL} then no normalization is performed along this direction.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.norm()} was renamed to \code{norm_coords()} to create a more
+\code{layout.norm()} was renamed to \code{\link[=norm_coords]{norm_coords()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.random.Rd
+++ b/man/layout.random.Rd
@@ -14,7 +14,7 @@ layout.random(..., params = list())
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.random()} was renamed to \code{layout_randomly()} to create a more
+\code{layout.random()} was renamed to \code{\link[=layout_randomly]{layout_randomly()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.reingold.tilford.Rd
+++ b/man/layout.reingold.tilford.Rd
@@ -14,7 +14,7 @@ layout.reingold.tilford(..., params = list())
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.reingold.tilford()} was renamed to \code{layout_as_tree()} to create a more
+\code{layout.reingold.tilford()} was renamed to \code{\link[=layout_as_tree]{layout_as_tree()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.sphere.Rd
+++ b/man/layout.sphere.Rd
@@ -14,7 +14,7 @@ layout.sphere(..., params = list())
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.sphere()} was renamed to \code{layout_on_sphere()} to create a more
+\code{layout.sphere()} was renamed to \code{\link[=layout_on_sphere]{layout_on_sphere()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.star.Rd
+++ b/man/layout.star.Rd
@@ -18,7 +18,7 @@ The default ordering is given by the vertex ids.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.star()} was renamed to \code{layout_as_star()} to create a more
+\code{layout.star()} was renamed to \code{\link[=layout_as_star]{layout_as_star()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/layout.sugiyama.Rd
+++ b/man/layout.sugiyama.Rd
@@ -46,7 +46,7 @@ them.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{layout.sugiyama()} was renamed to \code{layout_with_sugiyama()} to create a more
+\code{layout.sugiyama()} was renamed to \code{\link[=layout_with_sugiyama]{layout_with_sugiyama()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/leading.eigenvector.community.Rd
+++ b/man/leading.eigenvector.community.Rd
@@ -46,7 +46,7 @@ the modularity matrix. See details below.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{leading.eigenvector.community()} was renamed to \code{cluster_leading_eigen()} to create a more
+\code{leading.eigenvector.community()} was renamed to \code{\link[=cluster_leading_eigen]{cluster_leading_eigen()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/line.graph.Rd
+++ b/man/line.graph.Rd
@@ -12,7 +12,7 @@ line.graph(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{line.graph()} was renamed to \code{make_line_graph()} to create a more
+\code{line.graph()} was renamed to \code{\link[=make_line_graph]{make_line_graph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/list.edge.attributes.Rd
+++ b/man/list.edge.attributes.Rd
@@ -12,7 +12,7 @@ list.edge.attributes(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{list.edge.attributes()} was renamed to \code{edge_attr_names()} to create a more
+\code{list.edge.attributes()} was renamed to \code{\link[=edge_attr_names]{edge_attr_names()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/list.graph.attributes.Rd
+++ b/man/list.graph.attributes.Rd
@@ -12,7 +12,7 @@ list.graph.attributes(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{list.graph.attributes()} was renamed to \code{graph_attr_names()} to create a more
+\code{list.graph.attributes()} was renamed to \code{\link[=graph_attr_names]{graph_attr_names()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/list.vertex.attributes.Rd
+++ b/man/list.vertex.attributes.Rd
@@ -12,7 +12,7 @@ list.vertex.attributes(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{list.vertex.attributes()} was renamed to \code{vertex_attr_names()} to create a more
+\code{list.vertex.attributes()} was renamed to \code{\link[=vertex_attr_names]{vertex_attr_names()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/maxcohesion.Rd
+++ b/man/maxcohesion.Rd
@@ -9,7 +9,7 @@ maxcohesion(blocks)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{maxcohesion()} was renamed to \code{max_cohesion()} to create a more
+\code{maxcohesion()} was renamed to \code{\link[=max_cohesion]{max_cohesion()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/maximal.cliques.Rd
+++ b/man/maximal.cliques.Rd
@@ -30,7 +30,7 @@ whitespace.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{maximal.cliques()} was renamed to \code{max_cliques()} to create a more
+\code{maximal.cliques()} was renamed to \code{\link[=max_cliques]{max_cliques()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/maximal.cliques.count.Rd
+++ b/man/maximal.cliques.count.Rd
@@ -24,7 +24,7 @@ parallelize the finding of maximal cliques.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{maximal.cliques.count()} was renamed to \code{count_max_cliques()} to create a more
+\code{maximal.cliques.count()} was renamed to \code{\link[=count_max_cliques]{count_max_cliques()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/maximal.independent.vertex.sets.Rd
+++ b/man/maximal.independent.vertex.sets.Rd
@@ -12,7 +12,7 @@ maximal.independent.vertex.sets(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{maximal.independent.vertex.sets()} was renamed to \code{max_ivs()} to create a more
+\code{maximal.independent.vertex.sets()} was renamed to \code{\link[=max_ivs]{max_ivs()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/maximal_ivs.Rd
+++ b/man/maximal_ivs.Rd
@@ -12,7 +12,7 @@ maximal_ivs(graph)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{maximal_ivs()} was renamed to \code{max_ivs()} to create a more
+\code{maximal_ivs()} was renamed to \code{\link[=max_ivs]{max_ivs()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/maximum.bipartite.matching.Rd
+++ b/man/maximum.bipartite.matching.Rd
@@ -35,7 +35,7 @@ is ignored.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{maximum.bipartite.matching()} was renamed to \code{max_bipartite_match()} to create a more
+\code{maximum.bipartite.matching()} was renamed to \code{\link[=max_bipartite_match]{max_bipartite_match()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/maximum.cardinality.search.Rd
+++ b/man/maximum.cardinality.search.Rd
@@ -13,7 +13,7 @@ ignored, as the algorithm is defined for undirected graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{maximum.cardinality.search()} was renamed to \code{max_cardinality()} to create a more
+\code{maximum.cardinality.search()} was renamed to \code{\link[=max_cardinality]{max_cardinality()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/minimal.st.separators.Rd
+++ b/man/minimal.st.separators.Rd
@@ -13,7 +13,7 @@ ignored.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{minimal.st.separators()} was renamed to \code{min_st_separators()} to create a more
+\code{minimal.st.separators()} was renamed to \code{\link[=min_st_separators]{min_st_separators()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/minimum.size.separators.Rd
+++ b/man/minimum.size.separators.Rd
@@ -13,7 +13,7 @@ ignored.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{minimum.size.separators()} was renamed to \code{min_separators()} to create a more
+\code{minimum.size.separators()} was renamed to \code{\link[=min_separators]{min_separators()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/minimum.spanning.tree.Rd
+++ b/man/minimum.spanning.tree.Rd
@@ -26,7 +26,7 @@ algorithm is chosen, otherwise the unweighted algorithm is used.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{minimum.spanning.tree()} was renamed to \code{mst()} to create a more
+\code{minimum.spanning.tree()} was renamed to \code{\link[=mst]{mst()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/mod.matrix.Rd
+++ b/man/mod.matrix.Rd
@@ -21,7 +21,7 @@ modularity. Ignored for undirected graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{mod.matrix()} was renamed to \code{modularity_matrix()} to create a more
+\code{mod.matrix()} was renamed to \code{\link[=modularity_matrix]{modularity_matrix()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/multilevel.community.Rd
+++ b/man/multilevel.community.Rd
@@ -26,7 +26,7 @@ is set to 1.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{multilevel.community()} was renamed to \code{cluster_louvain()} to create a more
+\code{multilevel.community()} was renamed to \code{\link[=cluster_louvain]{cluster_louvain()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/neighborhood.size.Rd
+++ b/man/neighborhood.size.Rd
@@ -33,7 +33,7 @@ argument is ignored for undirected graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{neighborhood.size()} was renamed to \code{ego_size()} to create a more
+\code{neighborhood.size()} was renamed to \code{\link[=ego_size]{ego_size()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/no.clusters.Rd
+++ b/man/no.clusters.Rd
@@ -16,7 +16,7 @@ connected components to search. It is ignored for undirected graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{no.clusters()} was renamed to \code{count_components()} to create a more
+\code{no.clusters()} was renamed to \code{\link[=count_components]{count_components()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/optimal.community.Rd
+++ b/man/optimal.community.Rd
@@ -20,7 +20,7 @@ edge weight means a stronger connection for this function.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{optimal.community()} was renamed to \code{cluster_optimal()} to create a more
+\code{optimal.community()} was renamed to \code{\link[=cluster_optimal]{cluster_optimal()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/page.rank.Rd
+++ b/man/page.rank.Rd
@@ -57,7 +57,7 @@ implementation is used.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{page.rank()} was renamed to \code{page_rank()} to create a more
+\code{page.rank()} was renamed to \code{\link[=page_rank]{page_rank()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/path.length.hist.Rd
+++ b/man/path.length.hist.Rd
@@ -15,7 +15,7 @@ this argument is ignored for undirected graphs.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{path.length.hist()} was renamed to \code{distance_table()} to create a more
+\code{path.length.hist()} was renamed to \code{\link[=distance_table]{distance_table()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/permute.vertices.Rd
+++ b/man/permute.vertices.Rd
@@ -16,7 +16,7 @@ first element is the new id of vertex 1, etc. Every number between one and
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{permute.vertices()} was renamed to \code{permute()} to create a more
+\code{permute.vertices()} was renamed to \code{\link[=permute]{permute()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/piecewise.layout.Rd
+++ b/man/piecewise.layout.Rd
@@ -17,7 +17,7 @@ function.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{piecewise.layout()} was renamed to \code{layout_components()} to create a more
+\code{piecewise.layout()} was renamed to \code{\link[=layout_components]{layout_components()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/plotHierarchy.Rd
+++ b/man/plotHierarchy.Rd
@@ -21,7 +21,7 @@ them to \code{plot.igraph()}.  \code{\link[=print]{print()}} and \code{\link[=su
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{plotHierarchy()} was renamed to \code{plot_hierarchy()} to create a more
+\code{plotHierarchy()} was renamed to \code{\link[=plot_hierarchy]{plot_hierarchy()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/power.law.fit.Rd
+++ b/man/power.law.fit.Rd
@@ -46,7 +46,7 @@ implementation.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{power.law.fit()} was renamed to \code{fit_power_law()} to create a more
+\code{power.law.fit()} was renamed to \code{\link[=fit_power_law]{fit_power_law()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/preference.game.Rd
+++ b/man/preference.game.Rd
@@ -38,7 +38,7 @@ an undirected graph, it must be symmetric.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{preference.game()} was renamed to \code{sample_pref()} to create a more
+\code{preference.game()} was renamed to \code{\link[=sample_pref]{sample_pref()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/read.graph.Rd
+++ b/man/read.graph.Rd
@@ -27,7 +27,7 @@ insensitive.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{read.graph()} was renamed to \code{read_graph()} to create a more
+\code{read.graph()} was renamed to \code{\link[=read_graph]{read_graph()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/remove.edge.attribute.Rd
+++ b/man/remove.edge.attribute.Rd
@@ -14,7 +14,7 @@ remove.edge.attribute(graph, name)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{remove.edge.attribute()} was renamed to \code{delete_edge_attr()} to create a more
+\code{remove.edge.attribute()} was renamed to \code{\link[=delete_edge_attr]{delete_edge_attr()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/remove.graph.attribute.Rd
+++ b/man/remove.graph.attribute.Rd
@@ -14,7 +14,7 @@ remove.graph.attribute(graph, name)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{remove.graph.attribute()} was renamed to \code{delete_graph_attr()} to create a more
+\code{remove.graph.attribute()} was renamed to \code{\link[=delete_graph_attr]{delete_graph_attr()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/remove.vertex.attribute.Rd
+++ b/man/remove.vertex.attribute.Rd
@@ -14,7 +14,7 @@ remove.vertex.attribute(graph, name)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{remove.vertex.attribute()} was renamed to \code{delete_vertex_attr()} to create a more
+\code{remove.vertex.attribute()} was renamed to \code{\link[=delete_vertex_attr]{delete_vertex_attr()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/running.mean.Rd
+++ b/man/running.mean.Rd
@@ -15,7 +15,7 @@ i.e. smaller than the length of \code{v}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{running.mean()} was renamed to \code{running_mean()} to create a more
+\code{running.mean()} was renamed to \code{\link[=running_mean]{running_mean()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/sbm.game.Rd
+++ b/man/sbm.game.Rd
@@ -25,7 +25,7 @@ group. The sum of the vector must match the number of vertices.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{sbm.game()} was renamed to \code{sample_sbm()} to create a more
+\code{sbm.game()} was renamed to \code{\link[=sample_sbm]{sample_sbm()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/set.edge.attribute.Rd
+++ b/man/set.edge.attribute.Rd
@@ -21,7 +21,7 @@ If \code{NULL}, the input is returned unchanged.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{set.edge.attribute()} was renamed to \code{set_edge_attr()} to create a more
+\code{set.edge.attribute()} was renamed to \code{\link[=set_edge_attr]{set_edge_attr()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/set.graph.attribute.Rd
+++ b/man/set.graph.attribute.Rd
@@ -16,7 +16,7 @@ set.graph.attribute(graph, name, value)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{set.graph.attribute()} was renamed to \code{set_graph_attr()} to create a more
+\code{set.graph.attribute()} was renamed to \code{\link[=set_graph_attr]{set_graph_attr()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/set.vertex.attribute.Rd
+++ b/man/set.vertex.attribute.Rd
@@ -21,7 +21,7 @@ If \code{NULL}, the input is returned unchanged.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{set.vertex.attribute()} was renamed to \code{set_vertex_attr()} to create a more
+\code{set.vertex.attribute()} was renamed to \code{\link[=set_vertex_attr]{set_vertex_attr()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/shortest.paths.Rd
+++ b/man/shortest.paths.Rd
@@ -51,7 +51,7 @@ used, regardless of this argument.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{shortest.paths()} was renamed to \code{distances()} to create a more
+\code{shortest.paths()} was renamed to \code{\link[=distances]{distances()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/showtrace.Rd
+++ b/man/showtrace.Rd
@@ -9,7 +9,7 @@ showtrace(communities)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{showtrace()} was renamed to \code{show_trace()} to create a more
+\code{showtrace()} was renamed to \code{\link[=show_trace]{show_trace()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/spinglass.community.Rd
+++ b/man/spinglass.community.Rd
@@ -87,7 +87,7 @@ is ignored if the \sQuote{orig} implementation is chosen.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{spinglass.community()} was renamed to \code{cluster_spinglass()} to create a more
+\code{spinglass.community()} was renamed to \code{\link[=cluster_spinglass]{cluster_spinglass()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/stCuts.Rd
+++ b/man/stCuts.Rd
@@ -16,7 +16,7 @@ stCuts(graph, source, target)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{stCuts()} was renamed to \code{st_cuts()} to create a more
+\code{stCuts()} was renamed to \code{\link[=st_cuts]{st_cuts()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/stMincuts.Rd
+++ b/man/stMincuts.Rd
@@ -22,7 +22,7 @@ here.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{stMincuts()} was renamed to \code{st_min_cuts()} to create a more
+\code{stMincuts()} was renamed to \code{\link[=st_min_cuts]{st_min_cuts()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/static.fitness.game.Rd
+++ b/man/static.fitness.game.Rd
@@ -33,7 +33,7 @@ graph.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{static.fitness.game()} was renamed to \code{sample_fitness()} to create a more
+\code{static.fitness.game()} was renamed to \code{\link[=sample_fitness]{sample_fitness()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/static.power.law.game.Rd
+++ b/man/static.power.law.game.Rd
@@ -41,7 +41,7 @@ finite size correction of Cho et al., see references below.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{static.power.law.game()} was renamed to \code{sample_fitness_pl()} to create a more
+\code{static.power.law.game()} was renamed to \code{\link[=sample_fitness_pl]{sample_fitness_pl()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/subgraph.centrality.Rd
+++ b/man/subgraph.centrality.Rd
@@ -16,7 +16,7 @@ loops edges from the graph before the calculation.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{subgraph.centrality()} was renamed to \code{subgraph_centrality()} to create a more
+\code{subgraph.centrality()} was renamed to \code{\link[=subgraph_centrality]{subgraph_centrality()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/subgraph.edges.Rd
+++ b/man/subgraph.edges.Rd
@@ -17,7 +17,7 @@ not have any adjacent edges in \code{eids}.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{subgraph.edges()} was renamed to \code{subgraph_from_edges()} to create a more
+\code{subgraph.edges()} was renamed to \code{\link[=subgraph_from_edges]{subgraph_from_edges()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/tkplot.canvas.Rd
+++ b/man/tkplot.canvas.Rd
@@ -12,7 +12,7 @@ tkplot.canvas(tkp.id)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{tkplot.canvas()} was renamed to \code{tk_canvas()} to create a more
+\code{tkplot.canvas()} was renamed to \code{\link[=tk_canvas]{tk_canvas()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/tkplot.center.Rd
+++ b/man/tkplot.center.Rd
@@ -12,7 +12,7 @@ tkplot.center(tkp.id)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{tkplot.center()} was renamed to \code{tk_center()} to create a more
+\code{tkplot.center()} was renamed to \code{\link[=tk_center]{tk_center()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/tkplot.close.Rd
+++ b/man/tkplot.close.Rd
@@ -14,7 +14,7 @@ tkplot.close(tkp.id, window.close = TRUE)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{tkplot.close()} was renamed to \code{tk_close()} to create a more
+\code{tkplot.close()} was renamed to \code{\link[=tk_close]{tk_close()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/tkplot.export.postscript.Rd
+++ b/man/tkplot.export.postscript.Rd
@@ -12,7 +12,7 @@ tkplot.export.postscript(tkp.id)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{tkplot.export.postscript()} was renamed to \code{tk_postscript()} to create a more
+\code{tkplot.export.postscript()} was renamed to \code{\link[=tk_postscript]{tk_postscript()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/tkplot.fit.to.screen.Rd
+++ b/man/tkplot.fit.to.screen.Rd
@@ -16,7 +16,7 @@ tkplot.fit.to.screen(tkp.id, width = NULL, height = NULL)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{tkplot.fit.to.screen()} was renamed to \code{tk_fit()} to create a more
+\code{tkplot.fit.to.screen()} was renamed to \code{\link[=tk_fit]{tk_fit()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/tkplot.getcoords.Rd
+++ b/man/tkplot.getcoords.Rd
@@ -14,7 +14,7 @@ tkplot.getcoords(tkp.id, norm = FALSE)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{tkplot.getcoords()} was renamed to \code{tk_coords()} to create a more
+\code{tkplot.getcoords()} was renamed to \code{\link[=tk_coords]{tk_coords()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/tkplot.off.Rd
+++ b/man/tkplot.off.Rd
@@ -9,7 +9,7 @@ tkplot.off()
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{tkplot.off()} was renamed to \code{tk_off()} to create a more
+\code{tkplot.off()} was renamed to \code{\link[=tk_off]{tk_off()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/tkplot.reshape.Rd
+++ b/man/tkplot.reshape.Rd
@@ -19,7 +19,7 @@ the complete list.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{tkplot.reshape()} was renamed to \code{tk_reshape()} to create a more
+\code{tkplot.reshape()} was renamed to \code{\link[=tk_reshape]{tk_reshape()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/tkplot.rotate.Rd
+++ b/man/tkplot.rotate.Rd
@@ -16,7 +16,7 @@ tkplot.rotate(tkp.id, degree = NULL, rad = NULL)
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{tkplot.rotate()} was renamed to \code{tk_rotate()} to create a more
+\code{tkplot.rotate()} was renamed to \code{\link[=tk_rotate]{tk_rotate()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/tkplot.setcoords.Rd
+++ b/man/tkplot.setcoords.Rd
@@ -15,7 +15,7 @@ vertices, in absolute coordinates.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{tkplot.setcoords()} was renamed to \code{tk_set_coords()} to create a more
+\code{tkplot.setcoords()} was renamed to \code{\link[=tk_set_coords]{tk_set_coords()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/topological.sort.Rd
+++ b/man/topological.sort.Rd
@@ -18,7 +18,7 @@ nodes from which it receives edges. Nodes with no outgoing edges go first.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{topological.sort()} was renamed to \code{topo_sort()} to create a more
+\code{topological.sort()} was renamed to \code{\link[=topo_sort]{topo_sort()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/triad.census.Rd
+++ b/man/triad.census.Rd
@@ -13,7 +13,7 @@ results a warning, and undefined results.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{triad.census()} was renamed to \code{triad_census()} to create a more
+\code{triad.census()} was renamed to \code{\link[=triad_census]{triad_census()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/unfold.tree.Rd
+++ b/man/unfold.tree.Rd
@@ -20,7 +20,7 @@ search is performed. Typically it contains one vertex per component.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{unfold.tree()} was renamed to \code{unfold_tree()} to create a more
+\code{unfold.tree()} was renamed to \code{\link[=unfold_tree]{unfold_tree()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/vertex.connectivity.Rd
+++ b/man/vertex.connectivity.Rd
@@ -24,7 +24,7 @@ thanks Peter.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{vertex.connectivity()} was renamed to \code{vertex_connectivity()} to create a more
+\code{vertex.connectivity()} was renamed to \code{\link[=vertex_connectivity]{vertex_connectivity()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/vertex.disjoint.paths.Rd
+++ b/man/vertex.disjoint.paths.Rd
@@ -16,7 +16,7 @@ can be \code{NULL}, see details below.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{vertex.disjoint.paths()} was renamed to \code{vertex_disjoint_paths()} to create a more
+\code{vertex.disjoint.paths()} was renamed to \code{\link[=vertex_disjoint_paths]{vertex_disjoint_paths()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/vertex.shapes.Rd
+++ b/man/vertex.shapes.Rd
@@ -14,7 +14,7 @@ vertex shapes are returned.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{vertex.shapes()} was renamed to \code{shapes()} to create a more
+\code{vertex.shapes()} was renamed to \code{\link[=shapes]{shapes()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/walktrap.community.Rd
+++ b/man/walktrap.community.Rd
@@ -41,7 +41,7 @@ for the split corresponding to the highest modularity value.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{walktrap.community()} was renamed to \code{cluster_walktrap()} to create a more
+\code{walktrap.community()} was renamed to \code{\link[=cluster_walktrap]{cluster_walktrap()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/watts.strogatz.game.Rd
+++ b/man/watts.strogatz.game.Rd
@@ -25,7 +25,7 @@ generated graph.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{watts.strogatz.game()} was renamed to \code{sample_smallworld()} to create a more
+\code{watts.strogatz.game()} was renamed to \code{\link[=sample_smallworld]{sample_smallworld()}} to create a more
 consistent API.
 }
 \keyword{internal}

--- a/man/weighted_cliques.Rd
+++ b/man/weighted_cliques.Rd
@@ -34,7 +34,7 @@ or only the maximal ones (\code{TRUE}).}
 \value{
 \code{weighted_cliques()} and \code{largest_weighted_cliques()} return a
 list containing numeric vectors of vertex IDs. Each list element is a weighted
-clique, i.e. a vertex sequence of class \code{\link[=V]{igraph.vs()}}.
+clique, i.e. a vertex sequence of class \link[=V]{igraph.vs}.
 
 \code{weighted_clique_num()} returns an integer scalar.
 }

--- a/man/write.graph.Rd
+++ b/man/write.graph.Rd
@@ -28,7 +28,7 @@ this argument is case insensitive.}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-\code{write.graph()} was renamed to \code{write_graph()} to create a more
+\code{write.graph()} was renamed to \code{\link[=write_graph]{write_graph()}} to create a more
 consistent API.
 }
 \keyword{internal}


### PR DESCRIPTION
This is a simple find-and-replace job to actually link to replacements of deprecated functions instead of simply mentioning them.

Is there a reason it wasn't done this way? Perhaps it is not standard in the R world?

Do we want ``[`some_fun()`]`` (inline code) or simply ``[some_fun()]`` (not in code style)? I see both styles used at the moment.

I am hoping this encourages people to upgrade to the non-deprecated alternative more quickly. I still see tutorials published with the old names ...

The search pattern was:

```
was renamed to (`.+?`)
```