### PR TITLE
chore: `mode` argument of centralization functions

### DIFF
--- a/R/centralization.R
+++ b/R/centralization.R
@@ -56,6 +56,8 @@ centralization.evcent.tmax <- function(
 #' `centralization.evcent()` was renamed to [centr_eigen()] to create a more
 #' consistent API.
 #' @inheritParams centr_eigen
+#' @param directed logical scalar, whether to use directed shortest paths for
+#'   calculating eigenvector centrality.
 #' @keywords internal
 #' @export
 centralization.evcent <- function(
@@ -569,12 +571,22 @@ centr_clo_tmax <- centralization_closeness_tmax_impl
 #' See [centralize()] for a summary of graph centralization.
 #'
 #' @param graph The input graph.
-#' @param directed logical scalar, whether to use directed shortest paths for
-#'   calculating eigenvector centrality.
+#' @param directed `r lifecycle::badge("deprecated")` Use `mode` instead.
 #' @param scale `r lifecycle::badge("deprecated")` Ignored. Computing
 #' eigenvector centralization requires normalized eigenvector centrality scores.
 #' @param options This is passed to [eigen_centrality()], the options
 #'   for the ARPACK eigensolver.
+#' @param mode How to consider edge directions in directed graphs.
+#' It is ignored for undirected graphs.
+#' Possible values:
+#'   - `"out"` the left eigenvector of the adjacency matrix is calculated,
+#' i.e. the centrality of a vertex is proportional to the sum of centralities
+#' of vertices pointing to it. This is the standard eigenvector centrality.
+#'   - `"in"` the right eigenvector of the adjacency matrix is calculated,
+#' i.e. the centrality of a vertex is proportional to the sum of centralities
+#' of vertices it points to.
+#'   - `"all"` edge directions are ignored,
+#' and the unweighted eigenvector centrality is calculated.
 #' @param normalized Logical scalar. Whether to normalize the graph level
 #'   centrality score by dividing by the theoretical maximum.
 #' @return A named list with the following components:
@@ -617,10 +629,11 @@ centr_clo_tmax <- centralization_closeness_tmax_impl
 #' @cdocs igraph_centralization_eigenvector_centrality
 centr_eigen <- function(
   graph,
-  directed = FALSE,
+  directed = deprecated(),
   scale = deprecated(),
   options = arpack_defaults(),
-  normalized = TRUE
+  normalized = TRUE,
+  mode = c("out", "in", "all")
 ) {
   if (lifecycle::is_present(scale)) {
     lifecycle::deprecate_soft(
@@ -631,12 +644,35 @@ centr_eigen <- function(
     )
   }
 
+  mode <- igraph.match.arg(mode)
+
+  if (lifecycle::is_present(directed)) {
+    if (directed) {
+      lifecycle::deprecate_soft(
+        "2.2.0",
+        "eigen_centrality(directed)",
+        details = "Use the mode argument."
+      )
+      if (!lifecycle::is_present(mode)) {
+        mode <- "out"
+      }
+    } else {
+      lifecycle::deprecate_soft(
+        "2.2.0",
+        "eigen_centrality(directed)",
+        details = "Use the mode argument."
+      )
+      if (!lifecycle::is_present(mode)) {
+        mode <- "all"
+      }
+    }
+  }
+
   centralization_eigenvector_centrality_impl(
     graph = graph,
-    directed = directed,
     options = options,
     normalized = normalized,
-    scale = TRUE
+    mode = mode
   )
 }
 
@@ -670,8 +706,9 @@ centr_eigen <- function(
 centr_eigen_tmax <- function(
   graph = NULL,
   nodes = 0,
-  directed = FALSE,
-  scale = deprecated()
+  directed = deprecated(),
+  scale = deprecated(),
+  mode = c("out", "in", "all")
 ) {
   if (lifecycle::is_present(scale)) {
     lifecycle::deprecate_soft(
@@ -681,11 +718,33 @@ centr_eigen_tmax <- function(
       The argument will be removed in the future."
     )
   }
+  mode <- igraph.match.arg(mode)
+
+  if (lifecycle::is_present(directed)) {
+    if (directed) {
+      lifecycle::deprecate_soft(
+        "2.2.0",
+        "eigen_centrality(directed)",
+        details = "Use the mode argument."
+      )
+      if (!lifecycle::is_present(mode)) {
+        mode <- "out"
+      }
+    } else {
+      lifecycle::deprecate_soft(
+        "2.2.0",
+        "eigen_centrality(directed)",
+        details = "Use the mode argument."
+      )
+      if (!lifecycle::is_present(mode)) {
+        mode <- "all"
+      }
+    }
+  }
 
   centralization_eigenvector_centrality_tmax_impl(
     graph = graph,
     nodes = nodes,
-    directed = directed,
-    scale = TRUE
+    mode = mode
   )
 }

--- a/man/centr_eigen.Rd
+++ b/man/centr_eigen.Rd
@@ -6,17 +6,17 @@
 \usage{
 centr_eigen(
   graph,
-  directed = FALSE,
+  directed = deprecated(),
   scale = deprecated(),
   options = arpack_defaults(),
-  normalized = TRUE
+  normalized = TRUE,
+  mode = c("out", "in", "all")
 )
 }
 \arguments{
 \item{graph}{The input graph.}
 
-\item{directed}{logical scalar, whether to use directed shortest paths for
-calculating eigenvector centrality.}
+\item{directed}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{mode} instead.}
 
 \item{scale}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Ignored. Computing
 eigenvector centralization requires normalized eigenvector centrality scores.}
@@ -26,6 +26,20 @@ for the ARPACK eigensolver.}
 
 \item{normalized}{Logical scalar. Whether to normalize the graph level
 centrality score by dividing by the theoretical maximum.}
+
+\item{mode}{How to consider edge directions in directed graphs.
+It is ignored for undirected graphs.
+Possible values:
+\itemize{
+\item \code{"out"} the left eigenvector of the adjacency matrix is calculated,
+i.e. the centrality of a vertex is proportional to the sum of centralities
+of vertices pointing to it. This is the standard eigenvector centrality.
+\item \code{"in"} the right eigenvector of the adjacency matrix is calculated,
+i.e. the centrality of a vertex is proportional to the sum of centralities
+of vertices it points to.
+\item \code{"all"} edge directions are ignored,
+and the unweighted eigenvector centrality is calculated.
+}}
 }
 \value{
 A named list with the following components:

--- a/man/centr_eigen_tmax.Rd
+++ b/man/centr_eigen_tmax.Rd
@@ -7,8 +7,9 @@
 centr_eigen_tmax(
   graph = NULL,
   nodes = 0,
-  directed = FALSE,
-  scale = deprecated()
+  directed = deprecated(),
+  scale = deprecated(),
+  mode = c("out", "in", "all")
 )
 }
 \arguments{


### PR DESCRIPTION
>  - `igraph_eigenvector_centrality()`, `igraph_centralization_eigenvector_centrality()` and `igraph_centralization_eigenvector_centrality_tmax()` now use a `mode` parameter with possible values `IGRAPH_OUT`, `IGRAPH_IN` or `IGRAPH_ALL` to control how edge directions are considered. Previously they used a boolean `directed` parameter.

Like #2200