### PR TITLE
fledge: CRAN release v2.3.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ message: 'To cite package "igraph" in publications use:'
 type: software
 license: GPL-2.0-or-later
 title: 'igraph: Network Analysis and Visualization'
-version: 2.3.0
+version: 2.3.1
 identifiers:
 - type: doi
   value: 10.32614/CRAN.package.igraph
@@ -135,7 +135,7 @@ references:
   - family-names: Salmon
     given-names: Maëlle
   year: '2026'
-  notes: R package version 2.3.0
+  notes: R package version 2.3.1
   doi: 10.5281/zenodo.7682609
   url: https://CRAN.R-project.org/package=igraph
 - type: software
@@ -145,9 +145,10 @@ references:
   authors:
   - name: R Core Team
   institution:
-    name: R Foundation for Statistical Computing
+    name: 'R Foundation for Statistical Computing (ROR: <https://ror.org/05qewa988>)'
     address: Vienna, Austria
   year: '2026'
+  doi: 10.32614/R.manuals
 - type: software
   title: 'R: A Language and Environment for Statistical Computing'
   notes: Depends
@@ -155,9 +156,10 @@ references:
   authors:
   - name: R Core Team
   institution:
-    name: R Foundation for Statistical Computing
+    name: 'R Foundation for Statistical Computing (ROR: <https://ror.org/05qewa988>)'
     address: Vienna, Austria
   year: '2026'
+  doi: 10.32614/R.manuals
   version: '>= 3.5.0'
 - type: software
   title: cli
@@ -178,9 +180,10 @@ references:
   authors:
   - name: R Core Team
   institution:
-    name: R Foundation for Statistical Computing
+    name: 'R Foundation for Statistical Computing (ROR: <https://ror.org/05qewa988>)'
     address: Vienna, Austria
   year: '2026'
+  doi: 10.32614/R.manuals
 - type: software
   title: grDevices
   abstract: 'R: A Language and Environment for Statistical Computing'
@@ -188,9 +191,10 @@ references:
   authors:
   - name: R Core Team
   institution:
-    name: R Foundation for Statistical Computing
+    name: 'R Foundation for Statistical Computing (ROR: <https://ror.org/05qewa988>)'
     address: Vienna, Austria
   year: '2026'
+  doi: 10.32614/R.manuals
 - type: software
   title: lifecycle
   abstract: 'lifecycle: Manage the Life Cycle of your Package Functions'
@@ -276,9 +280,10 @@ references:
   authors:
   - name: R Core Team
   institution:
-    name: R Foundation for Statistical Computing
+    name: 'R Foundation for Statistical Computing (ROR: <https://ror.org/05qewa988>)'
     address: Vienna, Austria
   year: '2026'
+  doi: 10.32614/R.manuals
 - type: software
   title: utils
   abstract: 'R: A Language and Environment for Statistical Computing'
@@ -286,9 +291,10 @@ references:
   authors:
   - name: R Core Team
   institution:
-    name: R Foundation for Statistical Computing
+    name: 'R Foundation for Statistical Computing (ROR: <https://ror.org/05qewa988>)'
     address: Vienna, Austria
   year: '2026'
+  doi: 10.32614/R.manuals
 - type: software
   title: vctrs
   abstract: 'vctrs: Vector Helpers'
@@ -563,9 +569,10 @@ references:
   authors:
   - name: R Core Team
   institution:
-    name: R Foundation for Statistical Computing
+    name: 'R Foundation for Statistical Computing (ROR: <https://ror.org/05qewa988>)'
     address: Vienna, Austria
   year: '2026'
+  doi: 10.32614/R.manuals
 - type: software
   title: tcltk
   abstract: 'R: A Language and Environment for Statistical Computing'
@@ -573,9 +580,10 @@ references:
   authors:
   - name: R Core Team
   institution:
-    name: R Foundation for Statistical Computing
+    name: 'R Foundation for Statistical Computing (ROR: <https://ror.org/05qewa988>)'
     address: Vienna, Austria
   year: '2026'
+  doi: 10.32614/R.manuals
 - type: software
   title: testthat
   abstract: 'testthat: Unit Testing for R'
@@ -642,7 +650,7 @@ references:
   title: graph
   abstract: 'graph: graph: A package to handle graph data structures'
   notes: Enhances
-  repository: https://bioc-release.r-universe.dev
+  repository: https://bioconductor.org/
   authors:
   - family-names: Gentleman
     given-names: R
@@ -657,6 +665,7 @@ references:
   - family-names: Shannon
     given-names: Paul
   year: '2026'
+  doi: 10.18129/B9.bioc.graph
 - type: software
   title: cpp11
   abstract: 'cpp11: A C++11 Interface for R''s C Interface'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: igraph
 Title: Network Analysis and Visualization
-Version: 2.3.0.9001
+Version: 2.3.1
 Authors@R: c(
     person("Gábor", "Csárdi", , "csardi.gabor@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0001-7098-9676")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,11 +4,7 @@
 
 ## Bug fixes
 
-- Correct LTO type mismatch warnings in `cpp11.cpp` declarations (#2620).
-
-## Uncategorized
-
-- Switching to development version.
+- Fix mismatches between C function signatures and function calls. This only affects private functions that are defined but not yet used (#2620).
 
 
 # igraph 2.3.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,12 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# igraph 2.3.0.9001
+# igraph 2.3.1
 
 ## Bug fixes
 
 - Correct LTO type mismatch warnings in `cpp11.cpp` declarations (#2620).
 
-
-# igraph 2.3.0.9000
+## Uncategorized
 
 - Switching to development version.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -2,6 +2,6 @@ igraph 2.3.1
 
 ## Cran Repository Policy
 
-- [ ] Reviewed CRP last edited 2026-04-21.
+- [x] Reviewed CRP last edited 2026-04-21.
 
 See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2026-02-20%7D...master@%7B2026-04-21%7D

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,7 @@
-igraph 2.3.0
+igraph 2.3.1
 
 ## Cran Repository Policy
 
-- [x] Reviewed CRP last edited 2026-02-20.
+- [ ] Reviewed CRP last edited 2026-04-21.
+
+See changes at https://github.com/eddelbuettel/crp/compare/master@%7B2026-02-20%7D...master@%7B2026-04-21%7D


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2026-04-30, problems found: https://cran.r-project.org/web/checks/check_results_igraph.html
- [ ] ERROR: r-release-macos-x86_64
     Installation failed.
- [ ] other_issue: NA
See: <https://www.stats.ox.ac.uk/pub/bdr/memtests/gcc-ASAN/igraph>
- [ ] other_issue: NA
See: <https://www.stats.ox.ac.uk/pub/bdr/LTO/igraph.out>

Check results at: https://cran.r-project.org/web/checks/check_results_igraph.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`