### PR TITLE
test: don't `library(Matrix)` in tests

### DIFF
--- a/tests/testthat/test-structural-properties.R
+++ b/tests/testthat/test-structural-properties.R
@@ -753,7 +753,6 @@ test_that("coreness() works", {
 
 test_that("laplacian_matrix() works", {
   skip_if_not_installed("Matrix")
-  library("Matrix")
   mat <- rbind(
     c(116, 210, 200),
     c(210, 386, 380),


### PR DESCRIPTION
<!-- The following text must be left intact and the box checked before the PR can be merged. -->

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

`library()` has some pretty "strong" side-effects, better to avoid it. I don't think it's needed anyway -- `skip_if_not_installed()` will do `requireNamespace()` which will have the more "minor" side-effect of loading {Matrix} namespace.