### PR TITLE
docs: use "ID"/"IDs" consistently in documentation prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ pak::pak(dependencies = "Config/Needs/build")
 - Document all arguments and return values
 - Document internal functions using devtag (work in progress)
 - Link to C documentation using `@cdocs` tag: `#' @cdocs igraph_function_name`
+- Write "ID"/"IDs" (not "id"/"ids") when referring to vertex/edge IDs in documentation *prose*. Lowercase stays only where the token is code: argument names, runnable `@examples`, and spans in `` `...` `` or `\code{}`. Run `Rscript tools/check-id-casing.R` to find violations in roxygen prose.
 - Always run `devtools::document()` after updating documentation
 
 ### Naming Conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,15 @@ igraph` to update the `.Rd` files.
 
 - Links to C docs are added automatically thanks to the igraph.r2cdocs's roclet.
 
+- Write "ID"/"IDs" (not "id"/"ids") when referring to vertex or edge IDs in
+documentation prose. Lowercase stays only where the token is code: argument
+names, runnable `@examples`, and spans wrapped in `` `...` `` or `\code{}`. You
+can check roxygen prose for stray lowercase forms with:
+
+```sh
+Rscript tools/check-id-casing.R
+```
+
 ### Maintaining igraph.r2cdocs
 
 To update the data (when the C docs index has changed after a release) in https://github.com/igraph/igraph.r2cdocs/, run the script that is `data-raw`, commit the csv file and push.

--- a/R/attributes.R
+++ b/R/attributes.R
@@ -1204,12 +1204,12 @@ delete_edge_attr <- function(graph, name) {
 #' vertices.
 #'
 #' In igraph vertices can always be identified and specified via their numeric
-#' vertex ids. This is, however, not always convenient, and in many cases there
-#' exist symbolic ids that correspond to the vertices. To allow this more
+#' vertex IDs. This is, however, not always convenient, and in many cases there
+#' exist symbolic IDs that correspond to the vertices. To allow this more
 #' flexible identification of vertices, one can assign a vertex attribute
 #' called \sQuote{name} to an igraph graph. After doing this, the symbolic
 #' vertex names can be used in all igraph functions, instead of the numeric
-#' ids.
+#' IDs.
 #'
 #' Note that the uniqueness of vertex names are currently not enforced in
 #' igraph, you have to check that for yourself, when assigning the vertex

--- a/R/bipartite.R
+++ b/R/bipartite.R
@@ -124,7 +124,7 @@ bipartite.mapping <- function(graph) {
 #'   graph), then the multiplicity of the A-B edge in the projection will be 2.
 #' @param probe1 This argument can be used to specify the order of the
 #'   projections in the resulting list. If given, then it is considered as a
-#'   vertex id (or a symbolic vertex name); the projection containing this vertex
+#'   vertex ID (or a symbolic vertex name); the projection containing this vertex
 #'   will be the first one in the result list.  This argument is ignored if only
 #'   one projection is requested in argument `which`.
 #' @param which A character scalar to specify which projection(s) to calculate.

--- a/R/centrality.R
+++ b/R/centrality.R
@@ -1399,7 +1399,7 @@ strength <- function(
 #' @param weights `NULL`, or the vector of edge weights to use for the
 #'   computation. If `NULL`, then the \sQuote{weight} attibute is used. Note
 #'   that this measure is not defined for unweighted graphs.
-#' @param vids The vertex ids for which to calculate the measure.
+#' @param vids The vertex IDs for which to calculate the measure.
 #' @return A numeric vector, its length is the number of vertices.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
 #' @references Nathan Eagle, Michael Macy and Rob Claxton: Network Diversity

--- a/R/cliques.R
+++ b/R/cliques.R
@@ -213,12 +213,12 @@ clique.number <- function(graph) {
 #'   so will cause R to crash due to reentrancy issues. Extract
 #'   any needed graph information before calling the function with a callback, or
 #'   use collector mode (the default) and process results afterward.
-#' @return `cliques()` returns a list containing numeric vectors of vertex ids if
+#' @return `cliques()` returns a list containing numeric vectors of vertex IDs if
 #'   `callback` is `NULL`. Each list element is a clique, i.e. a vertex sequence
 #'   of class [igraph.vs][V]. If `callback` is provided, returns `NULL` invisibly.
 #'
 #'   `largest_cliques()` and `clique_num()` return a list containing numeric
-#'   vectors of vertex ids. Each list element is a clique, i.e. a vertex sequence
+#'   vectors of vertex IDs. Each list element is a clique, i.e. a vertex sequence
 #'   of class [igraph.vs][V].
 #'
 #'   `max_cliques()` returns `NULL`, invisibly, if its `file`
@@ -286,7 +286,7 @@ largest_cliques <- function(graph) {
 }
 
 #' @rdname cliques
-#' @param subset If not `NULL`, then it must be a vector of vertex ids,
+#' @param subset If not `NULL`, then it must be a vector of vertex IDs,
 #'   numeric or symbolic if the graph is named. The algorithm is run from these
 #'   vertices only, so only a subset of all maximal cliques is returned. See the
 #'   Eppstein paper for details. This argument makes it possible to easily
@@ -294,7 +294,7 @@ largest_cliques <- function(graph) {
 #' @param file If not `NULL`, then it must be a file name, i.e. a
 #'   character scalar. The output of the algorithm is written to this file. (If
 #'   it exists, then it will be overwritten.) Each clique will be a separate line
-#'   in the file, given with the numeric ids of its vertices, separated by
+#'   in the file, given with the numeric IDs of its vertices, separated by
 #'   whitespace.
 #' @export
 max_cliques <- function(
@@ -534,7 +534,7 @@ weighted_clique_num <- function(graph, vertex.weights = NULL) {
 #' @return `ivs()`,
 #'   `largest_ivs()` and
 #'   `max_ivs()` return a list containing numeric
-#'   vertex ids, each list element is an independent vertex set.
+#'   vertex IDs, each list element is an independent vertex set.
 #'
 #'   `ivs_size()` returns an integer constant.
 #' @author Tamas Nepusz \email{ntamas@@gmail.com} ported it from the Very Nauty

--- a/R/cocitation.R
+++ b/R/cocitation.R
@@ -37,7 +37,7 @@
 #' in the future.
 #'
 #' @param graph The graph object to analyze
-#' @param v Vertex sequence or numeric vector, the vertex ids for which the
+#' @param v Vertex sequence or numeric vector, the vertex IDs for which the
 #'   cocitation or bibliographic coupling values we want to calculate. The
 #'   default is all vertices.
 #' @return A numeric matrix with `length(v)` lines and

--- a/R/cohesive.blocks.R
+++ b/R/cohesive.blocks.R
@@ -152,7 +152,7 @@ blockGraphs <- function(blocks, graph) {
 #'
 #' The function `blocks()` returns the actual blocks stored in the
 #' `cohesiveBlocks` object. They are returned in a list of numeric
-#' vectors, each containing vertex ids.
+#' vectors, each containing vertex IDs.
 #'
 #' The function `graphs_from_cohesive_blocks()` is similar, but returns the blocks as
 #' (induced) subgraphs of the input graph. The various (graph, vertex and edge)
@@ -163,7 +163,7 @@ blockGraphs <- function(blocks, graph) {
 #' `blocks()` and `graphs_from_cohesive_blocks()` functions.
 #'
 #' The block hierarchy can be queried using the `hierarchy()` function. It
-#' returns an igraph graph, its vertex ids are ordered according the order of
+#' returns an igraph graph, its vertex IDs are ordered according the order of
 #' the blocks in the `blocks()` and `graphs_from_cohesive_blocks()`, `cohesion()`,
 #' etc. functions.
 #'
@@ -208,7 +208,7 @@ blockGraphs <- function(blocks, graph) {
 #' blocks. The first block always corresponds to the whole graph, even if its
 #' cohesion is zero. Then cohesion of the block and the number of vertices in
 #' the block are shown. The last part is only printed if the display is wide
-#' enough and shows the vertices in the blocks, ordered by vertex ids.
+#' enough and shows the vertices in the blocks, ordered by vertex IDs.
 #' \sQuote{o} means that the vertex is included, a dot means that it is not,
 #' and the vertices are shown in groups of ten.
 #'
@@ -264,7 +264,7 @@ blockGraphs <- function(blocks, graph) {
 #'   them to `plot.igraph()`.  [print()] and [summary()] ignore them.
 #' @return `cohesive_blocks()` returns a `cohesiveBlocks` object.
 #'
-#'   `blocks()` returns a list of numeric vectors, containing vertex ids.
+#'   `blocks()` returns a list of numeric vectors, containing vertex IDs.
 #'
 #'   `graphs_from_cohesive_blocks()` returns a list of igraph graphs, corresponding to the
 #'   cohesive blocks.

--- a/R/community.R
+++ b/R/community.R
@@ -491,11 +491,11 @@ code.length <- function(communities) {
 #' returns the number of communities.
 #'
 #' The `sizes()` function returns the community sizes, in the order of their
-#' ids.
+#' IDs.
 #'
 #' `membership()` gives the division of the vertices, into communities. It
-#' returns a numeric vector, one value for each vertex, the id of its
-#' community. Community ids start from one. Note that some algorithms calculate
+#' returns a numeric vector, one value for each vertex, the ID of its
+#' community. Community IDs start from one. Note that some algorithms calculate
 #' the complete (or incomplete) hierarchical structure of the communities, and
 #' not just a single partitioning. For these algorithms typically the
 #' membership for the highest modularity value is returned, but see also the
@@ -504,7 +504,7 @@ code.length <- function(communities) {
 #' `communities()` is also the name of a function, that returns a list of
 #' communities, each identified by their vertices. The vertices will have
 #' symbolic names if the `add.vertex.names` igraph option is set, and the
-#' graph itself was named. Otherwise numeric vertex ids are used.
+#' graph itself was named. Otherwise numeric vertex IDs are used.
 #'
 #' `modularity()` gives the modularity score of the partitioning. (See
 #' [modularity.igraph()] for details. For algorithms that do not
@@ -514,7 +514,7 @@ code.length <- function(communities) {
 #' the community structure.
 #'
 #' `crossing()` returns a logical vector, with one value for each edge,
-#' ordered according to the edge ids. The value is `TRUE` iff the edge
+#' ordered according to the edge IDs. The value is `TRUE` iff the edge
 #' connects two different communities, according to the (best) membership
 #' vector, as returned by `membership()`.
 #'
@@ -744,7 +744,7 @@ print.communities <- function(x, ...) {
 #'
 #' @param graph The graph of the community structure.
 #' @param membership The membership vector of the community structure, a
-#'   numeric vector denoting the id of the community for each vertex. It
+#'   numeric vector denoting the ID of the community for each vertex. It
 #'   might be `NULL` for hierarchical community structures.
 #' @param algorithm Character string, the algorithm that generated
 #'   the community structure, it can be arbitrary.
@@ -756,7 +756,7 @@ print.communities <- function(x, ...) {
 #' @return A `communities` object.
 #'   \describe{
 #'     \item{membership}{
-#'       A numeric vector giving the community id for each vertex.
+#'       A numeric vector giving the community ID for each vertex.
 #'     }
 #'     \item{modularity}{
 #'       The modularity score of the partition.
@@ -1373,7 +1373,7 @@ community.to.membership2 <- function(merges, vcount, steps) {
 #' optimizing the an energy function.
 #'
 #' If the `vertex` argument is given and it is not `NULL`, then it
-#' must be a vertex id, and the same energy function is used to find the
+#' must be a vertex ID, and the same energy function is used to find the
 #' community of the the given vertex. See also the examples below.
 #'
 #' @param graph The input graph. Edge directions are ignored in directed graphs.
@@ -1436,7 +1436,7 @@ community.to.membership2 <- function(merges, vcount, steps) {
 #'   named list is returned with the following components:
 #'   \describe{
 #'     \item{community}{
-#'       Numeric vector giving the ids of the vertices in the same community as `vertex`.
+#'       Numeric vector giving the IDs of the vertices in the same community as `vertex`.
 #'     }
 #'     \item{cohesion}{
 #'       The cohesion score of the result, see references.
@@ -1956,7 +1956,7 @@ cluster_walktrap <- function(
 #'   itself is divisive and not agglomerative: it builds the tree from top to
 #'   bottom. There is one line for each merge (i.e. split) in matrix, the first
 #'   line is the first merge (last split). The communities are identified by
-#'   integer number starting from one. Community ids smaller than or equal to
+#'   integer number starting from one. Community IDs smaller than or equal to
 #'   \eqn{N}, the number of vertices in the graph, belong to singleton
 #'   communities, i.e. individual vertices. Before the first merge we have \eqn{N}
 #'   communities numbered from one to \eqn{N}. The first merge, the first line of
@@ -2947,7 +2947,7 @@ dendPlotPhylo <- function(
 #' @aliases compare.communities compare.membership
 #' @param comm1 A [communities()] object containing a community
 #'   structure; or a numeric vector, the membership vector of the first community
-#'   structure. The membership vector should contain the community id of each
+#'   structure. The membership vector should contain the community ID of each
 #'   vertex, the numbering of the communities starts with one.
 #' @param comm2 A [communities()] object containing a community
 #'   structure; or a numeric vector, the membership vector of the second
@@ -3140,7 +3140,7 @@ split_join_distance <- function(comm1, comm2) {
 #'   below.
 #' @return A named list of numeric or character vectors. The names are just
 #'   numbers that refer to the groups. The vectors themselves are numeric or
-#'   symbolic vertex ids.
+#'   symbolic vertex IDs.
 #' @seealso [components()] and the various community finding
 #' functions.
 #' @examples
@@ -3205,7 +3205,7 @@ communities <- groups.communities
 #'
 #' @param graph The input graph, it can be directed or undirected.
 #' @param mapping A numeric vector that specifies the mapping. Its elements
-#'   correspond to the vertices, and for each element the id in the new graph is
+#'   correspond to the vertices, and for each element the ID in the new graph is
 #'   given.
 #' @param vertex.attr.comb Specifies how to combine the vertex attributes in
 #'   the new graph. Please see [attribute.combination()] for details.
@@ -3268,7 +3268,7 @@ contract <- function(
 #' @return A named list with two components:
 #'   \describe{
 #'     \item{membership}{
-#'       numeric vector giving the cluster id to which each vertex belongs.
+#'       numeric vector giving the cluster ID to which each vertex belongs.
 #'     }
 #'     \item{distances}{
 #'       numeric vector giving the distance of each vertex from its generator

--- a/R/components.R
+++ b/R/components.R
@@ -290,7 +290,7 @@ bridges <- function(graph) {
 #'     }
 #'     \item{tree_edges}{
 #'       The components themselves, a list of numeric vectors.
-#'       Each vector is a set of edge ids giving the edges in a biconnected component.
+#'       Each vector is a set of edge IDs giving the edges in a biconnected component.
 #'       These edges define a spanning tree of the component.
 #'     }
 #'     \item{component_edges}{

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -346,7 +346,7 @@ get.adjacency.sparse <- function(
 #'   numeric. If the `sparse` argument is `FALSE`, then character is
 #'   also allowed. The reason for the difference is that the `Matrix`
 #'   package does not support character sparse matrices yet.
-#' @param edges `r lifecycle::badge("deprecated")` Logical scalar, whether to return the edge ids in the matrix.
+#' @param edges `r lifecycle::badge("deprecated")` Logical scalar, whether to return the edge IDs in the matrix.
 #'   For non-existant edges zero is returned.
 #' @param names Logical constant, whether to assign row and column names
 #'   to the matrix. These are only assigned if the `name` vertex attribute
@@ -433,7 +433,7 @@ as_adj <- function(
 #' @param graph The graph to convert.
 #' @param names Whether to return a character matrix containing vertex
 #'   names (i.e. the `name` vertex attribute) if they exist or numeric
-#'   vertex ids.
+#'   vertex IDs.
 #' @return A `ecount(graph)` by 2 numeric matrix.
 #' @seealso [graph_from_adjacency_matrix()], [read_graph()]
 #' @keywords graphs
@@ -601,12 +601,12 @@ as_undirected <- function(
 #' Create adjacency lists from a graph, either for adjacent edges or for
 #' neighboring vertices
 #'
-#' `as_adj_list()` returns a list of numeric vectors, which include the ids
+#' `as_adj_list()` returns a list of numeric vectors, which include the IDs
 #' of neighbor vertices (according to the `mode` argument) of all
 #' vertices.
 #'
 #' `as_adj_edge_list()` returns a list of numeric vectors, which include the
-#' ids of adjacent edges (according to the `mode` argument) of all
+#' IDs of adjacent edges (according to the `mode` argument) of all
 #' vertices.
 #'
 #' @param graph The input graph.
@@ -808,7 +808,7 @@ graph_from_graphnel <- function(
 #' `as_graphnel()` converts an igraph graph to a graphNEL graph. It
 #' converts all graph/vertex/edge attributes. If the igraph graph has a
 #' vertex attribute \sQuote{`name`}, then it will be used to assign
-#' vertex names in the graphNEL graph. Otherwise numeric igraph vertex ids
+#' vertex names in the graphNEL graph. Otherwise numeric igraph vertex IDs
 #' will be used for this purpose.
 #'
 #' @param graph An igraph graph object.
@@ -1070,7 +1070,7 @@ get.incidence.sparse <- function(
 #' @param names Logical scalar, if `TRUE` and the vertices in the graph
 #'   are named (i.e. the graph has a vertex attribute called `name`), then
 #'   vertex names will be added to the result as row and column names. Otherwise
-#'   the ids of the vertices are used as row and column names.
+#'   the IDs of the vertices are used as row and column names.
 #' @param sparse Logical scalar, if it is `TRUE` then a sparse matrix is
 #'   created, you will need the `Matrix` package for this.
 #' @return A sparse or dense matrix.
@@ -1254,8 +1254,8 @@ graph_from_adj_list <- function(
 #' in that row. The names of the columns that contain the metadata
 #' of the incident vertices are prefixed with `from_` and `to_`.
 #' The first two columns are always named `from` and `to` and
-#' they contain the numeric ids of the incident vertices. The rows are
-#' listed in the order of numeric vertex ids.
+#' they contain the numeric IDs of the incident vertices. The rows are
+#' listed in the order of numeric vertex IDs.
 #'
 #' @param graph Input graph
 #' @return A long data frame.
@@ -1488,14 +1488,14 @@ graph.data.frame <- function(d, directed = TRUE, vertices = NULL) {
 #' the graph and also the edge attributes are returned. The edges will be in
 #' the first two columns, named `from` and `to`. (This also denotes
 #' edge direction for directed graphs.)  For named graphs, the vertex names
-#' will be included in these columns, for other graphs, the numeric vertex ids.
+#' will be included in these columns, for other graphs, the numeric vertex IDs.
 #' The edge attributes will be in the other columns. It is not a good idea to
 #' have an edge attribute named `from` or `to`, because then the
 #' column named in the data frame will not be unique. The edges are listed in
-#' the order of their numeric ids.
+#' the order of their numeric IDs.
 #'
 #' If the `what` argument is `vertices`, then vertex attributes are
-#' returned. Vertices are listed in the order of their numeric vertex ids.
+#' returned. Vertices are listed in the order of their numeric vertex IDs.
 #'
 #' If the `what` argument is `both`, then both vertex and edge data
 #' is returned, in a list with named entries `vertices` and `edges`.
@@ -1639,9 +1639,9 @@ from_data_frame <- function(...) constructor_spec(graph_from_data_frame, ...)
 #'
 #' `graph_from_edgelist()` creates a graph from an edge list. Its argument
 #' is a two-column matrix, each row defines one edge. If it is
-#' a numeric matrix then its elements are interpreted as vertex ids. If
+#' a numeric matrix then its elements are interpreted as vertex IDs. If
 #' it is a character matrix then it is interpreted as symbolic vertex
-#' names and a vertex id will be assigned to each name, and also a
+#' names and a vertex ID will be assigned to each name, and also a
 #' `name` vertex attribute will be added.
 #'
 #' @concept Edge list

--- a/R/cycles.R
+++ b/R/cycles.R
@@ -36,7 +36,7 @@
 #'   and `all` ignores edge directions. Ignored in undirected graphs.
 #' @return A list of integer vectors, each integer vector is a path from
 #'   the source vertex to one of the target vertices. A path is given by its
-#'   vertex ids.
+#'   vertex IDs.
 #' @keywords graphs
 #' @examples
 #'

--- a/R/efficiency.R
+++ b/R/efficiency.R
@@ -40,7 +40,7 @@
 #' @param weights The edge weights. All edge weights must be non-negative;
 #'   additionally, no edge weight may be NaN. If it is `NULL` (the default)
 #'   and the graph has a `weight` edge attribute, then it is used automatically.
-#' @param vids The vertex ids of the vertices for which the calculation will be done.
+#' @param vids The vertex IDs of the vertices for which the calculation will be done.
 #'   Applies to the local efficiency calculation only.
 #' @param directed Logical scalar, whether to consider directed paths. Ignored
 #'   for undirected graphs.

--- a/R/eulerian.R
+++ b/R/eulerian.R
@@ -46,10 +46,10 @@
 #'   entries:
 #'   \describe{
 #'     \item{epath}{
-#'       A vector containing the edge ids along the Eulerian path or cycle.
+#'       A vector containing the edge IDs along the Eulerian path or cycle.
 #'     }
 #'     \item{vpath}{
-#'       A vector containing the vertex ids along the Eulerian path or cycle.
+#'       A vector containing the vertex IDs along the Eulerian path or cycle.
 #'     }
 #'   }
 #'

--- a/R/flow.R
+++ b/R/flow.R
@@ -341,8 +341,8 @@ dominator.tree <- function(graph, root, mode = c("out", "in", "all", "total")) {
 #' used to calculate the minimum cut.
 #'
 #' @param graph The input graph.
-#' @param source The id of the source vertex.
-#' @param target The id of the target vertex (sometimes also called sink).
+#' @param source The ID of the source vertex.
+#' @param target The ID of the target vertex (sometimes also called sink).
 #' @param capacity Vector giving the capacity of the edges. If this is
 #'   `NULL` (the default) then the `capacity` edge attribute is used.
 #' @param value.only Logical scalar, if `TRUE` only the minimum cut value
@@ -478,9 +478,9 @@ min_cut <- function(
 #'
 #' @aliases cohesion
 #' @param graph,x The input graph.
-#' @param source The id of the source vertex, for `vertex_connectivity()` it
+#' @param source The ID of the source vertex, for `vertex_connectivity()` it
 #'   can be `NULL`, see details below.
-#' @param target The id of the target vertex, for `vertex_connectivity()` it
+#' @param target The ID of the target vertex, for `vertex_connectivity()` it
 #'   can be `NULL`, see details below.
 #' @param checks Logical constant. Whether to check that the graph is connected
 #'   and also the degree of the vertices. If the graph is not (strongly)
@@ -585,9 +585,9 @@ vertex_connectivity <- function(
 #'
 
 #' @param graph The input graph.
-#' @param source The id of the source vertex, for `edge_connectivity()` it
+#' @param source The ID of the source vertex, for `edge_connectivity()` it
 #'   can be `NULL`, see details below.
-#' @param target The id of the target vertex, for `edge_connectivity()` it
+#' @param target The ID of the target vertex, for `edge_connectivity()` it
 #'   can be `NULL`, see details below.
 #' @param checks Logical constant. Whether to check that the graph is connected
 #'   and also the degree of the vertices. If the graph is not (strongly)
@@ -704,11 +704,11 @@ cohesion.igraph <- function(x, checks = TRUE, ...) {
 #' @return A list with entries:
 #'   \describe{
 #'     \item{cuts}{
-#'       A list of numeric vectors containing edge ids.
+#'       A list of numeric vectors containing edge IDs.
 #'       Each vector is an \eqn{(s,t)}-cut.
 #'     }
 #'     \item{partition1s}{
-#'       A list of numeric vectors containing vertex ids, they correspond to the edge cuts.
+#'       A list of numeric vectors containing vertex IDs, they correspond to the edge cuts.
 #'       Each vertex set is a generator of the corresponding cut, i.e. in the graph \eqn{G=(V,E)},
 #'       the vertex set \eqn{X} and its complementer \eqn{V-X},
 #'       generates the cut that contains exactly the edges that go from \eqn{X} to \eqn{V-X}.
@@ -758,8 +758,8 @@ st_cuts <- function(graph, source, target) {
 #' An \eqn{(s,t)}-cut is minimum if it is of the smallest possible size.
 #'
 #' @param graph The input graph. It must be directed.
-#' @param source The id of the source vertex.
-#' @param target The id of the target vertex.
+#' @param source The ID of the source vertex.
+#' @param target The ID of the target vertex.
 #' @param capacity Numeric vector giving the edge capacities. If this is
 #'   `NULL` and the graph has a `weight` edge attribute, then this
 #'   attribute defines the edge capacities. For forcing unit edge capacities,
@@ -771,10 +771,10 @@ st_cuts <- function(graph, source, target) {
 #'       Numeric scalar, the size of the minimum cut(s).
 #'     }
 #'     \item{cuts}{
-#'       A list of numeric vectors containing edge ids. Each vector is a minimum \eqn{(s,t)}-cut.
+#'       A list of numeric vectors containing edge IDs. Each vector is a minimum \eqn{(s,t)}-cut.
 #'     }
 #'     \item{partition1s}{
-#'       A list of numeric vectors containing vertex ids,
+#'       A list of numeric vectors containing vertex IDs,
 #'       they correspond to the edge cuts.
 #'       Each vertex set is a generator of the corresponding cut, i.e. in the graph \eqn{G=(V,E)},
 #'       the vertex set \eqn{X} and its complementer \eqn{V-X},
@@ -827,7 +827,7 @@ st_min_cuts <- function(graph, source, target, capacity = NULL) {
 #' @param graph A directed graph. If it is not a flowgraph, and it contains
 #'   some vertices not reachable from the root vertex, then these vertices will
 #'   be collected and returned as part of the result.
-#' @param root The id of the root (or source) vertex, this will be the root of
+#' @param root The ID of the root (or source) vertex, this will be the root of
 #'   the tree.
 #' @param mode Constant, must be \sQuote{`in`} or \sQuote{`out`}. If
 #'   it is \sQuote{`in`}, then all directions are considered as opposite to
@@ -841,11 +841,11 @@ st_min_cuts <- function(graph, source, target, capacity = NULL) {
 #'     }
 #'     \item{domtree}{
 #'       A graph object, the dominator tree.
-#'       Its vertex ids are the as the vertex ids of the input graph.
+#'       Its vertex IDs are the as the vertex IDs of the input graph.
 #'       Isolate vertices are the ones that are unreachable from the root.
 #'     }
 #'     \item{leftout}{
-#'       A numeric vector containing the vertex ids that are unreachable from the root.
+#'       A numeric vector containing the vertex IDs that are unreachable from the root.
 #'     }
 #'   }
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
@@ -910,7 +910,7 @@ dominator_tree <- function(graph, root, mode = c("out", "in", "all", "total")) {
 #' @param graph The input graph. It may be directed, but edge directions are
 #'   ignored.
 #' @return A list of numeric vectors. Each vector contains a vertex set
-#'   (defined by vertex ids), each vector is an (s,t) separator of the input
+#'   (defined by vertex IDs), each vector is an (s,t) separator of the input
 #'   graph, for some \eqn{s} and \eqn{t}.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
 #' @references Anne Berry, Jean-Paul Bordat and Olivier Cogis: Generating All
@@ -966,8 +966,8 @@ min_st_separators <- function(graph) {
 #' is the flow of maximum value.
 #'
 #' @param graph The input graph.
-#' @param source The id of the source vertex.
-#' @param target The id of the target vertex (sometimes also called sink).
+#' @param source The ID of the source vertex.
+#' @param target The ID of the target vertex (sometimes also called sink).
 #' @param capacity Vector giving the capacity of the edges. If this is
 #'   `NULL` (the default) then the `capacity` edge attribute is used.
 #'   Note that the `weight` edge attribute is not used by this function.
@@ -981,17 +981,17 @@ min_st_separators <- function(graph) {
 #'       For undirected graphs this entry is bit trickier,
 #'       since for these the flow direction is not predetermined by the edge direction.
 #'       For these graphs the elements of the this vector can be negative,
-#'       this means that the flow goes from the bigger vertex id to the smaller one.
-#'       Positive values mean that the flow goes from the smaller vertex id to the bigger one.
+#'       this means that the flow goes from the bigger vertex ID to the smaller one.
+#'       Positive values mean that the flow goes from the smaller vertex ID to the bigger one.
 #'     }
 #'     \item{cut}{
-#'       A numeric vector of edge ids, the minimum cut corresponding to the maximum flow.
+#'       A numeric vector of edge IDs, the minimum cut corresponding to the maximum flow.
 #'     }
 #'     \item{partition1}{
-#'       A numeric vector of vertex ids, the vertices in the first partition of the minimum cut corresponding to the maximum flow.
+#'       A numeric vector of vertex IDs, the vertices in the first partition of the minimum cut corresponding to the maximum flow.
 #'     }
 #'     \item{partition2}{
-#'       A numeric vector of vertex ids, the vertices in the second partition of the minimum cut corresponding to the maximum flow.
+#'       A numeric vector of vertex IDs, the vertices in the second partition of the minimum cut corresponding to the maximum flow.
 #'     }
 #'     \item{stats}{
 #'       A list with some statistics from the push-relabel algorithm.
@@ -1034,7 +1034,7 @@ max_flow <- function(graph, source, target, capacity = NULL) {
 #'
 #' @param graph The input graph. It may be directed, but edge directions are
 #'   ignored.
-#' @param candidate A numeric vector giving the vertex ids of the candidate
+#' @param candidate A numeric vector giving the vertex IDs of the candidate
 #'   separator.
 #' @return A logical scalar, whether the supplied vertex set is a (minimal)
 #'   vertex separator or not.
@@ -1067,7 +1067,7 @@ is_separator <- function(graph, candidate) {
 #'
 #' @param graph The input graph. It may be directed, but edge directions are
 #'   ignored.
-#' @param candidate A numeric vector giving the vertex ids of the candidate
+#' @param candidate A numeric vector giving the vertex IDs of the candidate
 #'   separator.
 #' @return A logical scalar, whether the supplied vertex set is a (minimal)
 #'   vertex separator or not.

--- a/R/foreign.R
+++ b/R/foreign.R
@@ -214,7 +214,7 @@ write.graph.fromraw <- function(buffer, file) {
 #'       then vertex IDs will be assigned to vertex names in the order of
 #'       their appearance in the .ncol file.
 #'       If it is not `character(0)` and some unknown vertex names are found
-#'       in the .ncol file then new vertex ids will be assigned to them.
+#'       in the .ncol file then new vertex IDs will be assigned to them.
 #'     }
 #'     \item{names}{
 #'       Logical value, if `TRUE` (the default)
@@ -415,7 +415,7 @@ read_graph <- function(
 #' @section GML format:
 #' GML is a quite general textual format.
 #' \describe{
-#'   \item{id}{Optional numeric vertex IDs to use.}
+#'   \item{ID}{Optional numeric vertex IDs to use.}
 #'   \item{creator}{Optional string specifying the creator of the file.}
 #' }
 #'

--- a/R/games.R
+++ b/R/games.R
@@ -839,7 +839,7 @@ aging.prefatt.game <- function(
 #'   Before the 0.6 version igraph used this algorithm if `power` was not
 #'   one, or `zero.appeal` was not one.  `bag` is the algorithm that
 #'   was previously (before version 0.6) used if `power` was one and
-#'   `zero.appeal` was one as well. It works by putting the ids of the
+#'   `zero.appeal` was one as well. It works by putting the IDs of the
 #'   vertices into a bag (multiset, really), exactly as many times as their
 #'   (in-)degree, plus once more. Then the required number of cited vertices are
 #'   drawn from the bag, with replacement. This method might generate multiple

--- a/R/glet.R
+++ b/R/glet.R
@@ -68,14 +68,14 @@ graphlets.candidate.basis <- function(graph, weights = NULL) {
 #'   and this argument is `NULL` (the default), then the `weight` edge
 #'   attribute is used.
 #' @param niter Integer scalar, the number of iterations to perform.
-#' @param cliques A list of vertex ids, the graphlet basis to use for the
+#' @param cliques A list of vertex IDs, the graphlet basis to use for the
 #'   projection.
 #' @param Mu Starting weights for the projection.
 #' @return `graphlets()` returns a list with two members:
 #'   \describe{
 #'     \item{cliques}{
 #'       A list of subgraphs, the candidate graphlet basis.
-#'       Each subgraph is give by a vector of vertex ids.
+#'       Each subgraph is give by a vector of vertex IDs.
 #'     }
 #'     \item{Mu}{
 #'       The weights of the subgraphs in graphlet basis.
@@ -86,7 +86,7 @@ graphlets.candidate.basis <- function(graph, weights = NULL) {
 #'   \describe{
 #'     \item{cliques}{
 #'       A list of subgraphs, the candidate graphlet basis.
-#'       Each subgraph is give by a vector of vertex ids.
+#'       Each subgraph is give by a vector of vertex IDs.
 #'     }
 #'     \item{thresholds}{
 #'       The weight thresholds used for finding the subgraphs.

--- a/R/hrg.R
+++ b/R/hrg.R
@@ -291,10 +291,10 @@ fit_hrg <- function(graph, hrg = NULL, start = FALSE, steps = 0) {
 #'   following members:
 #'   \describe{
 #'     \item{parents}{
-#'       For each vertex, the id of its parent vertex is stored,
+#'       For each vertex, the ID of its parent vertex is stored,
 #'       or zero, if the vertex is the root vertex in the tree.
-#'       The first n vertex ids (from 0) refer to the original vertices of the graph,
-#'       the other ids refer to vertex groups.
+#'       The first n vertex IDs (from 0) refer to the original vertices of the graph,
+#'       the other IDs refer to vertex groups.
 #'     }
 #'     \item{weights}{
 #'       Numeric vector, counts the number of times a given tree split
@@ -328,7 +328,7 @@ consensus_tree <- function(
 #'
 #' @param graph The igraph graph to create the HRG from.
 #' @param prob A vector of probabilities, one for each vertex, in the order of
-#'   vertex ids.
+#'   vertex IDs.
 #' @return `hrg()` returns an `igraphHRG` object.
 #'
 #' @family hierarchical random graph functions
@@ -412,7 +412,7 @@ sample_hrg <- function(hrg) {
 #' @return A list with entries:
 #'   \describe{
 #'     \item{edges}{
-#'       The predicted edges, in a two-column matrix of vertex ids.
+#'       The predicted edges, in a two-column matrix of vertex IDs.
 #'     }
 #'     \item{prob}{
 #'       Probabilities of these edges, according to the fitted model.

--- a/R/igraph-package.R
+++ b/R/igraph-package.R
@@ -84,7 +84,7 @@ NULL
 #'   To create small graphs with a given structure probably the
 #'   [graph_from_literal()] function is easiest. It uses R's formula
 #'   interface, its manual page contains many examples. Another option is
-#'   [make_graph()], which takes numeric vertex ids directly.
+#'   [make_graph()], which takes numeric vertex IDs directly.
 #'   [graph_from_atlas()] creates graph from the Graph Atlas,
 #'   [make_graph()] can create some special graphs.
 #'
@@ -99,18 +99,18 @@ NULL
 #'   ([sample_smallworld()]).
 #'
 #' @section Vertex and edge IDs:
-#'   Vertices and edges have numerical vertex ids in igraph. Vertex ids are
+#'   Vertices and edges have numerical vertex IDs in igraph. Vertex IDs are
 #'   always consecutive and they start with one. I.e. for a graph with
-#'   \eqn{n} vertices the vertex ids are between \eqn{1} and
+#'   \eqn{n} vertices the vertex IDs are between \eqn{1} and
 #'   \eqn{n}. If some operation changes the number of vertices in the
 #'   graphs, e.g. a subgraph is created via [induced_subgraph()], then
 #'   the vertices are renumbered to satisfy this criteria.
 #'
-#'   The same is true for the edges as well, edge ids are always between
+#'   The same is true for the edges as well, edge IDs are always between
 #'   one and \eqn{m}, the total number of edges in the graph.
 #'
 #'   It is often desirable to follow vertices along a number of graph
-#'   operations, and vertex ids don't allow this because of the
+#'   operations, and vertex IDs don't allow this because of the
 #'   renumbering. The solution is to assign attributes to the
 #'   vertices. These are kept by all operations, if possible. See more
 #'   about attributes in the next section.
@@ -124,7 +124,7 @@ NULL
 #'
 #'   Some vertex/edge/graph attributes are treated specially. One of them
 #'   is the \sQuote{name} attribute. This is used for printing the graph
-#'   instead of the numerical ids, if it exists. Vertex names can also be
+#'   instead of the numerical IDs, if it exists. Vertex names can also be
 #'   used to specify a vector or set of vertices, in all igraph
 #'   functions. E.g. [degree()] has a `v` argument
 #'   that gives the vertices for which the degree is calculated. This

--- a/R/indexing.R
+++ b/R/indexing.R
@@ -128,7 +128,7 @@ get_adjacency_submatrix <- function(x, i, j, attr = NULL) {
 #'   \item The `from` and `to` arguments can be used to check
 #'     the existence of many edges. In this case, both `from` and
 #'     `to` must be present and they must have the same length. They
-#'     must contain vertex ids or names. A numeric vector is returned, of
+#'     must contain vertex IDs or names. A numeric vector is returned, of
 #'     the same length as `from` and `to`, it contains ones
 #'     for existing edges edges and zeros for non-existing ones.
 #'     Example: \preformatted{  graph[from=1:3, to=c(2,3,5)]}.
@@ -136,9 +136,9 @@ get_adjacency_submatrix <- function(x, i, j, attr = NULL) {
 #'     weights. For non-esistent edges zero weights are returned. Other
 #'     edge attributes can be queried as well, by giving the `attr`
 #'     argument.
-#'   \item Querying edge ids instead of the existance of edges or edge
+#'   \item Querying edge IDs instead of the existance of edges or edge
 #'     attributes. E.g. \preformatted{  graph[1, 2, edges=TRUE]}
-#'     returns the id of the edge between vertices 1 and 2, or zero if
+#'     returns the ID of the edge between vertices 1 and 2, or zero if
 #'     there is no such edge.
 #'   \item Adding one or more edges to a graph. For this the element(s) of
 #'     the imaginary adjacency matrix must be set to a non-zero numeric
@@ -162,7 +162,7 @@ get_adjacency_submatrix <- function(x, i, j, attr = NULL) {
 #'     As this can be used to delete edges between two sets of vertices,
 #'     either pairwise: \preformatted{  graph[from=v, to=w] <- FALSE}
 #'     or not: \preformatted{  graph[v, w] <- FALSE }
-#'     if \eqn{v} and \eqn{w} are vectors of edge ids or names.
+#'     if \eqn{v} and \eqn{w} are vectors of edge IDs or names.
 #' }
 #'
 #' \sQuote{`[`} allows logical indices and negative indices as well,
@@ -173,29 +173,29 @@ get_adjacency_submatrix <- function(x, i, j, attr = NULL) {
 #'  creates a star graph.
 #'
 #' Of course, the indexing operators support vertex names,
-#' so instead of a numeric vertex id a vertex can also be given to
+#' so instead of a numeric vertex ID a vertex can also be given to
 #' \sQuote{`[`} and \sQuote{`[[`}.
 #'
 #' @param x The graph.
-#' @param i Index. Vertex ids or names or logical vectors. See details
+#' @param i Index. Vertex IDs or names or logical vectors. See details
 #'   below.
-#' @param j Index. Vertex ids or names or logical vectors. See details
+#' @param j Index. Vertex IDs or names or logical vectors. See details
 #'   below.
 #' @param ... Currently ignored.
-#' @param from A numeric or character vector giving vertex ids or
+#' @param from A numeric or character vector giving vertex IDs or
 #'   names. Together with the `to` argument, it can be used to
 #'   query/set a sequence of edges. See details below. This argument cannot
 #'   be present together with any of the `i` and `j` arguments
 #'   and if it is present, then the `to` argument must be present as
 #'   well.
-#' @param to A numeric or character vector giving vertex ids or
+#' @param to A numeric or character vector giving vertex IDs or
 #'   names. Together with the `from` argument, it can be used to
 #'   query/set a sequence of edges. See details below. This argument cannot
 #'   be present together with any of the `i` and `j` arguments
 #'   and if it is present, then the `from` argument must be present as
 #'   well.
 #' @param sparse Logical scalar, whether to return sparse matrices.
-#' @param edges Logical scalar, whether to return edge ids.
+#' @param edges Logical scalar, whether to return edge IDs.
 #' @param drop Ignored.
 #' @param attr If not `NULL`, then it should be the name of an edge
 #'   attribute. This attribute is queried and returned.
@@ -323,9 +323,9 @@ get_adjacency_submatrix <- function(x, i, j, attr = NULL) {
 #'     if the `edges` argument is set to
 #'     `TRUE`: \preformatted{  graph[[1:3, , edges=TRUE]]
 #' graph[[, 1:3, edges=TRUE]]}
-#'   \item Querying the edge ids between two sets or vertices,
+#'   \item Querying the edge IDs between two sets or vertices,
 #'     if both indices are used. E.g. \preformatted{  graph[[v, w, edges=TRUE]]}
-#'     gives the edge ids of all the edges that exist from vertices
+#'     gives the edge IDs of all the edges that exist from vertices
 #'     \eqn{v} to vertices \eqn{w}.
 #'  }
 #'
@@ -337,19 +337,19 @@ get_adjacency_submatrix <- function(x, i, j, attr = NULL) {
 #' \sQuote{`[[`} operators allows logical indices and negative indices
 #' as well, with the usual R semantics.
 #'
-#' Vertex names are also supported, so instead of a numeric vertex id a
+#' Vertex names are also supported, so instead of a numeric vertex ID a
 #' vertex can also be given to \sQuote{`[`} and \sQuote{`[[`}.
 #'
 #' @param x The graph.
 #' @param i Index, integer, character or logical, see details below.
 #' @param j Index, integer, character or logical, see details below.
-#' @param from A numeric or character vector giving vertex ids or
+#' @param from A numeric or character vector giving vertex IDs or
 #'   names. Together with the `to` argument, it can be used to
 #'   query/set a sequence of edges. See details below. This argument cannot
 #'   be present together with any of the `i` and `j` arguments
 #'   and if it is present, then the `to` argument must be present as
 #'   well.
-#' @param to A numeric or character vector giving vertex ids or
+#' @param to A numeric or character vector giving vertex IDs or
 #'   names. Together with the `from` argument, it can be used to
 #'   query/set a sequence of edges. See details below. This argument cannot
 #'   be present together with any of the `i` and `j` arguments
@@ -358,7 +358,7 @@ get_adjacency_submatrix <- function(x, i, j, attr = NULL) {
 #' @param ... Additional arguments are not used currently.
 #' @param directed Logical scalar, whether to consider edge directions
 #'   in directed graphs. It is ignored for undirected graphs.
-#' @param edges Logical scalar, whether to return edge ids.
+#' @param edges Logical scalar, whether to return edge IDs.
 #' @param exact Ignored.
 #'
 #' @family structural queries

--- a/R/interface.R
+++ b/R/interface.R
@@ -105,7 +105,7 @@ add.edges <- function(graph, edges, ..., attr = list()) {
 #' Add edges to a graph
 #'
 #' The new edges are given as a vertex sequence, e.g. internal
-#' numeric vertex ids, or vertex names. The first edge points from
+#' numeric vertex IDs, or vertex names. The first edge points from
 #' `edges[1]` to `edges[2]`, the second from `edges[3]`
 #' to `edges[4]`, etc.
 #'
@@ -419,8 +419,8 @@ is_directed <- function(graph) {
 #' @param graph The input graph
 #' @param es The sequence of edges to query
 #' @param names Whether to return vertex names or
-#'   numeric vertex ids. By default vertex names are used.
-#' @return A two column matrix of vertex names or vertex ids.
+#'   numeric vertex IDs. By default vertex names are used.
+#' @return A two column matrix of vertex names or vertex IDs.
 #'
 #' @aliases get.edges
 #' @family structural queries
@@ -497,13 +497,13 @@ el_to_vec <- function(x, call = rlang::caller_env()) {
 }
 
 
-#' Find the edge ids based on the incident vertices of the edges
+#' Find the edge IDs based on the incident vertices of the edges
 #'
 #' Find the edges in an igraph graph that have the specified end points. This
 #' function handles multi-graph (graphs with multiple edges) and can consider
 #' or ignore the edge directions in directed graphs.
 #'
-#' igraph vertex ids are natural numbers, starting from one, up to the number
+#' igraph vertex IDs are natural numbers, starting from one, up to the number
 #' of vertices in the graph. Similarly, edges are also numbered from one, up to
 #' the number of edges.
 #'
@@ -512,7 +512,7 @@ el_to_vec <- function(x, call = rlang::caller_env()) {
 #'
 #' @param graph The input graph.
 #' @param vp The incident vertices, given as a two-column data frame, two-column matrix,
-#'   or vector of vertex ids or symbolic vertex names.
+#'   or vector of vertex IDs or symbolic vertex names.
 #'   For a vector, the values are interpreted pairwise, i.e. the first and second are used for
 #'   the first edge, the third and fourth for the second, etc.
 #' @param directed Logical scalar, whether to consider edge directions in
@@ -520,7 +520,7 @@ el_to_vec <- function(x, call = rlang::caller_env()) {
 #' @param error Logical scalar, whether to report an error if an edge is not
 #'   found in the graph. If `FALSE`, then no error is reported, and zero is
 #'   returned for the non-existant edge(s).
-#' @return A numeric vector of edge ids, one for each pair of input vertices.
+#' @return A numeric vector of edge IDs, one for each pair of input vertices.
 #'   If there is no edge in the input graph for a given pair of vertices, then
 #'   zero is reported. (If the `error` argument is `FALSE`.)
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
@@ -559,7 +559,7 @@ get_edge_ids <- function(graph, vp, directed = TRUE, error = FALSE) {
   )
 }
 
-#' Find the edge ids based on the incident vertices of the edges
+#' Find the edge IDs based on the incident vertices of the edges
 #'
 #' @description
 #' `r lifecycle::badge("deprecated")`

--- a/R/iterators.R
+++ b/R/iterators.R
@@ -101,17 +101,17 @@ add_vses_graph_ref <- function(vses, graph) {
   vses
 }
 
-#' Get the id of a graph
+#' Get the ID of a graph
 #'
-#' Graph ids are used to check that a vertex or edge sequence
+#' Graph IDs are used to check that a vertex or edge sequence
 #' belongs to a graph. If you create a new graph by changing the
-#' structure of a graph, the new graph will have a new id.
-#' Changing the attributes will not change the id.
+#' structure of a graph, the new graph will have a new ID.
+#' Changing the attributes will not change the ID.
 #'
 #' @param x A graph or a vertex sequence or an edge sequence.
 #' @param ... Not used currently.
-#' @return The id of the graph, a character scalar. For
-#'   vertex and edge sequences the id of the graph they were created from.
+#' @return The ID of the graph, a character scalar. For
+#'   vertex and edge sequences the ID of the graph they were created from.
 #'
 #' @export
 #' @examples
@@ -210,13 +210,13 @@ inside_square_error <- function(fn_name, call = rlang::caller_env()) {
 #' another graph.
 #'
 #' At the implementation level, a vertex sequence is simply a vector
-#' containing numeric vertex ids, but it has a special class attribute
+#' containing numeric vertex IDs, but it has a special class attribute
 #' which makes it possible to perform graph specific operations on it, like
 #' selecting a subset of the vertices based on graph structure, or vertex
 #' attributes.
 #'
 #' A vertex sequence is most often created by the `V()` function. The
-#' result of this includes all vertices in increasing vertex id order. A
+#' result of this includes all vertices in increasing vertex ID order. A
 #' vertex sequence can be indexed by a numeric vector, just like a regular
 #' R vector. See \code{\link{[.igraph.vs}} and additional links to other
 #' vertex sequence operations below.
@@ -233,7 +233,7 @@ inside_square_error <- function(fn_name, call = rlang::caller_env()) {
 #'
 #' @param graph The graph
 #' @return A vertex sequence containing all vertices, in the order
-#'   of their numeric vertex ids.
+#'   of their numeric vertex IDs.
 #'
 #' @family vertex and edge sequences
 #' @export
@@ -295,7 +295,7 @@ unsafe_create_es <- function(graph, idx, es = NULL) {
 
 #' Edges of a graph
 #'
-#' An edge sequence is a vector containing numeric edge ids, with a special
+#' An edge sequence is a vector containing numeric edge IDs, with a special
 #' class attribute that allows custom operations: selecting subsets of
 #' edges based on attributes, or graph structure, creating the
 #' intersection, union of edges, etc.
@@ -309,7 +309,7 @@ unsafe_create_es <- function(graph, idx, es = NULL) {
 #' another graph.
 #'
 #' An edge sequence is most often created by the `E()` function. The
-#' result includes edges in increasing edge id order by default (if. none
+#' result includes edges in increasing edge ID order by default (if. none
 #' of the `P` and `path` arguments are used). An edge
 #' sequence can be indexed by a numeric vector, just like a regular R
 #' vector. See links to other edge sequence operations below.
@@ -879,7 +879,7 @@ simple_es_index <- function(x, i, na_ok = FALSE) {
 #'     to select edges with the given names. Note that a graph may
 #'     have edge names and vertex names, and both can be used to select
 #'     edges. Edge names are simply used as names of the numeric
-#'     edge id vector. Vertex names effectively only work in graphs without
+#'     edge ID vector. Vertex names effectively only work in graphs without
 #'     multiple edges, and must be separated with a `|` bar character
 #'     to select an edges that incident to the two given vertices. See
 #'     examples below.
@@ -1966,7 +1966,7 @@ rev.igraph.es <- rev.igraph.vs
 #'
 #' @details
 #' For graphs without names, a numeric vector is returned, containing the
-#' internal numeric vertex or edge ids.
+#' internal numeric vertex or edge IDs.
 #'
 #' For graphs with names, and vertex sequences, the vertex names are
 #' returned in a character vector.

--- a/R/layout.R
+++ b/R/layout.R
@@ -526,7 +526,7 @@ print.igraph_layout_spec <- function(x, ...) {
 #'
 #' @param ... Named arguments that define the modifier. Must include:
 #'   \describe{
-#'     \item{id}{A unique identifier string for the modifier}
+#'     \item{ID}{A unique identifier string for the modifier}
 #'     \item{type}{Either `"pre"` for pre-layout or `"post"` for post-layout}
 #'     \item{args}{A list of arguments to pass to the apply function}
 #'     \item{apply}{A function with signature
@@ -735,10 +735,10 @@ as_bipartite <- function(...) layout_spec(layout_as_bipartite, ...)
 #' order of the vertices can be also given.
 #'
 #' @param graph The graph to layout.
-#' @param center The id of the vertex to put in the center. By default it is
+#' @param center The ID of the vertex to put in the center. By default it is
 #'   the first vertex.
 #' @param order Numeric vector, the order of the vertices along the perimeter.
-#'   The default ordering is given by the vertex ids.
+#'   The default ordering is given by the vertex IDs.
 #' @return A matrix with two columns and as many rows as the number of vertices
 #'   in the input graph.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
@@ -794,7 +794,7 @@ as_star <- function(...) layout_spec(layout_as_star, ...)
 #'
 #' @param graph The input graph.
 #' @param root The index of the root vertex or root vertices.  If this is a
-#'   non-empty vector then the supplied vertex ids are used as the roots of the
+#'   non-empty vector then the supplied vertex IDs are used as the roots of the
 #'   trees (or a single tree if the graph is connected).  If it is an empty
 #'   vector, then the root vertices are automatically calculated based on
 #'   topological sorting, performed with the opposite mode than the `mode`
@@ -902,7 +902,7 @@ layout.reingold.tilford <- function(..., params = list()) {
 
 #' Graph layout with vertices on a circle.
 #'
-#' Place vertices on a circle, in the order of their vertex ids.
+#' Place vertices on a circle, in the order of their vertex IDs.
 #'
 #' If you want to order the vertices differently, then permute them using the
 #' [permute()] function.
@@ -1149,7 +1149,7 @@ on_grid <- function(...) layout_spec(layout_on_grid, ...)
 #' Graph layout with vertices on the surface of a sphere
 #'
 #' Place vertices on a sphere, approximately uniformly, in the order of their
-#' vertex ids.
+#' vertex IDs.
 #'
 #' `layout_on_sphere()` places the vertices (approximately) uniformly on the
 #' surface of a sphere, this is thus a 3d layout. It is not clear however what
@@ -1449,7 +1449,7 @@ with_dh <- function(...) layout_spec(layout_with_dh, ...)
 #'  (with a warning).
 #' @param maxiter A deprecated synonym of `niter`, for compatibility.
 #' @return A two- or three-column matrix, each row giving the coordinates of a
-#'   vertex, according to the ids of the vertex ids.
+#'   vertex, according to the IDs of the vertex IDs.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
 #' @seealso [layout_with_drl()], [layout_with_kk()] for
 #' other layout algorithms.
@@ -1998,7 +1998,7 @@ layout.kamada.kawai <- function(..., params = list()) {
 #'   repulsion forces between vertices only vertices in the same or neighboring
 #'   grid cells are taken into account (the fourth root of the number of
 #'   `area`.
-#' @param root The id of the vertex to place at the middle of the layout. The
+#' @param root The ID of the vertex to place at the middle of the layout. The
 #'   default value is -1 which means that a random vertex is selected.
 #' @return A numeric matrix with two columns and as many rows as vertices.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}

--- a/R/make.R
+++ b/R/make.R
@@ -1380,7 +1380,7 @@ with_graph_ <- function(...) {
 #' @param edges A vector defining the edges, the first edge points
 #'   from the first element to the second, the second edge from the third
 #'   to the fourth, etc. For a numeric vector, these are interpreted
-#'   as internal vertex ids. For character vectors, they are interpreted
+#'   as internal vertex IDs. For character vectors, they are interpreted
 #'   as vertex names.
 #'
 #'   Alternatively, this can be a character scalar, the name of a
@@ -1398,9 +1398,9 @@ with_graph_ <- function(...) {
 #'   Passed to `make_directed_graph()` or `make_undirected_graph()`.
 #' @param n The number of vertices in the graph. This argument is
 #'   ignored (with a warning) if `edges` are symbolic vertex names. It
-#'   is also ignored if there is a bigger vertex id in `edges`. This
+#'   is also ignored if there is a bigger vertex ID in `edges`. This
 #'   means that for this function it is safe to supply zero here if the
-#'   vertex with the largest id is not an isolate.
+#'   vertex with the largest ID is not an isolate.
 #' @param isolates Character vector, names of isolate vertices,
 #'   for symbolic edge lists. It is ignored for numeric edge lists.
 #' @param directed Whether to create a directed graph.
@@ -2293,7 +2293,7 @@ from_prufer <- function(prufer) {
 #' }
 #'
 #' @concept Graph Atlas.
-#' @param n The id of the graph to create.
+#' @param n The ID of the graph to create.
 #' @return An igraph graph.
 #'
 #' @family deterministic constructors

--- a/R/minimum.spanning.tree.R
+++ b/R/minimum.spanning.tree.R
@@ -53,7 +53,7 @@ minimum.spanning.tree <- function(
 #'
 #' @param graph The graph object to analyze.
 #' @param weights Numeric vector giving the weights of the edges in the
-#'   graph. The order is determined by the edge ids. This is ignored if the
+#'   graph. The order is determined by the edge IDs. This is ignored if the
 #'   `unweighted` algorithm is chosen. Edge weights are interpreted as
 #'   distances.
 #' @param algorithm The algorithm to use for calculation. `unweighted` can

--- a/R/operators.R
+++ b/R/operators.R
@@ -456,7 +456,7 @@ union.default <- function(...) {
 #'
 #' If the `byname` argument is `TRUE` (or `auto` and all graphs
 #' are named), then the operation is performed on symbolic vertex names instead
-#' of the internal numeric vertex ids.
+#' of the internal numeric vertex IDs.
 #'
 #' `union()` keeps the attributes of all graphs. All graph, vertex and
 #' edge attributes are copied to the result. If an attribute is present in
@@ -537,7 +537,7 @@ intersection <- function(...) {
 #'
 #' If the `byname` argument is `TRUE` (or `auto` and all graphs
 #' are named), then the operation is performed on symbolic vertex names instead
-#' of the internal numeric vertex ids.
+#' of the internal numeric vertex IDs.
 #'
 #' `intersection()` keeps the attributes of all graphs. All graph,
 #' vertex and edge attributes are copied to the result. If an attribute is
@@ -624,7 +624,7 @@ difference <- function(...) {
 #'
 #' If the `byname` argument is `TRUE` (or `auto` and the graphs
 #' are all named), then the operation is performed based on symbolic vertex
-#' names. Otherwise numeric vertex ids are used.
+#' names. Otherwise numeric vertex IDs are used.
 #'
 #' `difference()` keeps all attributes (graph, vertex and edge) of the
 #' first graph.
@@ -762,7 +762,7 @@ complementer <- function(graph, loops = FALSE) {
 #'
 #' If the `byname` argument is `TRUE` (or `auto` and the graphs
 #' are all named), then the operation is performed based on symbolic vertex
-#' names. Otherwise numeric vertex ids are used.
+#' names. Otherwise numeric vertex IDs are used.
 #'
 #' `compose()` keeps the attributes of both graphs. All graph, vertex
 #' and edge attributes are copied to the result. If an attribute is present in
@@ -896,7 +896,7 @@ compose <- function(g1, g2, byname = "auto") {
 #' @details
 #' When adding edges via `+`, all unnamed arguments of
 #' `edge()` (or `edges()`) are concatenated, and then passed to
-#' [add_edges()]. They are interpreted as pairs of vertex ids,
+#' [add_edges()]. They are interpreted as pairs of vertex IDs,
 #' and an edge will added between each pair. Named arguments will be
 #' used as edge attributes for the new edges.
 #'
@@ -1070,7 +1070,7 @@ path <- function(...) {
 #'     the arguments of the `edges()` function.
 #'
 #'     The unnamed arguments of `edges()` are concatenated and used
-#'     as vertex ids of the end points of the new edges. The named
+#'     as vertex IDs of the end points of the new edges. The named
 #'     arguments will be added as edge attributes.
 #'
 #'     Examples: \preformatted{  g <- make_empty_graph() +
@@ -1089,7 +1089,7 @@ path <- function(...) {
 #'     new edges that form a path are added. The edges and possibly their
 #'     attributes are specified as the arguments to the `path()`
 #'     function. The non-named arguments are concatenated and interpreted
-#'     as the vertex ids along the path. The remaining arguments are added
+#'     as the vertex IDs along the path. The remaining arguments are added
 #'     as edge attributes.
 #'
 #'     Examples: \preformatted{  g <- make_empty_graph() + vertices(letters[1:10])
@@ -1202,7 +1202,7 @@ path <- function(...) {
 #' \item If it is an igraph graph object, then the difference of the
 #'   two graphs is calculated, see [difference()].
 #' \item If it is a numeric or character vector, then it is interpreted
-#'   as a vector of vertex ids and the specified vertices will be
+#'   as a vector of vertex IDs and the specified vertices will be
 #'   deleted from the graph. Example: \preformatted{  g <- make_ring(10)
 #' V(g)$name <- letters[1:10]
 #' g <- g - c("a", "b")}
@@ -1214,7 +1214,7 @@ path <- function(...) {
 #' \item If it is an object created with the [vertex()] (or the
 #'   [vertices()]) function, then all arguments of [vertices()] are
 #'   concatenated and the result is interpreted as a vector of vertex
-#'   ids. These vertices will be removed from the graph.
+#'   IDs. These vertices will be removed from the graph.
 #' \item If it is an object created with the [edge()] (or the
 #'   [edges()]) function, then all arguments of [edges()] are
 #'   concatenated and then interpreted as edges to be removed from the

--- a/R/other.R
+++ b/R/other.R
@@ -72,7 +72,7 @@ convex.hull <- function(data) {
 #' bin width.
 #'
 #' The running mean of `v` is a `w` vector of length
-#' `length(v)-binwidth+1`. The first element of `w` id the average of
+#' `length(v)-binwidth+1`. The first element of `w` ID the average of
 #' the first `binwidth` elements of `v`, the second element of
 #' `w` is the average of elements `2:(binwidth+1)`, etc.
 #'

--- a/R/paths.R
+++ b/R/paths.R
@@ -96,7 +96,7 @@ is.dag <- function(graph) {
 #'   no cutoff is used.
 #' @return A list of integer vectors, each integer vector is a path from
 #'   the source vertex to one of the target vertices. A path is given by its
-#'   vertex ids.
+#'   vertex IDs.
 #' @keywords graphs
 #' @examples
 #'

--- a/R/plot.R
+++ b/R/plot.R
@@ -38,7 +38,7 @@
 #'   to modify this.
 #' @param ylim The limits for the vertical axis, it is unlikely that you want
 #'   to modify this.
-#' @param mark.groups A list of vertex id vectors. It is interpreted as a set
+#' @param mark.groups A list of vertex ID vectors. It is interpreted as a set
 #'   of vertex groups. Each vertex group is highlighted, by plotting a colored
 #'   smoothed polygon around and \dQuote{under} it. See the arguments below to
 #'   control the look of the polygons.
@@ -49,7 +49,7 @@
 #'   used for the different vertex groups.
 #' @param mark.col A scalar or vector giving the colors of marking the
 #'   polygons, in any format accepted by [graphics::xspline()]; e.g.
-#'   numeric color ids, symbolic color names, or colors in RGB.
+#'   numeric color IDs, symbolic color names, or colors in RGB.
 #' @param mark.border A scalar or vector giving the colors of the borders of
 #'   the vertex group marking polygons. If it is `NA`, then no border is
 #'   drawn.

--- a/R/plot.common.R
+++ b/R/plot.common.R
@@ -148,7 +148,7 @@
 #' }
 #' \item{label}{
 #'   The vertex labels. They will be converted to character.
-#'   Specify `NA` to omit vertex labels. The default vertex labels are the vertex ids.
+#'   Specify `NA` to omit vertex labels. The default vertex labels are the vertex IDs.
 #' }
 #' \item{label.family}{
 #'   The

--- a/R/plot.shapes.R
+++ b/R/plot.shapes.R
@@ -196,7 +196,7 @@ add.vertex.shape <- function(
 #'       The coordinates of the vertices, a matrix with two columns.
 #'     }
 #'     \item{v}{
-#'       The ids of the vertices to plot. It should match the number of rows in the `coords` argument.
+#'       The IDs of the vertices to plot. It should match the number of rows in the `coords` argument.
 #'     }
 #'     \item{params}{
 #'       The same as for the clipping function, see above.

--- a/R/print.R
+++ b/R/print.R
@@ -521,7 +521,7 @@ print_all <- function(object, ...) {
 #' The first line always
 #' starts with `IGRAPH`, showing you that the object is an igraph graph.
 #' Then a seven character code is printed, this the first seven characters
-#' of the unique id of the graph. See [graph_id()] for more.
+#' of the unique ID of the graph. See [graph_id()] for more.
 #' Then a four letter long code string is printed. The first letter
 #' distinguishes between directed (\sQuote{`D`}) and undirected
 #' (\sQuote{`U`}) graphs. The second letter is \sQuote{`N`} for named
@@ -557,7 +557,7 @@ print_all <- function(object, ...) {
 #'   attributes.
 #' @param edge.attributes Logical constant, whether to print edge attributes.
 #' @param names Logical constant, whether to print symbolic vertex names (i.e.
-#'   the `name` vertex attribute) or vertex ids.
+#'   the `name` vertex attribute) or vertex IDs.
 #' @param max.lines The maximum number of lines to use. The rest of the
 #'   output will be truncated.
 #' @param id Whether to print the graph ID.

--- a/R/scan.R
+++ b/R/scan.R
@@ -335,7 +335,7 @@ local_scan <- function(
 #'       It is `NA` for the initial `tau + ell` time steps.
 #'     }
 #'     \item{arg_max_v}{
-#'       The (numeric) vertex ids for the vertex with the largest locality statistics, at each time step.
+#'       The (numeric) vertex IDs for the vertex with the largest locality statistics, at each time step.
 #'       It is `NA` for the initial `tau + ell` time steps.
 #'     }
 #'   }

--- a/R/similarity.R
+++ b/R/similarity.R
@@ -26,7 +26,7 @@
 #' 25(3):211-230, 2003.
 #'
 #' @param graph The input graph.
-#' @param vids The vertex ids for which the similarity is calculated.
+#' @param vids The vertex IDs for which the similarity is calculated.
 #' @param mode The type of neighboring vertices to use for the calculation,
 #'   possible values: \sQuote{`out`}, \sQuote{`in`},
 #'   \sQuote{`all`}.

--- a/R/structural-properties.R
+++ b/R/structural-properties.R
@@ -704,7 +704,7 @@ average.path.length <- function(
 #' many shortest paths of the length of the diameter, then it returns the first
 #' one found.
 #'
-#' `farthest_vertices()` returns two vertex ids, the vertices which are
+#' `farthest_vertices()` returns two vertex IDs, the vertices which are
 #' connected by the diameter path.
 #'
 #' @param graph The graph to analyze.
@@ -874,7 +874,7 @@ mean_distance <- function(
 #'
 #'
 #' @param graph The graph to analyze.
-#' @param v The ids of vertices of which the degree will be calculated.
+#' @param v The IDs of vertices of which the degree will be calculated.
 #' @param mode Character string, \dQuote{out} for out-degree, \dQuote{in} for
 #'   in-degree or \dQuote{total} for the sum of the two. For undirected graphs
 #'   this argument is ignored. \dQuote{all} is a synonym of \dQuote{total}.
@@ -1084,7 +1084,7 @@ degree_distribution <- function(graph, cumulative = FALSE, ...) {
 #'
 #'   For `shortest_paths()` a named list with four entries is returned:
 #'   \item{vpath}{This itself is a list, of length `length(to)`; list
-#'   element `i` contains the vertex ids on the path from vertex `from`
+#'   element `i` contains the vertex IDs on the path from vertex `from`
 #'   to vertex `to[i]` (or the other way for directed graphs depending on
 #'   the `mode` argument). The vector also contains `from` and `i`
 #'   as the first and last elements. If `from` is the same as `i` then
@@ -1092,8 +1092,8 @@ degree_distribution <- function(graph, cumulative = FALSE, ...) {
 #'   numeric vector of length zero is returned as the list element. If this
 #'   output is not requested in the `output` argument, then it will be
 #'   `NULL`.} \item{epath}{This is a list similar to `vpath`, but the
-#'   vectors of the list contain the edge ids along the shortest paths, instead
-#'   of the vertex ids. This entry is set to `NULL` if it is not requested
+#'   vectors of the list contain the edge IDs along the shortest paths, instead
+#'   of the vertex IDs. This entry is set to `NULL` if it is not requested
 #'   in the `output` argument.} \item{predecessors}{Numeric vector, the
 #'   predecessor of each vertex in the `to` argument, or `NULL` if it
 #'   was not requested.} \item{inbound_edges}{Numeric vector, the inbound edge
@@ -1108,7 +1108,7 @@ degree_distribution <- function(graph, cumulative = FALSE, ...) {
 #'     }
 #'     \item{epaths}{
 #'       This is a list similar to vpaths, but the vectors of the list
-#'       contain the edge ids along the shortest paths, instead of the vertex ids.
+#'       contain the edge IDs along the shortest paths, instead of the vertex IDs.
 #'     }
 #'     \item{nrgeo}{
 #'       A vector in which each element is the number of shortest paths (geodesics)
@@ -1261,7 +1261,7 @@ distances <- function(
 
 #' @rdname distances
 #' @param from Numeric constant, the vertex from or to the shortest paths will
-#'   be calculated. Note that right now this is not a vector of vertex ids, but
+#'   be calculated. Note that right now this is not a vector of vertex IDs, but
 #'   only a single vertex.
 #' @param output Character scalar, defines how to report the shortest paths.
 #'   \dQuote{vpath} means that the vertices along the paths are reported, this
@@ -1504,7 +1504,7 @@ k_shortest_paths <- function(
 #'   are listed. If \dQuote{out} all vertices reachable from `v` are
 #'   returned. If \dQuote{all} returns the union of these. It is ignored for
 #'   undirected graphs.
-#' @return Numeric vector, the ids of the vertices in the same component as
+#' @return Numeric vector, the IDs of the vertices in the same component as
 #'   `v`.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
 #' @seealso [components()]
@@ -1606,7 +1606,7 @@ induced_subgraph <- function(
 }
 
 #' @rdname subgraph
-#' @param eids The edge ids of the edges that will be kept in the result graph.
+#' @param eids The edge IDs of the edges that will be kept in the result graph.
 #' @param delete.vertices Logical scalar, whether to remove vertices that do
 #'   not have any adjacent edges in `eids`.
 #' @export
@@ -1710,7 +1710,7 @@ subgraph.edges <- function(graph, eids, delete.vertices = TRUE) {
 #'       The same as `barrat`.
 #'     }
 #'   }
-#' @param vids The vertex ids for the local transitivity will be calculated.
+#' @param vids The vertex IDs for the local transitivity will be calculated.
 #'   This will be ignored for global transitivity types.  The default value is
 #'   `NULL`, in this case all vertices are considered. It is slightly faster
 #'   to supply `NULL` here than `V(graph)`.
@@ -2415,7 +2415,7 @@ feedback_vertex_set <- function(graph, weights = NULL, algo = c("exact_ip")) {
 #'       Integer constant, the girth of the graph, or `Inf` if the graph is acyclic.
 #'     }
 #'     \item{circle}{
-#'       Numeric vector with the vertex ids in the shortest circle.
+#'       Numeric vector with the vertex IDs in the shortest circle.
 #'     }
 #'   }
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
@@ -2609,7 +2609,7 @@ count_loops <- function(graph) {
 #'   `TRUE`, then additional searches are performed until all vertices are
 #'   visited.
 #' @param restricted `NULL` (=no restriction), or a vector of vertices
-#'   (ids or symbolic names). In the latter case, the search is restricted to the
+#'   (IDs or symbolic names). In the latter case, the search is restricted to the
 #'   given vertices.
 #' @param order Logical scalar, whether to return the ordering of the vertices.
 #' @param rank Logical scalar, whether to return the rank of the vertices.
@@ -2640,7 +2640,7 @@ count_loops <- function(graph) {
 #'       Note that for undirected graphs this is always \sQuote{all}, irrespectively of the supplied value.
 #'     }
 #'     \item{order}{
-#'       The vertex ids, in the order in which they were visited by the search.
+#'       The vertex IDs, in the order in which they were visited by the search.
 #'       A vertex sequence (`igraph.vs`), or a numeric vector if the
 #'       `return.vs.es` option (see [igraph_options()]) is `FALSE`.
 #'     }
@@ -2916,10 +2916,10 @@ bfs <- function(
 #'       Note that for undirected graphs this is always \sQuote{all}, irrespectively of the supplied value.
 #'     }
 #'     \item{order}{
-#'       Numeric vector. The vertex ids, in the order in which they were visited by the search.
+#'       Numeric vector. The vertex IDs, in the order in which they were visited by the search.
 #'     }
 #'     \item{order.out}{
-#'       Numeric vector, the vertex ids, in the order of the completion of their subtree.
+#'       Numeric vector, the vertex IDs, in the order of the completion of their subtree.
 #'     }
 #'     \item{parent}{
 #'       Numeric vector. The parent of each vertex, i.e. the vertex it was discovered from.
@@ -3119,7 +3119,7 @@ dfs <- function(
 #'   For `components()` a named list with three components:
 #'   \describe{
 #'     \item{membership}{
-#'       numeric vector giving the cluster id to which each vertex belongs.
+#'       numeric vector giving the cluster ID to which each vertex belongs.
 #'     }
 #'     \item{csize}{
 #'       numeric vector giving the sizes of the clusters.
@@ -3473,7 +3473,7 @@ laplacian_matrix <- function(
 #'     }
 #'     \item{matching}{
 #'       The matching itself.
-#'       Numeric vertex id, or vertex names if the graph was named.
+#'       Numeric vertex ID, or vertex names if the graph was named.
 #'       Non-matched vertices are denoted by `NA`.
 #'     }
 #'   }
@@ -3576,7 +3576,7 @@ max_bipartite_match <- function(
 #'
 #' @param graph The input graph.
 #' @param eids Edge sequence, the edges that will be probed. By default is
-#'   includes all edges in the order of their ids.
+#'   includes all edges in the order of their IDs.
 #' @param loops Logical, whether to consider directed self-loops to be mutual.
 #' @return A logical vector of the same length as the number of edges supplied.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}

--- a/R/tkplot.R
+++ b/R/tkplot.R
@@ -230,10 +230,10 @@ assign(".next", 1, .tkplot.env)
 #'
 #' The `tkplot()` command creates a new Tk window with the graphical
 #' representation of `graph`. The command returns an integer number, the
-#' tkplot id. The other commands utilize this id to be able to query or
+#' tkplot ID. The other commands utilize this ID to be able to query or
 #' manipulate the plot.
 #'
-#' `tk_close()` closes the Tk plot with id `tkp.id`.
+#' `tk_close()` closes the Tk plot with ID `tkp.id`.
 #'
 #' `tk_off()` closes all Tk plots.
 #'
@@ -266,7 +266,7 @@ assign(".next", 1, .tkplot.env)
 #' tkplot.center tkplot.rotate
 #' @param graph The `graph` to plot.
 #' @param canvas.width,canvas.height The size of the tkplot drawing area.
-#' @param tkp.id The id of the tkplot window to close/reshape/etc.
+#' @param tkp.id The ID of the tkplot window to close/reshape/etc.
 #' @param window.close Leave this on the default value.
 #' @param width The width of the rectangle for generating new coordinates.
 #' @param height The height of the rectangle for generating new coordinates.
@@ -278,7 +278,7 @@ assign(".next", 1, .tkplot.env)
 #' @param rad The degree to rotate the plot, in radian.
 #' @param \dots Additional plotting parameters. See [igraph.plotting] for
 #'   the complete list.
-#' @return `tkplot()` returns an integer, the id of the plot, this can be
+#' @return `tkplot()` returns an integer, the ID of the plot, this can be
 #'   used to manipulate it from the command line.
 #'
 #'   `tk_canvas()` returns `tkwin` object, the Tk canvas.

--- a/R/topology.R
+++ b/R/topology.R
@@ -468,7 +468,7 @@ is_isomorphic_to <- isomorphic
 #' \describe{
 #'     \item{domains}{
 #'       If not `NULL`, then it specifies matching restrictions.
-#'       It must be a list of `target` vertex sets, given as numeric vertex ids or symbolic vertex names.
+#'       It must be a list of `target` vertex sets, given as numeric vertex IDs or symbolic vertex names.
 #'       The length of the list must be `vcount(pattern)` and for each vertex in `pattern`
 #'       it gives the allowed matching vertices in `target`.
 #'       Defaults to `NULL`.
@@ -657,7 +657,7 @@ graph.count.isomorphisms.vf2 <- function(
 #' \describe{
 #'     \item{domains}{
 #'       If not `NULL`, then it specifies matching restrictions.
-#'       It must be a list of `target` vertex sets, given as numeric vertex ids or symbolic vertex names.
+#'       It must be a list of `target` vertex sets, given as numeric vertex IDs or symbolic vertex names.
 #'       The length of the list must be `vcount(pattern)` and for each vertex in `pattern`
 #'       it gives the allowed matching vertices in `target`.
 #'       Defaults to `NULL`.
@@ -844,7 +844,7 @@ isomorphisms <- function(graph1, graph2, method = "vf2", ..., callback = NULL) {
 #' \describe{
 #'     \item{domains}{
 #'       If not `NULL`, then it specifies matching restrictions.
-#'       It must be a list of `target` vertex sets, given as numeric vertex ids or symbolic vertex names.
+#'       It must be a list of `target` vertex sets, given as numeric vertex IDs or symbolic vertex names.
 #'       The length of the list must be `vcount(pattern)` and for each vertex in `pattern`
 #'       it gives the allowed matching vertices in `target`.
 #'       Defaults to `NULL`.
@@ -1158,7 +1158,7 @@ canonical_permutation <- function(
 
 #' Permute the vertices of a graph
 #'
-#' Create a new graph, by permuting vertex ids.
+#' Create a new graph, by permuting vertex IDs.
 #'
 #' This function creates a new graph from the input graph by permuting its
 #' vertices according to the specified mapping. Call this function with the
@@ -1169,7 +1169,7 @@ canonical_permutation <- function(
 #'
 #' @param graph The input graph, it can directed or undirected.
 #' @param permutation A numeric vector giving the permutation to apply. The
-#'   first element is the new id of vertex 1, etc. Every number between one and
+#'   first element is the new ID of vertex 1, etc. Every number between one and
 #'   `vcount(graph)` must appear exactly once.
 #' @return A new graph object.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}

--- a/R/triangles.R
+++ b/R/triangles.R
@@ -56,9 +56,9 @@ adjacent.triangles <- function(graph, vids = V(graph)) {
 #' @param graph The input graph. It might be directed, but edge directions are
 #'   ignored.
 #' @param vids The vertices to query, all of them by default. This might be a
-#'   vector of numeric ids, or a character vector of symbolic vertex names for
+#'   vector of numeric IDs, or a character vector of symbolic vertex names for
 #'   named graphs.
-#' @return For `triangles()` a numeric vector of vertex ids, the first three
+#' @return For `triangles()` a numeric vector of vertex IDs, the first three
 #'   vertices belong to the first triangle found, etc.
 #'
 #'   For `count_triangles()` a numeric vector, the number of triangles for all

--- a/man/E.Rd
+++ b/man/E.Rd
@@ -25,7 +25,7 @@ argument, for directed graphs.}
 An edge sequence of the graph.
 }
 \description{
-An edge sequence is a vector containing numeric edge ids, with a special
+An edge sequence is a vector containing numeric edge IDs, with a special
 class attribute that allows custom operations: selecting subsets of
 edges based on attributes, or graph structure, creating the
 intersection, union of edges, etc.
@@ -39,7 +39,7 @@ the specific edges of that graph, and cannot be used together with
 another graph.
 
 An edge sequence is most often created by the \code{E()} function. The
-result includes edges in increasing edge id order by default (if. none
+result includes edges in increasing edge ID order by default (if. none
 of the \code{P} and \code{path} arguments are used). An edge
 sequence can be indexed by a numeric vector, just like a regular R
 vector. See links to other edge sequence operations below.

--- a/man/V.Rd
+++ b/man/V.Rd
@@ -11,7 +11,7 @@ V(graph)
 }
 \value{
 A vertex sequence containing all vertices, in the order
-of their numeric vertex ids.
+of their numeric vertex IDs.
 }
 \description{
 Create a vertex sequence (vs) containing all vertices of a graph.
@@ -26,13 +26,13 @@ the specific vertices of that graph, and cannot be used together with
 another graph.
 
 At the implementation level, a vertex sequence is simply a vector
-containing numeric vertex ids, but it has a special class attribute
+containing numeric vertex IDs, but it has a special class attribute
 which makes it possible to perform graph specific operations on it, like
 selecting a subset of the vertices based on graph structure, or vertex
 attributes.
 
 A vertex sequence is most often created by the \code{V()} function. The
-result of this includes all vertices in increasing vertex id order. A
+result of this includes all vertices in increasing vertex ID order. A
 vertex sequence can be indexed by a numeric vector, just like a regular
 R vector. See \code{\link{[.igraph.vs}} and additional links to other
 vertex sequence operations below.

--- a/man/aaa-igraph-package.Rd
+++ b/man/aaa-igraph-package.Rd
@@ -61,7 +61,7 @@ deterministic and stochastic; stochastic graph constructors are called
 To create small graphs with a given structure probably the
 \code{\link[=graph_from_literal]{graph_from_literal()}} function is easiest. It uses R's formula
 interface, its manual page contains many examples. Another option is
-\code{\link[=make_graph]{make_graph()}}, which takes numeric vertex ids directly.
+\code{\link[=make_graph]{make_graph()}}, which takes numeric vertex IDs directly.
 \code{\link[=graph_from_atlas]{graph_from_atlas()}} creates graph from the Graph Atlas,
 \code{\link[=make_graph]{make_graph()}} can create some special graphs.
 
@@ -78,18 +78,18 @@ some recent  popular models, like preferential attachment
 
 \section{Vertex and edge IDs}{
 
-Vertices and edges have numerical vertex ids in igraph. Vertex ids are
+Vertices and edges have numerical vertex IDs in igraph. Vertex IDs are
 always consecutive and they start with one. I.e. for a graph with
-\eqn{n} vertices the vertex ids are between \eqn{1} and
+\eqn{n} vertices the vertex IDs are between \eqn{1} and
 \eqn{n}. If some operation changes the number of vertices in the
 graphs, e.g. a subgraph is created via \code{\link[=induced_subgraph]{induced_subgraph()}}, then
 the vertices are renumbered to satisfy this criteria.
 
-The same is true for the edges as well, edge ids are always between
+The same is true for the edges as well, edge IDs are always between
 one and \eqn{m}, the total number of edges in the graph.
 
 It is often desirable to follow vertices along a number of graph
-operations, and vertex ids don't allow this because of the
+operations, and vertex IDs don't allow this because of the
 renumbering. The solution is to assign attributes to the
 vertices. These are kept by all operations, if possible. See more
 about attributes in the next section.
@@ -105,7 +105,7 @@ attribute values, see \code{\link[=vertex_attr]{vertex_attr()}},
 
 Some vertex/edge/graph attributes are treated specially. One of them
 is the \sQuote{name} attribute. This is used for printing the graph
-instead of the numerical ids, if it exists. Vertex names can also be
+instead of the numerical IDs, if it exists. Vertex names can also be
 used to specify a vector or set of vertices, in all igraph
 functions. E.g. \code{\link[=degree]{degree()}} has a \code{v} argument
 that gives the vertices for which the degree is calculated. This

--- a/man/add_edges.Rd
+++ b/man/add_edges.Rd
@@ -25,7 +25,7 @@ The graph, with the edges (and attributes) added.
 }
 \description{
 The new edges are given as a vertex sequence, e.g. internal
-numeric vertex ids, or vertex names. The first edge points from
+numeric vertex IDs, or vertex names. The first edge points from
 \code{edges[1]} to \code{edges[2]}, the second from \code{edges[3]}
 to \code{edges[4]}, etc.
 }

--- a/man/adjacent.triangles.Rd
+++ b/man/adjacent.triangles.Rd
@@ -11,7 +11,7 @@ adjacent.triangles(graph, vids = V(graph))
 ignored.}
 
 \item{vids}{The vertices to query, all of them by default. This might be a
-vector of numeric ids, or a character vector of symbolic vertex names for
+vector of numeric IDs, or a character vector of symbolic vertex names for
 named graphs.}
 }
 \description{

--- a/man/all_simple_paths.Rd
+++ b/man/all_simple_paths.Rd
@@ -32,7 +32,7 @@ no cutoff is used.}
 \value{
 A list of integer vectors, each integer vector is a path from
 the source vertex to one of the target vertices. A path is given by its
-vertex ids.
+vertex IDs.
 }
 \description{
 This function lists all simple paths from one source vertex to another

--- a/man/as_adj.Rd
+++ b/man/as_adj.Rd
@@ -35,7 +35,7 @@ numeric. If the \code{sparse} argument is \code{FALSE}, then character is
 also allowed. The reason for the difference is that the \code{Matrix}
 package does not support character sparse matrices yet.}
 
-\item{edges}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Logical scalar, whether to return the edge ids in the matrix.
+\item{edges}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Logical scalar, whether to return the edge IDs in the matrix.
 For non-existant edges zero is returned.}
 
 \item{names}{Logical constant, whether to assign row and column names

--- a/man/as_adj_list.Rd
+++ b/man/as_adj_list.Rd
@@ -43,12 +43,12 @@ Create adjacency lists from a graph, either for adjacent edges or for
 neighboring vertices
 }
 \details{
-\code{as_adj_list()} returns a list of numeric vectors, which include the ids
+\code{as_adj_list()} returns a list of numeric vectors, which include the IDs
 of neighbor vertices (according to the \code{mode} argument) of all
 vertices.
 
 \code{as_adj_edge_list()} returns a list of numeric vectors, which include the
-ids of adjacent edges (according to the \code{mode} argument) of all
+IDs of adjacent edges (according to the \code{mode} argument) of all
 vertices.
 
 If \code{igraph_opt("return.vs.es")} is true (default), the numeric

--- a/man/as_adjacency_matrix.Rd
+++ b/man/as_adjacency_matrix.Rd
@@ -35,7 +35,7 @@ numeric. If the \code{sparse} argument is \code{FALSE}, then character is
 also allowed. The reason for the difference is that the \code{Matrix}
 package does not support character sparse matrices yet.}
 
-\item{edges}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Logical scalar, whether to return the edge ids in the matrix.
+\item{edges}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Logical scalar, whether to return the edge IDs in the matrix.
 For non-existant edges zero is returned.}
 
 \item{names}{Logical constant, whether to assign row and column names

--- a/man/as_biadjacency_matrix.Rd
+++ b/man/as_biadjacency_matrix.Rd
@@ -30,7 +30,7 @@ included.}
 \item{names}{Logical scalar, if \code{TRUE} and the vertices in the graph
 are named (i.e. the graph has a vertex attribute called \code{name}), then
 vertex names will be added to the result as row and column names. Otherwise
-the ids of the vertices are used as row and column names.}
+the IDs of the vertices are used as row and column names.}
 
 \item{sparse}{Logical scalar, if it is \code{TRUE} then a sparse matrix is
 created, you will need the \code{Matrix} package for this.}

--- a/man/as_edgelist.Rd
+++ b/man/as_edgelist.Rd
@@ -11,7 +11,7 @@ as_edgelist(graph, names = TRUE)
 
 \item{names}{Whether to return a character matrix containing vertex
 names (i.e. the \code{name} vertex attribute) if they exist or numeric
-vertex ids.}
+vertex IDs.}
 }
 \value{
 A \code{ecount(graph)} by 2 numeric matrix.

--- a/man/as_graphnel.Rd
+++ b/man/as_graphnel.Rd
@@ -21,7 +21,7 @@ the igraph and the graphNEL objects.
 \code{as_graphnel()} converts an igraph graph to a graphNEL graph. It
 converts all graph/vertex/edge attributes. If the igraph graph has a
 vertex attribute \sQuote{\code{name}}, then it will be used to assign
-vertex names in the graphNEL graph. Otherwise numeric igraph vertex ids
+vertex names in the graphNEL graph. Otherwise numeric igraph vertex IDs
 will be used for this purpose.
 }
 \section{Related documentation in the C library}{

--- a/man/as_ids.Rd
+++ b/man/as_ids.Rd
@@ -23,7 +23,7 @@ Convert a vertex or edge sequence to an ordinary vector
 }
 \details{
 For graphs without names, a numeric vector is returned, containing the
-internal numeric vertex or edge ids.
+internal numeric vertex or edge IDs.
 
 For graphs with names, and vertex sequences, the vertex names are
 returned in a character vector.

--- a/man/as_long_data_frame.Rd
+++ b/man/as_long_data_frame.Rd
@@ -19,8 +19,8 @@ all metadata about that edge and its incident vertices are included
 in that row. The names of the columns that contain the metadata
 of the incident vertices are prefixed with \code{from_} and \code{to_}.
 The first two columns are always named \code{from} and \code{to} and
-they contain the numeric ids of the incident vertices. The rows are
-listed in the order of numeric vertex ids.
+they contain the numeric IDs of the incident vertices. The rows are
+listed in the order of numeric vertex IDs.
 }
 \section{Related documentation in the C library}{
 \href{https://igraph.org/c/html/0.10.17/igraph-Structural.html#igraph_get_edgelist}{\code{get_edgelist()}}, \href{https://igraph.org/c/html/0.10.17/igraph-Basic.html#igraph_vcount}{\code{vcount()}}

--- a/man/ba.game.Rd
+++ b/man/ba.game.Rd
@@ -52,7 +52,7 @@ partial prefix-sum tree, but the generation of multiple edges is allowed.
 Before the 0.6 version igraph used this algorithm if \code{power} was not
 one, or \code{zero.appeal} was not one.  \code{bag} is the algorithm that
 was previously (before version 0.6) used if \code{power} was one and
-\code{zero.appeal} was one as well. It works by putting the ids of the
+\code{zero.appeal} was one as well. It works by putting the IDs of the
 vertices into a bag (multiset, really), exactly as many times as their
 (in-)degree, plus once more. Then the required number of cited vertices are
 drawn from the bag, with replacement. This method might generate multiple

--- a/man/barabasi.game.Rd
+++ b/man/barabasi.game.Rd
@@ -52,7 +52,7 @@ partial prefix-sum tree, but the generation of multiple edges is allowed.
 Before the 0.6 version igraph used this algorithm if \code{power} was not
 one, or \code{zero.appeal} was not one.  \code{bag} is the algorithm that
 was previously (before version 0.6) used if \code{power} was one and
-\code{zero.appeal} was one as well. It works by putting the ids of the
+\code{zero.appeal} was one as well. It works by putting the IDs of the
 vertices into a bag (multiset, really), exactly as many times as their
 (in-)degree, plus once more. Then the required number of cited vertices are
 drawn from the bag, with replacement. This method might generate multiple

--- a/man/bfs.Rd
+++ b/man/bfs.Rd
@@ -46,7 +46,7 @@ vertices that are unreachable from the given root vertex (or vertices). If
 visited.}
 
 \item{restricted}{\code{NULL} (=no restriction), or a vector of vertices
-(ids or symbolic names). In the latter case, the search is restricted to the
+(IDs or symbolic names). In the latter case, the search is restricted to the
 given vertices.}
 
 \item{order}{Logical scalar, whether to return the ordering of the vertices.}
@@ -89,7 +89,7 @@ Character scalar. The \code{mode} argument of the function call.
 Note that for undirected graphs this is always \sQuote{all}, irrespectively of the supplied value.
 }
 \item{order}{
-The vertex ids, in the order in which they were visited by the search.
+The vertex IDs, in the order in which they were visited by the search.
 A vertex sequence (\code{igraph.vs}), or a numeric vector if the
 \code{return.vs.es} option (see \code{\link[=igraph_options]{igraph_options()}}) is \code{FALSE}.
 }

--- a/man/biconnected_components.Rd
+++ b/man/biconnected_components.Rd
@@ -18,7 +18,7 @@ Numeric scalar, an integer giving the number of biconnected components in the gr
 }
 \item{tree_edges}{
 The components themselves, a list of numeric vectors.
-Each vector is a set of edge ids giving the edges in a biconnected component.
+Each vector is a set of edge IDs giving the edges in a biconnected component.
 These edges define a spanning tree of the component.
 }
 \item{component_edges}{

--- a/man/bipartite.projection.Rd
+++ b/man/bipartite.projection.Rd
@@ -29,7 +29,7 @@ graph), then the multiplicity of the A-B edge in the projection will be 2.}
 
 \item{probe1}{This argument can be used to specify the order of the
 projections in the resulting list. If given, then it is considered as a
-vertex id (or a symbolic vertex name); the projection containing this vertex
+vertex ID (or a symbolic vertex name); the projection containing this vertex
 will be the first one in the result list.  This argument is ignored if only
 one projection is requested in argument \code{which}.}
 

--- a/man/bipartite_projection.Rd
+++ b/man/bipartite_projection.Rd
@@ -32,7 +32,7 @@ graph), then the multiplicity of the A-B edge in the projection will be 2.}
 
 \item{probe1}{This argument can be used to specify the order of the
 projections in the resulting list. If given, then it is considered as a
-vertex id (or a symbolic vertex name); the projection containing this vertex
+vertex ID (or a symbolic vertex name); the projection containing this vertex
 will be the first one in the result list.  This argument is ignored if only
 one projection is requested in argument \code{which}.}
 

--- a/man/cliques.Rd
+++ b/man/cliques.Rd
@@ -61,7 +61,7 @@ so will cause R to crash due to reentrancy issues. Extract
 any needed graph information before calling the function with a callback, or
 use collector mode (the default) and process results afterward.}
 
-\item{subset}{If not \code{NULL}, then it must be a vector of vertex ids,
+\item{subset}{If not \code{NULL}, then it must be a vector of vertex IDs,
 numeric or symbolic if the graph is named. The algorithm is run from these
 vertices only, so only a subset of all maximal cliques is returned. See the
 Eppstein paper for details. This argument makes it possible to easily
@@ -70,7 +70,7 @@ parallelize the finding of maximal cliques.}
 \item{file}{If not \code{NULL}, then it must be a file name, i.e. a
 character scalar. The output of the algorithm is written to this file. (If
 it exists, then it will be overwritten.) Each clique will be a separate line
-in the file, given with the numeric ids of its vertices, separated by
+in the file, given with the numeric IDs of its vertices, separated by
 whitespace.}
 
 \item{vertex.weights}{Vertex weight vector. If the graph has a \code{weight}
@@ -87,12 +87,12 @@ or only the maximal ones (\code{TRUE}).}
 \item{directed}{Whether to consider edge directions.}
 }
 \value{
-\code{cliques()} returns a list containing numeric vectors of vertex ids if
+\code{cliques()} returns a list containing numeric vectors of vertex IDs if
 \code{callback} is \code{NULL}. Each list element is a clique, i.e. a vertex sequence
 of class \link[=V]{igraph.vs}. If \code{callback} is provided, returns \code{NULL} invisibly.
 
 \code{largest_cliques()} and \code{clique_num()} return a list containing numeric
-vectors of vertex ids. Each list element is a clique, i.e. a vertex sequence
+vectors of vertex IDs. Each list element is a clique, i.e. a vertex sequence
 of class \link[=V]{igraph.vs}.
 
 \code{max_cliques()} returns \code{NULL}, invisibly, if its \code{file}

--- a/man/cluster_edge_betweenness.Rd
+++ b/man/cluster_edge_betweenness.Rd
@@ -39,7 +39,7 @@ argument is called \code{merges}, even if the community structure algorithm
 itself is divisive and not agglomerative: it builds the tree from top to
 bottom. There is one line for each merge (i.e. split) in matrix, the first
 line is the first merge (last split). The communities are identified by
-integer number starting from one. Community ids smaller than or equal to
+integer number starting from one. Community IDs smaller than or equal to
 \eqn{N}, the number of vertices in the graph, belong to singleton
 communities, i.e. individual vertices. Before the first merge we have \eqn{N}
 communities numbered from one to \eqn{N}. The first merge, the first line of

--- a/man/cluster_spinglass.Rd
+++ b/man/cluster_spinglass.Rd
@@ -93,7 +93,7 @@ If the \code{vertex} argument is present, i.e. the second form is used then a
 named list is returned with the following components:
 \describe{
 \item{community}{
-Numeric vector giving the ids of the vertices in the same community as \code{vertex}.
+Numeric vector giving the IDs of the vertices in the same community as \code{vertex}.
 }
 \item{cohesion}{
 The cohesion score of the result, see references.
@@ -129,7 +129,7 @@ community detection. If the \code{vertex} argument is not given (or it is
 optimizing the an energy function.
 
 If the \code{vertex} argument is given and it is not \code{NULL}, then it
-must be a vertex id, and the same energy function is used to find the
+must be a vertex ID, and the same energy function is used to find the
 community of the the given vertex. See also the examples below.
 }
 \section{Related documentation in the C library}{

--- a/man/cocitation.Rd
+++ b/man/cocitation.Rd
@@ -12,7 +12,7 @@ bibcoupling(graph, v = V(graph))
 \arguments{
 \item{graph}{The graph object to analyze}
 
-\item{v}{Vertex sequence or numeric vector, the vertex ids for which the
+\item{v}{Vertex sequence or numeric vector, the vertex IDs for which the
 cocitation or bibliographic coupling values we want to calculate. The
 default is all vertices.}
 }

--- a/man/cohesive_blocks.Rd
+++ b/man/cohesive_blocks.Rd
@@ -114,7 +114,7 @@ See details below.}
 \value{
 \code{cohesive_blocks()} returns a \code{cohesiveBlocks} object.
 
-\code{blocks()} returns a list of numeric vectors, containing vertex ids.
+\code{blocks()} returns a list of numeric vectors, containing vertex IDs.
 
 \code{graphs_from_cohesive_blocks()} returns a list of igraph graphs, corresponding to the
 cohesive blocks.
@@ -163,7 +163,7 @@ it gives the number of blocks.
 
 The function \code{blocks()} returns the actual blocks stored in the
 \code{cohesiveBlocks} object. They are returned in a list of numeric
-vectors, each containing vertex ids.
+vectors, each containing vertex IDs.
 
 The function \code{graphs_from_cohesive_blocks()} is similar, but returns the blocks as
 (induced) subgraphs of the input graph. The various (graph, vertex and edge)
@@ -174,7 +174,7 @@ different blocks. The order of the blocks is the same as for the
 \code{blocks()} and \code{graphs_from_cohesive_blocks()} functions.
 
 The block hierarchy can be queried using the \code{hierarchy()} function. It
-returns an igraph graph, its vertex ids are ordered according the order of
+returns an igraph graph, its vertex IDs are ordered according the order of
 the blocks in the \code{blocks()} and \code{graphs_from_cohesive_blocks()}, \code{cohesion()},
 etc. functions.
 
@@ -219,7 +219,7 @@ The left part shows the block structure, in this case for five
 blocks. The first block always corresponds to the whole graph, even if its
 cohesion is zero. Then cohesion of the block and the number of vertices in
 the block are shown. The last part is only printed if the display is wide
-enough and shows the vertices in the blocks, ordered by vertex ids.
+enough and shows the vertices in the blocks, ordered by vertex IDs.
 \sQuote{o} means that the vertex is included, a dot means that it is not,
 and the vertices are shown in groups of ten.
 

--- a/man/communities.Rd
+++ b/man/communities.Rd
@@ -168,11 +168,11 @@ The \code{length} generic function call be called on \code{communities} and
 returns the number of communities.
 
 The \code{sizes()} function returns the community sizes, in the order of their
-ids.
+IDs.
 
 \code{membership()} gives the division of the vertices, into communities. It
-returns a numeric vector, one value for each vertex, the id of its
-community. Community ids start from one. Note that some algorithms calculate
+returns a numeric vector, one value for each vertex, the ID of its
+community. Community IDs start from one. Note that some algorithms calculate
 the complete (or incomplete) hierarchical structure of the communities, and
 not just a single partitioning. For these algorithms typically the
 membership for the highest modularity value is returned, but see also the
@@ -181,7 +181,7 @@ manual pages of the individual algorithms.
 \code{communities()} is also the name of a function, that returns a list of
 communities, each identified by their vertices. The vertices will have
 symbolic names if the \code{add.vertex.names} igraph option is set, and the
-graph itself was named. Otherwise numeric vertex ids are used.
+graph itself was named. Otherwise numeric vertex IDs are used.
 
 \code{modularity()} gives the modularity score of the partitioning. (See
 \code{\link[=modularity.igraph]{modularity.igraph()}} for details. For algorithms that do not
@@ -191,7 +191,7 @@ result a single partitioning, the highest modularity value is returned.
 the community structure.
 
 \code{crossing()} returns a logical vector, with one value for each edge,
-ordered according to the edge ids. The value is \code{TRUE} iff the edge
+ordered according to the edge IDs. The value is \code{TRUE} iff the edge
 connects two different communities, according to the (best) membership
 vector, as returned by \code{membership()}.
 

--- a/man/compare.Rd
+++ b/man/compare.Rd
@@ -15,7 +15,7 @@ compare(
 \arguments{
 \item{comm1}{A \code{\link[=communities]{communities()}} object containing a community
 structure; or a numeric vector, the membership vector of the first community
-structure. The membership vector should contain the community id of each
+structure. The membership vector should contain the community ID of each
 vertex, the numbering of the communities starts with one.}
 
 \item{comm2}{A \code{\link[=communities]{communities()}} object containing a community

--- a/man/components.Rd
+++ b/man/components.Rd
@@ -40,7 +40,7 @@ For \code{is_connected()} a logical constant.
 For \code{components()} a named list with three components:
 \describe{
 \item{membership}{
-numeric vector giving the cluster id to which each vertex belongs.
+numeric vector giving the cluster ID to which each vertex belongs.
 }
 \item{csize}{
 numeric vector giving the sizes of the clusters.

--- a/man/compose.Rd
+++ b/man/compose.Rd
@@ -35,7 +35,7 @@ other is undirected.
 
 If the \code{byname} argument is \code{TRUE} (or \code{auto} and the graphs
 are all named), then the operation is performed based on symbolic vertex
-names. Otherwise numeric vertex ids are used.
+names. Otherwise numeric vertex IDs are used.
 
 \code{compose()} keeps the attributes of both graphs. All graph, vertex
 and edge attributes are copied to the result. If an attribute is present in

--- a/man/consensus_tree.Rd
+++ b/man/consensus_tree.Rd
@@ -27,10 +27,10 @@ is an \code{igraphHRGConsensus} object, the second is an
 following members:
 \describe{
 \item{parents}{
-For each vertex, the id of its parent vertex is stored,
+For each vertex, the ID of its parent vertex is stored,
 or zero, if the vertex is the root vertex in the tree.
-The first n vertex ids (from 0) refer to the original vertices of the graph,
-the other ids refer to vertex groups.
+The first n vertex IDs (from 0) refer to the original vertices of the graph,
+the other IDs refer to vertex groups.
 }
 \item{weights}{
 Numeric vector, counts the number of times a given tree split

--- a/man/contract.Rd
+++ b/man/contract.Rd
@@ -10,7 +10,7 @@ contract(graph, mapping, vertex.attr.comb = igraph_opt("vertex.attr.comb"))
 \item{graph}{The input graph, it can be directed or undirected.}
 
 \item{mapping}{A numeric vector that specifies the mapping. Its elements
-correspond to the vertices, and for each element the id in the new graph is
+correspond to the vertices, and for each element the ID in the new graph is
 given.}
 
 \item{vertex.attr.comb}{Specifies how to combine the vertex attributes in

--- a/man/contract.vertices.Rd
+++ b/man/contract.vertices.Rd
@@ -14,7 +14,7 @@ contract.vertices(
 \item{graph}{The input graph, it can be directed or undirected.}
 
 \item{mapping}{A numeric vector that specifies the mapping. Its elements
-correspond to the vertices, and for each element the id in the new graph is
+correspond to the vertices, and for each element the ID in the new graph is
 given.}
 
 \item{vertex.attr.comb}{Specifies how to combine the vertex attributes in

--- a/man/count_subgraph_isomorphisms.Rd
+++ b/man/count_subgraph_isomorphisms.Rd
@@ -37,7 +37,7 @@ the following extra arguments:
 \describe{
 \item{domains}{
 If not \code{NULL}, then it specifies matching restrictions.
-It must be a list of \code{target} vertex sets, given as numeric vertex ids or symbolic vertex names.
+It must be a list of \code{target} vertex sets, given as numeric vertex IDs or symbolic vertex names.
 The length of the list must be \code{vcount(pattern)} and for each vertex in \code{pattern}
 it gives the allowed matching vertices in \code{target}.
 Defaults to \code{NULL}.

--- a/man/count_triangles.Rd
+++ b/man/count_triangles.Rd
@@ -14,11 +14,11 @@ count_triangles(graph, vids = V(graph))
 ignored.}
 
 \item{vids}{The vertices to query, all of them by default. This might be a
-vector of numeric ids, or a character vector of symbolic vertex names for
+vector of numeric IDs, or a character vector of symbolic vertex names for
 named graphs.}
 }
 \value{
-For \code{triangles()} a numeric vector of vertex ids, the first three
+For \code{triangles()} a numeric vector of vertex IDs, the first three
 vertices belong to the first triangle found, etc.
 
 For \code{count_triangles()} a numeric vector, the number of triangles for all

--- a/man/create.communities.Rd
+++ b/man/create.communities.Rd
@@ -16,7 +16,7 @@ create.communities(
 \item{graph}{The graph of the community structure.}
 
 \item{membership}{The membership vector of the community structure, a
-numeric vector denoting the id of the community for each vertex. It
+numeric vector denoting the ID of the community for each vertex. It
 might be \code{NULL} for hierarchical community structures.}
 
 \item{algorithm}{Character string, the algorithm that generated

--- a/man/degree.Rd
+++ b/man/degree.Rd
@@ -30,7 +30,7 @@ degree_distribution(graph, cumulative = FALSE, ...)
 \arguments{
 \item{graph}{The graph to analyze.}
 
-\item{v}{The ids of vertices of which the degree will be calculated.}
+\item{v}{The IDs of vertices of which the degree will be calculated.}
 
 \item{mode}{Character string, \dQuote{out} for out-degree, \dQuote{in} for
 in-degree or \dQuote{total} for the sum of the two. For undirected graphs

--- a/man/dfs.Rd
+++ b/man/dfs.Rd
@@ -77,10 +77,10 @@ Character scalar. The \code{mode} argument of the function call.
 Note that for undirected graphs this is always \sQuote{all}, irrespectively of the supplied value.
 }
 \item{order}{
-Numeric vector. The vertex ids, in the order in which they were visited by the search.
+Numeric vector. The vertex IDs, in the order in which they were visited by the search.
 }
 \item{order.out}{
-Numeric vector, the vertex ids, in the order of the completion of their subtree.
+Numeric vector, the vertex IDs, in the order of the completion of their subtree.
 }
 \item{parent}{
 Numeric vector. The parent of each vertex, i.e. the vertex it was discovered from.

--- a/man/diameter.Rd
+++ b/man/diameter.Rd
@@ -51,7 +51,7 @@ The diameter is calculated by using a breadth-first search like method.
 many shortest paths of the length of the diameter, then it returns the first
 one found.
 
-\code{farthest_vertices()} returns two vertex ids, the vertices which are
+\code{farthest_vertices()} returns two vertex IDs, the vertices which are
 connected by the diameter path.
 }
 \section{Related documentation in the C library}{

--- a/man/difference.igraph.Rd
+++ b/man/difference.igraph.Rd
@@ -35,7 +35,7 @@ new graph. The corresponding operator is \verb{\%m\%}.
 
 If the \code{byname} argument is \code{TRUE} (or \code{auto} and the graphs
 are all named), then the operation is performed based on symbolic vertex
-names. Otherwise numeric vertex ids are used.
+names. Otherwise numeric vertex IDs are used.
 
 \code{difference()} keeps all attributes (graph, vertex and edge) of the
 first graph.

--- a/man/distances.Rd
+++ b/man/distances.Rd
@@ -98,7 +98,7 @@ i.e. if there are no edge weights, then the unweighted algorithm will be
 used, regardless of this argument.}
 
 \item{from}{Numeric constant, the vertex from or to the shortest paths will
-be calculated. Note that right now this is not a vector of vertex ids, but
+be calculated. Note that right now this is not a vector of vertex IDs, but
 only a single vertex.}
 
 \item{output}{Character scalar, defines how to report the shortest paths.
@@ -129,7 +129,7 @@ itself is always zero. For unreachable vertices \code{Inf} is included.
 
 For \code{shortest_paths()} a named list with four entries is returned:
 \item{vpath}{This itself is a list, of length \code{length(to)}; list
-element \code{i} contains the vertex ids on the path from vertex \code{from}
+element \code{i} contains the vertex IDs on the path from vertex \code{from}
 to vertex \code{to[i]} (or the other way for directed graphs depending on
 the \code{mode} argument). The vector also contains \code{from} and \code{i}
 as the first and last elements. If \code{from} is the same as \code{i} then
@@ -137,8 +137,8 @@ it is only included once. If there is no path between two vertices then a
 numeric vector of length zero is returned as the list element. If this
 output is not requested in the \code{output} argument, then it will be
 \code{NULL}.} \item{epath}{This is a list similar to \code{vpath}, but the
-vectors of the list contain the edge ids along the shortest paths, instead
-of the vertex ids. This entry is set to \code{NULL} if it is not requested
+vectors of the list contain the edge IDs along the shortest paths, instead
+of the vertex IDs. This entry is set to \code{NULL} if it is not requested
 in the \code{output} argument.} \item{predecessors}{Numeric vector, the
 predecessor of each vertex in the \code{to} argument, or \code{NULL} if it
 was not requested.} \item{inbound_edges}{Numeric vector, the inbound edge
@@ -153,7 +153,7 @@ The shortest paths to the same vertex are collected into consecutive elements of
 }
 \item{epaths}{
 This is a list similar to vpaths, but the vectors of the list
-contain the edge ids along the shortest paths, instead of the vertex ids.
+contain the edge IDs along the shortest paths, instead of the vertex IDs.
 }
 \item{nrgeo}{
 A vector in which each element is the number of shortest paths (geodesics)

--- a/man/diversity.Rd
+++ b/man/diversity.Rd
@@ -13,7 +13,7 @@ diversity(graph, weights = NULL, vids = V(graph))
 computation. If \code{NULL}, then the \sQuote{weight} attibute is used. Note
 that this measure is not defined for unweighted graphs.}
 
-\item{vids}{The vertex ids for which to calculate the measure.}
+\item{vids}{The vertex IDs for which to calculate the measure.}
 }
 \value{
 A numeric vector, its length is the number of vertices.

--- a/man/dominator.tree.Rd
+++ b/man/dominator.tree.Rd
@@ -11,7 +11,7 @@ dominator.tree(graph, root, mode = c("out", "in", "all", "total"))
 some vertices not reachable from the root vertex, then these vertices will
 be collected and returned as part of the result.}
 
-\item{root}{The id of the root (or source) vertex, this will be the root of
+\item{root}{The ID of the root (or source) vertex, this will be the root of
 the tree.}
 
 \item{mode}{Constant, must be \sQuote{\verb{in}} or \sQuote{\code{out}}. If

--- a/man/dominator_tree.Rd
+++ b/man/dominator_tree.Rd
@@ -11,7 +11,7 @@ dominator_tree(graph, root, mode = c("out", "in", "all", "total"))
 some vertices not reachable from the root vertex, then these vertices will
 be collected and returned as part of the result.}
 
-\item{root}{The id of the root (or source) vertex, this will be the root of
+\item{root}{The ID of the root (or source) vertex, this will be the root of
 the tree.}
 
 \item{mode}{Constant, must be \sQuote{\verb{in}} or \sQuote{\code{out}}. If
@@ -28,11 +28,11 @@ For the root vertex itself it contains minus one.
 }
 \item{domtree}{
 A graph object, the dominator tree.
-Its vertex ids are the as the vertex ids of the input graph.
+Its vertex IDs are the as the vertex IDs of the input graph.
 Isolate vertices are the ones that are unreachable from the root.
 }
 \item{leftout}{
-A numeric vector containing the vertex ids that are unreachable from the root.
+A numeric vector containing the vertex IDs that are unreachable from the root.
 }
 }
 }

--- a/man/edge.Rd
+++ b/man/edge.Rd
@@ -25,7 +25,7 @@ edges to/from graphs.
 
 When adding edges via \code{+}, all unnamed arguments of
 \code{edge()} (or \code{edges()}) are concatenated, and then passed to
-\code{\link[=add_edges]{add_edges()}}. They are interpreted as pairs of vertex ids,
+\code{\link[=add_edges]{add_edges()}}. They are interpreted as pairs of vertex IDs,
 and an edge will added between each pair. Named arguments will be
 used as edge attributes for the new edges.
 

--- a/man/edge.betweenness.community.Rd
+++ b/man/edge.betweenness.community.Rd
@@ -39,7 +39,7 @@ argument is called \code{merges}, even if the community structure algorithm
 itself is divisive and not agglomerative: it builds the tree from top to
 bottom. There is one line for each merge (i.e. split) in matrix, the first
 line is the first merge (last split). The communities are identified by
-integer number starting from one. Community ids smaller than or equal to
+integer number starting from one. Community IDs smaller than or equal to
 \eqn{N}, the number of vertices in the graph, belong to singleton
 communities, i.e. individual vertices. Before the first merge we have \eqn{N}
 communities numbered from one to \eqn{N}. The first merge, the first line of

--- a/man/edge.connectivity.Rd
+++ b/man/edge.connectivity.Rd
@@ -9,10 +9,10 @@ edge.connectivity(graph, source = NULL, target = NULL, checks = TRUE)
 \arguments{
 \item{graph}{The input graph.}
 
-\item{source}{The id of the source vertex, for \code{edge_connectivity()} it
+\item{source}{The ID of the source vertex, for \code{edge_connectivity()} it
 can be \code{NULL}, see details below.}
 
-\item{target}{The id of the target vertex, for \code{edge_connectivity()} it
+\item{target}{The ID of the target vertex, for \code{edge_connectivity()} it
 can be \code{NULL}, see details below.}
 
 \item{checks}{Logical constant. Whether to check that the graph is connected

--- a/man/edge.disjoint.paths.Rd
+++ b/man/edge.disjoint.paths.Rd
@@ -9,10 +9,10 @@ edge.disjoint.paths(graph, source = NULL, target = NULL, checks = TRUE)
 \arguments{
 \item{graph}{The input graph.}
 
-\item{source}{The id of the source vertex, for \code{edge_connectivity()} it
+\item{source}{The ID of the source vertex, for \code{edge_connectivity()} it
 can be \code{NULL}, see details below.}
 
-\item{target}{The id of the target vertex, for \code{edge_connectivity()} it
+\item{target}{The ID of the target vertex, for \code{edge_connectivity()} it
 can be \code{NULL}, see details below.}
 
 \item{checks}{Logical constant. Whether to check that the graph is connected

--- a/man/edge_connectivity.Rd
+++ b/man/edge_connectivity.Rd
@@ -15,10 +15,10 @@ adhesion(graph, checks = TRUE)
 \arguments{
 \item{graph}{The input graph.}
 
-\item{source}{The id of the source vertex, for \code{edge_connectivity()} it
+\item{source}{The ID of the source vertex, for \code{edge_connectivity()} it
 can be \code{NULL}, see details below.}
 
-\item{target}{The id of the target vertex, for \code{edge_connectivity()} it
+\item{target}{The ID of the target vertex, for \code{edge_connectivity()} it
 can be \code{NULL}, see details below.}
 
 \item{checks}{Logical constant. Whether to check that the graph is connected

--- a/man/ends.Rd
+++ b/man/ends.Rd
@@ -13,10 +13,10 @@ ends(graph, es, names = TRUE)
 \item{es}{The sequence of edges to query}
 
 \item{names}{Whether to return vertex names or
-numeric vertex ids. By default vertex names are used.}
+numeric vertex IDs. By default vertex names are used.}
 }
 \value{
-A two column matrix of vertex names or vertex ids.
+A two column matrix of vertex names or vertex IDs.
 }
 \description{
 Incident vertices of some graph edges

--- a/man/find_cycle.Rd
+++ b/man/find_cycle.Rd
@@ -16,7 +16,7 @@ and \code{all} ignores edge directions. Ignored in undirected graphs.}
 \value{
 A list of integer vectors, each integer vector is a path from
 the source vertex to one of the target vertices. A path is given by its
-vertex ids.
+vertex IDs.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/man/get.adjacency.Rd
+++ b/man/get.adjacency.Rd
@@ -35,7 +35,7 @@ numeric. If the \code{sparse} argument is \code{FALSE}, then character is
 also allowed. The reason for the difference is that the \code{Matrix}
 package does not support character sparse matrices yet.}
 
-\item{edges}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Logical scalar, whether to return the edge ids in the matrix.
+\item{edges}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Logical scalar, whether to return the edge IDs in the matrix.
 For non-existant edges zero is returned.}
 
 \item{names}{Logical constant, whether to assign row and column names

--- a/man/get.all.shortest.paths.Rd
+++ b/man/get.all.shortest.paths.Rd
@@ -16,7 +16,7 @@ get.all.shortest.paths(
 \item{graph}{The graph to work on.}
 
 \item{from}{Numeric constant, the vertex from or to the shortest paths will
-be calculated. Note that right now this is not a vector of vertex ids, but
+be calculated. Note that right now this is not a vector of vertex IDs, but
 only a single vertex.}
 
 \item{to}{Numeric vector, the vertices to which the shortest paths will be

--- a/man/get.edge.ids.Rd
+++ b/man/get.edge.ids.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/interface.R
 \name{get.edge.ids}
 \alias{get.edge.ids}
-\title{Find the edge ids based on the incident vertices of the edges}
+\title{Find the edge IDs based on the incident vertices of the edges}
 \usage{
 get.edge.ids(graph, vp, directed = TRUE, error = FALSE, multi = deprecated())
 }
@@ -10,7 +10,7 @@ get.edge.ids(graph, vp, directed = TRUE, error = FALSE, multi = deprecated())
 \item{graph}{The input graph.}
 
 \item{vp}{The incident vertices, given as a two-column data frame, two-column matrix,
-or vector of vertex ids or symbolic vertex names.
+or vector of vertex IDs or symbolic vertex names.
 For a vector, the values are interpreted pairwise, i.e. the first and second are used for
 the first edge, the third and fourth for the second, etc.}
 

--- a/man/get.edgelist.Rd
+++ b/man/get.edgelist.Rd
@@ -11,7 +11,7 @@ get.edgelist(graph, names = TRUE)
 
 \item{names}{Whether to return a character matrix containing vertex
 names (i.e. the \code{name} vertex attribute) if they exist or numeric
-vertex ids.}
+vertex IDs.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/get.incidence.Rd
+++ b/man/get.incidence.Rd
@@ -24,7 +24,7 @@ included.}
 \item{names}{Logical scalar, if \code{TRUE} and the vertices in the graph
 are named (i.e. the graph has a vertex attribute called \code{name}), then
 vertex names will be added to the result as row and column names. Otherwise
-the ids of the vertices are used as row and column names.}
+the IDs of the vertices are used as row and column names.}
 
 \item{sparse}{Logical scalar, if it is \code{TRUE} then a sparse matrix is
 created, you will need the \code{Matrix} package for this.}

--- a/man/get.shortest.paths.Rd
+++ b/man/get.shortest.paths.Rd
@@ -20,7 +20,7 @@ get.shortest.paths(
 \item{graph}{The graph to work on.}
 
 \item{from}{Numeric constant, the vertex from or to the shortest paths will
-be calculated. Note that right now this is not a vector of vertex ids, but
+be calculated. Note that right now this is not a vector of vertex IDs, but
 only a single vertex.}
 
 \item{to}{Numeric vector, the vertices to which the shortest paths will be

--- a/man/get_edge_ids.Rd
+++ b/man/get_edge_ids.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/interface.R
 \name{get_edge_ids}
 \alias{get_edge_ids}
-\title{Find the edge ids based on the incident vertices of the edges}
+\title{Find the edge IDs based on the incident vertices of the edges}
 \usage{
 get_edge_ids(graph, vp, directed = TRUE, error = FALSE)
 }
@@ -10,7 +10,7 @@ get_edge_ids(graph, vp, directed = TRUE, error = FALSE)
 \item{graph}{The input graph.}
 
 \item{vp}{The incident vertices, given as a two-column data frame, two-column matrix,
-or vector of vertex ids or symbolic vertex names.
+or vector of vertex IDs or symbolic vertex names.
 For a vector, the values are interpreted pairwise, i.e. the first and second are used for
 the first edge, the third and fourth for the second, etc.}
 
@@ -22,7 +22,7 @@ found in the graph. If \code{FALSE}, then no error is reported, and zero is
 returned for the non-existant edge(s).}
 }
 \value{
-A numeric vector of edge ids, one for each pair of input vertices.
+A numeric vector of edge IDs, one for each pair of input vertices.
 If there is no edge in the input graph for a given pair of vertices, then
 zero is reported. (If the \code{error} argument is \code{FALSE}.)
 }
@@ -32,7 +32,7 @@ function handles multi-graph (graphs with multiple edges) and can consider
 or ignore the edge directions in directed graphs.
 }
 \details{
-igraph vertex ids are natural numbers, starting from one, up to the number
+igraph vertex IDs are natural numbers, starting from one, up to the number
 of vertices in the graph. Similarly, edges are also numbered from one, up to
 the number of edges.
 

--- a/man/girth.Rd
+++ b/man/girth.Rd
@@ -19,7 +19,7 @@ A named list with two components:
 Integer constant, the girth of the graph, or \code{Inf} if the graph is acyclic.
 }
 \item{circle}{
-Numeric vector with the vertex ids in the shortest circle.
+Numeric vector with the vertex IDs in the shortest circle.
 }
 }
 }

--- a/man/global_efficiency.Rd
+++ b/man/global_efficiency.Rd
@@ -33,7 +33,7 @@ and the graph has a \code{weight} edge attribute, then it is used automatically.
 \item{directed}{Logical scalar, whether to consider directed paths. Ignored
 for undirected graphs.}
 
-\item{vids}{The vertex ids of the vertices for which the calculation will be done.
+\item{vids}{The vertex IDs of the vertices for which the calculation will be done.
 Applies to the local efficiency calculation only.}
 
 \item{mode}{Specifies how to define the local neighborhood of a vertex in

--- a/man/graph.Rd
+++ b/man/graph.Rd
@@ -18,7 +18,7 @@ graph(
 \item{edges}{A vector defining the edges, the first edge points
 from the first element to the second, the second edge from the third
 to the fourth, etc. For a numeric vector, these are interpreted
-as internal vertex ids. For character vectors, they are interpreted
+as internal vertex IDs. For character vectors, they are interpreted
 as vertex names.
 
 Alternatively, this can be a character scalar, the name of a
@@ -38,9 +38,9 @@ Passed to \code{make_directed_graph()} or \code{make_undirected_graph()}.}
 
 \item{n}{The number of vertices in the graph. This argument is
 ignored (with a warning) if \code{edges} are symbolic vertex names. It
-is also ignored if there is a bigger vertex id in \code{edges}. This
+is also ignored if there is a bigger vertex ID in \code{edges}. This
 means that for this function it is safe to supply zero here if the
-vertex with the largest id is not an isolate.}
+vertex with the largest ID is not an isolate.}
 
 \item{isolates}{Character vector, names of isolate vertices,
 for symbolic edge lists. It is ignored for numeric edge lists.}

--- a/man/graph.atlas.Rd
+++ b/man/graph.atlas.Rd
@@ -7,7 +7,7 @@
 graph.atlas(n)
 }
 \arguments{
-\item{n}{The id of the graph to create.}
+\item{n}{The ID of the graph to create.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/graph.bfs.Rd
+++ b/man/graph.bfs.Rd
@@ -42,7 +42,7 @@ vertices that are unreachable from the given root vertex (or vertices). If
 visited.}
 
 \item{restricted}{\code{NULL} (=no restriction), or a vector of vertices
-(ids or symbolic names). In the latter case, the search is restricted to the
+(IDs or symbolic names). In the latter case, the search is restricted to the
 given vertices.}
 
 \item{order}{Logical scalar, whether to return the ordering of the vertices.}

--- a/man/graph.diversity.Rd
+++ b/man/graph.diversity.Rd
@@ -13,7 +13,7 @@ graph.diversity(graph, weights = NULL, vids = V(graph))
 computation. If \code{NULL}, then the \sQuote{weight} attibute is used. Note
 that this measure is not defined for unweighted graphs.}
 
-\item{vids}{The vertex ids for which to calculate the measure.}
+\item{vids}{The vertex IDs for which to calculate the measure.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/graph.famous.Rd
+++ b/man/graph.famous.Rd
@@ -18,7 +18,7 @@ graph.famous(
 \item{edges}{A vector defining the edges, the first edge points
 from the first element to the second, the second edge from the third
 to the fourth, etc. For a numeric vector, these are interpreted
-as internal vertex ids. For character vectors, they are interpreted
+as internal vertex IDs. For character vectors, they are interpreted
 as vertex names.
 
 Alternatively, this can be a character scalar, the name of a
@@ -38,9 +38,9 @@ Passed to \code{make_directed_graph()} or \code{make_undirected_graph()}.}
 
 \item{n}{The number of vertices in the graph. This argument is
 ignored (with a warning) if \code{edges} are symbolic vertex names. It
-is also ignored if there is a bigger vertex id in \code{edges}. This
+is also ignored if there is a bigger vertex ID in \code{edges}. This
 means that for this function it is safe to supply zero here if the
-vertex with the largest id is not an isolate.}
+vertex with the largest ID is not an isolate.}
 
 \item{isolates}{Character vector, names of isolate vertices,
 for symbolic edge lists. It is ignored for numeric edge lists.}

--- a/man/graph.maxflow.Rd
+++ b/man/graph.maxflow.Rd
@@ -9,9 +9,9 @@ graph.maxflow(graph, source, target, capacity = NULL)
 \arguments{
 \item{graph}{The input graph.}
 
-\item{source}{The id of the source vertex.}
+\item{source}{The ID of the source vertex.}
 
-\item{target}{The id of the target vertex (sometimes also called sink).}
+\item{target}{The ID of the target vertex (sometimes also called sink).}
 
 \item{capacity}{Vector giving the capacity of the edges. If this is
 \code{NULL} (the default) then the \code{capacity} edge attribute is used.

--- a/man/graph.mincut.Rd
+++ b/man/graph.mincut.Rd
@@ -15,9 +15,9 @@ graph.mincut(
 \arguments{
 \item{graph}{The input graph.}
 
-\item{source}{The id of the source vertex.}
+\item{source}{The ID of the source vertex.}
 
-\item{target}{The id of the target vertex (sometimes also called sink).}
+\item{target}{The ID of the target vertex (sometimes also called sink).}
 
 \item{capacity}{Vector giving the capacity of the edges. If this is
 \code{NULL} (the default) then the \code{capacity} edge attribute is used.}

--- a/man/graph_from_atlas.Rd
+++ b/man/graph_from_atlas.Rd
@@ -10,7 +10,7 @@ graph_from_atlas(n)
 atlas(n)
 }
 \arguments{
-\item{n}{The id of the graph to create.}
+\item{n}{The ID of the graph to create.}
 }
 \value{
 An igraph graph.

--- a/man/graph_from_data_frame.Rd
+++ b/man/graph_from_data_frame.Rd
@@ -71,14 +71,14 @@ If the \code{what} argument is \code{edges} (the default), then the edges of
 the graph and also the edge attributes are returned. The edges will be in
 the first two columns, named \code{from} and \code{to}. (This also denotes
 edge direction for directed graphs.)  For named graphs, the vertex names
-will be included in these columns, for other graphs, the numeric vertex ids.
+will be included in these columns, for other graphs, the numeric vertex IDs.
 The edge attributes will be in the other columns. It is not a good idea to
 have an edge attribute named \code{from} or \code{to}, because then the
 column named in the data frame will not be unique. The edges are listed in
-the order of their numeric ids.
+the order of their numeric IDs.
 
 If the \code{what} argument is \code{vertices}, then vertex attributes are
-returned. Vertices are listed in the order of their numeric vertex ids.
+returned. Vertices are listed in the order of their numeric vertex IDs.
 
 If the \code{what} argument is \code{both}, then both vertex and edge data
 is returned, in a list with named entries \code{vertices} and \code{edges}.

--- a/man/graph_from_edgelist.Rd
+++ b/man/graph_from_edgelist.Rd
@@ -22,9 +22,9 @@ An igraph graph.
 \description{
 \code{graph_from_edgelist()} creates a graph from an edge list. Its argument
 is a two-column matrix, each row defines one edge. If it is
-a numeric matrix then its elements are interpreted as vertex ids. If
+a numeric matrix then its elements are interpreted as vertex IDs. If
 it is a character matrix then it is interpreted as symbolic vertex
-names and a vertex id will be assigned to each name, and also a
+names and a vertex ID will be assigned to each name, and also a
 \code{name} vertex attribute will be added.
 }
 \section{Related documentation in the C library}{

--- a/man/graph_id.Rd
+++ b/man/graph_id.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/iterators.R
 \name{graph_id}
 \alias{graph_id}
-\title{Get the id of a graph}
+\title{Get the ID of a graph}
 \usage{
 graph_id(x, ...)
 }
@@ -12,14 +12,14 @@ graph_id(x, ...)
 \item{...}{Not used currently.}
 }
 \value{
-The id of the graph, a character scalar. For
-vertex and edge sequences the id of the graph they were created from.
+The ID of the graph, a character scalar. For
+vertex and edge sequences the ID of the graph they were created from.
 }
 \description{
-Graph ids are used to check that a vertex or edge sequence
+Graph IDs are used to check that a vertex or edge sequence
 belongs to a graph. If you create a new graph by changing the
-structure of a graph, the new graph will have a new id.
-Changing the attributes will not change the id.
+structure of a graph, the new graph will have a new ID.
+Changing the attributes will not change the ID.
 }
 \examples{
 g <- make_ring(10)

--- a/man/graphlet_basis.Rd
+++ b/man/graphlet_basis.Rd
@@ -26,7 +26,7 @@ graphlets(graph, weights = NULL, niter = 1000)
 and this argument is \code{NULL} (the default), then the \code{weight} edge
 attribute is used.}
 
-\item{cliques}{A list of vertex ids, the graphlet basis to use for the
+\item{cliques}{A list of vertex IDs, the graphlet basis to use for the
 projection.}
 
 \item{niter}{Integer scalar, the number of iterations to perform.}
@@ -38,7 +38,7 @@ projection.}
 \describe{
 \item{cliques}{
 A list of subgraphs, the candidate graphlet basis.
-Each subgraph is give by a vector of vertex ids.
+Each subgraph is give by a vector of vertex IDs.
 }
 \item{Mu}{
 The weights of the subgraphs in graphlet basis.
@@ -49,7 +49,7 @@ The weights of the subgraphs in graphlet basis.
 \describe{
 \item{cliques}{
 A list of subgraphs, the candidate graphlet basis.
-Each subgraph is give by a vector of vertex ids.
+Each subgraph is give by a vector of vertex IDs.
 }
 \item{thresholds}{
 The weight thresholds used for finding the subgraphs.

--- a/man/graphlets.project.Rd
+++ b/man/graphlets.project.Rd
@@ -20,7 +20,7 @@ graphlets.project(
 and this argument is \code{NULL} (the default), then the \code{weight} edge
 attribute is used.}
 
-\item{cliques}{A list of vertex ids, the graphlet basis to use for the
+\item{cliques}{A list of vertex IDs, the graphlet basis to use for the
 projection.}
 
 \item{niter}{Integer scalar, the number of iterations to perform.}

--- a/man/groups.Rd
+++ b/man/groups.Rd
@@ -15,7 +15,7 @@ below.}
 \value{
 A named list of numeric or character vectors. The names are just
 numbers that refer to the groups. The vectors themselves are numeric or
-symbolic vertex ids.
+symbolic vertex IDs.
 }
 \description{
 Create a list of vertex groups from some graph clustering or community

--- a/man/has_eulerian_path.Rd
+++ b/man/has_eulerian_path.Rd
@@ -25,10 +25,10 @@ For \code{eulerian_path()} and \code{eulerian_cycle()}, a named list with two
 entries:
 \describe{
 \item{epath}{
-A vector containing the edge ids along the Eulerian path or cycle.
+A vector containing the edge IDs along the Eulerian path or cycle.
 }
 \item{vpath}{
-A vector containing the vertex ids along the Eulerian path or cycle.
+A vector containing the vertex IDs along the Eulerian path or cycle.
 }
 }
 }

--- a/man/hrg.Rd
+++ b/man/hrg.Rd
@@ -10,7 +10,7 @@ hrg(graph, prob)
 \item{graph}{The igraph graph to create the HRG from.}
 
 \item{prob}{A vector of probabilities, one for each vertex, in the order of
-vertex ids.}
+vertex IDs.}
 }
 \value{
 \code{hrg()} returns an \code{igraphHRG} object.

--- a/man/hrg.create.Rd
+++ b/man/hrg.create.Rd
@@ -10,7 +10,7 @@ hrg.create(graph, prob)
 \item{graph}{The igraph graph to create the HRG from.}
 
 \item{prob}{A vector of probabilities, one for each vertex, in the order of
-vertex ids.}
+vertex IDs.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/igraph-es-indexing.Rd
+++ b/man/igraph-es-indexing.Rd
@@ -48,7 +48,7 @@ index is \code{TRUE} are selected.
 to select edges with the given names. Note that a graph may
 have edge names and vertex names, and both can be used to select
 edges. Edge names are simply used as names of the numeric
-edge id vector. Vertex names effectively only work in graphs without
+edge ID vector. Vertex names effectively only work in graphs without
 multiple edges, and must be separated with a \code{|} bar character
 to select an edges that incident to the two given vertices. See
 examples below.

--- a/man/igraph-minus.Rd
+++ b/man/igraph-minus.Rd
@@ -26,7 +26,7 @@ the type of the right hand side argument:
 \item If it is an igraph graph object, then the difference of the
 two graphs is calculated, see \code{\link[=difference]{difference()}}.
 \item If it is a numeric or character vector, then it is interpreted
-as a vector of vertex ids and the specified vertices will be
+as a vector of vertex IDs and the specified vertices will be
 deleted from the graph. Example: \preformatted{  g <- make_ring(10)
 V(g)$name <- letters[1:10]
 g <- g - c("a", "b")}
@@ -38,7 +38,7 @@ function), then these edges will be deleted from the graph.
 \item If it is an object created with the \code{\link[=vertex]{vertex()}} (or the
 \code{\link[=vertices]{vertices()}}) function, then all arguments of \code{\link[=vertices]{vertices()}} are
 concatenated and the result is interpreted as a vector of vertex
-ids. These vertices will be removed from the graph.
+IDs. These vertices will be removed from the graph.
 \item If it is an object created with the \code{\link[=edge]{edge()}} (or the
 \code{\link[=edges]{edges()}}) function, then all arguments of \code{\link[=edges]{edges()}} are
 concatenated and then interpreted as edges to be removed from the

--- a/man/intersection.igraph.Rd
+++ b/man/intersection.igraph.Rd
@@ -33,7 +33,7 @@ operator is \verb{\%s\%}.
 
 If the \code{byname} argument is \code{TRUE} (or \code{auto} and all graphs
 are named), then the operation is performed on symbolic vertex names instead
-of the internal numeric vertex ids.
+of the internal numeric vertex IDs.
 
 \code{intersection()} keeps the attributes of all graphs. All graph,
 vertex and edge attributes are copied to the result. If an attribute is

--- a/man/is.minimal.separator.Rd
+++ b/man/is.minimal.separator.Rd
@@ -10,7 +10,7 @@ is.minimal.separator(graph, candidate)
 \item{graph}{The input graph. It may be directed, but edge directions are
 ignored.}
 
-\item{candidate}{A numeric vector giving the vertex ids of the candidate
+\item{candidate}{A numeric vector giving the vertex IDs of the candidate
 separator.}
 }
 \description{

--- a/man/is.mutual.Rd
+++ b/man/is.mutual.Rd
@@ -10,7 +10,7 @@ is.mutual(graph, eids = E(graph), loops = TRUE)
 \item{graph}{The input graph.}
 
 \item{eids}{Edge sequence, the edges that will be probed. By default is
-includes all edges in the order of their ids.}
+includes all edges in the order of their IDs.}
 
 \item{loops}{Logical, whether to consider directed self-loops to be mutual.}
 }

--- a/man/is.separator.Rd
+++ b/man/is.separator.Rd
@@ -10,7 +10,7 @@ is.separator(graph, candidate)
 \item{graph}{The input graph. It may be directed, but edge directions are
 ignored.}
 
-\item{candidate}{A numeric vector giving the vertex ids of the candidate
+\item{candidate}{A numeric vector giving the vertex IDs of the candidate
 separator.}
 }
 \description{

--- a/man/is_min_separator.Rd
+++ b/man/is_min_separator.Rd
@@ -10,7 +10,7 @@ is_min_separator(graph, candidate)
 \item{graph}{The input graph. It may be directed, but edge directions are
 ignored.}
 
-\item{candidate}{A numeric vector giving the vertex ids of the candidate
+\item{candidate}{A numeric vector giving the vertex IDs of the candidate
 separator.}
 }
 \value{

--- a/man/is_named.Rd
+++ b/man/is_named.Rd
@@ -18,12 +18,12 @@ vertices.
 }
 \details{
 In igraph vertices can always be identified and specified via their numeric
-vertex ids. This is, however, not always convenient, and in many cases there
-exist symbolic ids that correspond to the vertices. To allow this more
+vertex IDs. This is, however, not always convenient, and in many cases there
+exist symbolic IDs that correspond to the vertices. To allow this more
 flexible identification of vertices, one can assign a vertex attribute
 called \sQuote{name} to an igraph graph. After doing this, the symbolic
 vertex names can be used in all igraph functions, instead of the numeric
-ids.
+IDs.
 
 Note that the uniqueness of vertex names are currently not enforced in
 igraph, you have to check that for yourself, when assigning the vertex

--- a/man/is_separator.Rd
+++ b/man/is_separator.Rd
@@ -10,7 +10,7 @@ is_separator(graph, candidate)
 \item{graph}{The input graph. It may be directed, but edge directions are
 ignored.}
 
-\item{candidate}{A numeric vector giving the vertex ids of the candidate
+\item{candidate}{A numeric vector giving the vertex IDs of the candidate
 separator.}
 }
 \value{

--- a/man/ivs.Rd
+++ b/man/ivs.Rd
@@ -36,7 +36,7 @@ vertex sets to find. \code{NULL} means no limit.}
 \code{ivs()},
 \code{largest_ivs()} and
 \code{max_ivs()} return a list containing numeric
-vertex ids, each list element is an independent vertex set.
+vertex IDs, each list element is an independent vertex set.
 
 \code{ivs_size()} returns an integer constant.
 

--- a/man/layout.star.Rd
+++ b/man/layout.star.Rd
@@ -9,11 +9,11 @@ layout.star(graph, center = V(graph)[1], order = NULL)
 \arguments{
 \item{graph}{The graph to layout.}
 
-\item{center}{The id of the vertex to put in the center. By default it is
+\item{center}{The ID of the vertex to put in the center. By default it is
 the first vertex.}
 
 \item{order}{Numeric vector, the order of the vertices along the perimeter.
-The default ordering is given by the vertex ids.}
+The default ordering is given by the vertex IDs.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/layout_as_star.Rd
+++ b/man/layout_as_star.Rd
@@ -12,11 +12,11 @@ as_star(...)
 \arguments{
 \item{graph}{The graph to layout.}
 
-\item{center}{The id of the vertex to put in the center. By default it is
+\item{center}{The ID of the vertex to put in the center. By default it is
 the first vertex.}
 
 \item{order}{Numeric vector, the order of the vertices along the perimeter.
-The default ordering is given by the vertex ids.}
+The default ordering is given by the vertex IDs.}
 
 \item{...}{Arguments to pass to \code{layout_as_star()}.}
 }

--- a/man/layout_as_tree.Rd
+++ b/man/layout_as_tree.Rd
@@ -20,7 +20,7 @@ as_tree(...)
 \item{graph}{The input graph.}
 
 \item{root}{The index of the root vertex or root vertices.  If this is a
-non-empty vector then the supplied vertex ids are used as the roots of the
+non-empty vector then the supplied vertex IDs are used as the roots of the
 trees (or a single tree if the graph is connected).  If it is an empty
 vector, then the root vertices are automatically calculated based on
 topological sorting, performed with the opposite mode than the \code{mode}

--- a/man/layout_in_circle.Rd
+++ b/man/layout_in_circle.Rd
@@ -22,7 +22,7 @@ desired placement. Vertices that are not included here will be placed at
 A numeric matrix with two columns, and one row for each vertex.
 }
 \description{
-Place vertices on a circle, in the order of their vertex ids.
+Place vertices on a circle, in the order of their vertex IDs.
 }
 \details{
 If you want to order the vertices differently, then permute them using the

--- a/man/layout_modifier.Rd
+++ b/man/layout_modifier.Rd
@@ -9,7 +9,7 @@ layout_modifier(...)
 \arguments{
 \item{...}{Named arguments that define the modifier. Must include:
 \describe{
-\item{id}{A unique identifier string for the modifier}
+\item{ID}{A unique identifier string for the modifier}
 \item{type}{Either \code{"pre"} for pre-layout or \code{"post"} for post-layout}
 \item{args}{A list of arguments to pass to the apply function}
 \item{apply}{A function with signature

--- a/man/layout_on_sphere.Rd
+++ b/man/layout_on_sphere.Rd
@@ -19,7 +19,7 @@ A numeric matrix with three columns, and one row for each vertex.
 }
 \description{
 Place vertices on a sphere, approximately uniformly, in the order of their
-vertex ids.
+vertex IDs.
 }
 \details{
 \code{layout_on_sphere()} places the vertices (approximately) uniformly on the

--- a/man/layout_with_fr.Rd
+++ b/man/layout_with_fr.Rd
@@ -84,7 +84,7 @@ arguments are not supported from igraph version 0.8.0 and are ignored
 }
 \value{
 A two- or three-column matrix, each row giving the coordinates of a
-vertex, according to the ids of the vertex ids.
+vertex, according to the IDs of the vertex IDs.
 }
 \description{
 Place vertices on the plane using the force-directed layout algorithm by

--- a/man/layout_with_lgl.Rd
+++ b/man/layout_with_lgl.Rd
@@ -39,7 +39,7 @@ repulsion forces between vertices only vertices in the same or neighboring
 grid cells are taken into account (the fourth root of the number of
 \code{area}.}
 
-\item{root}{The id of the vertex to place at the middle of the layout. The
+\item{root}{The ID of the vertex to place at the middle of the layout. The
 default value is -1 which means that a random vertex is selected.}
 
 \item{...}{Passed to \code{layout_with_lgl()}.}

--- a/man/make_clusters.Rd
+++ b/man/make_clusters.Rd
@@ -16,7 +16,7 @@ make_clusters(
 \item{graph}{The graph of the community structure.}
 
 \item{membership}{The membership vector of the community structure, a
-numeric vector denoting the id of the community for each vertex. It
+numeric vector denoting the ID of the community for each vertex. It
 might be \code{NULL} for hierarchical community structures.}
 
 \item{algorithm}{Character string, the algorithm that generated
@@ -33,7 +33,7 @@ modularity values is calculated automatically.}
 A \code{communities} object.
 \describe{
 \item{membership}{
-A numeric vector giving the community id for each vertex.
+A numeric vector giving the community ID for each vertex.
 }
 \item{modularity}{
 The modularity score of the partition.

--- a/man/make_graph.Rd
+++ b/man/make_graph.Rd
@@ -31,7 +31,7 @@ undirected_graph(...)
 \item{edges}{A vector defining the edges, the first edge points
 from the first element to the second, the second edge from the third
 to the fourth, etc. For a numeric vector, these are interpreted
-as internal vertex ids. For character vectors, they are interpreted
+as internal vertex IDs. For character vectors, they are interpreted
 as vertex names.
 
 Alternatively, this can be a character scalar, the name of a
@@ -51,9 +51,9 @@ Passed to \code{make_directed_graph()} or \code{make_undirected_graph()}.}
 
 \item{n}{The number of vertices in the graph. This argument is
 ignored (with a warning) if \code{edges} are symbolic vertex names. It
-is also ignored if there is a bigger vertex id in \code{edges}. This
+is also ignored if there is a bigger vertex ID in \code{edges}. This
 means that for this function it is safe to supply zero here if the
-vertex with the largest id is not an isolate.}
+vertex with the largest ID is not an isolate.}
 
 \item{isolates}{Character vector, names of isolate vertices,
 for symbolic edge lists. It is ignored for numeric edge lists.}

--- a/man/matching.Rd
+++ b/man/matching.Rd
@@ -57,7 +57,7 @@ For unweighted graphs this is the same as the size of the matching.
 }
 \item{matching}{
 The matching itself.
-Numeric vertex id, or vertex names if the graph was named.
+Numeric vertex ID, or vertex names if the graph was named.
 Non-matched vertices are denoted by \code{NA}.
 }
 }

--- a/man/max_flow.Rd
+++ b/man/max_flow.Rd
@@ -9,9 +9,9 @@ max_flow(graph, source, target, capacity = NULL)
 \arguments{
 \item{graph}{The input graph.}
 
-\item{source}{The id of the source vertex.}
+\item{source}{The ID of the source vertex.}
 
-\item{target}{The id of the target vertex (sometimes also called sink).}
+\item{target}{The ID of the target vertex (sometimes also called sink).}
 
 \item{capacity}{Vector giving the capacity of the edges. If this is
 \code{NULL} (the default) then the \code{capacity} edge attribute is used.
@@ -28,17 +28,17 @@ A numeric vector, the flow itself, one entry for each edge.
 For undirected graphs this entry is bit trickier,
 since for these the flow direction is not predetermined by the edge direction.
 For these graphs the elements of the this vector can be negative,
-this means that the flow goes from the bigger vertex id to the smaller one.
-Positive values mean that the flow goes from the smaller vertex id to the bigger one.
+this means that the flow goes from the bigger vertex ID to the smaller one.
+Positive values mean that the flow goes from the smaller vertex ID to the bigger one.
 }
 \item{cut}{
-A numeric vector of edge ids, the minimum cut corresponding to the maximum flow.
+A numeric vector of edge IDs, the minimum cut corresponding to the maximum flow.
 }
 \item{partition1}{
-A numeric vector of vertex ids, the vertices in the first partition of the minimum cut corresponding to the maximum flow.
+A numeric vector of vertex IDs, the vertices in the first partition of the minimum cut corresponding to the maximum flow.
 }
 \item{partition2}{
-A numeric vector of vertex ids, the vertices in the second partition of the minimum cut corresponding to the maximum flow.
+A numeric vector of vertex IDs, the vertices in the second partition of the minimum cut corresponding to the maximum flow.
 }
 \item{stats}{
 A list with some statistics from the push-relabel algorithm.

--- a/man/maximal.cliques.Rd
+++ b/man/maximal.cliques.Rd
@@ -15,7 +15,7 @@ maximal.cliques(graph, min = NULL, max = NULL, subset = NULL, file = NULL)
 \item{max}{Numeric constant, upper limit on the size of the cliques to find.
 \code{NULL} means no limit.}
 
-\item{subset}{If not \code{NULL}, then it must be a vector of vertex ids,
+\item{subset}{If not \code{NULL}, then it must be a vector of vertex IDs,
 numeric or symbolic if the graph is named. The algorithm is run from these
 vertices only, so only a subset of all maximal cliques is returned. See the
 Eppstein paper for details. This argument makes it possible to easily
@@ -24,7 +24,7 @@ parallelize the finding of maximal cliques.}
 \item{file}{If not \code{NULL}, then it must be a file name, i.e. a
 character scalar. The output of the algorithm is written to this file. (If
 it exists, then it will be overwritten.) Each clique will be a separate line
-in the file, given with the numeric ids of its vertices, separated by
+in the file, given with the numeric IDs of its vertices, separated by
 whitespace.}
 }
 \description{

--- a/man/maximal.cliques.count.Rd
+++ b/man/maximal.cliques.count.Rd
@@ -15,7 +15,7 @@ maximal.cliques.count(graph, min = NULL, max = NULL, subset = NULL)
 \item{max}{Numeric constant, upper limit on the size of the cliques to find.
 \code{NULL} means no limit.}
 
-\item{subset}{If not \code{NULL}, then it must be a vector of vertex ids,
+\item{subset}{If not \code{NULL}, then it must be a vector of vertex IDs,
 numeric or symbolic if the graph is named. The algorithm is run from these
 vertices only, so only a subset of all maximal cliques is returned. See the
 Eppstein paper for details. This argument makes it possible to easily

--- a/man/min_cut.Rd
+++ b/man/min_cut.Rd
@@ -15,9 +15,9 @@ min_cut(
 \arguments{
 \item{graph}{The input graph.}
 
-\item{source}{The id of the source vertex.}
+\item{source}{The ID of the source vertex.}
 
-\item{target}{The id of the target vertex (sometimes also called sink).}
+\item{target}{The ID of the target vertex (sometimes also called sink).}
 
 \item{capacity}{Vector giving the capacity of the edges. If this is
 \code{NULL} (the default) then the \code{capacity} edge attribute is used.}

--- a/man/min_st_separators.Rd
+++ b/man/min_st_separators.Rd
@@ -12,7 +12,7 @@ ignored.}
 }
 \value{
 A list of numeric vectors. Each vector contains a vertex set
-(defined by vertex ids), each vector is an (s,t) separator of the input
+(defined by vertex IDs), each vector is an (s,t) separator of the input
 graph, for some \eqn{s} and \eqn{t}.
 }
 \description{

--- a/man/minimum.spanning.tree.Rd
+++ b/man/minimum.spanning.tree.Rd
@@ -10,7 +10,7 @@ minimum.spanning.tree(graph, weights = NULL, algorithm = NULL, ...)
 \item{graph}{The graph object to analyze.}
 
 \item{weights}{Numeric vector giving the weights of the edges in the
-graph. The order is determined by the edge ids. This is ignored if the
+graph. The order is determined by the edge IDs. This is ignored if the
 \code{unweighted} algorithm is chosen. Edge weights are interpreted as
 distances.}
 

--- a/man/mst.Rd
+++ b/man/mst.Rd
@@ -10,7 +10,7 @@ mst(graph, weights = NULL, algorithm = NULL, ...)
 \item{graph}{The graph object to analyze.}
 
 \item{weights}{Numeric vector giving the weights of the edges in the
-graph. The order is determined by the edge ids. This is ignored if the
+graph. The order is determined by the edge IDs. This is ignored if the
 \code{unweighted} algorithm is chosen. Edge weights are interpreted as
 distances.}
 

--- a/man/permute.Rd
+++ b/man/permute.Rd
@@ -10,14 +10,14 @@ permute(graph, permutation)
 \item{graph}{The input graph, it can directed or undirected.}
 
 \item{permutation}{A numeric vector giving the permutation to apply. The
-first element is the new id of vertex 1, etc. Every number between one and
+first element is the new ID of vertex 1, etc. Every number between one and
 \code{vcount(graph)} must appear exactly once.}
 }
 \value{
 A new graph object.
 }
 \description{
-Create a new graph, by permuting vertex ids.
+Create a new graph, by permuting vertex IDs.
 }
 \details{
 This function creates a new graph from the input graph by permuting its

--- a/man/permute.vertices.Rd
+++ b/man/permute.vertices.Rd
@@ -10,7 +10,7 @@ permute.vertices(graph, permutation)
 \item{graph}{The input graph, it can directed or undirected.}
 
 \item{permutation}{A numeric vector giving the permutation to apply. The
-first element is the new id of vertex 1, etc. Every number between one and
+first element is the new ID of vertex 1, etc. Every number between one and
 \code{vcount(graph)} must appear exactly once.}
 }
 \description{

--- a/man/plot.common.Rd
+++ b/man/plot.common.Rd
@@ -157,7 +157,7 @@ By default vertices are drawn as circles.
 }
 \item{label}{
 The vertex labels. They will be converted to character.
-Specify \code{NA} to omit vertex labels. The default vertex labels are the vertex ids.
+Specify \code{NA} to omit vertex labels. The default vertex labels are the vertex IDs.
 }
 \item{label.family}{
 The

--- a/man/plot.igraph.Rd
+++ b/man/plot.igraph.Rd
@@ -35,7 +35,7 @@ to modify this.}
 \item{ylim}{The limits for the vertical axis, it is unlikely that you want
 to modify this.}
 
-\item{mark.groups}{A list of vertex id vectors. It is interpreted as a set
+\item{mark.groups}{A list of vertex ID vectors. It is interpreted as a set
 of vertex groups. Each vertex group is highlighted, by plotting a colored
 smoothed polygon around and \dQuote{under} it. See the arguments below to
 control the look of the polygons.}
@@ -48,7 +48,7 @@ used for the different vertex groups.}
 
 \item{mark.col}{A scalar or vector giving the colors of marking the
 polygons, in any format accepted by \code{\link[graphics:xspline]{graphics::xspline()}}; e.g.
-numeric color ids, symbolic color names, or colors in RGB.}
+numeric color IDs, symbolic color names, or colors in RGB.}
 
 \item{mark.border}{A scalar or vector giving the colors of the borders of
 the vertex group marking polygons. If it is \code{NA}, then no border is

--- a/man/plus-.igraph.Rd
+++ b/man/plus-.igraph.Rd
@@ -55,7 +55,7 @@ graph. The new edges and possibly their attributes can be specified as
 the arguments of the \code{edges()} function.
 
 The unnamed arguments of \code{edges()} are concatenated and used
-as vertex ids of the end points of the new edges. The named
+as vertex IDs of the end points of the new edges. The named
 arguments will be added as edge attributes.
 
 Examples: \preformatted{  g <- make_empty_graph() +
@@ -73,7 +73,7 @@ the graph.
 new edges that form a path are added. The edges and possibly their
 attributes are specified as the arguments to the \code{path()}
 function. The non-named arguments are concatenated and interpreted
-as the vertex ids along the path. The remaining arguments are added
+as the vertex IDs along the path. The remaining arguments are added
 as edge attributes.
 
 Examples: \preformatted{  g <- make_empty_graph() + vertices(letters[1:10])

--- a/man/predict_edges.Rd
+++ b/man/predict_edges.Rd
@@ -34,7 +34,7 @@ number for a more accurate prediction.}
 A list with entries:
 \describe{
 \item{edges}{
-The predicted edges, in a two-column matrix of vertex ids.
+The predicted edges, in a two-column matrix of vertex IDs.
 }
 \item{prob}{
 Probabilities of these edges, according to the fitted model.

--- a/man/print.igraph.Rd
+++ b/man/print.igraph.Rd
@@ -35,7 +35,7 @@ attributes.}
 \item{edge.attributes}{Logical constant, whether to print edge attributes.}
 
 \item{names}{Logical constant, whether to print symbolic vertex names (i.e.
-the \code{name} vertex attribute) or vertex ids.}
+the \code{name} vertex attribute) or vertex IDs.}
 
 \item{max.lines}{The maximum number of lines to use. The rest of the
 output will be truncated.}
@@ -74,7 +74,7 @@ vertices: \preformatted{    IGRAPH badcafe DNW- 10 9 -- In-star
 The first line always
 starts with \code{IGRAPH}, showing you that the object is an igraph graph.
 Then a seven character code is printed, this the first seven characters
-of the unique id of the graph. See \code{\link[=graph_id]{graph_id()}} for more.
+of the unique ID of the graph. See \code{\link[=graph_id]{graph_id()}} for more.
 Then a four letter long code string is printed. The first letter
 distinguishes between directed (\sQuote{\code{D}}) and undirected
 (\sQuote{\code{U}}) graphs. The second letter is \sQuote{\code{N}} for named

--- a/man/read_graph.Rd
+++ b/man/read_graph.Rd
@@ -82,7 +82,7 @@ If \code{character(0)} (the default) is given here
 then vertex IDs will be assigned to vertex names in the order of
 their appearance in the .ncol file.
 If it is not \code{character(0)} and some unknown vertex names are found
-in the .ncol file then new vertex ids will be assigned to them.
+in the .ncol file then new vertex IDs will be assigned to them.
 }
 \item{names}{
 Logical value, if \code{TRUE} (the default)

--- a/man/running_mean.Rd
+++ b/man/running_mean.Rd
@@ -21,7 +21,7 @@ bin width.
 }
 \details{
 The running mean of \code{v} is a \code{w} vector of length
-\code{length(v)-binwidth+1}. The first element of \code{w} id the average of
+\code{length(v)-binwidth+1}. The first element of \code{w} ID the average of
 the first \code{binwidth} elements of \code{v}, the second element of
 \code{w} is the average of elements \code{2:(binwidth+1)}, etc.
 }

--- a/man/sample_pa.Rd
+++ b/man/sample_pa.Rd
@@ -66,7 +66,7 @@ partial prefix-sum tree, but the generation of multiple edges is allowed.
 Before the 0.6 version igraph used this algorithm if \code{power} was not
 one, or \code{zero.appeal} was not one.  \code{bag} is the algorithm that
 was previously (before version 0.6) used if \code{power} was one and
-\code{zero.appeal} was one as well. It works by putting the ids of the
+\code{zero.appeal} was one as well. It works by putting the IDs of the
 vertices into a bag (multiset, really), exactly as many times as their
 (in-)degree, plus once more. Then the required number of cited vertices are
 drawn from the bag, with replacement. This method might generate multiple

--- a/man/scan_stat.Rd
+++ b/man/scan_stat.Rd
@@ -33,7 +33,7 @@ The scan statistics in each time step.
 It is \code{NA} for the initial \code{tau + ell} time steps.
 }
 \item{arg_max_v}{
-The (numeric) vertex ids for the vertex with the largest locality statistics, at each time step.
+The (numeric) vertex IDs for the vertex with the largest locality statistics, at each time step.
 It is \code{NA} for the initial \code{tau + ell} time steps.
 }
 }

--- a/man/shapes.Rd
+++ b/man/shapes.Rd
@@ -95,7 +95,7 @@ The plotting function has the following arguments:
 The coordinates of the vertices, a matrix with two columns.
 }
 \item{v}{
-The ids of the vertices to plot. It should match the number of rows in the \code{coords} argument.
+The IDs of the vertices to plot. It should match the number of rows in the \code{coords} argument.
 }
 \item{params}{
 The same as for the clipping function, see above.

--- a/man/similarity.Rd
+++ b/man/similarity.Rd
@@ -15,7 +15,7 @@ similarity(
 \arguments{
 \item{graph}{The input graph.}
 
-\item{vids}{The vertex ids for which the similarity is calculated.}
+\item{vids}{The vertex IDs for which the similarity is calculated.}
 
 \item{mode}{The type of neighboring vertices to use for the calculation,
 possible values: \sQuote{\code{out}}, \sQuote{\verb{in}},

--- a/man/similarity.dice.Rd
+++ b/man/similarity.dice.Rd
@@ -14,7 +14,7 @@ similarity.dice(
 \arguments{
 \item{graph}{The input graph.}
 
-\item{vids}{The vertex ids for which the similarity is calculated.}
+\item{vids}{The vertex IDs for which the similarity is calculated.}
 
 \item{mode}{The type of neighboring vertices to use for the calculation,
 possible values: \sQuote{\code{out}}, \sQuote{\verb{in}},

--- a/man/similarity.invlogweighted.Rd
+++ b/man/similarity.invlogweighted.Rd
@@ -13,7 +13,7 @@ similarity.invlogweighted(
 \arguments{
 \item{graph}{The input graph.}
 
-\item{vids}{The vertex ids for which the similarity is calculated.}
+\item{vids}{The vertex IDs for which the similarity is calculated.}
 
 \item{mode}{The type of neighboring vertices to use for the calculation,
 possible values: \sQuote{\code{out}}, \sQuote{\verb{in}},

--- a/man/similarity.jaccard.Rd
+++ b/man/similarity.jaccard.Rd
@@ -14,7 +14,7 @@ similarity.jaccard(
 \arguments{
 \item{graph}{The input graph.}
 
-\item{vids}{The vertex ids for which the similarity is calculated.}
+\item{vids}{The vertex IDs for which the similarity is calculated.}
 
 \item{mode}{The type of neighboring vertices to use for the calculation,
 possible values: \sQuote{\code{out}}, \sQuote{\verb{in}},

--- a/man/stMincuts.Rd
+++ b/man/stMincuts.Rd
@@ -9,9 +9,9 @@ stMincuts(graph, source, target, capacity = NULL)
 \arguments{
 \item{graph}{The input graph. It must be directed.}
 
-\item{source}{The id of the source vertex.}
+\item{source}{The ID of the source vertex.}
 
-\item{target}{The id of the target vertex.}
+\item{target}{The ID of the target vertex.}
 
 \item{capacity}{Numeric vector giving the edge capacities. If this is
 \code{NULL} and the graph has a \code{weight} edge attribute, then this

--- a/man/st_cuts.Rd
+++ b/man/st_cuts.Rd
@@ -17,11 +17,11 @@ st_cuts(graph, source, target)
 A list with entries:
 \describe{
 \item{cuts}{
-A list of numeric vectors containing edge ids.
+A list of numeric vectors containing edge IDs.
 Each vector is an \eqn{(s,t)}-cut.
 }
 \item{partition1s}{
-A list of numeric vectors containing vertex ids, they correspond to the edge cuts.
+A list of numeric vectors containing vertex IDs, they correspond to the edge cuts.
 Each vertex set is a generator of the corresponding cut, i.e. in the graph \eqn{G=(V,E)},
 the vertex set \eqn{X} and its complementer \eqn{V-X},
 generates the cut that contains exactly the edges that go from \eqn{X} to \eqn{V-X}.

--- a/man/st_min_cuts.Rd
+++ b/man/st_min_cuts.Rd
@@ -9,9 +9,9 @@ st_min_cuts(graph, source, target, capacity = NULL)
 \arguments{
 \item{graph}{The input graph. It must be directed.}
 
-\item{source}{The id of the source vertex.}
+\item{source}{The ID of the source vertex.}
 
-\item{target}{The id of the target vertex.}
+\item{target}{The ID of the target vertex.}
 
 \item{capacity}{Numeric vector giving the edge capacities. If this is
 \code{NULL} and the graph has a \code{weight} edge attribute, then this
@@ -26,10 +26,10 @@ A list with entries:
 Numeric scalar, the size of the minimum cut(s).
 }
 \item{cuts}{
-A list of numeric vectors containing edge ids. Each vector is a minimum \eqn{(s,t)}-cut.
+A list of numeric vectors containing edge IDs. Each vector is a minimum \eqn{(s,t)}-cut.
 }
 \item{partition1s}{
-A list of numeric vectors containing vertex ids,
+A list of numeric vectors containing vertex IDs,
 they correspond to the edge cuts.
 Each vertex set is a generator of the corresponding cut, i.e. in the graph \eqn{G=(V,E)},
 the vertex set \eqn{X} and its complementer \eqn{V-X},

--- a/man/sub-.igraph.Rd
+++ b/man/sub-.igraph.Rd
@@ -20,22 +20,22 @@
 \arguments{
 \item{x}{The graph.}
 
-\item{i}{Index. Vertex ids or names or logical vectors. See details
+\item{i}{Index. Vertex IDs or names or logical vectors. See details
 below.}
 
-\item{j}{Index. Vertex ids or names or logical vectors. See details
+\item{j}{Index. Vertex IDs or names or logical vectors. See details
 below.}
 
 \item{...}{Currently ignored.}
 
-\item{from}{A numeric or character vector giving vertex ids or
+\item{from}{A numeric or character vector giving vertex IDs or
 names. Together with the \code{to} argument, it can be used to
 query/set a sequence of edges. See details below. This argument cannot
 be present together with any of the \code{i} and \code{j} arguments
 and if it is present, then the \code{to} argument must be present as
 well.}
 
-\item{to}{A numeric or character vector giving vertex ids or
+\item{to}{A numeric or character vector giving vertex IDs or
 names. Together with the \code{from} argument, it can be used to
 query/set a sequence of edges. See details below. This argument cannot
 be present together with any of the \code{i} and \code{j} arguments
@@ -44,7 +44,7 @@ well.}
 
 \item{sparse}{Logical scalar, whether to return sparse matrices.}
 
-\item{edges}{Logical scalar, whether to return edge ids.}
+\item{edges}{Logical scalar, whether to return edge IDs.}
 
 \item{drop}{Ignored.}
 
@@ -75,7 +75,7 @@ two return part of it.
 \item The \code{from} and \code{to} arguments can be used to check
 the existence of many edges. In this case, both \code{from} and
 \code{to} must be present and they must have the same length. They
-must contain vertex ids or names. A numeric vector is returned, of
+must contain vertex IDs or names. A numeric vector is returned, of
 the same length as \code{from} and \code{to}, it contains ones
 for existing edges edges and zeros for non-existing ones.
 Example: \preformatted{  graph[from=1:3, to=c(2,3,5)]}.
@@ -83,9 +83,9 @@ Example: \preformatted{  graph[from=1:3, to=c(2,3,5)]}.
 weights. For non-esistent edges zero weights are returned. Other
 edge attributes can be queried as well, by giving the \code{attr}
 argument.
-\item Querying edge ids instead of the existance of edges or edge
+\item Querying edge IDs instead of the existance of edges or edge
 attributes. E.g. \preformatted{  graph[1, 2, edges=TRUE]}
-returns the id of the edge between vertices 1 and 2, or zero if
+returns the ID of the edge between vertices 1 and 2, or zero if
 there is no such edge.
 \item Adding one or more edges to a graph. For this the element(s) of
 the imaginary adjacency matrix must be set to a non-zero numeric
@@ -109,7 +109,7 @@ removes the edge from vertex \eqn{v} to vertex \eqn{w}.
 As this can be used to delete edges between two sets of vertices,
 either pairwise: \preformatted{  graph[from=v, to=w] <- FALSE}
 or not: \preformatted{  graph[v, w] <- FALSE }
-if \eqn{v} and \eqn{w} are vectors of edge ids or names.
+if \eqn{v} and \eqn{w} are vectors of edge IDs or names.
 }
 
 \sQuote{\code{[}} allows logical indices and negative indices as well,
@@ -120,7 +120,7 @@ G[-1,1] <- TRUE}
 creates a star graph.
 
 Of course, the indexing operators support vertex names,
-so instead of a numeric vertex id a vertex can also be given to
+so instead of a numeric vertex ID a vertex can also be given to
 \sQuote{\code{[}} and \sQuote{\code{[[}}.
 }
 \seealso{

--- a/man/sub-sub-.igraph.Rd
+++ b/man/sub-sub-.igraph.Rd
@@ -13,14 +13,14 @@
 
 \item{j}{Index, integer, character or logical, see details below.}
 
-\item{from}{A numeric or character vector giving vertex ids or
+\item{from}{A numeric or character vector giving vertex IDs or
 names. Together with the \code{to} argument, it can be used to
 query/set a sequence of edges. See details below. This argument cannot
 be present together with any of the \code{i} and \code{j} arguments
 and if it is present, then the \code{to} argument must be present as
 well.}
 
-\item{to}{A numeric or character vector giving vertex ids or
+\item{to}{A numeric or character vector giving vertex IDs or
 names. Together with the \code{from} argument, it can be used to
 query/set a sequence of edges. See details below. This argument cannot
 be present together with any of the \code{i} and \code{j} arguments
@@ -32,7 +32,7 @@ well.}
 \item{directed}{Logical scalar, whether to consider edge directions
 in directed graphs. It is ignored for undirected graphs.}
 
-\item{edges}{Logical scalar, whether to return edge ids.}
+\item{edges}{Logical scalar, whether to return edge IDs.}
 
 \item{exact}{Ignored.}
 }
@@ -52,9 +52,9 @@ or the 1:3 vertices. (For undirected graphs they are equivalent.)
 if the \code{edges} argument is set to
 \code{TRUE}: \preformatted{  graph[[1:3, , edges=TRUE]]
 graph[[, 1:3, edges=TRUE]]}
-\item Querying the edge ids between two sets or vertices,
+\item Querying the edge IDs between two sets or vertices,
 if both indices are used. E.g. \preformatted{  graph[[v, w, edges=TRUE]]}
-gives the edge ids of all the edges that exist from vertices
+gives the edge IDs of all the edges that exist from vertices
 \eqn{v} to vertices \eqn{w}.
 }
 
@@ -66,7 +66,7 @@ graph[[from = v, to = w, edges = TRUE]]}
 \sQuote{\code{[[}} operators allows logical indices and negative indices
 as well, with the usual R semantics.
 
-Vertex names are also supported, so instead of a numeric vertex id a
+Vertex names are also supported, so instead of a numeric vertex ID a
 vertex can also be given to \sQuote{\code{[}} and \sQuote{\code{[[}}.
 }
 \seealso{

--- a/man/subcomponent.Rd
+++ b/man/subcomponent.Rd
@@ -18,7 +18,7 @@ returned. If \dQuote{all} returns the union of these. It is ignored for
 undirected graphs.}
 }
 \value{
-Numeric vector, the ids of the vertices in the same component as
+Numeric vector, the IDs of the vertices in the same component as
 \code{v}.
 }
 \description{

--- a/man/subgraph.Rd
+++ b/man/subgraph.Rd
@@ -31,7 +31,7 @@ scratch. \sQuote{\code{auto}} chooses between the two implementations
 automatically, using heuristics based on the size of the original and the
 result graph.}
 
-\item{eids}{The edge ids of the edges that will be kept in the result graph.}
+\item{eids}{The edge IDs of the edges that will be kept in the result graph.}
 
 \item{delete.vertices}{Logical scalar, whether to remove vertices that do
 not have any adjacent edges in \code{eids}.}

--- a/man/subgraph.edges.Rd
+++ b/man/subgraph.edges.Rd
@@ -9,7 +9,7 @@ subgraph.edges(graph, eids, delete.vertices = TRUE)
 \arguments{
 \item{graph}{The original graph.}
 
-\item{eids}{The edge ids of the edges that will be kept in the result graph.}
+\item{eids}{The edge IDs of the edges that will be kept in the result graph.}
 
 \item{delete.vertices}{Logical scalar, whether to remove vertices that do
 not have any adjacent edges in \code{eids}.}

--- a/man/subgraph_isomorphic.Rd
+++ b/man/subgraph_isomorphic.Rd
@@ -50,7 +50,7 @@ the following extra arguments:
 \describe{
 \item{domains}{
 If not \code{NULL}, then it specifies matching restrictions.
-It must be a list of \code{target} vertex sets, given as numeric vertex ids or symbolic vertex names.
+It must be a list of \code{target} vertex sets, given as numeric vertex IDs or symbolic vertex names.
 The length of the list must be \code{vcount(pattern)} and for each vertex in \code{pattern}
 it gives the allowed matching vertices in \code{target}.
 Defaults to \code{NULL}.

--- a/man/subgraph_isomorphisms.Rd
+++ b/man/subgraph_isomorphisms.Rd
@@ -56,7 +56,7 @@ the following extra arguments:
 \describe{
 \item{domains}{
 If not \code{NULL}, then it specifies matching restrictions.
-It must be a list of \code{target} vertex sets, given as numeric vertex ids or symbolic vertex names.
+It must be a list of \code{target} vertex sets, given as numeric vertex IDs or symbolic vertex names.
 The length of the list must be \code{vcount(pattern)} and for each vertex in \code{pattern}
 it gives the allowed matching vertices in \code{target}.
 Defaults to \code{NULL}.

--- a/man/tkplot.Rd
+++ b/man/tkplot.Rd
@@ -44,7 +44,7 @@ tk_canvas(tkp.id)
 \item{\dots}{Additional plotting parameters. See \link{igraph.plotting} for
 the complete list.}
 
-\item{tkp.id}{The id of the tkplot window to close/reshape/etc.}
+\item{tkp.id}{The ID of the tkplot window to close/reshape/etc.}
 
 \item{window.close}{Leave this on the default value.}
 
@@ -66,7 +66,7 @@ vertices, in absolute coordinates.}
 \item{rad}{The degree to rotate the plot, in radian.}
 }
 \value{
-\code{tkplot()} returns an integer, the id of the plot, this can be
+\code{tkplot()} returns an integer, the ID of the plot, this can be
 used to manipulate it from the command line.
 
 \code{tk_canvas()} returns \code{tkwin} object, the Tk canvas.
@@ -112,10 +112,10 @@ used.
 
 The \code{tkplot()} command creates a new Tk window with the graphical
 representation of \code{graph}. The command returns an integer number, the
-tkplot id. The other commands utilize this id to be able to query or
+tkplot ID. The other commands utilize this ID to be able to query or
 manipulate the plot.
 
-\code{tk_close()} closes the Tk plot with id \code{tkp.id}.
+\code{tk_close()} closes the Tk plot with ID \code{tkp.id}.
 
 \code{tk_off()} closes all Tk plots.
 

--- a/man/tkplot.canvas.Rd
+++ b/man/tkplot.canvas.Rd
@@ -7,7 +7,7 @@
 tkplot.canvas(tkp.id)
 }
 \arguments{
-\item{tkp.id}{The id of the tkplot window to close/reshape/etc.}
+\item{tkp.id}{The ID of the tkplot window to close/reshape/etc.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/tkplot.center.Rd
+++ b/man/tkplot.center.Rd
@@ -7,7 +7,7 @@
 tkplot.center(tkp.id)
 }
 \arguments{
-\item{tkp.id}{The id of the tkplot window to close/reshape/etc.}
+\item{tkp.id}{The ID of the tkplot window to close/reshape/etc.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/tkplot.close.Rd
+++ b/man/tkplot.close.Rd
@@ -7,7 +7,7 @@
 tkplot.close(tkp.id, window.close = TRUE)
 }
 \arguments{
-\item{tkp.id}{The id of the tkplot window to close/reshape/etc.}
+\item{tkp.id}{The ID of the tkplot window to close/reshape/etc.}
 
 \item{window.close}{Leave this on the default value.}
 }

--- a/man/tkplot.export.postscript.Rd
+++ b/man/tkplot.export.postscript.Rd
@@ -7,7 +7,7 @@
 tkplot.export.postscript(tkp.id)
 }
 \arguments{
-\item{tkp.id}{The id of the tkplot window to close/reshape/etc.}
+\item{tkp.id}{The ID of the tkplot window to close/reshape/etc.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/tkplot.fit.to.screen.Rd
+++ b/man/tkplot.fit.to.screen.Rd
@@ -7,7 +7,7 @@
 tkplot.fit.to.screen(tkp.id, width = NULL, height = NULL)
 }
 \arguments{
-\item{tkp.id}{The id of the tkplot window to close/reshape/etc.}
+\item{tkp.id}{The ID of the tkplot window to close/reshape/etc.}
 
 \item{width}{The width of the rectangle for generating new coordinates.}
 

--- a/man/tkplot.getcoords.Rd
+++ b/man/tkplot.getcoords.Rd
@@ -7,7 +7,7 @@
 tkplot.getcoords(tkp.id, norm = FALSE)
 }
 \arguments{
-\item{tkp.id}{The id of the tkplot window to close/reshape/etc.}
+\item{tkp.id}{The ID of the tkplot window to close/reshape/etc.}
 
 \item{norm}{Logical, should we norm the coordinates.}
 }

--- a/man/tkplot.reshape.Rd
+++ b/man/tkplot.reshape.Rd
@@ -7,7 +7,7 @@
 tkplot.reshape(tkp.id, newlayout, ..., params)
 }
 \arguments{
-\item{tkp.id}{The id of the tkplot window to close/reshape/etc.}
+\item{tkp.id}{The ID of the tkplot window to close/reshape/etc.}
 
 \item{newlayout}{The new layout, see the \code{layout} parameter of tkplot.}
 

--- a/man/tkplot.rotate.Rd
+++ b/man/tkplot.rotate.Rd
@@ -7,7 +7,7 @@
 tkplot.rotate(tkp.id, degree = NULL, rad = NULL)
 }
 \arguments{
-\item{tkp.id}{The id of the tkplot window to close/reshape/etc.}
+\item{tkp.id}{The ID of the tkplot window to close/reshape/etc.}
 
 \item{degree}{The degree to rotate the plot.}
 

--- a/man/tkplot.setcoords.Rd
+++ b/man/tkplot.setcoords.Rd
@@ -7,7 +7,7 @@
 tkplot.setcoords(tkp.id, coords)
 }
 \arguments{
-\item{tkp.id}{The id of the tkplot window to close/reshape/etc.}
+\item{tkp.id}{The ID of the tkplot window to close/reshape/etc.}
 
 \item{coords}{Two-column numeric matrix, the new coordinates of the
 vertices, in absolute coordinates.}

--- a/man/transitivity.Rd
+++ b/man/transitivity.Rd
@@ -47,7 +47,7 @@ The same as \code{barrat}.
 }
 }}
 
-\item{vids}{The vertex ids for the local transitivity will be calculated.
+\item{vids}{The vertex IDs for the local transitivity will be calculated.
 This will be ignored for global transitivity types.  The default value is
 \code{NULL}, in this case all vertices are considered. It is slightly faster
 to supply \code{NULL} here than \code{V(graph)}.}

--- a/man/union.igraph.Rd
+++ b/man/union.igraph.Rd
@@ -30,7 +30,7 @@ can be also used via the \verb{\%u\%} operator.
 
 If the \code{byname} argument is \code{TRUE} (or \code{auto} and all graphs
 are named), then the operation is performed on symbolic vertex names instead
-of the internal numeric vertex ids.
+of the internal numeric vertex IDs.
 
 \code{union()} keeps the attributes of all graphs. All graph, vertex and
 edge attributes are copied to the result. If an attribute is present in

--- a/man/vertex.connectivity.Rd
+++ b/man/vertex.connectivity.Rd
@@ -7,10 +7,10 @@
 vertex.connectivity(graph, source = NULL, target = NULL, checks = TRUE)
 }
 \arguments{
-\item{source}{The id of the source vertex, for \code{vertex_connectivity()} it
+\item{source}{The ID of the source vertex, for \code{vertex_connectivity()} it
 can be \code{NULL}, see details below.}
 
-\item{target}{The id of the target vertex, for \code{vertex_connectivity()} it
+\item{target}{The ID of the target vertex, for \code{vertex_connectivity()} it
 can be \code{NULL}, see details below.}
 
 \item{checks}{Logical constant. Whether to check that the graph is connected

--- a/man/vertex.disjoint.paths.Rd
+++ b/man/vertex.disjoint.paths.Rd
@@ -7,10 +7,10 @@
 vertex.disjoint.paths(graph, source = NULL, target = NULL)
 }
 \arguments{
-\item{source}{The id of the source vertex, for \code{vertex_connectivity()} it
+\item{source}{The ID of the source vertex, for \code{vertex_connectivity()} it
 can be \code{NULL}, see details below.}
 
-\item{target}{The id of the target vertex, for \code{vertex_connectivity()} it
+\item{target}{The ID of the target vertex, for \code{vertex_connectivity()} it
 can be \code{NULL}, see details below.}
 }
 \description{

--- a/man/vertex_connectivity.Rd
+++ b/man/vertex_connectivity.Rd
@@ -16,10 +16,10 @@ vertex_disjoint_paths(graph, source = NULL, target = NULL)
 \arguments{
 \item{graph, x}{The input graph.}
 
-\item{source}{The id of the source vertex, for \code{vertex_connectivity()} it
+\item{source}{The ID of the source vertex, for \code{vertex_connectivity()} it
 can be \code{NULL}, see details below.}
 
-\item{target}{The id of the target vertex, for \code{vertex_connectivity()} it
+\item{target}{The ID of the target vertex, for \code{vertex_connectivity()} it
 can be \code{NULL}, see details below.}
 
 \item{checks}{Logical constant. Whether to check that the graph is connected

--- a/man/voronoi_cells.Rd
+++ b/man/voronoi_cells.Rd
@@ -40,7 +40,7 @@ and \code{"last"} takes the last one.}
 A named list with two components:
 \describe{
 \item{membership}{
-numeric vector giving the cluster id to which each vertex belongs.
+numeric vector giving the cluster ID to which each vertex belongs.
 }
 \item{distances}{
 numeric vector giving the distance of each vertex from its generator

--- a/man/which_mutual.Rd
+++ b/man/which_mutual.Rd
@@ -10,7 +10,7 @@ which_mutual(graph, eids = E(graph), loops = TRUE)
 \item{graph}{The input graph.}
 
 \item{eids}{Edge sequence, the edges that will be probed. By default is
-includes all edges in the order of their ids.}
+includes all edges in the order of their IDs.}
 
 \item{loops}{Logical, whether to consider directed self-loops to be mutual.}
 }

--- a/man/write_graph.Rd
+++ b/man/write_graph.Rd
@@ -102,7 +102,7 @@ or NULL to use the "capacity" attribute if it exists.}
 
 GML is a quite general textual format.
 \describe{
-\item{id}{Optional numeric vertex IDs to use.}
+\item{ID}{Optional numeric vertex IDs to use.}
 \item{creator}{Optional string specifying the creator of the file.}
 }
 }

--- a/tools/check-id-casing.R
+++ b/tools/check-id-casing.R
@@ -1,0 +1,207 @@
+#!/usr/bin/env Rscript
+
+# Enforce the documentation convention "ID" / "IDs" (not "id" / "ids") in
+# *prose*, while leaving code untouched. The igraph docs decision is that the
+# concept is written "ID(s)" in manual-page text, but lowercase stays wherever
+# the token is code: argument names, runnable examples, and \code{}/`...` spans.
+#
+# This scans roxygen source in R/ (not the regenerated man/*.Rd) and reports
+# every bare lowercase "id"/"ids" (and stray title-case "Id"/"Ids") that
+# survives once code contexts are stripped out. Exits non-zero when anything is
+# found, so it can gate CI.
+#
+# Usage:
+#   Rscript tools/check-id-casing.R            # scans R/
+#   Rscript tools/check-id-casing.R R vignettes
+#
+# It is deliberately plain base R (no package deps) so it runs in a bare CI
+# step before the package is installed.
+
+args <- commandArgs(trailingOnly = TRUE)
+roots <- if (length(args) > 0) args else "R"
+
+# Roxygen tags whose value is an identifier / markup, not prose: skip the whole
+# line. (@param/@field/@slot are handled separately - they have a leading
+# identifier followed by a prose description.)
+identifier_tags <- c(
+  "name", "rdname", "aliases", "family", "keywords", "concept",
+  "usage", "docType", "encoding", "useDynLib", "import", "importFrom",
+  "importClassesFrom", "importMethodsFrom", "export", "exportClass",
+  "exportMethod", "exportS3Method", "rawNamespace", "S3method",
+  "inheritParams", "inherit", "inheritDotParams", "inheritSection",
+  "template", "templateVar", "includeRmd", "eval", "evalRd", "evalNamespace",
+  "backref", "order", "md", "noMd", "noRd", "format", "source"
+)
+
+# Strip everything that counts as "code" from a line of prose, so the leftover
+# is only natural-language text we should hold to the ID(s) convention.
+strip_code <- function(x) {
+  # backtick spans: `foo_bar()`
+  x <- gsub("`[^`]*`", " ", x, perl = TRUE)
+  # \href{url}{text}: drop the URL, keep the visible (prose) text
+  x <- gsub("\\\\href\\{[^}]*\\}\\{([^}]*)\\}", " \\1 ", x, perl = TRUE)
+  # \link[=target]{text} / \link{text}: identifier target, drop entirely
+  x <- gsub("\\\\link(\\[[^]]*\\])?\\{[^}]*\\}", " ", x, perl = TRUE)
+  # single-argument code/markup commands whose braces hold code or identifiers
+  code_cmds <- paste(
+    c(
+      "code", "verb", "eqn", "deqn", "preformatted", "samp", "kbd", "file",
+      "pkg", "env", "command", "option", "var", "url", "email", "method",
+      "S4method", "linkS4class", "dontrun", "donttest", "dontshow", "Sexpr"
+    ),
+    collapse = "|"
+  )
+  x <- gsub(
+    sprintf("\\\\(%s)\\{[^}]*\\}", code_cmds), " ", x,
+    perl = TRUE
+  )
+  x
+}
+
+# Words that violate the convention once code is stripped: lowercase id/ids and
+# the title-case Id/Ids. "ID"/"IDs" are correct and never flagged.
+bad_word <- "\\b(id|ids|Id|Ids)\\b"
+
+scan_file <- function(path) {
+  lines <- readLines(path, warn = FALSE, encoding = "UTF-8")
+  findings <- list()
+
+  in_roxygen <- FALSE
+  in_examples <- FALSE
+  in_fence <- FALSE
+  # brace depth inside an open, multi-line \preformatted{ ... } block (used by
+  # manual `@section Examples:` blocks, which are code, not prose)
+  pre_depth <- 0L
+
+  count_braces <- function(s) {
+    nchar(gsub("[^{]", "", s)) - nchar(gsub("[^}]", "", s))
+  }
+
+  for (i in seq_along(lines)) {
+    line <- lines[[i]]
+    is_roxygen <- grepl("^\\s*#'", line, perl = TRUE)
+
+    if (!is_roxygen) {
+      # leaving (or between) roxygen blocks resets per-block state
+      in_roxygen <- FALSE
+      in_examples <- FALSE
+      in_fence <- FALSE
+      pre_depth <- 0L
+      next
+    }
+    in_roxygen <- TRUE
+
+    # content after the leading  #'
+    content <- sub("^\\s*#'\\s?", "", line, perl = TRUE)
+
+    # markdown fenced code block: ```{r} ... ``` is runnable code, not prose
+    if (grepl("^\\s*```", content, perl = TRUE)) {
+      in_fence <- !in_fence
+      next
+    }
+    if (in_fence) {
+      next
+    }
+
+    # already inside a multi-line \preformatted block: all code, just track depth
+    if (pre_depth > 0L) {
+      pre_depth <- pre_depth + count_braces(content)
+      next
+    }
+
+    # tag at the start of this line, if any
+    tag <- NA_character_
+    m <- regmatches(content, regexec("^@(\\w+)", content, perl = TRUE))[[1]]
+    if (length(m) == 2) {
+      tag <- m[[2]]
+    }
+
+    # @examples / @examplesIf open a code block that runs until the next tag
+    if (!is.na(tag)) {
+      in_examples <- tag %in% c("examples", "examplesIf")
+    }
+    if (in_examples) {
+      next
+    }
+
+    if (!is.na(tag) && tag %in% identifier_tags) {
+      next
+    }
+
+    text <- content
+
+    # @param / @field / @slot: drop the leading identifier token(s), keep the
+    # description. Names may be comma-separated (e.g. @param from,to ...).
+    if (!is.na(tag) && tag %in% c("param", "field", "slot")) {
+      text <- sub("^@\\w+\\s+\\S+", " ", text, perl = TRUE)
+    } else if (!is.na(tag)) {
+      # any other prose-bearing tag: drop just the @tag token
+      text <- sub("^@\\w+", " ", text, perl = TRUE)
+    }
+
+    text <- strip_code(text)
+
+    # an unbalanced \preformatted{ opens a multi-line code block: prose before
+    # it still counts, everything from it onward is code
+    pre_open <- regexpr("\\\\preformatted\\{", text, perl = TRUE)
+    if (pre_open != -1L) {
+      after <- substring(text, pre_open)
+      pre_depth <- count_braces(after)
+      text <- substring(text, 1, pre_open - 1L)
+    }
+
+    if (grepl(bad_word, text, perl = TRUE)) {
+      hits <- regmatches(text, gregexpr(bad_word, text, perl = TRUE))[[1]]
+      findings[[length(findings) + 1]] <- list(
+        line = i,
+        words = unique(hits),
+        src = trimws(line)
+      )
+    }
+  }
+
+  findings
+}
+
+r_files <- character()
+for (root in roots) {
+  if (!dir.exists(root)) {
+    next
+  }
+  r_files <- c(
+    r_files,
+    list.files(root, pattern = "\\.[Rr]$", recursive = TRUE, full.names = TRUE)
+  )
+}
+r_files <- sort(unique(r_files))
+
+total <- 0L
+n_files <- 0L
+for (path in r_files) {
+  findings <- scan_file(path)
+  if (length(findings) == 0) {
+    next
+  }
+  n_files <- n_files + 1L
+  cat(sprintf("\n%s\n", path))
+  for (f in findings) {
+    total <- total + length(f$words)
+    cat(sprintf(
+      "  %s:%d  [%s]  %s\n",
+      path, f$line, paste(f$words, collapse = ", "), f$src
+    ))
+  }
+}
+
+cat(sprintf(
+  "\n%s: %d prose occurrence(s) of lowercase id/ids across %d file(s).\n",
+  if (total == 0) "OK" else "FAIL",
+  total,
+  n_files
+))
+cat("Convention: write \"ID\"/\"IDs\" in documentation prose. Lowercase only\n")
+cat("for argument names, runnable @examples, and code in `...` / \\code{}.\n")
+
+if (total > 0) {
+  quit(status = 1L)
+}

--- a/tools/check-id-casing.R
+++ b/tools/check-id-casing.R
@@ -52,7 +52,9 @@ strip_code <- function(x) {
     collapse = "|"
   )
   x <- gsub(
-    sprintf("\\\\(%s)\\{[^}]*\\}", code_cmds), " ", x,
+    sprintf("\\\\(%s)\\{[^}]*\\}", code_cmds),
+    " ",
+    x,
     perl = TRUE
   )
   x
@@ -188,7 +190,10 @@ for (path in r_files) {
     total <- total + length(f$words)
     cat(sprintf(
       "  %s:%d  [%s]  %s\n",
-      path, f$line, paste(f$words, collapse = ", "), f$src
+      path,
+      f$line,
+      paste(f$words, collapse = ", "),
+      f$src
     ))
   }
 }


### PR DESCRIPTION
Fix #1683

Sweep roxygen prose to write "ID"/"IDs" instead of "id"/"ids" when referring to vertex and edge IDs, per the agreed convention. Lowercase is preserved where the token is code: argument names, runnable `@examples`, `\preformatted` and fenced code blocks, and `` `...` `` / `\code{}` spans.

Add `tools/check-id-casing.R`, a dependency-free checker that flags stray lowercase id/ids in roxygen prose, and document the convention in AGENTS.md and CONTRIBUTING.md.