### PR TITLE
fix: touchstone empty results table for branches with a slash

### DIFF
--- a/.github/workflows/touchstone-receive.yaml
+++ b/.github/workflows/touchstone-receive.yaml
@@ -63,6 +63,13 @@ jobs:
           cache-version: 1
           benchmarking_repo: ${{ matrix.config.benchmarking_repo }}
           benchmarking_ref: ${{ matrix.config.benchmarking_ref }}
-          benchmarking_path: ${{ matrix.config.benchmarking_path }} 
+          benchmarking_path: ${{ matrix.config.benchmarking_path }}
           force_upstream: true
           r-version: ${{ matrix.config.r }}
+          # Install the {touchstone} R package from the same commit as the
+          # action above. The default ('@v1') predates the fix that encodes
+          # filesystem-unsafe characters in branch names, so head branches with
+          # a "/" (e.g. feat/foo) get stored as a nested records/<bench>/feat/foo
+          # directory; benchmark_analyze() then can't match base+head and
+          # silently drops every benchmark, producing an empty results table.
+          touchstone_ref: "@7e6072a25d1f8d72649188bc711113039ef94b75"


### PR DESCRIPTION
## Problem

Touchstone now posts PR comments, but the results table is empty — only the header/footer render (see [example](https://github.com/igraph/rigraph/pull/2682#issuecomment-4623603358)).

## Root cause

The benchmarks run fine and records are uploaded, but `benchmark_analyze()` discards all of them with:

> Ignoring all benchmarks that don't have exactly those two branches.

The downloaded `results` artifact shows why — records for a head branch like `feat/print-style-modern` are stored as:

```
records/graph_from_data_frame/main
records/graph_from_data_frame/feat/print-style-modern   ← the "/" nests a directory
```

The receive action installs the **{touchstone} R package** from its `touchstone_ref` input, which defaults to **`@v1`**. That tag predates the upstream commits *"support branch names with slashes"* / *"encode all filesystem-unsafe characters in branch names"* (2025-11-27), so it has no `branch_encode()`. The raw `/` in the branch name nests a subdirectory, `benchmark_analyze()` can't match a benchmark that has exactly the base+head branches, and every benchmark is dropped → empty table.

We previously pinned the **action wrapper** to a default-branch SHA (`7e6072a`) to get `artifact@v4/v5`, but the *R package* was still installed from `@v1`. This is the remaining half of that version mismatch.

## Fix

Pin `touchstone_ref` to the same commit the action wrapper already uses, so the installed R package includes `branch_encode()`/`branch_decode()`.

Only affects `R/**` etc. via the receive trigger; this PR's own branch (`fix-touchstone-slash-branches`, no slash) wouldn't have surfaced the bug, so once merged a slash-named branch is the real end-to-end test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)