### PR TITLE
fix: handle new names from C in `average_path_length_impl()`

### DIFF
--- a/R/structural-properties.R
+++ b/R/structural-properties.R
@@ -842,8 +842,28 @@ farthest_vertices <- function(
 #' @export
 #' @rdname distances
 #' @cdocs igraph_average_path_length
-mean_distance <- average_path_length_impl
+mean_distance <- function(
+  graph,
+  weights = NULL,
+  directed = TRUE,
+  unconnected = TRUE,
+  details = FALSE
+) {
+  res <- average_path_length_impl(
+    graph,
+    weights = weights,
+    directed = directed,
+    unconn = unconnected,
+    details = details
+  )
 
+  if (details) {
+    res$unconnected <- res$unconn_pair
+    res$unconn_pair <- NULL
+  }
+
+  res
+}
 
 #' Degree and degree distribution of the vertices
 #'


### PR DESCRIPTION
@szhorvat two automatic names changed here, I wonder whether I should rather handle this in some YAML (what I tried failed)

- the argument `unconnected` is now `unconn`
- the element of the output list `unconnected` is now `unconn_pair`

What I tried to edit was `src/vendor/cigraph/interfaces/functions.yaml`:

```yaml
igraph_average_path_length:
    PARAMS: GRAPH graph, OPTIONAL EDGE_WEIGHTS weights, PRIMARY OUT REAL res,
        OPTIONAL OUT REAL unconnected, BOOLEAN directed=True, BOOLEAN unconnected=True
    DEPS: weights ON graph
```

Doing this created two arguments called unconnected. :sweat_smile: 