### PR TITLE
fix: repair touchstone benchmark CI

### DIFF
--- a/.github/workflows/touchstone-comment.yaml
+++ b/.github/workflows/touchstone-comment.yaml
@@ -26,6 +26,10 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: lorenzwalthert/touchstone/actions/comment@v1
+      # Pinned to a default-branch SHA: the released tags (v1, v1.0.1) still
+      # use actions/{upload,download}-artifact@v2, which GitHub now auto-fails.
+      # This commit uses artifact@v4/v5 and github-script@v7. Bump to a tag once
+      # upstream cuts a release that includes the fix.
+      - uses: lorenzwalthert/touchstone/actions/comment@7e6072a25d1f8d72649188bc711113039ef94b75
         with: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/touchstone-comment.yaml
+++ b/.github/workflows/touchstone-comment.yaml
@@ -18,8 +18,13 @@ permissions:
 jobs:
   upload:
     runs-on: ubuntu-latest
+    # Require the receive run to have actually succeeded. Without the
+    # conclusion check this job also runs when receive was skipped/failed, then
+    # crashes downloading the missing "pr" artifact ("Cannot read properties of
+    # undefined (reading 'id')").
     if: >
-      ${{ github.event.workflow_run.event == 'pull_request' }}
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: lorenzwalthert/touchstone/actions/comment@v1
         with: 

--- a/.github/workflows/touchstone-receive.yaml
+++ b/.github/workflows/touchstone-receive.yaml
@@ -54,7 +54,11 @@ jobs:
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: lorenzwalthert/touchstone/actions/receive@v1
+      # Pinned to a default-branch SHA: the released tags (v1, v1.0.1) still
+      # use actions/{upload,download}-artifact@v2, which GitHub now auto-fails.
+      # This commit uses artifact@v4/v5 and github-script@v7. Bump to a tag once
+      # upstream cuts a release that includes the fix.
+      - uses: lorenzwalthert/touchstone/actions/receive@7e6072a25d1f8d72649188bc711113039ef94b75
         with:
           cache-version: 1
           benchmarking_repo: ${{ matrix.config.benchmarking_repo }}

--- a/.github/workflows/touchstone-receive.yaml
+++ b/.github/workflows/touchstone-receive.yaml
@@ -21,14 +21,14 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ubuntu-latest 
-    if:
-      true &&
-      (
-        github.event.pull_request.author_association == 'OWNER' ||
-        github.event.pull_request.author_association == 'MEMBER' ||
-        github.event.pull_request.author_association == 'COLLABORATOR' 
-      )
+    runs-on: ubuntu-latest
+    # Only run for PRs from branches in this repo (not forks). Creating a
+    # same-repo branch requires push access, so this is the safety gate that
+    # keeps untrusted fork code from running with the workflow token. We do
+    # *not* gate on author_association: it is derived from the webhook payload,
+    # which reports CONTRIBUTOR/NONE (never MEMBER) for users whose org
+    # membership is private, silently skipping legitimate maintainer PRs.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       config: ${{ steps.read_touchstone_config.outputs.config }}
     steps:
@@ -38,14 +38,9 @@ jobs:
           fetch-depth: 0
 
       - id: read_touchstone_config
-        run: |
-          content=`cat ./touchstone/config.json`
-          # the following lines are only required for multi line json
-          content="${content//'%'/'%25'}"
-          content="${content//$'\n'/'%0A'}"
-          content="${content//$'\r'/'%0D'}"
-          # end of optional handling for multi line json
-          echo "::set-output name=config::$content"
+        # Compact the (possibly pretty-printed) config to a single line so it
+        # can be passed through $GITHUB_OUTPUT without multi-line escaping.
+        run: echo "config=$(jq -c . ./touchstone/config.json)" >> "$GITHUB_OUTPUT"
   build:
     needs: prepare
     runs-on: ${{ matrix.config.os }}


### PR DESCRIPTION
The touchstone benchmark CI added in #2685 failed on its first run ([example](https://github.com/igraph/rigraph/actions/runs/26946685203/job/79501303006)). Three linked problems:

### 1. Receive workflow skipped every maintainer PR (root cause)
`prepare` gated on `author_association == OWNER/MEMBER/COLLABORATOR`. That value comes from the `pull_request` **webhook payload**, which reports `CONTRIBUTOR`/`NONE` (never `MEMBER`) for maintainers whose org membership is **private** — so the gate was false, both jobs skipped, and no `"pr"` artifact was produced.

→ Gate on the PR head being a **same-repo branch** instead. Creating a same-repo branch requires push access, so this is the real security boundary against untrusted fork code, and it's immune to membership visibility.

### 2. Comment workflow crashed instead of no-op'ing (the visible error)
It only checked `workflow_run.event == 'pull_request'`, so it ran after the skipped receive run and died downloading the missing artifact: `Cannot read properties of undefined (reading 'id')`.

→ Also require `workflow_run.conclusion == 'success'`.

### 3. Deprecated `::set-output` (latent)
Would have left `needs.prepare.outputs.config` empty once `prepare` actually ran, breaking the `fromJson` build matrix.

→ Switch to `$GITHUB_OUTPUT`, compacting `config.json` with `jq -c` (drops the multi-line escaping hack).

This PR touches `.github/workflows/touchstone-*.yaml`, which is in the receive trigger's path filter, so it exercises the fixed workflow itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)