### PR TITLE
feat: new arguments `vids_from` and `vids_to` for `similarity()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -83,5 +83,5 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE, roclets = c("collate", "rd", "namespace",
     "igraph.r2cdocs::cdocs_roclet", "devtag::dev_roclet"), packages =
     "igraph.r2cdocs")
-RoxygenNote: 7.3.2.9000
+RoxygenNote: 7.3.3.9000
 SystemRequirements: libxml2 (optional), glpk (>= 4.57, optional)

--- a/R/similarity.R
+++ b/R/similarity.R
@@ -26,7 +26,9 @@
 #' 25(3):211-230, 2003.
 #'
 #' @param graph The input graph.
-#' @param vids The vertex ids for which the similarity is calculated.
+#' @param vids lifecycle::badge("deprecated")
+#' @param vids_from The vertex ids from which the similarity is calculated.
+#' @param vids_to The vertex ids to which the similarity is calculated.
 #' @param mode The type of neighboring vertices to use for the calculation,
 #'   possible values: \sQuote{`out`}, \sQuote{`in`},
 #'   \sQuote{`all`}.
@@ -52,7 +54,7 @@
 #' similarity(g, method = "jaccard")
 similarity <- function(
   graph,
-  vids = V(graph),
+  vids = deprecated(),
   mode = c(
     "all",
     "out",
@@ -64,16 +66,46 @@ similarity <- function(
     "jaccard",
     "dice",
     "invlogweighted"
-  )
+  ),
+  vids_from = V(graph),
+  vids_to = V(graph)
 ) {
-  method <- igraph.match.arg(method)
-  if (method == "jaccard") {
-    similarity_jaccard_impl(graph, vids, mode, loops)
-  } else if (method == "dice") {
-    similarity_dice_impl(graph, vids, mode, loops)
-  } else if (method == "invlogweighted") {
-    similarity_inverse_log_weighted_impl(graph, vids, mode)
+  if (lifecycle::is_present(vids)) {
+    lifecycle::deprecate_soft(
+      "similarity(vids =)",
+      I("similarity(vids_from =, vids_to =)"),
+      when = "3.0.0"
+    )
+    if (!lifecycle::is_present(vids_from)) {
+      vids_from <- vids
+    }
   }
+
+  method <- igraph.match.arg(method)
+
+  switch(
+    method,
+    jaccard = similarity_jaccard_impl(
+      graph,
+      vit.from = vids_from,
+      vit.to = vids_to,
+      mode = mode,
+      loops = loops
+    ),
+    dice = similarity_dice_impl(
+      graph,
+      vit.from = vids_from,
+      vit.to = vids_to,
+      mode = mode,
+      loops = loops
+    ),
+    invlogweighted = similarity_inverse_log_weighted_impl(
+      graph,
+      vit.from = vids_from,
+      vit.to = vids_to,
+      mode = mode
+    )
+  )
 }
 
 #' Similarity measures of two vertices (Jaccard)
@@ -83,6 +115,7 @@ similarity <- function(
 #'
 #' Please use [similarity()] with `method = "jaccard"` instead.
 #' @inheritParams similarity
+#' @param vids The vertex ids for which the similarity is calculated.
 #' @keywords internal
 #' @export
 similarity.jaccard <- function(
@@ -114,6 +147,7 @@ similarity.jaccard <- function(
 #'
 #' Please use [similarity()] with `method = "dice"` instead.
 #' @inheritParams similarity
+#' @param vids The vertex ids for which the similarity is calculated.
 #' @keywords internal
 #' @export
 similarity.dice <- function(
@@ -145,6 +179,7 @@ similarity.dice <- function(
 #'
 #' Please use [similarity()] with `method = "invlogweighted"` instead.
 #' @inheritParams similarity
+#' @param vids The vertex ids for which the similarity is calculated.
 #' @keywords internal
 #' @export
 similarity.invlogweighted <- function(

--- a/R/similarity.R
+++ b/R/similarity.R
@@ -27,8 +27,10 @@
 #'
 #' @param graph The input graph.
 #' @param vids lifecycle::badge("deprecated")
-#' @param vids_from The vertex ids from which the similarity is calculated.
-#' @param vids_to The vertex ids to which the similarity is calculated.
+#' @param vids_from The vertex IDs of the first set of vertices of the pairs
+#' for which the calculation will be done.
+#' @param vids_to The vertex IDs of the second set of vertices of the pairs
+#' for which the calculation will be done.
 #' @param mode The type of neighboring vertices to use for the calculation,
 #'   possible values: \sQuote{`out`}, \sQuote{`in`},
 #'   \sQuote{`all`}.
@@ -68,7 +70,7 @@ similarity <- function(
     "invlogweighted"
   ),
   vids_from = V(graph),
-  vids_to = V(graph)
+  vids_to = vids_from
 ) {
   if (lifecycle::is_present(vids)) {
     lifecycle::deprecate_soft(
@@ -78,6 +80,7 @@ similarity <- function(
     )
     if (!lifecycle::is_present(vids_from)) {
       vids_from <- vids
+      vids_to <- vids_from
     }
   }
 

--- a/man/similarity.Rd
+++ b/man/similarity.Rd
@@ -6,16 +6,18 @@
 \usage{
 similarity(
   graph,
-  vids = V(graph),
+  vids = deprecated(),
   mode = c("all", "out", "in", "total"),
   loops = FALSE,
-  method = c("jaccard", "dice", "invlogweighted")
+  method = c("jaccard", "dice", "invlogweighted"),
+  vids_from = V(graph),
+  vids_to = V(graph)
 )
 }
 \arguments{
 \item{graph}{The input graph.}
 
-\item{vids}{The vertex ids for which the similarity is calculated.}
+\item{vids}{lifecycle::badge("deprecated")}
 
 \item{mode}{The type of neighboring vertices to use for the calculation,
 possible values: \sQuote{\code{out}}, \sQuote{\verb{in}},
@@ -25,6 +27,10 @@ possible values: \sQuote{\code{out}}, \sQuote{\verb{in}},
 sets.}
 
 \item{method}{The method to use.}
+
+\item{vids_from}{The vertex ids from which the similarity is calculated.}
+
+\item{vids_to}{The vertex ids to which the similarity is calculated.}
 }
 \value{
 A \code{length(vids)} by \code{length(vids)} numeric matrix

--- a/man/similarity.Rd
+++ b/man/similarity.Rd
@@ -11,7 +11,7 @@ similarity(
   loops = FALSE,
   method = c("jaccard", "dice", "invlogweighted"),
   vids_from = V(graph),
-  vids_to = V(graph)
+  vids_to = vids_from
 )
 }
 \arguments{
@@ -28,9 +28,11 @@ sets.}
 
 \item{method}{The method to use.}
 
-\item{vids_from}{The vertex ids from which the similarity is calculated.}
+\item{vids_from}{The vertex IDs of the first set of vertices of the pairs
+for which the calculation will be done.}
 
-\item{vids_to}{The vertex ids to which the similarity is calculated.}
+\item{vids_to}{The vertex IDs of the second set of vertices of the pairs
+for which the calculation will be done.}
 }
 \value{
 A \code{length(vids)} by \code{length(vids)} numeric matrix


### PR DESCRIPTION
This makes the test-similarity.R test pass again.

Do you agree on the way I added the new parameters? We can't put them at the same place as in the C core, since that would break existing code that relies on argument position rather than argument name.

Relevant lines in the C changelog:

>  - `igraph_similarity_jaccard()` and `igraph_similarity_dice()` now take two sets of vertices to create vertex pairs of, instead of one.

PR in the C core: https://github.com/igraph/igraph/pull/2346

I haven't found the documentation for this in the C core, which could mean I didn't search properly.