### PR TITLE
fix: harden air support and broaden migration fixture to the full arg-matching matrix

### DIFF
--- a/R/migration-fixture.R
+++ b/R/migration-fixture.R
@@ -1,11 +1,12 @@
 # Test fixture for the in-place argument-migration generator (tools/migrations.R,
 # tools/generate-migrations.R). `migration_fixture()` carries a generated
 # ARG_HANDLE block that recovers a legacy call to its pre-3.0.0 signature
-# f(graph, n, weight, type, directed) -- now
-# f(graph, n, ..., weights, type, directed) with weight renamed to weights. The
-# names are chosen so the tests can exercise renames, unique abbreviations and an
-# ambiguous one. It exists only to exercise the generator end-to-end; see
-# tests/testthat/test-migration-fixture.R.
+# f(graph, n, weight, kind, directed) -- now
+# f(graph, n, ..., weights, type, directed), with `weight` renamed to `weights`
+# and `kind` to `type` (`directed` survives unchanged). The names are chosen so
+# the tests can exercise two renames, unique and ambiguous abbreviations, and
+# base-R matching of the head args (`graph`, `n`). It exists only to exercise the
+# generator end-to-end; see tests/testthat/test-migration-fixture.R.
 
 #' @noRd
 migration_fixture <- function(
@@ -22,9 +23,9 @@ migration_fixture <- function(
       list(...),
       current = list(weights = weights, type = type, directed = directed),
       recover_new = c("weights", "type", "directed"),
-      recover_old = c("weight", "type", "directed"),
-      match_names = c("weight", "weights", "type", "directed"),
-      match_to = c("weights", "weights", "type", "directed"),
+      recover_old = c("weight", "kind", "directed"),
+      match_names = c("weight", "kind", "weights", "type", "directed"),
+      match_to = c("weights", "type", "weights", "type", "directed"),
       defaults = list(weights = NULL, type = "out", directed = FALSE),
       head_args = c("graph", "n"),
       fn_name = "migration_fixture"

--- a/tests/testthat/_snaps/migration-fixture.md
+++ b/tests/testthat/_snaps/migration-fixture.md
@@ -1,82 +1,236 @@
+# head args go through base R partial matching, not our recovery
+
+    Code
+      migration_fixture(gr = "G", n = 5)
+    Condition
+      Warning in `migration_fixture()`:
+      partial argument match of 'gr' to 'graph'
+    Output
+      $graph
+      [1] "G"
+      
+      $n
+      [1] 5
+      
+      $weights
+      NULL
+      
+      $type
+      [1] "out"
+      
+      $directed
+      [1] FALSE
+      
+
+---
+
+    Code
+      migration_fixture(g = "G", 5, kind = "in")
+    Condition
+      Warning in `migration_fixture()`:
+      partial argument match of 'g' to 'graph'
+      Warning:
+      Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
+      i Detected call: migration_fixture(graph, n, kind)
+      i Use instead: migration_fixture(graph, n, type = )
+    Output
+      $graph
+      [1] "G"
+      
+      $n
+      [1] 5
+      
+      $weights
+      NULL
+      
+      $type
+      [1] "in"
+      
+      $directed
+      [1] FALSE
+      
+
 # recovery deprecation messages
 
     Code
-      x <- migration_fixture("g", 5, 1:3, "in", TRUE)
+      migration_fixture("g", 5, 1:3, "in", TRUE)
     Condition
       Warning:
       Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
       i Detected call: migration_fixture(graph, n, weight, kind, directed)
       i Use instead: migration_fixture(graph, n, weights = , type = , directed = )
+    Output
+      $graph
+      [1] "g"
+      
+      $n
+      [1] 5
+      
+      $weights
+      [1] 1 2 3
+      
+      $type
+      [1] "in"
+      
+      $directed
+      [1] TRUE
+      
 
 ---
 
     Code
-      x <- migration_fixture("g", 5, 1:3)
+      migration_fixture("g", 5, 1:3)
     Condition
       Warning:
       Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
       i Detected call: migration_fixture(graph, n, weight)
       i Use instead: migration_fixture(graph, n, weights = )
+    Output
+      $graph
+      [1] "g"
+      
+      $n
+      [1] 5
+      
+      $weights
+      [1] 1 2 3
+      
+      $type
+      [1] "out"
+      
+      $directed
+      [1] FALSE
+      
 
 ---
 
     Code
-      x <- migration_fixture("g", 5, weight = 1:3)
+      migration_fixture("g", 5, weight = 1:3)
     Condition
       Warning:
       Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
       i Detected call: migration_fixture(graph, n, weight)
       i Use instead: migration_fixture(graph, n, weights = )
+    Output
+      $graph
+      [1] "g"
+      
+      $n
+      [1] 5
+      
+      $weights
+      [1] 1 2 3
+      
+      $type
+      [1] "out"
+      
+      $directed
+      [1] FALSE
+      
 
 ---
 
     Code
-      x <- migration_fixture("g", 5, kind = "in")
+      migration_fixture("g", 5, kind = "in")
     Condition
       Warning:
       Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
       i Detected call: migration_fixture(graph, n, kind)
       i Use instead: migration_fixture(graph, n, type = )
+    Output
+      $graph
+      [1] "g"
+      
+      $n
+      [1] 5
+      
+      $weights
+      NULL
+      
+      $type
+      [1] "in"
+      
+      $directed
+      [1] FALSE
+      
 
 ---
 
     Code
-      x <- migration_fixture("g", 5, kin = "in")
+      migration_fixture("g", 5, kin = "in")
     Condition
       Warning:
       Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
       i Detected call: migration_fixture(graph, n, kind)
       i Use instead: migration_fixture(graph, n, type = )
+    Output
+      $graph
+      [1] "g"
+      
+      $n
+      [1] 5
+      
+      $weights
+      NULL
+      
+      $type
+      [1] "in"
+      
+      $directed
+      [1] FALSE
+      
 
 ---
 
     Code
-      x <- migration_fixture("g", 5, dir = TRUE)
+      migration_fixture("g", 5, dir = TRUE)
     Condition
       Warning:
       Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
       i Detected call: migration_fixture(graph, n, directed)
       i Use instead: migration_fixture(graph, n, directed = )
+    Output
+      $graph
+      [1] "g"
+      
+      $n
+      [1] 5
+      
+      $weights
+      NULL
+      
+      $type
+      [1] "out"
+      
+      $directed
+      [1] TRUE
+      
 
 ---
 
     Code
-      x <- migration_fixture("g", 5, 1:3, dir = TRUE)
+      migration_fixture("g", 5, 1:3, dir = TRUE)
     Condition
       Warning:
       Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
       i Detected call: migration_fixture(graph, n, weight, directed)
       i Use instead: migration_fixture(graph, n, weights = , directed = )
-
----
-
-    Code
-      x <- migration_fixture(g = "G", 5, kind = "in")
-    Condition
-      Warning:
-      Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
-      i Detected call: migration_fixture(graph, n, kind)
-      i Use instead: migration_fixture(graph, n, type = )
+    Output
+      $graph
+      [1] "g"
+      
+      $n
+      [1] 5
+      
+      $weights
+      [1] 1 2 3
+      
+      $type
+      [1] "out"
+      
+      $directed
+      [1] TRUE
+      
 
 # error message snapshots
 

--- a/tests/testthat/_snaps/migration-fixture.md
+++ b/tests/testthat/_snaps/migration-fixture.md
@@ -5,7 +5,7 @@
     Condition
       Warning:
       Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
-      i Detected call: migration_fixture(graph, n, weight, type, directed)
+      i Detected call: migration_fixture(graph, n, weight, kind, directed)
       i Use instead: migration_fixture(graph, n, weights = , type = , directed = )
 
 ---
@@ -31,11 +31,21 @@
 ---
 
     Code
-      x <- migration_fixture("g", 5, ty = "in")
+      x <- migration_fixture("g", 5, kind = "in")
     Condition
       Warning:
       Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
-      i Detected call: migration_fixture(graph, n, type)
+      i Detected call: migration_fixture(graph, n, kind)
+      i Use instead: migration_fixture(graph, n, type = )
+
+---
+
+    Code
+      x <- migration_fixture("g", 5, kin = "in")
+    Condition
+      Warning:
+      Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
+      i Detected call: migration_fixture(graph, n, kind)
       i Use instead: migration_fixture(graph, n, type = )
 
 ---
@@ -57,6 +67,16 @@
       Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
       i Detected call: migration_fixture(graph, n, weight, directed)
       i Use instead: migration_fixture(graph, n, weights = , directed = )
+
+---
+
+    Code
+      x <- migration_fixture(g = "G", 5, kind = "in")
+    Condition
+      Warning:
+      Calling `migration_fixture()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
+      i Detected call: migration_fixture(graph, n, kind)
+      i Use instead: migration_fixture(graph, n, type = )
 
 # error message snapshots
 

--- a/tests/testthat/test-migration-fixture.R
+++ b/tests/testthat/test-migration-fixture.R
@@ -67,20 +67,17 @@ test_that("positional and named recovery can be mixed in one call", {
   expect_equal(res$type, "out")
 })
 
-test_that("head args are matched by base R, including abbreviations", {
-  rlang::local_options(lifecycle_verbosity = "warning")
-  # Abbreviating a head arg (before `...`) is plain R partial matching: it is
-  # resolved silently and is *not* deprecated.
-  expect_no_warning(res <- migration_fixture(gr = "G", n = 5))
-  expect_equal(res$graph, "G")
-
-  # A head abbreviation alongside a recovered tail arg: head stays silent, the
-  # tail arg is recovered with a single deprecation.
-  lifecycle::expect_deprecated(
-    res <- migration_fixture(g = "G", 5, kind = "in")
+test_that("head args go through base R partial matching, not our recovery", {
+  # Abbreviating a head arg (before `...`) is plain R partial matching, not our
+  # recovery. With `warnPartialMatchArgs` on, R emits its own partial-match
+  # warning and our deprecation does not fire; when a tail arg is abbreviated
+  # too, both warnings appear -- R's for the head, ours for the tail.
+  rlang::local_options(
+    lifecycle_verbosity = "warning",
+    warnPartialMatchArgs = TRUE
   )
-  expect_equal(res$graph, "G")
-  expect_equal(res$type, "in")
+  expect_snapshot(migration_fixture(gr = "G", n = 5))
+  expect_snapshot(migration_fixture(g = "G", 5, kind = "in"))
 })
 
 test_that("recovery emits a single deprecation warning, not one per slot", {
@@ -99,17 +96,17 @@ test_that("recovery emits a single deprecation warning, not one per slot", {
 # ---- deprecation message snapshots -----------------------------------------
 
 test_that("recovery deprecation messages", {
+  # No assignment, so the snapshot also shows the recovered values the call
+  # resolved to.
   rlang::local_options(lifecycle_verbosity = "warning")
-  expect_snapshot(x <- migration_fixture("g", 5, 1:3, "in", TRUE))
-  expect_snapshot(x <- migration_fixture("g", 5, 1:3))
-  expect_snapshot(x <- migration_fixture("g", 5, weight = 1:3))
-  expect_snapshot(x <- migration_fixture("g", 5, kind = "in"))
-  expect_snapshot(x <- migration_fixture("g", 5, kin = "in"))
-  expect_snapshot(x <- migration_fixture("g", 5, dir = TRUE))
+  expect_snapshot(migration_fixture("g", 5, 1:3, "in", TRUE))
+  expect_snapshot(migration_fixture("g", 5, 1:3))
+  expect_snapshot(migration_fixture("g", 5, weight = 1:3))
+  expect_snapshot(migration_fixture("g", 5, kind = "in"))
+  expect_snapshot(migration_fixture("g", 5, kin = "in"))
+  expect_snapshot(migration_fixture("g", 5, dir = TRUE))
   # mixed: a positional value and a named abbreviation in the same call
-  expect_snapshot(x <- migration_fixture("g", 5, 1:3, dir = TRUE))
-  # head abbreviation (g -> graph, by base R) does not appear in the message
-  expect_snapshot(x <- migration_fixture(g = "G", 5, kind = "in"))
+  expect_snapshot(migration_fixture("g", 5, 1:3, dir = TRUE))
 })
 
 test_that("error message snapshots", {

--- a/tests/testthat/test-migration-fixture.R
+++ b/tests/testthat/test-migration-fixture.R
@@ -1,7 +1,8 @@
 # Tests for the in-place argument-migration generator (tools/generate-migrations.R)
 # via the fixture `migration_fixture()` (R/migration-fixture.R). Old signature
-# f(graph, n, weight, type, directed); new f(graph, n, ..., weights, type,
-# directed) with weight -> weights.
+# f(graph, n, weight, kind, directed); new f(graph, n, ..., weights, type,
+# directed) with weight -> weights and kind -> type (directed survives). The
+# head args (graph, n) stay before `...` and are matched by base R.
 
 # ---- behaviour --------------------------------------------------------------
 
@@ -40,11 +41,17 @@ test_that("a legacy positional call is recovered", {
   )
 })
 
-test_that("a renamed-away old name and abbreviations are recovered by name", {
+test_that("renamed-away old names are recovered by name", {
   rlang::local_options(lifecycle_verbosity = "warning")
   lifecycle::expect_deprecated(res <- migration_fixture("g", 5, weight = 1:3))
   expect_equal(res$weights, 1:3)
-  lifecycle::expect_deprecated(res <- migration_fixture("g", 5, ty = "in"))
+  lifecycle::expect_deprecated(res <- migration_fixture("g", 5, kind = "in"))
+  expect_equal(res$type, "in")
+})
+
+test_that("abbreviations are recovered by partial match", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  lifecycle::expect_deprecated(res <- migration_fixture("g", 5, kin = "in"))
   expect_equal(res$type, "in")
   lifecycle::expect_deprecated(res <- migration_fixture("g", 5, dir = TRUE))
   expect_true(res$directed)
@@ -58,6 +65,22 @@ test_that("positional and named recovery can be mixed in one call", {
   expect_equal(res$weights, 1:3)
   expect_true(res$directed)
   expect_equal(res$type, "out")
+})
+
+test_that("head args are matched by base R, including abbreviations", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  # Abbreviating a head arg (before `...`) is plain R partial matching: it is
+  # resolved silently and is *not* deprecated.
+  expect_no_warning(res <- migration_fixture(gr = "G", n = 5))
+  expect_equal(res$graph, "G")
+
+  # A head abbreviation alongside a recovered tail arg: head stays silent, the
+  # tail arg is recovered with a single deprecation.
+  lifecycle::expect_deprecated(
+    res <- migration_fixture(g = "G", 5, kind = "in")
+  )
+  expect_equal(res$graph, "G")
+  expect_equal(res$type, "in")
 })
 
 test_that("recovery emits a single deprecation warning, not one per slot", {
@@ -80,10 +103,13 @@ test_that("recovery deprecation messages", {
   expect_snapshot(x <- migration_fixture("g", 5, 1:3, "in", TRUE))
   expect_snapshot(x <- migration_fixture("g", 5, 1:3))
   expect_snapshot(x <- migration_fixture("g", 5, weight = 1:3))
-  expect_snapshot(x <- migration_fixture("g", 5, ty = "in"))
+  expect_snapshot(x <- migration_fixture("g", 5, kind = "in"))
+  expect_snapshot(x <- migration_fixture("g", 5, kin = "in"))
   expect_snapshot(x <- migration_fixture("g", 5, dir = TRUE))
   # mixed: a positional value and a named abbreviation in the same call
   expect_snapshot(x <- migration_fixture("g", 5, 1:3, dir = TRUE))
+  # head abbreviation (g -> graph, by base R) does not appear in the message
+  expect_snapshot(x <- migration_fixture(g = "G", 5, kind = "in"))
 })
 
 test_that("error message snapshots", {
@@ -104,9 +130,9 @@ fixture_args <- function(
     dots,
     current = current,
     recover_new = c("weights", "type", "directed"),
-    recover_old = c("weight", "type", "directed"),
-    match_names = c("weight", "weights", "type", "directed"),
-    match_to = c("weights", "weights", "type", "directed"),
+    recover_old = c("weight", "kind", "directed"),
+    match_names = c("weight", "kind", "weights", "type", "directed"),
+    match_to = c("weights", "type", "weights", "type", "directed"),
     defaults = list(weights = NULL, type = "out", directed = FALSE),
     head_args = c("graph", "n"),
     fn_name = "migration_fixture"
@@ -123,7 +149,7 @@ test_that("migrate_recover_args() returns recovered values and message parts", {
   expect_match(res$what, "positional or abbreviated")
   expect_match(
     res$details[[1]],
-    "migration_fixture\\(graph, n, weight, type, directed\\)"
+    "migration_fixture\\(graph, n, weight, kind, directed\\)"
   )
   expect_match(res$details[[2]], "weights = , type = , directed = ")
 })

--- a/tests/testthat/test-migration-fixture.R
+++ b/tests/testthat/test-migration-fixture.R
@@ -201,3 +201,52 @@ test_that("the BEGIN marker may carry a trailing note", {
   m <- regmatches(marker, regexec(gen_env$begin_re, marker))[[1]]
   expect_identical(m[[3]], "foo")
 })
+
+test_that("render_call_arg() wraps long arguments the way air formats them", {
+  # The fixture's args stay under the 80-col width, but a real migration with
+  # more arguments overflows; the renderer must wrap exactly as `air` would so
+  # the after-install drift check (generator output vs air-formatted source)
+  # stays clean. `splice_blocks()` prepends 2 spaces to every block line, which
+  # the fit test accounts for.
+  generator <- testthat::test_path("..", "..", "tools", "generate-migrations.R")
+  skip_if_not(file.exists(generator))
+  gen_env <- new.env()
+  sys.source(generator, envir = gen_env)
+
+  # Short -> single line.
+  short <- gen_env$render_call_arg(
+    "head_args",
+    "c",
+    c('"graph"', '"n"'),
+    "character(0)"
+  )
+  expect_identical(short, '    head_args = c("graph", "n"),')
+
+  # Empty -> the supplied literal, on a single line (never `c()`/`list()`).
+  empty <- gen_env$render_call_arg(
+    "recover_old",
+    "c",
+    character(0),
+    "character(0)"
+  )
+  expect_identical(empty, "    recover_old = character(0),")
+
+  # Long -> one item per line, opening/closing on their own lines, and every
+  # emitted line (plus the 2-space splice indent) stays within 80 cols.
+  items <- c(
+    "weights = weights",
+    "attr = attr",
+    "edges = edges",
+    "names = names",
+    "sparse = sparse"
+  )
+  wrapped <- gen_env$render_call_arg("current", "list", items, "list()")
+  expect_gt(length(wrapped), 1L)
+  expect_identical(wrapped[[1]], "    current = list(")
+  expect_identical(wrapped[[length(wrapped)]], "    ),")
+  expect_identical(
+    wrapped[2:6],
+    paste0("      ", items, c(",", ",", ",", ",", ""))
+  )
+  expect_true(all(nchar(wrapped) + 2L <= 80L))
+})

--- a/tools/generate-migrations.R
+++ b/tools/generate-migrations.R
@@ -181,36 +181,46 @@ normalise_migration <- function(fn, entry) {
 
 # ---- rendering -------------------------------------------------------------
 
-render_chr_vec <- function(x) {
+# Quote each element of a character vector for emission as a literal `c(...)`.
+quote_items <- function(x) {
   if (length(x) == 0L) {
-    return("character(0)")
+    return(character(0))
   }
-  paste0("c(", paste0('"', x, '"', collapse = ", "), ")")
+  paste0('"', x, '"')
 }
 
-render_defaults_list <- function(entry) {
-  keep <- intersect(entry$tail, names(entry$defaults))
-  if (length(keep) == 0L) {
-    return("list()")
+# Render one `name = ctor(items)` argument of the migrate_recover_args() call,
+# laid out exactly as `air` (line-width 80) formats it: kept on one line when it
+# fits, otherwise wrapped one item per line. `splice_blocks()` prepends 2 spaces
+# of indentation to every block line, so the fit test accounts for that; the
+# call's own args sit at 4 spaces (final 6) and wrapped items at 6 (final 8).
+# `empty` is the literal emitted for zero items (e.g. "character(0)", "list()").
+render_call_arg <- function(name, ctor, items, empty, trailing = ",") {
+  arg_indent <- strrep(" ", 4L)
+  if (length(items) == 0L) {
+    return(paste0(arg_indent, name, " = ", empty, trailing))
   }
-  items <- vapply(
-    keep,
-    function(nm) {
-      paste0(nm, " = ", entry$defaults[[nm]])
-    },
-    character(1)
+  one_line <- paste0(
+    arg_indent,
+    name,
+    " = ",
+    ctor,
+    "(",
+    paste(items, collapse = ", "),
+    ")",
+    trailing
   )
-  paste0("list(", paste(items, collapse = ", "), ")")
-}
-
-# The new-API args (with defaults) whose current value we pass to the matcher for
-# conflict detection -- i.e. the recoverable args that have a formal default.
-render_current_list <- function(entry) {
-  keep <- intersect(entry$tail, names(entry$defaults))
-  if (length(keep) == 0L) {
-    return("list()")
+  if (nchar(one_line) + 2L <= 80L) {
+    return(one_line)
   }
-  paste0("list(", paste0(keep, " = ", keep, collapse = ", "), ")")
+  item_indent <- strrep(" ", 6L)
+  n <- length(items)
+  c(
+    paste0(arg_indent, name, " = ", ctor, "("),
+    paste0(item_indent, items[-n], ","),
+    paste0(item_indent, items[[n]]),
+    paste0(arg_indent, ")", trailing)
+  )
 }
 
 # Render the inline ARG_HANDLE block spliced into a function body between the
@@ -227,17 +237,24 @@ render_current_list <- function(entry) {
 # The whole thing is guarded by `...length() > 0L` so the common path (a correct
 # new-API call with nothing in `...`) skips the helper call entirely.
 render_arg_handle <- function(entry) {
+  keep <- intersect(entry$tail, names(entry$defaults))
+  default_items <- vapply(
+    keep,
+    function(nm) paste0(nm, " = ", entry$defaults[[nm]]),
+    character(1),
+    USE.NAMES = FALSE
+  )
   c(
     "if (...length() > 0L) {",
     "  .arg_handle <- migrate_recover_args(",
     "    list(...),",
-    paste0("    current = ", render_current_list(entry), ","),
-    paste0("    recover_new = ", render_chr_vec(entry$recover_new), ","),
-    paste0("    recover_old = ", render_chr_vec(entry$recover_old), ","),
-    paste0("    match_names = ", render_chr_vec(entry$match_names), ","),
-    paste0("    match_to = ", render_chr_vec(entry$match_to), ","),
-    paste0("    defaults = ", render_defaults_list(entry), ","),
-    paste0("    head_args = ", render_chr_vec(entry$head), ","),
+    render_call_arg("current", "list", paste0(keep, " = ", keep), "list()"),
+    render_call_arg("recover_new", "c", quote_items(entry$recover_new), "character(0)"),
+    render_call_arg("recover_old", "c", quote_items(entry$recover_old), "character(0)"),
+    render_call_arg("match_names", "c", quote_items(entry$match_names), "character(0)"),
+    render_call_arg("match_to", "c", quote_items(entry$match_to), "character(0)"),
+    render_call_arg("defaults", "list", default_items, "list()"),
+    render_call_arg("head_args", "c", quote_items(entry$head), "character(0)"),
     paste0("    fn_name = \"", entry$fn, "\""),
     "  )",
     "  list2env(.arg_handle$values, environment())",

--- a/tools/migrations.R
+++ b/tools/migrations.R
@@ -74,12 +74,14 @@ migrations <- list(
 
   # --- test fixture --------------------------------------------------------
   # Exercises the generator end-to-end without migrating a real function. The
-  # arg names are chosen to cover every recovery path: a rename (`weight ->
-  # weights`), unique abbreviations (`ty`, `dir`) and an ambiguous one (`weig`
-  # matches both `weight` and `weights`). Consumed by
+  # arg names are chosen to cover every recovery path: two renames (`weight ->
+  # weights`, `kind -> type`), a surviving arg (`directed`), unique
+  # abbreviations (`kin`, `dir`) and an ambiguous one (`weig` matches both
+  # `weight` and `weights`). Head args (`graph`, `n`) stay before `...` and are
+  # matched by base R, including abbreviations like `gr =`. Consumed by
   # tests/testthat/test-migration-fixture.R.
   migration_fixture = list(
-    old = function(graph, n, weight = weights, type, directed) {},
+    old = function(graph, n, weight = weights, kind = type, directed) {},
     new = function(
       graph,
       n,


### PR DESCRIPTION
Follow-up to #2684. Add a second rename to the fixture (`kind -> type`, in addition to `weight -> weights`) and snapshot the cross-product of call styles: positional, renamed-away old names, unique and ambiguous abbreviations, mixed positional+named, and head-arg abbreviations (`gr =`, `g =`).

Confirms the two matching regimes compose: head args before `...` are resolved silently by base R's partial matching (not deprecated), while renamed/abbreviated args after `...` are recovered with a single soft-deprecation. No behaviour change -- fixture and tests only.

@krlmlr did you expect any behaviour changes or just these tests?