### PR TITLE
docs: clarify that `girth()` returns `Inf` for acyclic graphs

### DIFF
--- a/R/structural-properties.R
+++ b/R/structural-properties.R
@@ -1937,7 +1937,7 @@ feedback_vertex_set <- feedback_vertex_set_impl
 #'   for undirected circles anyway.
 #' @param circle Logical scalar, whether to return the shortest circle itself.
 #' @return A named list with two components: \item{girth}{Integer constant, the
-#'   girth of the graph, or 0 if the graph is acyclic.} \item{circle}{Numeric
+#'   girth of the graph, or `Inf` if the graph is acyclic.} \item{circle}{Numeric
 #'   vector with the vertex ids in the shortest circle.}
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
 #' @references Alon Itai and Michael Rodeh: Finding a minimum circuit in a

--- a/man/girth.Rd
+++ b/man/girth.Rd
@@ -14,7 +14,7 @@ for undirected circles anyway.}
 }
 \value{
 A named list with two components: \item{girth}{Integer constant, the
-girth of the graph, or 0 if the graph is acyclic.} \item{circle}{Numeric
+girth of the graph, or \code{Inf} if the graph is acyclic.} \item{circle}{Numeric
 vector with the vertex ids in the shortest circle.}
 }
 \description{


### PR DESCRIPTION
<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->

<!-- The following text must be left intact and the box checked before the PR can be merged. -->

It appears that when the output for `girth` of acyclic graphs was updated to be `Inf` instead of 0 (cf. https://github.com/igraph/rigraph/commit/c9aef98e880e61881fe2a5a8dd6903e5b03d271b), this part of the documentation was not changed.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.
