### PR TITLE
docs: Add RCC smoke test fix workflow documentation

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -70,3 +70,4 @@
 ^man/handle_vertex_type_arg\.Rd$
 ^BRANCHES\.md$
 ^scripts$
+^\.claude$

--- a/.claude/skills/rcc-smoke-fix.md
+++ b/.claude/skills/rcc-smoke-fix.md
@@ -1,8 +1,8 @@
 Scheduled job: scan all `*-dev` branches (including `broken-*-dev`) in
 `krlmlr/rigraph` for the earliest commit whose `rcc` commit-status (set by the
 "Smoke test: stock R" job in the `rcc` workflow) is `failure` since 2026-04-11.
-For each such branch, if no `broken-<branch>-<sha7>` branch exists yet, create
-it, fix `testthat::test_local()` and `R CMD check .`, update snapshots, then
+For each such branch, if no `broken-<sha7>-dev` branch exists yet, create it,
+fix `testthat::test_local()` and `R CMD check .`, update snapshots, then
 cherry-pick all later vendor commits from the `*-dev` branch and push.
 Never modify vendored files (`src/vendor/`, `patch/`).
 
@@ -27,10 +27,10 @@ DEV_BRANCHES=$(git branch -r \
   | grep -E '\-dev$' \
   | sort)
 
-# All broken-* branches already on krlmlr (to skip re-doing work)
+# All broken-*-dev branches already on krlmlr (to skip re-doing work)
 BROKEN_BRANCHES=$(git branch -r \
   | grep -oP 'krlmlr/\K\S+' \
-  | grep -E '^broken-')
+  | grep -E '^broken-.*-dev$')
 
 echo "=== Dev branches ===" && echo "$DEV_BRANCHES"
 echo "=== Broken branches (existing) ===" && echo "$BROKEN_BRANCHES"
@@ -51,7 +51,7 @@ COMMITS_OLDEST_FIRST=$(git log "krlmlr/$BRANCH" \
 FIRST_FAIL=""
 while IFS= read -r SHA; do
   SHORT="${SHA:0:7}"
-  FIX_NAME="broken-${BRANCH}-${SHORT}"
+  FIX_NAME="broken-${SHORT}-dev"
 
   # Skip if fix branch already exists
   if echo "$BROKEN_BRANCHES" | grep -qxF "$FIX_NAME"; then
@@ -88,7 +88,7 @@ Repeat for each `NEEDS_FIX` pair `($BRANCH, $SHA)`:
 
 ```bash
 SHORT="${SHA:0:7}"
-FIX_BRANCH="broken-${BRANCH}-${SHORT}"
+FIX_BRANCH="broken-${SHORT}-dev"
 git checkout -B "$FIX_BRANCH" "$SHA"
 ```
 
@@ -168,10 +168,10 @@ Return to Step 3 / Step 4 for the next `NEEDS_FIX` entry.
 When all are processed, report a summary:
 
 ```
-Fixed: broken-main-dev-abc1234 (cherry-picked N commits)
-Fixed: broken-other-dev-def5678 (cherry-picked M commits)
-Skipped (already fixed): ...
-No failure found: ...
+Fixed: broken-abc1234-dev (from main-dev, cherry-picked N commits)
+Fixed: broken-def5678-dev (from other-dev, cherry-picked M commits)
+Skipped (already fixed): broken-abc1234-dev
+No failure found: yet-another-dev
 ```
 
 ---

--- a/.claude/skills/rcc-smoke-fix.md
+++ b/.claude/skills/rcc-smoke-fix.md
@@ -50,19 +50,11 @@ COMMITS_OLDEST_FIRST=$(git log "krlmlr/$BRANCH" \
 
 FIRST_FAIL=""
 while IFS= read -r SHA; do
-  FIX_NAME="broken-${SHA}-dev"
-
-  # Skip if fix branch already exists
-  if echo "$BROKEN_BRANCHES" | grep -qxF "$FIX_NAME"; then
-    # This exact failure is already handled — nothing more to do for this branch
-    break
-  fi
-
   # Check the rcc commit-status for this SHA (context = "rcc")
   STATUS=$(gh api "repos/$REPO/commits/$SHA/statuses" \
     | jq -r '[.[] | select(.context == "rcc")] | first | .state // "none"')
 
-  echo "$BRANCH  $SHORT  $STATUS"
+  echo "$BRANCH  ${SHA:0:7}  $STATUS"
 
   if [[ "$STATUS" == "failure" ]]; then
     FIRST_FAIL="$SHA"
@@ -70,8 +62,13 @@ while IFS= read -r SHA; do
   fi
 done <<< "$COMMITS_OLDEST_FIRST"
 
+# Existence check comes AFTER finding the earliest failure.
+# Checking inside the loop would short-circuit on a later already-fixed commit
+# before reaching an earlier failure that still has no fix branch.
 if [[ -z "$FIRST_FAIL" ]]; then
-  echo "$BRANCH: no unhandled rcc failure — skip"
+  echo "$BRANCH: no rcc failure — skip"
+elif echo "$BROKEN_BRANCHES" | grep -qxF "broken-${FIRST_FAIL}-dev"; then
+  echo "$BRANCH: broken-${FIRST_FAIL}-dev already exists — skip"
 else
   echo "NEEDS_FIX  $BRANCH  $FIRST_FAIL"
 fi
@@ -160,9 +157,7 @@ git diff --cached --quiet || \
   git commit -m "fix: R code and snapshots for failing rcc at ${SHORT}"
 ```
 
-### 4f. Cherry-pick all remaining vendor commits from *-dev
-
-These commits only touch `src/vendor/` and are guaranteed to apply cleanly.
+### 4f. Cherry-pick all remaining commits from *-dev
 
 ```bash
 # Commits on the *-dev branch that come *after* the failing commit
@@ -174,8 +169,28 @@ for C in $REMAINING; do
 done
 ```
 
-If a cherry-pick conflict occurs on a **non-vendored** file, stop immediately
-and report the conflict — it is unexpected.
+Most of these commits are vendor-only and apply cleanly. However, the range
+**may include non-vendor fix commits** (e.g. a later glue-code repair that was
+pushed directly to the `*-dev` branch). That is expected and correct — those
+fixes address *subsequent* breakages that were introduced after our fix point
+and must be carried forward.
+
+Conflict handling:
+- Conflict on `src/vendor/cigraph/` or `src/vendor/igraph_version.h`: should
+  never happen; stop and report.
+- Conflict on any other file (glue code, `patch/`, `R/`, tests): the
+  cherry-picked commit is a fix commit whose change overlaps with our own fix.
+  Resolve by accepting the cherry-picked version (`git checkout --theirs`) or
+  by merging manually, then `git cherry-pick --continue`. Do **not** use
+  `--skip` unless the commit is genuinely a no-op after our fix.
+
+After all cherry-picks, re-run the final check:
+
+```bash
+R CMD check . --no-manual --as-cran 2>&1 | tail -20
+```
+
+to confirm the fully-assembled branch is clean.
 
 ### 4g. Push the fix branch
 

--- a/.claude/skills/rcc-smoke-fix.md
+++ b/.claude/skills/rcc-smoke-fix.md
@@ -18,7 +18,7 @@ fi
 git fetch krlmlr --force --prune --tags
 ```
 
-## Step 2 — Collect all branches and existing broken-* branches in one pass
+## Step 2 — Collect all branches and existing `broken-*` branches in one pass
 
 ```bash
 # All krlmlr remote-tracking branches that end in -dev
@@ -36,7 +36,7 @@ echo "=== Dev branches ===" && echo "$DEV_BRANCHES"
 echo "=== Broken branches (existing) ===" && echo "$BROKEN_BRANCHES"
 ```
 
-## Step 3 — For each *-dev branch, find the earliest failing commit
+## Step 3 — For each `*-dev` branch, find the earliest failing commit
 
 Iterate over every entry in `$DEV_BRANCHES`. For each `$BRANCH`:
 
@@ -54,7 +54,7 @@ while IFS= read -r SHA; do
   STATUS=$(gh api "repos/$REPO/commits/$SHA/statuses" \
     | jq -r '[.[] | select(.context == "rcc")] | first | .state // "none"')
 
-  echo "$BRANCH  ${SHA:0:7}  $STATUS"
+  echo "$BRANCH  ${SHA}  $STATUS"
 
   if [[ "$STATUS" == "failure" ]]; then
     FIRST_FAIL="$SHA"
@@ -76,7 +76,7 @@ fi
 
 Collect all `NEEDS_FIX  <branch>  <sha>` lines. Process them in order.
 
-## Step 4 — Create, fix, and push a broken-* branch
+## Step 4 — Create, fix, and push a `broken-*` branch
 
 Repeat for each `NEEDS_FIX` pair `($BRANCH, $SHA)`:
 
@@ -115,9 +115,11 @@ Apply fixes in this priority order (stop at the first level that resolves the fa
 
 4. **Snapshots** (`tests/testthat/_snaps/`) — accept updated snapshots only after
    the underlying behaviour is confirmed correct:
-   ```
+
+   ```bash
    Rscript -e 'testthat::snapshot_accept()'
    ```
+
    Or for a single test file: `testthat::snapshot_accept("test-name")`.
 
 5. **Tests** (`tests/testthat/test-*.R`) — change test code **only as a last
@@ -146,18 +148,18 @@ R CMD check . --no-manual --as-cran 2>&1 | tail -20
 ```
 
 Must show `Status: OK` or at most `1 NOTE` (pre-existing CRAN notes are fine).
-Fail if there are ERRORs or new WARNINGs.
+Fix any new ERRORs or new WARNINGs.
 
 ### 4e. Commit the fix
 
 ```bash
-git add R/ tests/ man/ NAMESPACE DESCRIPTION
+git add -- R/ tests/ man/ NAMESPACE DESCRIPTION
 # Only if there are staged changes:
 git diff --cached --quiet || \
   git commit -m "fix: R code and snapshots for failing rcc at ${SHORT}"
 ```
 
-### 4f. Cherry-pick all remaining commits from *-dev
+### 4f. Cherry-pick all remaining commits from `*-dev`
 
 ```bash
 # Commits on the *-dev branch that come *after* the failing commit
@@ -176,6 +178,7 @@ fixes address *subsequent* breakages that were introduced after our fix point
 and must be carried forward.
 
 Conflict handling:
+
 - Conflict on `src/vendor/cigraph/` or `src/vendor/igraph_version.h`: should
   never happen; stop and report.
 - Conflict on any other file (glue code, `patch/`, `R/`, tests): the
@@ -203,7 +206,7 @@ git push krlmlr "$FIX_BRANCH" --force-with-lease
 Return to Step 3 / Step 4 for the next `NEEDS_FIX` entry.
 When all are processed, report a summary:
 
-```
+```text
 Fixed: broken-<sha40>-dev (from main-dev, cherry-picked N commits)
 Fixed: broken-<sha40>-dev (from other-dev, cherry-picked M commits)
 Skipped (already fixed): broken-<sha40>-dev exists

--- a/.claude/skills/rcc-smoke-fix.md
+++ b/.claude/skills/rcc-smoke-fix.md
@@ -1,10 +1,10 @@
 Scheduled job: scan all `*-dev` branches (including `broken-*-dev`) in
 `krlmlr/rigraph` for the earliest commit whose `rcc` commit-status (set by the
 "Smoke test: stock R" job in the `rcc` workflow) is `failure` since 2026-04-11.
-For each such branch, if no `broken-<sha7>-dev` branch exists yet, create it,
-fix `testthat::test_local()` and `R CMD check .`, update snapshots, then
-cherry-pick all later vendor commits from the `*-dev` branch and push.
-Never modify vendored files (`src/vendor/`, `patch/`).
+For each such branch, if no `broken-<sha>-dev` branch exists yet (full 40-char
+SHA), create it, fix `testthat::test_local()` and `R CMD check .`, update
+snapshots, then cherry-pick all later vendor commits from the `*-dev` branch
+and push. Never modify vendored C sources (`src/vendor/cigraph/`).
 
 ---
 
@@ -50,8 +50,7 @@ COMMITS_OLDEST_FIRST=$(git log "krlmlr/$BRANCH" \
 
 FIRST_FAIL=""
 while IFS= read -r SHA; do
-  SHORT="${SHA:0:7}"
-  FIX_NAME="broken-${SHORT}-dev"
+  FIX_NAME="broken-${SHA}-dev"
 
   # Skip if fix branch already exists
   if echo "$BROKEN_BRANCHES" | grep -qxF "$FIX_NAME"; then
@@ -87,8 +86,7 @@ Repeat for each `NEEDS_FIX` pair `($BRANCH, $SHA)`:
 ### 4a. Check out the failing commit on the new fix branch
 
 ```bash
-SHORT="${SHA:0:7}"
-FIX_BRANCH="broken-${SHORT}-dev"
+FIX_BRANCH="broken-${SHA}-dev"
 git checkout -B "$FIX_BRANCH" "$SHA"
 ```
 
@@ -101,17 +99,40 @@ Rscript -e 'testthat::test_local(stop_on_failure = FALSE)' 2>&1
 
 Read the output carefully.
 
-### 4c. Fix issues — allowed modifications
+### 4c. Fix issues — allowed modifications and priority order
 
-**You may only change files outside `src/vendor/` and `patch/`.** Typical fixes:
+**Never modify `src/vendor/cigraph/` or `src/vendor/igraph_version.h`.**
+Everything else — including `patch/` — may be changed.
+
+Apply fixes in this priority order (stop at the first level that resolves the failure):
+
+1. **`patch/`** — R-specific patches to the C core. Prefer adjusting or adding a
+   patch here when the C API changed in a way that breaks compilation or linking.
+   Assign the next available number; do not renumber existing patches.
+
+2. **Glue / Stimulus definitions** (`src/*.cpp`, auto-generated stubs, `.decor`
+   files, or Stimulus-style interface definitions) — adapt the R↔C bridge to a
+   changed C API before touching any R-level code.
+
+3. **R code** (`R/`) — update high-level R functions, fix argument handling, etc.
+
+4. **Snapshots** (`tests/testthat/_snaps/`) — accept updated snapshots only after
+   the underlying behaviour is confirmed correct:
+   ```
+   Rscript -e 'testthat::snapshot_accept()'
+   ```
+   Or for a single test file: `testthat::snapshot_accept("test-name")`.
+
+5. **Tests** (`tests/testthat/test-*.R`) — change test code **only as a last
+   resort**, e.g. when the test itself was testing a now-removed C-level detail.
+   Do not weaken assertions; adapt them to the new correct behaviour.
+
+Other common fixes:
 
 | Symptom | Fix |
 |---------|-----|
-| Snapshot mismatch | `Rscript -e 'testthat::snapshot_accept()'` then inspect diffs |
-| Snapshot mismatch (specific test) | `Rscript -e 'testthat::snapshot_accept("test-name")'` |
-| Logical test failure | Read failing test in `tests/testthat/test-*.R`; fix R code in `R/` |
-| Missing export / namespace | `Rscript -e 'roxygen2::roxygenize()'` |
-| NOTE / WARNING in R CMD check | Fix in `R/` or `man/` — never in `src/vendor/` |
+| Missing export / namespace error | `Rscript -e 'roxygen2::roxygenize()'` |
+| NOTE / WARNING in R CMD check | Fix in `R/`, `man/`, or `patch/` |
 
 After any change, re-run:
 
@@ -168,9 +189,9 @@ Return to Step 3 / Step 4 for the next `NEEDS_FIX` entry.
 When all are processed, report a summary:
 
 ```
-Fixed: broken-abc1234-dev (from main-dev, cherry-picked N commits)
-Fixed: broken-def5678-dev (from other-dev, cherry-picked M commits)
-Skipped (already fixed): broken-abc1234-dev
+Fixed: broken-<sha40>-dev (from main-dev, cherry-picked N commits)
+Fixed: broken-<sha40>-dev (from other-dev, cherry-picked M commits)
+Skipped (already fixed): broken-<sha40>-dev exists
 No failure found: yet-another-dev
 ```
 
@@ -178,8 +199,8 @@ No failure found: yet-another-dev
 
 ## Constraints (hard rules)
 
-- **Never** modify `src/vendor/cigraph/`, `patch/`, `src/vendor/igraph_version.h`,
-  or any `scripts/vendor*.sh` file.
+- **Never** modify `src/vendor/cigraph/`, `src/vendor/igraph_version.h`,
+  or any `scripts/vendor*.sh` file. `patch/` **may** be modified.
 - **Never** amend commits that have already been pushed.
 - **Commit status to check**: context `rcc` (not the full check-run name).
 - **Branch target**: all pushes go to the `krlmlr` remote (`krlmlr/rigraph`).

--- a/.claude/skills/rcc-smoke-fix.md
+++ b/.claude/skills/rcc-smoke-fix.md
@@ -1,0 +1,187 @@
+Scheduled job: scan all `*-dev` branches (including `broken-*-dev`) in
+`krlmlr/rigraph` for the earliest commit whose `rcc` commit-status (set by the
+"Smoke test: stock R" job in the `rcc` workflow) is `failure` since 2026-04-11.
+For each such branch, if no `broken-<branch>-<sha7>` branch exists yet, create
+it, fix `testthat::test_local()` and `R CMD check .`, update snapshots, then
+cherry-pick all later vendor commits from the `*-dev` branch and push.
+Never modify vendored files (`src/vendor/`, `patch/`).
+
+---
+
+## Step 1 — Refresh local mirror of krlmlr/rigraph (always, force-reset)
+
+```bash
+if ! git remote get-url krlmlr &>/dev/null 2>&1; then
+  git remote add krlmlr https://github.com/krlmlr/rigraph.git
+fi
+# Hard-reset: throw away any cached remote-tracking state
+git fetch krlmlr --force --prune --tags
+```
+
+## Step 2 — Collect all branches and existing broken-* branches in one pass
+
+```bash
+# All krlmlr remote-tracking branches that end in -dev
+DEV_BRANCHES=$(git branch -r \
+  | grep -oP 'krlmlr/\K\S+' \
+  | grep -E '\-dev$' \
+  | sort)
+
+# All broken-* branches already on krlmlr (to skip re-doing work)
+BROKEN_BRANCHES=$(git branch -r \
+  | grep -oP 'krlmlr/\K\S+' \
+  | grep -E '^broken-')
+
+echo "=== Dev branches ===" && echo "$DEV_BRANCHES"
+echo "=== Broken branches (existing) ===" && echo "$BROKEN_BRANCHES"
+```
+
+## Step 3 — For each *-dev branch, find the earliest failing commit
+
+Iterate over every entry in `$DEV_BRANCHES`. For each `$BRANCH`:
+
+```bash
+SINCE="2026-04-11"
+REPO="krlmlr/rigraph"
+
+# Commits on this branch since SINCE, oldest-first (first-parent only)
+COMMITS_OLDEST_FIRST=$(git log "krlmlr/$BRANCH" \
+  --first-parent --since="$SINCE" --format="%H" --reverse)
+
+FIRST_FAIL=""
+while IFS= read -r SHA; do
+  SHORT="${SHA:0:7}"
+  FIX_NAME="broken-${BRANCH}-${SHORT}"
+
+  # Skip if fix branch already exists
+  if echo "$BROKEN_BRANCHES" | grep -qxF "$FIX_NAME"; then
+    # This exact failure is already handled — nothing more to do for this branch
+    break
+  fi
+
+  # Check the rcc commit-status for this SHA (context = "rcc")
+  STATUS=$(gh api "repos/$REPO/commits/$SHA/statuses" \
+    | jq -r '[.[] | select(.context == "rcc")] | first | .state // "none"')
+
+  echo "$BRANCH  $SHORT  $STATUS"
+
+  if [[ "$STATUS" == "failure" ]]; then
+    FIRST_FAIL="$SHA"
+    break
+  fi
+done <<< "$COMMITS_OLDEST_FIRST"
+
+if [[ -z "$FIRST_FAIL" ]]; then
+  echo "$BRANCH: no unhandled rcc failure — skip"
+else
+  echo "NEEDS_FIX  $BRANCH  $FIRST_FAIL"
+fi
+```
+
+Collect all `NEEDS_FIX  <branch>  <sha>` lines. Process them in order.
+
+## Step 4 — Create, fix, and push a broken-* branch
+
+Repeat for each `NEEDS_FIX` pair `($BRANCH, $SHA)`:
+
+### 4a. Check out the failing commit on the new fix branch
+
+```bash
+SHORT="${SHA:0:7}"
+FIX_BRANCH="broken-${BRANCH}-${SHORT}"
+git checkout -B "$FIX_BRANCH" "$SHA"
+```
+
+### 4b. Install and run tests; collect failures
+
+```bash
+_R_SHLIB_STRIP_=true R CMD INSTALL . --no-byte-compile 2>&1 | tail -5
+Rscript -e 'testthat::test_local(stop_on_failure = FALSE)' 2>&1
+```
+
+Read the output carefully.
+
+### 4c. Fix issues — allowed modifications
+
+**You may only change files outside `src/vendor/` and `patch/`.** Typical fixes:
+
+| Symptom | Fix |
+|---------|-----|
+| Snapshot mismatch | `Rscript -e 'testthat::snapshot_accept()'` then inspect diffs |
+| Snapshot mismatch (specific test) | `Rscript -e 'testthat::snapshot_accept("test-name")'` |
+| Logical test failure | Read failing test in `tests/testthat/test-*.R`; fix R code in `R/` |
+| Missing export / namespace | `Rscript -e 'roxygen2::roxygenize()'` |
+| NOTE / WARNING in R CMD check | Fix in `R/` or `man/` — never in `src/vendor/` |
+
+After any change, re-run:
+
+```bash
+Rscript -e 'testthat::test_local(stop_on_failure = FALSE)' 2>&1
+```
+
+Iterate until all tests pass.
+
+### 4d. Final check
+
+```bash
+R CMD check . --no-manual --as-cran 2>&1 | tail -20
+```
+
+Must show `Status: OK` or at most `1 NOTE` (pre-existing CRAN notes are fine).
+Fail if there are ERRORs or new WARNINGs.
+
+### 4e. Commit the fix
+
+```bash
+git add R/ tests/ man/ NAMESPACE DESCRIPTION
+# Only if there are staged changes:
+git diff --cached --quiet || \
+  git commit -m "fix: R code and snapshots for failing rcc at ${SHORT}"
+```
+
+### 4f. Cherry-pick all remaining vendor commits from *-dev
+
+These commits only touch `src/vendor/` and are guaranteed to apply cleanly.
+
+```bash
+# Commits on the *-dev branch that come *after* the failing commit
+REMAINING=$(git log "${SHA}..krlmlr/${BRANCH}" \
+  --first-parent --format="%H" --reverse)
+
+for C in $REMAINING; do
+  git cherry-pick "$C" --allow-empty
+done
+```
+
+If a cherry-pick conflict occurs on a **non-vendored** file, stop immediately
+and report the conflict — it is unexpected.
+
+### 4g. Push the fix branch
+
+```bash
+git push krlmlr "$FIX_BRANCH" --force-with-lease
+```
+
+## Step 5 — Continue
+
+Return to Step 3 / Step 4 for the next `NEEDS_FIX` entry.
+When all are processed, report a summary:
+
+```
+Fixed: broken-main-dev-abc1234 (cherry-picked N commits)
+Fixed: broken-other-dev-def5678 (cherry-picked M commits)
+Skipped (already fixed): ...
+No failure found: ...
+```
+
+---
+
+## Constraints (hard rules)
+
+- **Never** modify `src/vendor/cigraph/`, `patch/`, `src/vendor/igraph_version.h`,
+  or any `scripts/vendor*.sh` file.
+- **Never** amend commits that have already been pushed.
+- **Commit status to check**: context `rcc` (not the full check-run name).
+- **Branch target**: all pushes go to the `krlmlr` remote (`krlmlr/rigraph`).
+- Branches being force-pushed to: always use the freshly-fetched `krlmlr/*`
+  ref; never rely on any previously-checked-out state.


### PR DESCRIPTION
## Description

This PR adds comprehensive documentation for a scheduled workflow that automatically detects and fixes failures in the `rcc` (smoke test) commit status across development branches in `krlmlr/rigraph`.

The documentation outlines a multi-step process to:
1. Scan all `*-dev` branches for the earliest commit with a failing `rcc` status since 2026-04-11
2. Create `broken-<sha>-dev` fix branches for failures without existing fixes
3. Fix test failures and R CMD check issues while preserving vendored C sources
4. Cherry-pick subsequent commits from the original branch to maintain continuity
5. Push the fixed branches back to the remote

## Key Features

- **Structured workflow**: Clear step-by-step instructions with bash commands
- **Safety constraints**: Hard rules preventing modification of vendored code and enforcing proper git practices
- **Fix priority order**: Guidance on where to apply fixes (patches → glue code → R code → snapshots → tests)
- **Conflict handling**: Instructions for resolving cherry-pick conflicts while respecting vendored code boundaries
- **Validation**: Final R CMD check verification before pushing

## Test Plan

N/A — This is documentation only. No code changes or automated tests are involved.

---

- [ ] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

https://claude.ai/code/session_01NMbDS1CNtybJEqfuzHgR3E