### PR TITLE
feat: implement read/write graphs from/to string

### DIFF
--- a/R/foreign.R
+++ b/R/foreign.R
@@ -174,7 +174,7 @@ write.graph.fromraw <- function(buffer, file) {
 #' @aliases LGL Pajek GraphML GML DL UCINET
 #' @param file The connection to read from. This can be a local file, or a
 #'   `http` or `ftp` connection. It can also be a character string with
-#'   the file name or URI.
+#'   the file name or URI or contain the graph in a single string.
 #' @param format Character constant giving the file format. Right now
 #'   `edgelist`, `pajek`, `ncol`, `lgl`, `graphml`,
 #'   `dimacs`, `graphdb`, `gml` and `dl` are supported,
@@ -362,7 +362,7 @@ read_graph <- function(
 #'
 #' @param graph The graph to export.
 #' @param file A connection or a string giving the file name to write the graph
-#'   to.
+#'   to. If file is `""`, `stdout()` or `"-"`, then the output is written directly to the terminal.
 #' @param format Character string giving the file format. Right now
 #'   `pajek`, `graphml`, `dot`, `gml`, `edgelist`,
 #'   `lgl`, `ncol`, `leda` and `dimacs` are implemented. As of igraph 0.4

--- a/R/foreign.R
+++ b/R/foreign.R
@@ -527,8 +527,8 @@ write_graph <- function(
 
     if (to_stdout) {
       raw_connection <- rawConnection(buffer)
+      on.exit(close(raw_connection))
       cat(readLines(raw_connection), sep = "\n")
-      close(raw_connection)
     } else {
       write.graph.fromraw(buffer, origfile)
     }

--- a/man/read.graph.Rd
+++ b/man/read.graph.Rd
@@ -14,7 +14,7 @@ read.graph(
 \arguments{
 \item{file}{The connection to read from. This can be a local file, or a
 \code{http} or \code{ftp} connection. It can also be a character string with
-the file name or URI.}
+the file name or URI or contain the graph in a single string.}
 
 \item{format}{Character constant giving the file format. Right now
 \code{edgelist}, \code{pajek}, \code{ncol}, \code{lgl}, \code{graphml},

--- a/man/read_graph.Rd
+++ b/man/read_graph.Rd
@@ -20,7 +20,7 @@ read_graph(
 \arguments{
 \item{file}{The connection to read from. This can be a local file, or a
 \code{http} or \code{ftp} connection. It can also be a character string with
-the file name or URI.}
+the file name or URI or contain the graph in a single string.}
 
 \item{format}{Character constant giving the file format. Right now
 \code{edgelist}, \code{pajek}, \code{ncol}, \code{lgl}, \code{graphml},

--- a/man/write.graph.Rd
+++ b/man/write.graph.Rd
@@ -16,7 +16,7 @@ write.graph(
 \item{graph}{The graph to export.}
 
 \item{file}{A connection or a string giving the file name to write the graph
-to.}
+to. If file is \code{""}, \code{stdout()} or \code{"-"}, then the output is written directly to the terminal.}
 
 \item{format}{Character string giving the file format. Right now
 \code{pajek}, \code{graphml}, \code{dot}, \code{gml}, \code{edgelist},

--- a/man/write_graph.Rd
+++ b/man/write_graph.Rd
@@ -16,7 +16,7 @@ write_graph(
 \item{graph}{The graph to export.}
 
 \item{file}{A connection or a string giving the file name to write the graph
-to.}
+to. If file is \code{""}, \code{stdout()} or \code{"-"}, then the output is written directly to the terminal.}
 
 \item{format}{Character string giving the file format. Right now
 \code{pajek}, \code{graphml}, \code{dot}, \code{gml}, \code{edgelist},

--- a/tests/testthat/_snaps/foreign.md
+++ b/tests/testthat/_snaps/foreign.md
@@ -73,3 +73,64 @@
       ! not_existing is not a valid graph type.
       i Must be one of r001, r005, r01, r02, m2D, m2Dr2, m2Dr4, m2Dr6, m3D, m3Dr2, m3Dr4, m3Dr6, m4D, m4Dr2, m4Dr4, m4Dr6, b03, b03m, ..., b09, and b09m.
 
+# read/write from/to string works
+
+    Code
+      write_graph(g, file = "", format = "graphml")
+    Output
+      <?xml version="1.0" encoding="UTF-8"?>
+      <graphml xmlns="http://graphml.graphdrawing.org/xmlns"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
+               http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+      <!-- Created by igraph -->
+        <key id="g_name" for="graph" attr.name="name" attr.type="string"/>
+        <key id="g_mutual" for="graph" attr.name="mutual" attr.type="boolean"/>
+        <key id="g_circular" for="graph" attr.name="circular" attr.type="boolean"/>
+        <graph id="G" edgedefault="undirected">
+          <data key="g_name">Ring graph</data>
+          <data key="g_mutual">false</data>
+          <data key="g_circular">true</data>
+          <node id="n0">
+          </node>
+          <node id="n1">
+          </node>
+          <node id="n2">
+          </node>
+          <node id="n3">
+          </node>
+          <node id="n4">
+          </node>
+          <node id="n5">
+          </node>
+          <node id="n6">
+          </node>
+          <node id="n7">
+          </node>
+          <node id="n8">
+          </node>
+          <node id="n9">
+          </node>
+          <edge source="n0" target="n1">
+          </edge>
+          <edge source="n1" target="n2">
+          </edge>
+          <edge source="n2" target="n3">
+          </edge>
+          <edge source="n3" target="n4">
+          </edge>
+          <edge source="n4" target="n5">
+          </edge>
+          <edge source="n5" target="n6">
+          </edge>
+          <edge source="n6" target="n7">
+          </edge>
+          <edge source="n7" target="n8">
+          </edge>
+          <edge source="n8" target="n9">
+          </edge>
+          <edge source="n0" target="n9">
+          </edge>
+        </graph>
+      </graphml>
+

--- a/tests/testthat/test-foreign.R
+++ b/tests/testthat/test-foreign.R
@@ -76,3 +76,12 @@ test_that("graph_from_graphdb works", {
     error = TRUE
   )
 })
+
+test_that("read/write from/to string works", {
+  g <- make_ring(10)
+
+  expect_snapshot(write_graph(g, file = "", format = "graphml"))
+  str <- r"---(0 1 1 2 2 3 3 4 4 5 5 6 6 7 7 8 8 9 0 9)---"
+  g2 <- read_graph(str, format = "edgelist", directed = FALSE)
+  expect_isomorphic(g, g2)
+})


### PR DESCRIPTION
Fix #543 

``` r
devtools::load_all("~/git/R_packages/rigraph")
#> ℹ Loading igraph
g <- make_ring(10)
write_graph(g, file = "", format = "graphml")
#> <?xml version="1.0" encoding="UTF-8"?>
#> <graphml xmlns="http://graphml.graphdrawing.org/xmlns"
#>          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
#>          xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
#>          http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
#> <!-- Created by igraph -->
#>   <key id="g_name" for="graph" attr.name="name" attr.type="string"/>
#>   <key id="g_mutual" for="graph" attr.name="mutual" attr.type="boolean"/>
#>   <key id="g_circular" for="graph" attr.name="circular" attr.type="boolean"/>
#>   <graph id="G" edgedefault="undirected">
#>     <data key="g_name">Ring graph</data>
#>     <data key="g_mutual">false</data>
#>     <data key="g_circular">true</data>
#>     <node id="n0">
#>     </node>
#>     <node id="n1">
#>     </node>
#>     <node id="n2">
#>     </node>
#>     <node id="n3">
#>     </node>
#>     <node id="n4">
#>     </node>
#>     <node id="n5">
#>     </node>
#>     <node id="n6">
#>     </node>
#>     <node id="n7">
#>     </node>
#>     <node id="n8">
#>     </node>
#>     <node id="n9">
#>     </node>
#>     <edge source="n0" target="n1">
#>     </edge>
#>     <edge source="n1" target="n2">
#>     </edge>
#>     <edge source="n2" target="n3">
#>     </edge>
#>     <edge source="n3" target="n4">
#>     </edge>
#>     <edge source="n4" target="n5">
#>     </edge>
#>     <edge source="n5" target="n6">
#>     </edge>
#>     <edge source="n6" target="n7">
#>     </edge>
#>     <edge source="n7" target="n8">
#>     </edge>
#>     <edge source="n8" target="n9">
#>     </edge>
#>     <edge source="n0" target="n9">
#>     </edge>
#>   </graph>
#> </graphml>


s1 <- r"---(<?xml version="1.0" encoding="UTF-8"?>
<graphml xmlns="http://graphml.graphdrawing.org/xmlns"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns
         http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
<!-- Created by igraph -->
  <key id="g_name" for="graph" attr.name="name" attr.type="string"/>
  <key id="g_mode" for="graph" attr.name="mode" attr.type="string"/>
  <key id="g_center" for="graph" attr.name="center" attr.type="double"/>
  <graph id="G" edgedefault="directed">
    <data key="g_name">In-star</data>
    <data key="g_mode">in</data>
    <data key="g_center">1</data>
    <node id="n0">
    </node>
    <node id="n1">
    </node>
    <edge source="n1" target="n0">
    </edge>
  </graph>
</graphml>
)---"
g1 <- read_graph(s1, format = "graphml")
g1
#> IGRAPH c88e052 D--- 2 1 -- In-star
#> + attr: name (g/c), mode (g/c), center (g/n), id (v/c)
#> + edge from c88e052:
#> [1] 2->1

g <- make_ring(10)
s1 <- r"---(0 1 1 2 2 3 3 4 4 5 5 6 6 7 7 8 8 9 0 9)---"
g1 <- read_graph(s1, format = "edgelist", directed = FALSE)
isomorphic(g, g1)
#> [1] TRUE
```

<sup>Created on 2025-07-09 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

cc @ntamas @szhorvat @clpippel since you all were discussing this. I hope I understood the issue correctly and the implemented solution makes sense