### PR TITLE
chore: autogenerate `igraph_diameter()`

### DIFF
--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -828,6 +828,19 @@ are_adjacent_impl <- function(graph, v1, v2) {
   res
 }
 
+diameter_impl <- function(graph, directed=TRUE, unconnected=TRUE) {
+  # Argument checks
+  ensure_igraph(graph)
+  directed <- as.logical(directed)
+  unconnected <- as.logical(unconnected)
+
+  on.exit( .Call(R_igraph_finalizer) )
+  # Function call
+  res <- .Call(R_igraph_diameter, graph, directed, unconnected)
+
+  res
+}
+
 closeness_impl <- function(graph, vids=V(graph), mode=c("out", "in", "all", "total"), weights=NULL, normalized=FALSE) {
   # Argument checks
   ensure_igraph(graph)

--- a/src/rinterface.c
+++ b/src/rinterface.c
@@ -2058,6 +2058,73 @@ SEXP R_igraph_are_adjacent(SEXP graph, SEXP v1, SEXP v2) {
 }
 
 /*-------------------------------------------/
+/ igraph_diameter                            /
+/-------------------------------------------*/
+SEXP R_igraph_diameter(SEXP graph, SEXP directed, SEXP unconnected) {
+                                        /* Declarations */
+  igraph_t c_graph;
+  igraph_real_t c_res;
+  igraph_integer_t c_from;
+  igraph_integer_t c_to;
+  igraph_vector_int_t c_vertex_path;
+  igraph_vector_int_t c_edge_path;
+  igraph_bool_t c_directed;
+  igraph_bool_t c_unconnected;
+  SEXP res;
+  SEXP from;
+  SEXP to;
+  SEXP vertex_path;
+  SEXP edge_path;
+
+  SEXP r_result, r_names;
+                                        /* Convert input */
+  R_SEXP_to_igraph(graph, &c_graph);
+  c_from=0;
+  c_to=0;
+  IGRAPH_R_CHECK(igraph_vector_int_init(&c_vertex_path, 0));
+  IGRAPH_FINALLY(igraph_vector_int_destroy, &c_vertex_path);
+  IGRAPH_R_CHECK(igraph_vector_int_init(&c_edge_path, 0));
+  IGRAPH_FINALLY(igraph_vector_int_destroy, &c_edge_path);
+  IGRAPH_R_CHECK_BOOL(directed);
+  c_directed = LOGICAL(directed)[0];
+  IGRAPH_R_CHECK_BOOL(unconnected);
+  c_unconnected = LOGICAL(unconnected)[0];
+                                        /* Call igraph */
+  IGRAPH_R_CHECK(igraph_diameter(&c_graph, &c_res, &c_from, &c_to, &c_vertex_path, &c_edge_path, c_directed, c_unconnected));
+
+                                        /* Convert output */
+  PROTECT(r_result=NEW_LIST(5));
+  PROTECT(r_names=NEW_CHARACTER(5));
+  PROTECT(res=NEW_NUMERIC(1));
+  REAL(res)[0]=c_res;
+  PROTECT(from=NEW_NUMERIC(1));
+  REAL(from)[0]=(double) c_from;
+  PROTECT(to=NEW_NUMERIC(1));
+  REAL(to)[0]=(double) c_to;
+  PROTECT(vertex_path=R_igraph_vector_int_to_SEXP(&c_vertex_path));
+  igraph_vector_int_destroy(&c_vertex_path);
+  IGRAPH_FINALLY_CLEAN(1);
+  PROTECT(edge_path=R_igraph_vector_int_to_SEXP(&c_edge_path));
+  igraph_vector_int_destroy(&c_edge_path);
+  IGRAPH_FINALLY_CLEAN(1);
+  SET_VECTOR_ELT(r_result, 0, res);
+  SET_VECTOR_ELT(r_result, 1, from);
+  SET_VECTOR_ELT(r_result, 2, to);
+  SET_VECTOR_ELT(r_result, 3, vertex_path);
+  SET_VECTOR_ELT(r_result, 4, edge_path);
+  SET_STRING_ELT(r_names, 0, Rf_mkChar("res"));
+  SET_STRING_ELT(r_names, 1, Rf_mkChar("from"));
+  SET_STRING_ELT(r_names, 2, Rf_mkChar("to"));
+  SET_STRING_ELT(r_names, 3, Rf_mkChar("vertex_path"));
+  SET_STRING_ELT(r_names, 4, Rf_mkChar("edge_path"));
+  SET_NAMES(r_result, r_names);
+  UNPROTECT(6);
+
+  UNPROTECT(1);
+  return(r_result);
+}
+
+/*-------------------------------------------/
 / igraph_closeness                           /
 /-------------------------------------------*/
 SEXP R_igraph_closeness(SEXP graph, SEXP vids, SEXP mode, SEXP weights, SEXP normalized) {

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -4013,29 +4013,6 @@ SEXP R_igraph_degree(SEXP graph, SEXP vids, SEXP pmode, SEXP ploops) {
   return result;
 }
 
-SEXP R_igraph_diameter(SEXP graph, SEXP pdirected, SEXP punconnected,
-                       SEXP pweights) {
-
-  igraph_t g;
-  igraph_bool_t directed=LOGICAL(pdirected)[0];
-  igraph_bool_t unconnected=LOGICAL(punconnected)[0];
-  igraph_vector_t weights;
-  igraph_real_t res;
-  SEXP result;
-
-  R_SEXP_to_igraph(graph, &g);
-  if (!Rf_isNull(pweights)) {
-    R_SEXP_to_vector(pweights, &weights);
-  }
-  IGRAPH_R_CHECK(igraph_diameter_dijkstra(&g, Rf_isNull(pweights) ? 0 : &weights, &res, 0, 0, 0, 0, directed, unconnected));
-
-  PROTECT(result=NEW_NUMERIC(1));
-  REAL(result)[0]=res;
-
-  UNPROTECT(1);
-  return result;
-}
-
 SEXP R_igraph_get_diameter(SEXP graph, SEXP pdirected, SEXP punconnected,
                            SEXP pweights) {
 

--- a/tools/stimulus/functions-R.yaml
+++ b/tools/stimulus/functions-R.yaml
@@ -245,7 +245,6 @@ igraph_are_connected:
 #######################################
 
 igraph_diameter:
-    IGNORE: RR, RC, RInit
 
 igraph_diameter_dijkstra:
     IGNORE: RR, RC, RInit


### PR DESCRIPTION
@szhorvat I don't understand why the autogenerated version doesn't have the `weights` argument that the non autogenerated version had. Was the R version different from the C version?

I know there are changes related to this in the develop branch of the C library but I was hoping to start the autogeneration for main.