### PR TITLE
chore: account for changes in weighted eccentricity+radius

### DIFF
--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -821,6 +821,14 @@ are_adjacent_impl <- function(graph, v1, v2) {
 diameter_impl <- function(graph, weights=NULL, directed=TRUE, unconnected=TRUE) {
   # Argument checks
   ensure_igraph(graph)
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+    weights <- E(graph)$weight
+  }
+  if (!is.null(weights) && any(!is.na(weights))) {
+    weights <- as.numeric(weights)
+  } else {
+    weights <- NULL
+  }
   directed <- as.logical(directed)
   unconnected <- as.logical(unconnected)
 
@@ -2278,6 +2286,14 @@ graph_center_impl <- function(graph, weights=NULL, mode=c("all", "out", "in", "t
 radius_impl <- function(graph, weights=NULL, mode=c("all", "out", "in", "total")) {
   # Argument checks
   ensure_igraph(graph)
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+    weights <- E(graph)$weight
+  }
+  if (!is.null(weights) && any(!is.na(weights))) {
+    weights <- as.numeric(weights)
+  } else {
+    weights <- NULL
+  }
   mode <- switch(igraph.match.arg(mode), "out"=1L, "in"=2L, "all"=3L, "total"=3L)
 
   on.exit( .Call(R_igraph_finalizer) )
@@ -2290,8 +2306,8 @@ radius_impl <- function(graph, weights=NULL, mode=c("all", "out", "in", "total")
 pseudo_diameter_impl <- function(graph, weights=NULL, start.vid, directed=TRUE, unconnected=TRUE) {
   # Argument checks
   ensure_igraph(graph)
-  if (is.null(weights) && "weight" %in% edge_attr_names(%I1%)) {
-    weights <- E(%I1%)$weight
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+    weights <- E(graph)$weight
   }
   if (!is.null(weights) && any(!is.na(weights))) {
     weights <- as.numeric(weights)
@@ -3040,8 +3056,8 @@ layout_drl_impl <- function(graph, res, use.seed=FALSE, options=drl_defaults$def
   res[] <- as.numeric(res)
   use.seed <- as.logical(use.seed)
   options <- modify_list(drl_defaults$default, options)
-  if (is.null(weights) && "weight" %in% edge_attr_names(%I1%)) {
-    weights <- E(%I1%)$weight
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+    weights <- E(graph)$weight
   }
   if (!is.null(weights) && any(!is.na(weights))) {
     weights <- as.numeric(weights)
@@ -3062,8 +3078,8 @@ layout_drl_3d_impl <- function(graph, res, use.seed=FALSE, options=drl_defaults$
   res[] <- as.numeric(res)
   use.seed <- as.logical(use.seed)
   options <- modify_list(drl_defaults$default, options)
-  if (is.null(weights) && "weight" %in% edge_attr_names(%I1%)) {
-    weights <- E(%I1%)$weight
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+    weights <- E(graph)$weight
   }
   if (!is.null(weights) && any(!is.na(weights))) {
     weights <- as.numeric(weights)

--- a/R/aaa-auto.R
+++ b/R/aaa-auto.R
@@ -2275,6 +2275,18 @@ graph_center_impl <- function(graph, weights=NULL, mode=c("all", "out", "in", "t
   res
 }
 
+radius_impl <- function(graph, weights=NULL, mode=c("all", "out", "in", "total")) {
+  # Argument checks
+  ensure_igraph(graph)
+  mode <- switch(igraph.match.arg(mode), "out"=1L, "in"=2L, "all"=3L, "total"=3L)
+
+  on.exit( .Call(R_igraph_finalizer) )
+  # Function call
+  res <- .Call(R_igraph_radius, graph, weights, mode)
+
+  res
+}
+
 pseudo_diameter_impl <- function(graph, weights=NULL, start.vid, directed=TRUE, unconnected=TRUE) {
   # Argument checks
   ensure_igraph(graph)

--- a/R/paths.R
+++ b/R/paths.R
@@ -293,10 +293,6 @@ eccentricity <- function(
     }
   }
 
-  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
-    weights <- as.numeric(E(graph)$weight)
-  }
-
   eccentricity_impl(graph, vids = vids, weights = weights, mode = mode)
 }
 
@@ -349,10 +345,6 @@ radius <- function(
     if (missing(mode) && length(dots) > 0) {
       mode <- dots[[1]]
     }
-  }
-
-  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
-    weights <- as.numeric(E(graph)$weight)
   }
 
   radius_impl(graph, weights = weights, mode = mode)

--- a/R/paths.R
+++ b/R/paths.R
@@ -293,7 +293,11 @@ eccentricity <- function(
     }
   }
 
-  eccentricity_dijkstra_impl(graph, vids = vids, weights = weights, mode = mode)
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+    weights <- as.numeric(E(graph)$weight)
+  }
+
+  eccentricity_impl(graph, vids = vids, weights = weights, mode = mode)
 }
 
 
@@ -347,7 +351,11 @@ radius <- function(
     }
   }
 
-  radius_dijkstra_impl(graph, weights = weights, mode = mode)
+  if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
+    weights <- as.numeric(E(graph)$weight)
+  }
+
+  radius_impl(graph, weights = weights, mode = mode)
 }
 
 #' Central vertices of a graph

--- a/src/rinterface.c
+++ b/src/rinterface.c
@@ -5531,6 +5531,38 @@ SEXP R_igraph_graph_center(SEXP graph, SEXP weights, SEXP mode) {
 }
 
 /*-------------------------------------------/
+/ igraph_radius                              /
+/-------------------------------------------*/
+SEXP R_igraph_radius(SEXP graph, SEXP weights, SEXP mode) {
+                                        /* Declarations */
+  igraph_t c_graph;
+  igraph_vector_t c_weights;
+  igraph_real_t c_radius;
+  igraph_neimode_t c_mode;
+  SEXP radius;
+
+  SEXP r_result;
+                                        /* Convert input */
+  R_SEXP_to_igraph(graph, &c_graph);
+  if (!Rf_isNull(weights)) {
+    R_SEXP_to_vector(weights, &c_weights);
+  }
+  c_mode = (igraph_neimode_t) Rf_asInteger(mode);
+                                        /* Call igraph */
+  GetRNGstate();
+  IGRAPH_R_CHECK(igraph_radius(&c_graph, (Rf_isNull(weights) ? NULL : &c_weights), &c_radius, c_mode));
+  PutRNGstate();
+
+                                        /* Convert output */
+  PROTECT(radius=NEW_NUMERIC(1));
+  REAL(radius)[0]=c_radius;
+  r_result = radius;
+
+  UNPROTECT(1);
+  return(r_result);
+}
+
+/*-------------------------------------------/
 / igraph_pseudo_diameter                     /
 /-------------------------------------------*/
 SEXP R_igraph_pseudo_diameter(SEXP graph, SEXP weights, SEXP start_vid, SEXP directed, SEXP unconnected) {

--- a/src/vendor/cigraph/interfaces/functions.yaml
+++ b/src/vendor/cigraph/interfaces/functions.yaml
@@ -1510,11 +1510,13 @@ igraph_layout_drl:
     PARAMS: |-
         GRAPH graph, INOUT MATRIX res, BOOLEAN use_seed=False,
         DRL_OPTIONS options=drl_defaults$default, OPTIONAL EDGE_WEIGHTS weights
+    DEPS: weights ON graph
 
 igraph_layout_drl_3d:
     PARAMS: |-
         GRAPH graph, INOUT MATRIX res, BOOLEAN use_seed=False,
         DRL_OPTIONS options=drl_defaults$default, OPTIONAL EDGE_WEIGHTS weights
+    DEPS: weights ON graph
 
 igraph_layout_merge_dla:
     PARAMS: GRAPH_PTR_LIST graphs, MATRIX_LIST coords, OUT MATRIX res

--- a/tools/stimulus/functions-R.yaml
+++ b/tools/stimulus/functions-R.yaml
@@ -246,8 +246,6 @@ igraph_are_connected:
 # Structural properties
 #######################################
 
-igraph_diameter:
-
 igraph_distances:
     IGNORE: RR, RC
 
@@ -449,7 +447,7 @@ igraph_contract_vertices:
 
 
 igraph_pseudo_diameter:
-    DEPS: start_vid ON graph
+    DEPS: start_vid ON graph, weights ON graph
 
 igraph_diversity:
 

--- a/tools/stimulus/functions-R.yaml
+++ b/tools/stimulus/functions-R.yaml
@@ -447,9 +447,6 @@ igraph_joint_type_distribution:
 
 igraph_contract_vertices:
 
-# We use igraph_radius_dijkstra instead
-igraph_radius:
-    IGNORE: RR, RC
 
 igraph_pseudo_diameter:
     DEPS: start_vid ON graph


### PR DESCRIPTION
@szhorvat this works as it makes two current failures disappear (from the "next"/"b-next" branches) but I'd like your advice on whether the changes I made should live in the stimulus config file instead. For later today if we have time!