### PR TITLE
fix: Resolve CRAN Fortran obsolescent character length warning in ARPACK

### DIFF
--- a/patch/0007-arpack-fix-obsolescent-character-length.patch
+++ b/patch/0007-arpack-fix-obsolescent-character-length.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Kirill=20M=C3=BCller?= <kirill@cynkra.com>
+Date: Wed, 21 May 2026 00:00:00 +0200
+Subject: [PATCH] arpack: fix obsolescent Fortran character length syntax
+
+CRAN reports "Obsolescent feature: Old-style character length at (1)"
+on r-devel-linux-x86_64-debian-gcc and r-release-linux-x86_64 (gcc-16,
+which adds -pedantic).  The form ``CHARACTER*n name`` is obsolescent
+while ``CHARACTER name*n`` is not -- adopt the latter form, matching
+``ivout.f`` and the local ``LINE*80`` declarations in the same files.
+
+Refs: https://github.com/igraph/rigraph/issues/1533
+---
+ src/vendor/arpack/dmout.f | 2 +-
+ src/vendor/arpack/dvout.f | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/vendor/arpack/dmout.f b/src/vendor/arpack/dmout.f
+index 59a407a..ec4a849 100644
+--- a/src/vendor/arpack/dmout.f
++++ b/src/vendor/arpack/dmout.f
+@@ -24,7 +24,7 @@
+ *     ...
+ *     ... SPECIFICATIONS FOR LOCAL VARIABLES
+ *     .. Scalar Arguments ..
+-      CHARACTER*( * )    IFMT
++      CHARACTER          IFMT*( * )
+       INTEGER            IDIGIT, LDA, LOUT, M, N
+ *     ..
+ *     .. Array Arguments ..
+diff --git a/src/vendor/arpack/dvout.f b/src/vendor/arpack/dvout.f
+index 3e855dd..dc8fe6c 100644
+--- a/src/vendor/arpack/dvout.f
++++ b/src/vendor/arpack/dvout.f
+@@ -21,7 +21,7 @@
+ *     ...
+ *     ... SPECIFICATIONS FOR LOCAL VARIABLES
+ *     .. Scalar Arguments ..
+-      CHARACTER*( * )    IFMT
++      CHARACTER          IFMT*( * )
+       INTEGER            IDIGIT, LOUT, N
+ *     ..
+ *     .. Array Arguments ..
+--
+2.49.0
+

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -106,6 +106,8 @@ while [ $commits_vendored -lt $num_commits ]; do
     for f in patch/*.patch; do
       if patch -i "$f" -p1 --forward --dry-run; then
         patch -i "$f" -p1 --forward --no-backup-if-mismatch
+      elif patch -i "$f" -p1 --reverse --dry-run >/dev/null 2>&1; then
+        echo "Patch $f already applied, skipping."
       else
         echo "Removing patch $f"
         rm "$f"

--- a/scripts/vendor-one.sh
+++ b/scripts/vendor-one.sh
@@ -103,11 +103,12 @@ while [ $commits_vendored -lt $num_commits ]; do
 
     rm -rf ${vendor_dir}/.git ${vendor_dir}/.github ${vendor_dir}/doc ${vendor_dir}/examples ${vendor_dir}/fuzzing ${vendor_dir}/tests ${vendor_dir}/tools ${vendor_dir}/build
 
+    # Apply patches in patch/*.patch.  See scripts/vendor.sh for the
+    # rationale on why patches that no longer apply forward are removed
+    # rather than kept around.
     for f in patch/*.patch; do
       if patch -i "$f" -p1 --forward --dry-run; then
         patch -i "$f" -p1 --forward --no-backup-if-mismatch
-      elif patch -i "$f" -p1 --reverse --dry-run >/dev/null 2>&1; then
-        echo "Patch $f already applied, skipping."
       else
         echo "Removing patch $f"
         rm "$f"

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -59,11 +59,18 @@ for commit in $original; do
 
   rm -rf ${vendor_dir}/.git ${vendor_dir}/.github ${vendor_dir}/doc ${vendor_dir}/examples ${vendor_dir}/fuzzing ${vendor_dir}/tests ${vendor_dir}/tools ${vendor_dir}/build
 
+  # Apply patches in patch/*.patch.
+  #
+  # If a patch no longer applies forward, it is removed:
+  # vendoring fetches fresh upstream sources that do not yet carry our
+  # changes, so a clean forward apply is the expected case.  A patch that
+  # fails to apply forward is either (a) already integrated upstream and
+  # no longer needed, or (b) broken by an upstream change that we must
+  # address explicitly.  Removing the stale patch surfaces case (b) via
+  # CI/CD instead of letting it rot silently.
   for f in patch/*.patch; do
     if patch -i "$f" -p1 --forward --dry-run; then
       patch -i "$f" -p1 --forward --no-backup-if-mismatch
-    elif patch -i "$f" -p1 --reverse --dry-run >/dev/null 2>&1; then
-      echo "Patch $f already applied, skipping."
     else
       echo "Removing patch $f"
       rm "$f"

--- a/scripts/vendor.sh
+++ b/scripts/vendor.sh
@@ -62,6 +62,8 @@ for commit in $original; do
   for f in patch/*.patch; do
     if patch -i "$f" -p1 --forward --dry-run; then
       patch -i "$f" -p1 --forward --no-backup-if-mismatch
+    elif patch -i "$f" -p1 --reverse --dry-run >/dev/null 2>&1; then
+      echo "Patch $f already applied, skipping."
     else
       echo "Removing patch $f"
       rm "$f"

--- a/src/vendor/arpack/dmout.f
+++ b/src/vendor/arpack/dmout.f
@@ -24,7 +24,7 @@
 *     ...
 *     ... SPECIFICATIONS FOR LOCAL VARIABLES
 *     .. Scalar Arguments ..
-      CHARACTER*( * )    IFMT
+      CHARACTER          IFMT*( * )
       INTEGER            IDIGIT, LDA, LOUT, M, N
 *     ..
 *     .. Array Arguments ..

--- a/src/vendor/arpack/dvout.f
+++ b/src/vendor/arpack/dvout.f
@@ -21,7 +21,7 @@
 *     ...
 *     ... SPECIFICATIONS FOR LOCAL VARIABLES
 *     .. Scalar Arguments ..
-      CHARACTER*( * )    IFMT
+      CHARACTER          IFMT*( * )
       INTEGER            IDIGIT, LOUT, N
 *     ..
 *     .. Array Arguments ..


### PR DESCRIPTION
## Summary

- CRAN v2.3.1 is `WARN` on `r-devel-linux-x86_64-debian-gcc` and `r-release-linux-x86_64` (gcc-16 with `-pedantic`) with `Obsolescent feature: Old-style character length at (1)`. Two declarations in vendored ARPACK still used the obsolescent `CHARACTER*( * )    IFMT` form:
  - `src/vendor/arpack/dmout.f:27`
  - `src/vendor/arpack/dvout.f:24`
- Switch both to `CHARACTER          IFMT*( * )`, matching the modern form already used in sibling `ivout.f` and for `LINE*80` in the same files. Same fix style as the prior pass in #1533.
- Add `patch/0007-arpack-fix-obsolescent-character-length.patch` so the change can be reapplied to a freshly vendored ARPACK source in the future.
- Document inline in `scripts/vendor.sh` why stale patches are intentionally removed (vendoring brings fresh upstream sources, so a clean forward apply is the expected case; a failure means upstream changed and we want CI to surface it).

Refs: #1533

## Test plan

- [x] `gfortran -Wall -pedantic` on every `src/vendor/arpack/*.f` — no more `obsolescent` warnings (also checked under `-std=f95`)
- [x] Patch applies cleanly to a copy of the files reset to the pre-fix state
- [ ] CRAN check on r-devel-linux-x86_64-debian-gcc / r-release-linux-x86_64 to confirm WARN clears

https://claude.ai/code/session_01VKN4mpTpmY7e4PVzMV99aR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VKN4mpTpmY7e4PVzMV99aR)_