### PR TITLE
test: withr-free local seed and RNG-state leak fixes

### DIFF
--- a/tests/testthat/_snaps/other.md
+++ b/tests/testthat/_snaps/other.md
@@ -26,7 +26,7 @@
 # VS/ES require explicit conversion
 
     Code
-      V(karate)
+      V(karate_oldstyle)
     Condition
       Error in `warn_version()`:
       ! This graph was created by a now unsupported old igraph version.

--- a/tests/testthat/helper-indexing.R
+++ b/tests/testthat/helper-indexing.R
@@ -24,9 +24,8 @@ make_test_weighted_tree <- function() {
 }
 
 make_scan_graphs <- function(version = 1) {
-  local_rng_version("3.5.0")
   if (version == 1) {
-    withr::local_seed(12345)
+    igraph_local_seed(12345, rng_version = "3.5.0")
     n <- 10^3
     p <- 0.1
     g <- sample_gnp(n, p)
@@ -36,7 +35,7 @@ make_scan_graphs <- function(version = 1) {
 
     list(g = g, gp = gp)
   } else if (version == 2) {
-    withr::local_seed(42)
+    igraph_local_seed(42, rng_version = "3.5.0")
     n <- 10^3
     p <- 0.1
     g <- sample_gnp(n, p, directed = TRUE)

--- a/tests/testthat/helper-test-functions.R
+++ b/tests/testthat/helper-test-functions.R
@@ -1,0 +1,275 @@
+# Helper functions extracted from individual test files. They live here (rather
+# than at the top of each test file) so they are sourced into the testthat
+# environment before tests run. The `test_that` override in setup.R re-injects
+# test code from a different scope, which would otherwise put file-local helpers
+# out of reach. Each block is annotated with the test file that uses it.
+
+# ---- test-embedding.R -------------------------------------------------------
+
+standardize_eigen_signs <- function(x) {
+  x <- zapsmall(x)
+  apply(x, 2, function(col) {
+    if (any(col < 0) && col[which(col != 0)[1]] < 0) {
+      -col
+    } else {
+      col
+    }
+  })
+}
+
+order_by_magnitude <- function(x) {
+  order(abs(x), sign(x), decreasing = TRUE)
+}
+
+sort_by_magnitude <- function(x) {
+  x[order_by_magnitude(x)]
+}
+
+# ---- test-operators.R -------------------------------------------------------
+
+order_by_two_first_columns <- function(x) x[order(x[, 1], x[, 2]), ]
+
+rn <- function(D) {
+  rownames(D) <- paste(D[, 1], D[, 2], sep = "-")
+  D
+}
+
+# Input/expected pairs for the unique()-on-vertex-sequence tests.
+unique_tests <- list(
+  list(1:5, 1:5),
+  list(c(1, 1, 2:5), 1:5),
+  list(c(1, 1, 1, 1), 1),
+  list(c(1, 2, 2, 2), 1:2),
+  list(c(2, 2, 1, 1), 2:1),
+  list(c(1, 2, 1, 2), 1:2),
+  list(c(), c())
+)
+
+# ---- test-glet.R ------------------------------------------------------------
+
+sortgl <- function(x) {
+  cl <- lapply(x$cliques, sort)
+  n <- lengths(cl)
+  list(cliques = cl[order(n)], thresholds = x$thresholds[order(n)])
+}
+
+threshold.net <- function(graph, level) {
+  N <- vcount(graph)
+  graph.t <- delete_edges(graph, which(E(graph)$weight < level))
+
+  clqt <- unvs(max_cliques(graph.t))
+  clqt <- lapply(clqt, sort)
+  clqt[order(lengths(clqt), decreasing = TRUE)]
+}
+
+graphlets.old <- function(graph) {
+  if (!is_weighted(graph)) {
+    cli::cli_abort("Graph not weighted")
+  }
+  if (min(E(graph)$weight) <= 0 || !all(is.finite(E(graph)$weight))) {
+    cli::cli_abort("Edge weights must be non-negative and finite")
+  }
+
+  ## Do all thresholds
+  cl <- lapply(sort(unique(E(graph)$weight)), function(w) {
+    threshold.net(graph, w)
+  })
+
+  ## Put the cliques in one long list
+  clv <- unlist(cl, recursive = FALSE)
+
+  ## Sort the vertices within the cliques
+  cls <- lapply(clv, sort)
+
+  ## Delete duplicate cliques
+  clu <- unique(cls)
+
+  ## Delete cliques that consist of single vertices
+  clf <- clu[lengths(clu) != 1]
+
+  clf
+}
+
+graphlets.project.old <- function(graph, cliques, iter, Mu = NULL) {
+  if (!is_weighted(graph)) {
+    cli::cli_abort("Graph not weighted")
+  }
+  if (min(E(graph)$weight) <= 0 || !all(is.finite(E(graph)$weight))) {
+    cli::cli_abort("Edge weights must be non-negative and finite")
+  }
+  if (
+    length(iter) != 1 ||
+      !is.numeric(iter) ||
+      !is.finite(iter) ||
+      iter != as.integer(iter)
+  ) {
+    cli::cli_abort("`iter' must be a non-negative finite integer scalar")
+  }
+
+  clf <- cliques
+
+  ## Create vertex-clique list first
+  vcl <- vector(length = vcount(graph), mode = "list")
+  for (i in seq_along(clf)) {
+    for (j in clf[[i]]) {
+      vcl[[j]] <- c(vcl[[j]], i)
+    }
+  }
+
+  ## Create edge-clique list from this, it is useful to have the edge list
+  ## of the graph at hand
+  el <- as_edgelist(graph, names = FALSE)
+  ecl <- vector(length = ecount(graph), mode = "list")
+  for (i in 1:ecount(graph)) {
+    edge <- el[i, ]
+    ecl[[i]] <- intersect(vcl[[edge[1]]], vcl[[edge[2]]])
+  }
+
+  ## We will also need a clique-edge list, the edges in the cliques
+  system.time({
+    cel <- vector(length = length(clf), mode = "list")
+    for (i in seq_along(ecl)) {
+      for (j in ecl[[i]]) {
+        cel[[j]] <- c(cel[[j]], i)
+      }
+    }
+  })
+
+  ## OK, we are ready to do the projection now
+  if (is.null(Mu)) {
+    Mu <- rep(1, length(clf))
+  }
+  origw <- E(graph)$weight
+  w <- numeric(length(ecl))
+  a <- sapply(clf, function(x) length(x) * (length(x) + 1) / 2)
+  for (i in 1:iter) {
+    for (j in seq_along(ecl)) {
+      w[j] <- sum(Mu[ecl[[j]]])
+    }
+    for (j in seq_along(clf)) {
+      Mu[j] <- Mu[j] * sum(origw[cel[[j]]] / (w[cel[[j]]] + 0.0001)) / a[j]
+    }
+  }
+
+  ## Sort the cliques according to their weights
+  Smb <- sort(Mu, decreasing = TRUE, index.return = TRUE)
+  list(cliques = clf[Smb$ix], Mu = Mu[Smb$ix])
+}
+
+# ---- test-migration-fixture.R -----------------------------------------------
+
+# Config equivalent to the fixture, for exercising the helper directly.
+fixture_args <- function(
+  dots,
+  current = list(weights = NULL, type = "out", directed = FALSE)
+) {
+  migrate_recover_args(
+    dots,
+    current = current,
+    recover_new = c("weights", "type", "directed"),
+    recover_old = c("weight", "kind", "directed"),
+    match_names = c("weight", "kind", "weights", "type", "directed"),
+    match_to = c("weights", "type", "weights", "type", "directed"),
+    defaults = list(weights = NULL, type = "out", directed = FALSE),
+    head_args = c("graph", "n"),
+    fn_name = "migration_fixture"
+  )
+}
+
+# ---- test-other.R -----------------------------------------------------------
+
+# A hand-built karate-club graph in the *old* igraph data format, used to test
+# that VS/ES require (and survive) an explicit upgrade. Renamed from the
+# file-local `names`/`karate` to avoid shadowing base `names()` once sourced
+# into the shared testthat environment.
+karate_oldstyle_names <- c(
+  "Mr Hi", "Actor 2", "Actor 3", "Actor 4",
+  "Actor 5", "Actor 6", "Actor 7", "Actor 8", "Actor 9", "Actor 10",
+  "Actor 11", "Actor 12", "Actor 13", "Actor 14", "Actor 15", "Actor 16",
+  "Actor 17", "Actor 18", "Actor 19", "Actor 20", "Actor 21", "Actor 22",
+  "Actor 23", "Actor 24", "Actor 25", "Actor 26", "Actor 27", "Actor 28",
+  "Actor 29", "Actor 30", "Actor 31", "Actor 32", "Actor 33", "John A"
+)
+
+karate_oldstyle <- structure(
+  list(
+    34,
+    FALSE,
+    c(
+      1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12,
+      13, 17, 19, 21, 31, 2, 3, 7, 13, 17, 19, 21, 30, 3, 7, 8, 9,
+      13, 27, 28, 32, 7, 12, 13, 6, 10, 6, 10, 16, 16, 30, 32, 33,
+      33, 33, 32, 33, 32, 33, 32, 33, 33, 32, 33, 32, 33, 25, 27, 29,
+      32, 33, 25, 27, 31, 31, 29, 33, 33, 31, 33, 32, 33, 32, 33, 32,
+      33, 33
+    ),
+    c(
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+      1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 4, 4, 5,
+      5, 5, 6, 8, 8, 8, 9, 13, 14, 14, 15, 15, 18, 18, 19, 20, 20,
+      22, 22, 23, 23, 23, 23, 23, 24, 24, 24, 25, 26, 26, 27, 28, 28,
+      29, 29, 30, 30, 31, 31, 32
+    ),
+    c(
+      0, 1, 16, 2, 17, 24, 3, 4, 5,
+      35, 37, 6, 18, 25, 32, 7, 26, 27, 8, 36, 38, 9, 10, 33, 11, 19,
+      28, 34, 39, 40, 12, 20, 13, 21, 14, 22, 57, 62, 29, 58, 63, 30,
+      59, 66, 23, 41, 15, 64, 65, 69, 31, 42, 46, 48, 50, 53, 55, 60,
+      71, 73, 75, 43, 44, 45, 47, 49, 51, 52, 54, 56, 61, 67, 68, 70,
+      72, 74, 76, 77
+    ),
+    c(
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+      13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+      29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
+      45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+      61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
+      77
+    ),
+    c(
+      0, 0, 1, 3, 6, 7, 8, 11, 15, 17, 18, 21, 22, 24, 28, 28,
+      28, 30, 32, 32, 34, 34, 36, 36, 36, 36, 38, 38, 41, 42, 44, 46,
+      50, 61, 78
+    ),
+    c(
+      0, 16, 24, 32, 35, 37, 40, 41, 41, 44, 45, 45,
+      45, 45, 46, 48, 50, 50, 50, 52, 53, 55, 55, 57, 62, 65, 66, 68,
+      69, 71, 73, 75, 77, 78, 78
+    ),
+    list(
+      c(1, 0, 1),
+      structure(
+        list(
+          name = "Zachary's karate club network",
+          Citation = "Wayne W. Zachary. An Information Flow Model for Conflict and Fission in Small Groups. Journal of Anthropological Research Vol. 33, No. 4 452-473",
+          Author = "Wayne W. Zachary"
+        ),
+        .Names = c("name", "Citation", "Author")
+      ),
+      structure(
+        list(
+          Faction = c(
+            1, 1, 1, 1, 1, 1, 1, 1,
+            2, 2, 1, 1, 1, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 2, 2, 2, 2, 2, 2,
+            2, 2, 2, 2, 2
+          ),
+          name = karate_oldstyle_names
+        ),
+        .Names = c("Faction", "name")
+      ),
+      structure(
+        list(
+          weight = c(
+            4,
+            5, 3, 3, 3, 3, 2, 2, 2, 3, 1, 3, 2, 2, 2, 2, 6, 3, 4, 5, 1, 2,
+            2, 2, 3, 4, 5, 1, 3, 2, 2, 2, 3, 3, 3, 2, 3, 5, 3, 3, 3, 3, 3,
+            4, 2, 3, 3, 2, 3, 4, 1, 2, 1, 3, 1, 2, 3, 5, 4, 3, 5, 4, 2, 3,
+            2, 7, 4, 2, 4, 2, 2, 4, 2, 3, 3, 4, 4, 5
+          )
+        ),
+        .Names = "weight"
+      )
+    )
+  ),
+  class = "igraph"
+)

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -6,13 +6,6 @@ skip_if_no_graphml <- function() {
   if (!has_graphml()) skip("No GraphML support")
 }
 
-local_rng_version <- function(version, .local_envir = parent.frame()) {
-  orig <- RNGkind()
-  withr::defer(do.call(RNGkind, as.list(orig)), envir = .local_envir)
-  suppressWarnings(RNGversion(version))
-  orig
-}
-
 # Restore the global RNG state (kind + .Random.seed) to a previously captured
 # snapshot. `kind` is the result of RNGkind() and `state` is .Random.seed before
 # the seed was set (or NULL if no RNG had been used yet). The kind is restored

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -6,48 +6,43 @@ skip_if_no_graphml <- function() {
   if (!has_graphml()) skip("No GraphML support")
 }
 
-# Restore the global RNG state (kind + .Random.seed) to a previously captured
-# snapshot. `kind` is the result of RNGkind() and `state` is .Random.seed before
-# the seed was set (or NULL if no RNG had been used yet). The kind is restored
-# first -- changing the RNG kind discards .Random.seed -- so that the seed
-# assignment is the final word and the state round-trips exactly.
-restore_rng_state <- function(kind, state) {
-  # suppressWarnings: restoring an older sampler (e.g. the "Rounding"
-  # sample.kind that RNGversion("3.5.0") selects) otherwise emits R's
-  # "non-uniform 'Rounding' sampler used" note. We're only putting back a state
-  # that was already in effect, so the note is noise.
-  suppressWarnings(do.call(RNGkind, as.list(kind)))
-  if (is.null(state)) {
-    if (exists(".Random.seed", envir = globalenv(), inherits = FALSE)) {
-      rm(".Random.seed", envir = globalenv())
-    }
-  } else {
-    assign(".Random.seed", state, envir = globalenv())
-  }
-}
-
-# Drop-in replacement for withr::local_seed() in tests. Sets the RNG seed (and
-# optionally pins the RNG version via `rng_version`, e.g. "3.5.0") and restores
-# the pre-call global RNG state when `.local_envir` exits (the current test_that
-# block, or the enclosing helper function when called from one). Self-contained:
-# it does its own save/restore, so it does not depend on withr's local_seed().
-# withr::defer is used only as the deferral primitive (it fires reliably in both
-# test blocks and function frames). Folding the version pin in here -- rather
-# than pairing a separate RNG-version helper with its own deferred restore --
-# keeps a single, correctly ordered restore point, so the seed never leaks.
+# Drop-in replacement for withr::local_seed() in tests.
+# Sets the RNG seed (and optionally pins the RNG version via `rng_version`,
+# e.g. "3.5.0") and restores the pre-call global RNG state when `.local_envir`
+# exits (the current test_that block, or the enclosing helper function when
+# called from one).
+#
+# Self-contained: it does its own save/restore, so it does not depend on withr's
+# local_seed() (whose RNG-version/kind restore has had ordering regressions, see
+# https://github.com/r-lib/withr/issues/167).
+# withr::defer is used only as the deferral primitive; it fires reliably in both
+# test blocks and function frames.
+#
+# The RNG version is pinned here rather than via a separate helper.
+# Pairing a separate RNG-version helper (with its own deferred restore) alongside
+# the seed restore ran the two restores in the wrong order and leaked the seed --
+# e.g. restoring the kind after the seed discards the seed again.
+# Folding the version pin into this one, correctly ordered restore point avoids
+# that, so the seed never leaks.
 igraph_local_seed <- function(
   seed,
   rng_version = NULL,
+  # kind/normal.kind/sample.kind mirror set.seed()'s arguments of the same names.
   kind = NULL,
   normal.kind = NULL,
   sample.kind = NULL,
   .local_envir = parent.frame()
 ) {
-  old_kind <- RNGkind()
-  old_seed <- get0(".Random.seed", envir = globalenv(), inherits = FALSE)
-  withr::defer(restore_rng_state(old_kind, old_seed), envir = .local_envir)
+  initial_kind <- RNGkind()
+  initial_seed <- get0(".Random.seed", envir = globalenv(), inherits = FALSE)
+  withr::defer(
+    restore_rng_state(initial_kind, initial_seed),
+    envir = .local_envir
+  )
 
   if (!is.null(rng_version)) {
+    # suppressWarnings: same "non-uniform 'Rounding' sampler used" note as in
+    # restore_rng_state() -- RNGversion("3.5.0") selects that older sampler.
     suppressWarnings(RNGversion(rng_version))
   }
 
@@ -58,18 +53,42 @@ igraph_local_seed <- function(
     sample.kind = sample.kind
   )
 
-  invisible(old_seed)
+  # Return the previous seed invisibly, mirroring withr::local_seed()'s contract.
+  invisible(initial_seed)
 }
 
 # Block form of igraph_local_seed(), mirroring withr::with_seed(): set the seed,
-# evaluate `code`, then restore the previous global RNG state. `code` is a
-# promise forced here -- after the seed is set -- and the seed is restored when
-# this function returns, so the seeding is scoped to exactly the block. Use this
-# (rather than igraph_local_seed) when a single test needs several independently
-# seeded blocks with other code between them.
+# evaluate `code`, then restore the previous global RNG state.
+# `code` is a promise forced here -- after the seed is set -- and the seed is
+# restored when this function returns, so the seeding is scoped to exactly the
+# block.
+# Use this (rather than igraph_local_seed) when a single test needs several
+# independently seeded blocks with other code between them.
 igraph_with_seed <- function(seed, code, rng_version = NULL, ...) {
   igraph_local_seed(seed, rng_version = rng_version, ...)
   code
+}
+
+# Restore the global RNG state (kind + .Random.seed) to a previously captured
+# snapshot.
+# `kind` is the result of RNGkind() and `state` is .Random.seed before the seed
+# was set (or NULL if no RNG had been used yet).
+# The kind is restored first -- changing the RNG kind discards .Random.seed --
+# so that the seed assignment is the final word and the state round-trips exactly.
+restore_rng_state <- function(kind, state) {
+  # suppressWarnings: restoring an older sampler (e.g. the "Rounding"
+  # sample.kind that RNGversion("3.5.0") selects) otherwise emits R's
+  # "non-uniform 'Rounding' sampler used" note.
+  # We're only putting back a state that was already in effect, so the note is
+  # noise.
+  suppressWarnings(do.call(RNGkind, as.list(kind)))
+  if (is.null(state)) {
+    if (exists(".Random.seed", envir = globalenv(), inherits = FALSE)) {
+      rm(".Random.seed", envir = globalenv())
+    }
+  } else {
+    assign(".Random.seed", state, envir = globalenv())
+  }
 }
 
 expect_isomorphic <- function(g1, g2, ...) {

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -19,7 +19,11 @@ local_rng_version <- function(version, .local_envir = parent.frame()) {
 # first -- changing the RNG kind discards .Random.seed -- so that the seed
 # assignment is the final word and the state round-trips exactly.
 restore_rng_state <- function(kind, state) {
-  do.call(RNGkind, as.list(kind))
+  # suppressWarnings: restoring an older sampler (e.g. the "Rounding"
+  # sample.kind that RNGversion("3.5.0") selects) otherwise emits R's
+  # "non-uniform 'Rounding' sampler used" note. We're only putting back a state
+  # that was already in effect, so the note is noise.
+  suppressWarnings(do.call(RNGkind, as.list(kind)))
   if (is.null(state)) {
     if (exists(".Random.seed", envir = globalenv(), inherits = FALSE)) {
       rm(".Random.seed", envir = globalenv())

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -53,7 +53,9 @@ igraph_local_seed <- function(
     sample.kind = sample.kind
   )
 
-  # Return the previous seed invisibly, mirroring withr::local_seed()'s contract.
+  # Return the previous seed invisibly, mirroring withr::local_dir()'s
+  # and withr::local_locale()'s contract.
+  # Interestingly, withr::local_seed() returns the new seed.
   invisible(initial_seed)
 }
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -13,6 +13,57 @@ local_rng_version <- function(version, .local_envir = parent.frame()) {
   orig
 }
 
+# Restore the global RNG state (kind + .Random.seed) to a previously captured
+# snapshot. `kind` is the result of RNGkind() and `state` is .Random.seed before
+# the seed was set (or NULL if no RNG had been used yet). The kind is restored
+# first -- changing the RNG kind discards .Random.seed -- so that the seed
+# assignment is the final word and the state round-trips exactly.
+restore_rng_state <- function(kind, state) {
+  do.call(RNGkind, as.list(kind))
+  if (is.null(state)) {
+    if (exists(".Random.seed", envir = globalenv(), inherits = FALSE)) {
+      rm(".Random.seed", envir = globalenv())
+    }
+  } else {
+    assign(".Random.seed", state, envir = globalenv())
+  }
+}
+
+# Drop-in replacement for withr::local_seed() in tests. Sets the RNG seed (and
+# optionally pins the RNG version via `rng_version`, e.g. "3.5.0") and restores
+# the pre-call global RNG state when `.local_envir` exits (the current test_that
+# block, or the enclosing helper function when called from one). Self-contained:
+# it does its own save/restore, so it does not depend on withr's local_seed().
+# withr::defer is used only as the deferral primitive (it fires reliably in both
+# test blocks and function frames). Folding the version pin in here -- rather
+# than pairing a separate RNG-version helper with its own deferred restore --
+# keeps a single, correctly ordered restore point, so the seed never leaks.
+igraph_local_seed <- function(
+  seed,
+  rng_version = NULL,
+  kind = NULL,
+  normal.kind = NULL,
+  sample.kind = NULL,
+  .local_envir = parent.frame()
+) {
+  old_kind <- RNGkind()
+  old_seed <- get0(".Random.seed", envir = globalenv(), inherits = FALSE)
+  withr::defer(restore_rng_state(old_kind, old_seed), envir = .local_envir)
+
+  if (!is.null(rng_version)) {
+    suppressWarnings(RNGversion(rng_version))
+  }
+
+  set.seed(
+    seed,
+    kind = kind,
+    normal.kind = normal.kind,
+    sample.kind = sample.kind
+  )
+
+  invisible(old_seed)
+}
+
 expect_isomorphic <- function(g1, g2, ...) {
   expect_true(isomorphic(g1, g2, ...))
 }

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -68,6 +68,17 @@ igraph_local_seed <- function(
   invisible(old_seed)
 }
 
+# Block form of igraph_local_seed(), mirroring withr::with_seed(): set the seed,
+# evaluate `code`, then restore the previous global RNG state. `code` is a
+# promise forced here -- after the seed is set -- and the seed is restored when
+# this function returns, so the seeding is scoped to exactly the block. Use this
+# (rather than igraph_local_seed) when a single test needs several independently
+# seeded blocks with other code between them.
+igraph_with_seed <- function(seed, code, rng_version = NULL, ...) {
+  igraph_local_seed(seed, rng_version = rng_version, ...)
+  code
+}
+
 expect_isomorphic <- function(g1, g2, ...) {
   expect_true(isomorphic(g1, g2, ...))
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -18,30 +18,30 @@ set.seed(42)
 # `igraph_local_seed()` (and its `restore_rng_state()` helper) live in helper.R
 # so they are visible both to test code and to helper functions that call them.
 
-# if (Sys.getenv("IGRAPH_CHECK_RNG_STATE") == "true") {
-# Check that tests don't change the random seed
-test_that <- function(name, code) {
-  # Forward the block to testthat as a literal language object. Do NOT use
-  # rlang::inject(testthat::test_that(name, !!code)) here: inject() walks the
-  # whole expression and eagerly processes every injection operator, including
-  # any !!/!!!/{{ the test body uses (e.g. `set_vertex_attrs(g, !!!attr_list)`),
-  # evaluating them in this frame where their locals don't exist. Embedding the
-  # captured code in the call hands it to testthat verbatim, so those operators
-  # are processed at test runtime instead.
-  code <- substitute(code)
-  before_state <- get0(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
-  eval(
-    as.call(list(quote(testthat::test_that), name, code)),
-    envir = parent.frame()
-  )
-  after_state <- get0(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
-  expect_identical(
-    before_state,
-    after_state,
-    info = paste0("Test '", name, "' changed the random seed")
-  )
+if (Sys.getenv("IGRAPH_CHECK_RNG_STATE") == "true") {
+  # Check that tests don't change the random seed
+  test_that <- function(name, code) {
+    # Forward the block to testthat as a literal language object. Do NOT use
+    # rlang::inject(testthat::test_that(name, !!code)) here: inject() walks the
+    # whole expression and eagerly processes every injection operator, including
+    # any !!/!!!/{{ the test body uses (e.g. `set_vertex_attrs(g, !!!attr_list)`),
+    # evaluating them in this frame where their locals don't exist. Embedding the
+    # captured code in the call hands it to testthat verbatim, so those operators
+    # are processed at test runtime instead.
+    code <- substitute(code)
+    before_state <- get0(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+    eval(
+      as.call(list(quote(testthat::test_that), name, code)),
+      envir = parent.frame()
+    )
+    after_state <- get0(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+    expect_identical(
+      before_state,
+      after_state,
+      info = paste0("Test '", name, "' changed the random seed")
+    )
+  }
 }
-# }
 
 # NOTE (why the override forwards `code` via substitute()/eval() instead of
 # rlang::inject): the earlier version used

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -18,16 +18,21 @@ set.seed(42)
 # `igraph_local_seed()` (and its `restore_rng_state()` helper) live in helper.R
 # so they are visible both to test code and to helper functions that call them.
 
+# The seed-leak check is opt-in: only a dedicated CI runner sets
+# IGRAPH_CHECK_RNG_STATE=true (see #2713). Keeping it gated (rather than
+# always-on) means a stray leak doesn't block unrelated local test runs, while
+# the dedicated runner still catches regressions.
 if (Sys.getenv("IGRAPH_CHECK_RNG_STATE") == "true") {
-  # Check that tests don't change the random seed
+  # Check that tests don't change the random seed.
   test_that <- function(name, code) {
     # Forward the block to testthat as a literal language object. Do NOT use
     # rlang::inject(testthat::test_that(name, !!code)) here: inject() walks the
-    # whole expression and eagerly processes every injection operator, including
-    # any !!/!!!/{{ the test body uses (e.g. `set_vertex_attrs(g, !!!attr_list)`),
-    # evaluating them in this frame where their locals don't exist. Embedding the
-    # captured code in the call hands it to testthat verbatim, so those operators
-    # are processed at test runtime instead.
+    # whole expression and eagerly processes every injection operator (!!, !!!,
+    # {{) in the test body. A test line like `set_vertex_attrs(g, !!!attr_list)`
+    # would then be spliced in *this* frame -- where `attr_list` doesn't exist
+    # yet -- giving "object 'attr_list' not found". Building the call with the
+    # captured block embedded as a literal hands it to testthat untouched, so
+    # those operators run at test time in the test's own scope.
     code <- substitute(code)
     before_state <- get0(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
     eval(
@@ -42,15 +47,3 @@ if (Sys.getenv("IGRAPH_CHECK_RNG_STATE") == "true") {
     )
   }
 }
-
-# NOTE (why the override forwards `code` via substitute()/eval() instead of
-# rlang::inject): the earlier version used
-#   code <- rlang::enexpr(code)
-#   rlang::inject(testthat::test_that(name, !!code))
-# which broke any test whose body contains an injection operator (!!, !!!, {{).
-# inject() processes ALL such operators in one pass, so a test line like
-# `set_vertex_attrs(g, !!!attr_list)` was spliced in this frame -- where
-# `attr_list` does not exist yet -- giving "object 'attr_list' not found".
-# Building the call with the captured block embedded as a literal hands it to
-# testthat untouched, so those operators run at test time in the test's own
-# scope. Don't reintroduce rlang::inject here.

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -5,17 +5,52 @@
 # is pinned off because the 7-character graph id is non-deterministic.
 igraph_options(print.style = "classic", print.id = FALSE)
 
-if (Sys.getenv("IGRAPH_CHECK_RNG_STATE") == "true") {
-  # Check that tests don't change the random seed
-  test_that <- function(name, code) {
-    code <- rlang::enexpr(code)
-    before_state <- get0(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
-    rlang::inject(testthat::test_that(name, !!code))
-    after_state <- get0(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
-    expect_identical(
-      before_state,
-      after_state,
-      info = paste0("Test '", name, "' changed the random seed")
-    )
-  }
+# Establish a baseline global RNG state so `.Random.seed` always exists before
+# any test runs. Without this, the first test to touch the RNG would *create*
+# `.Random.seed` from nothing (many igraph C functions initialise the RNG even
+# when they don't draw from it, e.g. voronoi_cells()), which the seed-leak check
+# below would flag. Restoring that absent state (as igraph_local_seed() faithfully
+# does when `before` was NULL) just pushes the creation onto the next test -- a
+# whack-a-mole. Pinning a baseline here means only tests that genuinely *advance*
+# the seed need igraph_local_seed().
+set.seed(42)
+
+# `igraph_local_seed()` (and its `restore_rng_state()` helper) live in helper.R
+# so they are visible both to test code and to helper functions that call them.
+
+# if (Sys.getenv("IGRAPH_CHECK_RNG_STATE") == "true") {
+# Check that tests don't change the random seed
+test_that <- function(name, code) {
+  # Forward the block to testthat as a literal language object. Do NOT use
+  # rlang::inject(testthat::test_that(name, !!code)) here: inject() walks the
+  # whole expression and eagerly processes every injection operator, including
+  # any !!/!!!/{{ the test body uses (e.g. `set_vertex_attrs(g, !!!attr_list)`),
+  # evaluating them in this frame where their locals don't exist. Embedding the
+  # captured code in the call hands it to testthat verbatim, so those operators
+  # are processed at test runtime instead.
+  code <- substitute(code)
+  before_state <- get0(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+  eval(
+    as.call(list(quote(testthat::test_that), name, code)),
+    envir = parent.frame()
+  )
+  after_state <- get0(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+  expect_identical(
+    before_state,
+    after_state,
+    info = paste0("Test '", name, "' changed the random seed")
+  )
 }
+# }
+
+# NOTE (why the override forwards `code` via substitute()/eval() instead of
+# rlang::inject): the earlier version used
+#   code <- rlang::enexpr(code)
+#   rlang::inject(testthat::test_that(name, !!code))
+# which broke any test whose body contains an injection operator (!!, !!!, {{).
+# inject() processes ALL such operators in one pass, so a test line like
+# `set_vertex_attrs(g, !!!attr_list)` was spliced in this frame -- where
+# `attr_list` does not exist yet -- giving "object 'attr_list' not found".
+# Building the call with the captured block embedded as a literal hands it to
+# testthat untouched, so those operators run at test time in the test's own
+# scope. Don't reintroduce rlang::inject here.

--- a/tests/testthat/test-aaa-auto.R
+++ b/tests/testthat/test-aaa-auto.R
@@ -12,7 +12,7 @@ skip_on_cran()
 
 # 1. empty_impl
 test_that("empty_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   expect_snapshot(empty_impl())
   expect_snapshot(empty_impl(
@@ -38,7 +38,7 @@ test_that("empty_impl basic", {
 })
 
 test_that("empty_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(empty_impl(
     n = -1
   ))
@@ -47,7 +47,7 @@ test_that("empty_impl errors", {
 # 2. add_edges_impl
 
 test_that("add_edges_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- empty_impl(
     n = 3
   )
@@ -68,7 +68,7 @@ test_that("add_edges_impl basic", {
 })
 
 test_that("add_edges_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(add_edges_impl(
     graph = NULL,
     edges = c(1, 2)
@@ -78,7 +78,7 @@ test_that("add_edges_impl errors", {
 # 3. copy_impl
 
 test_that("copy_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- empty_impl(
     n = 2
   )
@@ -98,7 +98,7 @@ test_that("copy_impl basic", {
 })
 
 test_that("copy_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(copy_impl(
     from = NULL
   ))
@@ -107,7 +107,7 @@ test_that("copy_impl errors", {
 # 4. delete_vertices_idx_impl
 
 test_that("delete_vertices_idx_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- empty_impl(
     n = 3
   )
@@ -129,7 +129,7 @@ test_that("delete_vertices_idx_impl basic", {
 })
 
 test_that("delete_vertices_idx_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(delete_vertices_idx_impl(
     graph = NULL,
     vertices = 1
@@ -139,7 +139,7 @@ test_that("delete_vertices_idx_impl errors", {
 # 5. vcount_impl
 
 test_that("vcount_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- empty_impl(
     n = 4
   )
@@ -158,7 +158,7 @@ test_that("vcount_impl basic", {
 })
 
 test_that("vcount_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(vcount_impl(
     graph = NULL
   ))
@@ -167,7 +167,7 @@ test_that("vcount_impl errors", {
 # 6. degree_impl
 
 test_that("degree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- empty_impl(
     n = 3
   )
@@ -190,7 +190,7 @@ test_that("degree_impl basic", {
 })
 
 test_that("degree_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(degree_impl(
     graph = NULL
   ))
@@ -199,7 +199,7 @@ test_that("degree_impl errors", {
 # 7. get_all_eids_between_impl
 
 test_that("get_all_eids_between_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- empty_impl(
     n = 2
   )
@@ -220,7 +220,7 @@ test_that("get_all_eids_between_impl basic", {
 })
 
 test_that("get_all_eids_between_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_all_eids_between_impl(
     graph = NULL,
     from = 1,
@@ -231,7 +231,7 @@ test_that("get_all_eids_between_impl errors", {
 # 8. wheel_impl
 
 test_that("wheel_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(wheel_impl(
     n = 5
   ))
@@ -249,7 +249,7 @@ test_that("wheel_impl basic", {
 })
 
 test_that("wheel_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(wheel_impl(
     n = -1
   ))
@@ -258,7 +258,7 @@ test_that("wheel_impl errors", {
 # 9. hypercube_impl
 
 test_that("hypercube_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(hypercube_impl(
     n = 3
   ))
@@ -275,7 +275,7 @@ test_that("hypercube_impl basic", {
 })
 
 test_that("hypercube_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(hypercube_impl(
     n = 10000
   ))
@@ -284,7 +284,7 @@ test_that("hypercube_impl errors", {
 # 10. square_lattice_impl
 
 test_that("square_lattice_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(square_lattice_impl(
     dimvector = c(2, 2)
   ))
@@ -304,7 +304,7 @@ test_that("square_lattice_impl basic", {
 })
 
 test_that("square_lattice_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(square_lattice_impl(
     dimvector = -1
   ))
@@ -313,7 +313,7 @@ test_that("square_lattice_impl errors", {
 # 11. triangular_lattice_impl
 
 test_that("triangular_lattice_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(triangular_lattice_impl(
     dimvector = c(2, 2)
   ))
@@ -331,7 +331,7 @@ test_that("triangular_lattice_impl basic", {
 })
 
 test_that("triangular_lattice_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(triangular_lattice_impl(
     dimvector = -1
   ))
@@ -340,7 +340,7 @@ test_that("triangular_lattice_impl errors", {
 # 12. path_graph_impl
 
 test_that("path_graph_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(path_graph_impl(
     n = 5
   ))
@@ -358,7 +358,7 @@ test_that("path_graph_impl basic", {
 })
 
 test_that("path_graph_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(path_graph_impl(
     n = -1
   ))
@@ -367,7 +367,7 @@ test_that("path_graph_impl errors", {
 # 13. cycle_graph_impl
 
 test_that("cycle_graph_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(cycle_graph_impl(
     n = 5
   ))
@@ -385,7 +385,7 @@ test_that("cycle_graph_impl basic", {
 })
 
 test_that("cycle_graph_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(cycle_graph_impl(
     n = -1
   ))
@@ -394,7 +394,7 @@ test_that("cycle_graph_impl errors", {
 # 14. symmetric_tree_impl
 
 test_that("symmetric_tree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(symmetric_tree_impl(
     branches = 3
   ))
@@ -411,7 +411,7 @@ test_that("symmetric_tree_impl basic", {
 })
 
 test_that("symmetric_tree_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(symmetric_tree_impl(
     branches = -1
   ))
@@ -420,7 +420,7 @@ test_that("symmetric_tree_impl errors", {
 # 15. regular_tree_impl
 
 test_that("regular_tree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(regular_tree_impl(
     h = 2
   ))
@@ -438,7 +438,7 @@ test_that("regular_tree_impl basic", {
 })
 
 test_that("regular_tree_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(regular_tree_impl(
     h = -1
   ))
@@ -447,7 +447,7 @@ test_that("regular_tree_impl errors", {
 # 16. full_citation_impl
 
 test_that("full_citation_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(full_citation_impl(
     n = 5
   ))
@@ -464,7 +464,7 @@ test_that("full_citation_impl basic", {
 })
 
 test_that("full_citation_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(full_citation_impl(
     n = -1
   ))
@@ -473,7 +473,7 @@ test_that("full_citation_impl errors", {
 # 17. atlas_impl
 
 test_that("atlas_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(atlas_impl(
     number = 0
   ))
@@ -489,7 +489,7 @@ test_that("atlas_impl basic", {
 })
 
 test_that("atlas_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(atlas_impl(
     number = -1
   ))
@@ -498,7 +498,7 @@ test_that("atlas_impl errors", {
 # 18. extended_chordal_ring_impl
 
 test_that("extended_chordal_ring_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(extended_chordal_ring_impl(
     nodes = 5,
     W = matrix(c(1, 2))
@@ -518,7 +518,7 @@ test_that("extended_chordal_ring_impl basic", {
 })
 
 test_that("extended_chordal_ring_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(extended_chordal_ring_impl(
     nodes = -1,
     W = matrix(c(1, 2))
@@ -528,7 +528,7 @@ test_that("extended_chordal_ring_impl errors", {
 # 19. graph_power_impl
 
 test_that("graph_power_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 5
   )
@@ -552,7 +552,7 @@ test_that("graph_power_impl basic", {
 })
 
 test_that("graph_power_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(graph_power_impl(
     graph = NULL,
     order = 2
@@ -562,7 +562,7 @@ test_that("graph_power_impl errors", {
 # 20. linegraph_impl
 
 test_that("linegraph_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 5
   )
@@ -579,7 +579,7 @@ test_that("linegraph_impl basic", {
 })
 
 test_that("linegraph_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(linegraph_impl(
     graph = NULL
   ))
@@ -587,7 +587,7 @@ test_that("linegraph_impl errors", {
 
 # 21. de_bruijn_impl
 test_that("de_bruijn_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(de_bruijn_impl(
     m = 2,
     n = 3
@@ -601,7 +601,7 @@ test_that("de_bruijn_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("de_bruijn_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(de_bruijn_impl(
     m = -1,
     n = 3
@@ -610,7 +610,7 @@ test_that("de_bruijn_impl errors", {
 
 # 22. kautz_impl
 test_that("kautz_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(kautz_impl(
     m = 2,
     n = 3
@@ -624,7 +624,7 @@ test_that("kautz_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("kautz_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(kautz_impl(
     m = -1,
     n = 3
@@ -633,7 +633,7 @@ test_that("kautz_impl errors", {
 
 # 23. lcf_vector_impl
 test_that("lcf_vector_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(lcf_vector_impl(
     n = 10,
     shifts = c(3, -3, 4),
@@ -649,7 +649,7 @@ test_that("lcf_vector_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("lcf_vector_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(lcf_vector_impl(
     n = -1,
     shifts = c(3, -3, 4),
@@ -659,7 +659,7 @@ test_that("lcf_vector_impl errors", {
 
 # 24. mycielski_graph_impl
 test_that("mycielski_graph_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(mycielski_graph_impl(
     k = 3
   ))
@@ -671,7 +671,7 @@ test_that("mycielski_graph_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("mycielski_graph_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(mycielski_graph_impl(
     k = -1
   ))
@@ -680,7 +680,7 @@ test_that("mycielski_graph_impl errors", {
 # 25. adjlist_impl
 test_that("adjlist_impl basic", {
   skip_if(Sys.getenv("R_SANITIZER") == "true")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(adjlist_impl(
     adjlist = list(c(2, 3), c(1), c(1)),
     mode = "out"
@@ -695,7 +695,7 @@ test_that("adjlist_impl basic", {
 })
 test_that("adjlist_impl errors", {
   skip_if(Sys.getenv("R_SANITIZER") == "true")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(adjlist_impl(
     adjlist = -1,
     mode = "out"
@@ -704,7 +704,7 @@ test_that("adjlist_impl errors", {
 
 # 26. full_bipartite_impl
 test_that("full_bipartite_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(full_bipartite_impl(
     n1 = 2,
     n2 = 3
@@ -724,7 +724,7 @@ test_that("full_bipartite_impl basic", {
   expect_type(result, "list")
 })
 test_that("full_bipartite_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(full_bipartite_impl(
     n1 = -1,
     n2 = 3
@@ -733,7 +733,7 @@ test_that("full_bipartite_impl errors", {
 
 # 27. full_multipartite_impl
 test_that("full_multipartite_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(full_multipartite_impl(
     n = c(2, 3, 4)
   ))
@@ -750,7 +750,7 @@ test_that("full_multipartite_impl basic", {
   expect_type(result, "list")
 })
 test_that("full_multipartite_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(full_multipartite_impl(
     n = -1
   ))
@@ -758,7 +758,7 @@ test_that("full_multipartite_impl errors", {
 
 # 28. realize_degree_sequence_impl
 test_that("realize_degree_sequence_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(realize_degree_sequence_impl(
     out_deg = c(2, 2, 2)
   ))
@@ -776,7 +776,7 @@ test_that("realize_degree_sequence_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("realize_degree_sequence_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(realize_degree_sequence_impl(
     out_deg = -1
   ))
@@ -784,7 +784,7 @@ test_that("realize_degree_sequence_impl errors", {
 
 # 29. realize_bipartite_degree_sequence_impl
 test_that("realize_bipartite_degree_sequence_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(realize_bipartite_degree_sequence_impl(
     degrees1 = c(2, 2),
     degrees2 = c(2, 2)
@@ -804,7 +804,7 @@ test_that("realize_bipartite_degree_sequence_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("realize_bipartite_degree_sequence_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     realize_bipartite_degree_sequence_impl(
       degrees1 = -1,
@@ -815,7 +815,7 @@ test_that("realize_bipartite_degree_sequence_impl errors", {
 
 # 30. circulant_impl
 test_that("circulant_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(circulant_impl(
     n = 5,
     shifts = c(1, 2)
@@ -834,7 +834,7 @@ test_that("circulant_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("circulant_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(circulant_impl(
     n = -1,
     shifts = c(1, 2)
@@ -843,7 +843,7 @@ test_that("circulant_impl errors", {
 
 # 31. generalized_petersen_impl
 test_that("generalized_petersen_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(generalized_petersen_impl(
     n = 5,
     k = 2
@@ -857,7 +857,7 @@ test_that("generalized_petersen_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("generalized_petersen_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(generalized_petersen_impl(
     n = -1,
     k = 2
@@ -866,7 +866,7 @@ test_that("generalized_petersen_impl errors", {
 
 # 32. turan_impl
 test_that("turan_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(turan_impl(
     n = 5,
     r = 2
@@ -880,7 +880,7 @@ test_that("turan_impl basic", {
   expect_type(result, "list")
 })
 test_that("turan_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(turan_impl(
     n = -1,
     r = 2
@@ -889,7 +889,7 @@ test_that("turan_impl errors", {
 
 # 33. erdos_renyi_game_gnp_impl
 test_that("erdos_renyi_game_gnp_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(erdos_renyi_game_gnp_impl(
     n = 5,
     p = 0.5
@@ -909,7 +909,7 @@ test_that("erdos_renyi_game_gnp_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("erdos_renyi_game_gnp_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(erdos_renyi_game_gnp_impl(
     n = -1,
     p = 0.5
@@ -918,7 +918,7 @@ test_that("erdos_renyi_game_gnp_impl errors", {
 
 # 34. erdos_renyi_game_gnm_impl
 test_that("erdos_renyi_game_gnm_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(erdos_renyi_game_gnm_impl(
     n = 5,
     m = 3
@@ -938,7 +938,7 @@ test_that("erdos_renyi_game_gnm_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("erdos_renyi_game_gnm_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(erdos_renyi_game_gnm_impl(
     n = -1,
     m = 3
@@ -947,7 +947,7 @@ test_that("erdos_renyi_game_gnm_impl errors", {
 
 # 35. growing_random_game_impl
 test_that("growing_random_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(growing_random_game_impl(
     n = 5,
     m = 2
@@ -967,7 +967,7 @@ test_that("growing_random_game_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("growing_random_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(growing_random_game_impl(
     n = -1,
     m = 2
@@ -976,7 +976,7 @@ test_that("growing_random_game_impl errors", {
 
 # 36. preference_game_impl
 test_that("preference_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(preference_game_impl(
     nodes = 5,
     types = 2,
@@ -996,7 +996,7 @@ test_that("preference_game_impl basic", {
   expect_type(result, "list")
 })
 test_that("preference_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     preference_game_impl(
       nodes = -1,
@@ -1010,7 +1010,7 @@ test_that("preference_game_impl errors", {
 
 # 37. asymmetric_preference_game_impl
 test_that("asymmetric_preference_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(asymmetric_preference_game_impl(
     nodes = 5,
     out_types = 2,
@@ -1030,7 +1030,7 @@ test_that("asymmetric_preference_game_impl basic", {
   expect_type(result, "list")
 })
 test_that("asymmetric_preference_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     asymmetric_preference_game_impl(
       nodes = -1,
@@ -1044,7 +1044,7 @@ test_that("asymmetric_preference_game_impl errors", {
 
 # 38. rewire_edges_impl
 test_that("rewire_edges_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 5
   )
@@ -1062,7 +1062,7 @@ test_that("rewire_edges_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("rewire_edges_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(rewire_edges_impl(
     graph = NULL,
     prob = 0.5
@@ -1071,7 +1071,7 @@ test_that("rewire_edges_impl errors", {
 
 # 39. rewire_directed_edges_impl
 test_that("rewire_directed_edges_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 5,
     directed = TRUE
@@ -1090,7 +1090,7 @@ test_that("rewire_directed_edges_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("rewire_directed_edges_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(rewire_directed_edges_impl(
     graph = NULL,
     prob = 0.5
@@ -1099,7 +1099,7 @@ test_that("rewire_directed_edges_impl errors", {
 
 # 40. forest_fire_game_impl
 test_that("forest_fire_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(forest_fire_game_impl(
     nodes = 5,
     fw_prob = 0.5
@@ -1120,7 +1120,7 @@ test_that("forest_fire_game_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("forest_fire_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(forest_fire_game_impl(
     nodes = -1,
     fw_prob = 0.5
@@ -1129,7 +1129,7 @@ test_that("forest_fire_game_impl errors", {
 
 # 41. simple_interconnected_islands_game_impl
 test_that("simple_interconnected_islands_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(simple_interconnected_islands_game_impl(
     islands_n = 2,
     islands_size = 3,
@@ -1147,7 +1147,7 @@ test_that("simple_interconnected_islands_game_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("simple_interconnected_islands_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     simple_interconnected_islands_game_impl(
       islands_n = -1,
@@ -1160,7 +1160,7 @@ test_that("simple_interconnected_islands_game_impl errors", {
 
 # 42. chung_lu_game_impl
 test_that("chung_lu_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(chung_lu_game_impl(
     out_weights = c(2, 2, 2)
   ))
@@ -1178,7 +1178,7 @@ test_that("chung_lu_game_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("chung_lu_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(chung_lu_game_impl(
     out_weights = -1
   ))
@@ -1186,7 +1186,7 @@ test_that("chung_lu_game_impl errors", {
 
 # 43. static_fitness_game_impl
 test_that("static_fitness_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(static_fitness_game_impl(
     no_of_edges = 3,
     fitness_out = c(1, 2, 3)
@@ -1207,7 +1207,7 @@ test_that("static_fitness_game_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("static_fitness_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(static_fitness_game_impl(
     no_of_edges = -1,
     fitness_out = c(1, 2, 3)
@@ -1216,7 +1216,7 @@ test_that("static_fitness_game_impl errors", {
 
 # 44. static_power_law_game_impl
 test_that("static_power_law_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(static_power_law_game_impl(
     no_of_nodes = 5,
     no_of_edges = 4,
@@ -1241,7 +1241,7 @@ test_that("static_power_law_game_impl basic", {
   expect_s3_class(result, "igraph")
 })
 test_that("static_power_law_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(static_power_law_game_impl(
     no_of_nodes = -1,
     no_of_edges = 4,
@@ -1252,7 +1252,7 @@ test_that("static_power_law_game_impl errors", {
 # 45. k_regular_game_impl
 
 test_that("k_regular_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(k_regular_game_impl(
     no_of_nodes = 5,
     k = 2
@@ -1273,7 +1273,7 @@ test_that("k_regular_game_impl basic", {
 })
 
 test_that("k_regular_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(k_regular_game_impl(
     no_of_nodes = -1,
     k = 2
@@ -1283,7 +1283,7 @@ test_that("k_regular_game_impl errors", {
 # 46. sbm_game_impl
 
 test_that("sbm_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(sbm_game_impl(
     n = 5,
     pref_matrix = matrix(0.5, 2, 2),
@@ -1307,7 +1307,7 @@ test_that("sbm_game_impl basic", {
 })
 
 test_that("sbm_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(sbm_game_impl(
     n = -1,
     pref_matrix = matrix(0.5, 2, 2),
@@ -1318,7 +1318,7 @@ test_that("sbm_game_impl errors", {
 # 47. hsbm_game_impl
 
 test_that("hsbm_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(hsbm_game_impl(
     n = 6,
     m = 2,
@@ -1339,7 +1339,7 @@ test_that("hsbm_game_impl basic", {
 })
 
 test_that("hsbm_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     hsbm_game_impl(
       n = -1,
@@ -1354,7 +1354,7 @@ test_that("hsbm_game_impl errors", {
 # 48. hsbm_list_game_impl
 
 test_that("hsbm_list_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   C <- matrix(
     c(
       1,
@@ -1389,7 +1389,7 @@ test_that("hsbm_list_game_impl basic", {
 })
 
 test_that("hsbm_list_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     hsbm_list_game_impl(
       n = -1,
@@ -1404,7 +1404,7 @@ test_that("hsbm_list_game_impl errors", {
 # 49. correlated_game_impl
 
 test_that("correlated_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 5
   )
@@ -1423,7 +1423,7 @@ test_that("correlated_game_impl basic", {
 })
 
 test_that("correlated_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(correlated_game_impl(
     old_graph = NULL,
     corr = 0.5
@@ -1433,7 +1433,7 @@ test_that("correlated_game_impl errors", {
 # 50. correlated_pair_game_impl
 
 test_that("correlated_pair_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(correlated_pair_game_impl(
     n = 5,
     corr = 0.5,
@@ -1456,7 +1456,7 @@ test_that("correlated_pair_game_impl basic", {
 })
 
 test_that("correlated_pair_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(correlated_pair_game_impl(
     n = -1,
     corr = 0.5,
@@ -1467,7 +1467,7 @@ test_that("correlated_pair_game_impl errors", {
 # 51. dot_product_game_impl
 
 test_that("dot_product_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(dot_product_game_impl(
     vecs = matrix(0.5, 5, 2)
   ))
@@ -1484,7 +1484,7 @@ test_that("dot_product_game_impl basic", {
 })
 
 test_that("dot_product_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(dot_product_game_impl(
     vecs = NULL
   ))
@@ -1493,7 +1493,7 @@ test_that("dot_product_game_impl errors", {
 # 52. sample_sphere_surface_impl
 
 test_that("sample_sphere_surface_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(sample_sphere_surface_impl(
     dim = 3,
     n = 5
@@ -1514,7 +1514,7 @@ test_that("sample_sphere_surface_impl basic", {
 })
 
 test_that("sample_sphere_surface_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(sample_sphere_surface_impl(
     dim = -1,
     n = 5
@@ -1524,7 +1524,7 @@ test_that("sample_sphere_surface_impl errors", {
 # 53. sample_sphere_volume_impl
 
 test_that("sample_sphere_volume_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(sample_sphere_volume_impl(
     dim = 3,
     n = 5
@@ -1545,7 +1545,7 @@ test_that("sample_sphere_volume_impl basic", {
 })
 
 test_that("sample_sphere_volume_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(sample_sphere_volume_impl(
     dim = -1,
     n = 5
@@ -1555,7 +1555,7 @@ test_that("sample_sphere_volume_impl errors", {
 # 54. sample_dirichlet_impl
 
 test_that("sample_dirichlet_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(sample_dirichlet_impl(
     n = 5,
     alpha = c(1, 1, 1)
@@ -1570,7 +1570,7 @@ test_that("sample_dirichlet_impl basic", {
 })
 
 test_that("sample_dirichlet_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(sample_dirichlet_impl(
     n = -1,
     alpha = c(1, 1, 1)
@@ -1580,7 +1580,7 @@ test_that("sample_dirichlet_impl errors", {
 # 55. are_adjacent_impl
 
 test_that("are_adjacent_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -1601,7 +1601,7 @@ test_that("are_adjacent_impl basic", {
 })
 
 test_that("are_adjacent_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(are_adjacent_impl(
     graph = NULL,
     v1 = 1,
@@ -1612,7 +1612,7 @@ test_that("are_adjacent_impl errors", {
 # 56. closeness_impl
 
 test_that("closeness_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -1634,7 +1634,7 @@ test_that("closeness_impl basic", {
 })
 
 test_that("closeness_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(closeness_impl(
     graph = NULL
   ))
@@ -1643,7 +1643,7 @@ test_that("closeness_impl errors", {
 # 57. closeness_cutoff_impl
 
 test_that("closeness_cutoff_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -1668,7 +1668,7 @@ test_that("closeness_cutoff_impl basic", {
 })
 
 test_that("closeness_cutoff_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(closeness_cutoff_impl(
     graph = NULL
   ))
@@ -1677,7 +1677,7 @@ test_that("closeness_cutoff_impl errors", {
 # 58. get_shortest_path_impl
 
 test_that("get_shortest_path_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -1698,7 +1698,7 @@ test_that("get_shortest_path_impl basic", {
 })
 
 test_that("get_shortest_path_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_shortest_path_impl(
     graph = NULL,
     from = 1,
@@ -1709,7 +1709,7 @@ test_that("get_shortest_path_impl errors", {
 # 59. get_shortest_path_bellman_ford_impl
 
 test_that("get_shortest_path_bellman_ford_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -1730,7 +1730,7 @@ test_that("get_shortest_path_bellman_ford_impl basic", {
 })
 
 test_that("get_shortest_path_bellman_ford_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_shortest_path_bellman_ford_impl(
     graph = NULL,
     from = 1,
@@ -1741,7 +1741,7 @@ test_that("get_shortest_path_bellman_ford_impl errors", {
 # 60. get_shortest_path_dijkstra_impl
 
 test_that("get_shortest_path_dijkstra_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -1762,7 +1762,7 @@ test_that("get_shortest_path_dijkstra_impl basic", {
 })
 
 test_that("get_shortest_path_dijkstra_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_shortest_path_dijkstra_impl(
     graph = NULL,
     from = 1,
@@ -1773,7 +1773,7 @@ test_that("get_shortest_path_dijkstra_impl errors", {
 # 61. get_all_shortest_paths_impl
 
 test_that("get_all_shortest_paths_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -1794,7 +1794,7 @@ test_that("get_all_shortest_paths_impl basic", {
 })
 
 test_that("get_all_shortest_paths_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_all_shortest_paths_impl(
     graph = NULL,
     from = 1,
@@ -1805,7 +1805,7 @@ test_that("get_all_shortest_paths_impl errors", {
 # 62. get_all_shortest_paths_dijkstra_impl
 
 test_that("get_all_shortest_paths_dijkstra_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -1826,7 +1826,7 @@ test_that("get_all_shortest_paths_dijkstra_impl basic", {
 })
 
 test_that("get_all_shortest_paths_dijkstra_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     get_all_shortest_paths_dijkstra_impl(
       graph = NULL,
@@ -1839,7 +1839,7 @@ test_that("get_all_shortest_paths_dijkstra_impl errors", {
 # 63. voronoi_impl
 
 test_that("voronoi_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -1864,7 +1864,7 @@ test_that("voronoi_impl basic", {
 })
 
 test_that("voronoi_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(voronoi_impl(
     graph = NULL,
     generators = 1
@@ -1874,7 +1874,7 @@ test_that("voronoi_impl errors", {
 # 64. get_all_simple_paths_impl
 
 test_that("get_all_simple_paths_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -1895,7 +1895,7 @@ test_that("get_all_simple_paths_impl basic", {
 })
 
 test_that("get_all_simple_paths_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_all_simple_paths_impl(
     graph = NULL,
     from = 1,
@@ -1906,7 +1906,7 @@ test_that("get_all_simple_paths_impl errors", {
 # 65. get_k_shortest_paths_impl
 
 test_that("get_k_shortest_paths_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -1929,7 +1929,7 @@ test_that("get_k_shortest_paths_impl basic", {
 })
 
 test_that("get_k_shortest_paths_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_k_shortest_paths_impl(
     graph = NULL,
     from = 1,
@@ -1941,7 +1941,7 @@ test_that("get_k_shortest_paths_impl errors", {
 # 66. get_widest_path_impl
 
 test_that("get_widest_path_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -1964,7 +1964,7 @@ test_that("get_widest_path_impl basic", {
 })
 
 test_that("get_widest_path_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_widest_path_impl(
     graph = NULL,
     from = 1,
@@ -1975,7 +1975,7 @@ test_that("get_widest_path_impl errors", {
 # 67. get_widest_paths_impl
 
 test_that("get_widest_paths_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -1998,7 +1998,7 @@ test_that("get_widest_paths_impl basic", {
 })
 
 test_that("get_widest_paths_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_widest_paths_impl(
     graph = NULL,
     from = 1,
@@ -2009,7 +2009,7 @@ test_that("get_widest_paths_impl errors", {
 # 70. spanner_impl
 
 test_that("spanner_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2028,7 +2028,7 @@ test_that("spanner_impl basic", {
 })
 
 test_that("spanner_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(spanner_impl(
     graph = NULL,
     stretch = 2
@@ -2038,7 +2038,7 @@ test_that("spanner_impl errors", {
 # 71. betweenness_cutoff_impl
 
 test_that("betweenness_cutoff_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2057,7 +2057,7 @@ test_that("betweenness_cutoff_impl basic", {
 })
 
 test_that("betweenness_cutoff_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(betweenness_cutoff_impl(
     graph = NULL,
     cutoff = 2
@@ -2067,7 +2067,7 @@ test_that("betweenness_cutoff_impl errors", {
 # 72. betweenness_subset_impl
 
 test_that("betweenness_subset_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2084,7 +2084,7 @@ test_that("betweenness_subset_impl basic", {
 })
 
 test_that("betweenness_subset_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(betweenness_subset_impl(
     graph = NULL
   ))
@@ -2093,7 +2093,7 @@ test_that("betweenness_subset_impl errors", {
 # 73. edge_betweenness_impl
 
 test_that("edge_betweenness_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2110,7 +2110,7 @@ test_that("edge_betweenness_impl basic", {
 })
 
 test_that("edge_betweenness_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(edge_betweenness_impl(
     graph = NULL
   ))
@@ -2119,7 +2119,7 @@ test_that("edge_betweenness_impl errors", {
 # 74. edge_betweenness_cutoff_impl
 
 test_that("edge_betweenness_cutoff_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2138,7 +2138,7 @@ test_that("edge_betweenness_cutoff_impl basic", {
 })
 
 test_that("edge_betweenness_cutoff_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(edge_betweenness_cutoff_impl(
     graph = NULL,
     cutoff = 2
@@ -2148,7 +2148,7 @@ test_that("edge_betweenness_cutoff_impl errors", {
 # 75. edge_betweenness_subset_impl
 
 test_that("edge_betweenness_subset_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2165,7 +2165,7 @@ test_that("edge_betweenness_subset_impl basic", {
 })
 
 test_that("edge_betweenness_subset_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(edge_betweenness_subset_impl(
     graph = NULL
   ))
@@ -2174,7 +2174,7 @@ test_that("edge_betweenness_subset_impl errors", {
 # 76. harmonic_centrality_cutoff_impl
 
 test_that("harmonic_centrality_cutoff_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2193,7 +2193,7 @@ test_that("harmonic_centrality_cutoff_impl basic", {
 })
 
 test_that("harmonic_centrality_cutoff_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     harmonic_centrality_cutoff_impl(
       graph = NULL,
@@ -2205,7 +2205,7 @@ test_that("harmonic_centrality_cutoff_impl errors", {
 # 77. personalized_pagerank_impl
 
 test_that("personalized_pagerank_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2227,7 +2227,7 @@ test_that("personalized_pagerank_impl basic", {
 })
 
 test_that("personalized_pagerank_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(personalized_pagerank_impl(
     graph = NULL
   ))
@@ -2236,7 +2236,7 @@ test_that("personalized_pagerank_impl errors", {
 # 78. personalized_pagerank_vs_impl
 
 test_that("personalized_pagerank_vs_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2261,7 +2261,7 @@ test_that("personalized_pagerank_vs_impl basic", {
 })
 
 test_that("personalized_pagerank_vs_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     personalized_pagerank_vs_impl(
       graph = NULL,
@@ -2273,7 +2273,7 @@ test_that("personalized_pagerank_vs_impl errors", {
 # 79. induced_subgraph_impl
 
 test_that("induced_subgraph_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2292,7 +2292,7 @@ test_that("induced_subgraph_impl basic", {
 })
 
 test_that("induced_subgraph_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(induced_subgraph_impl(
     graph = NULL,
     vids = 1:2
@@ -2302,7 +2302,7 @@ test_that("induced_subgraph_impl errors", {
 # 80. subgraph_from_edges_impl
 
 test_that("subgraph_from_edges_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2321,7 +2321,7 @@ test_that("subgraph_from_edges_impl basic", {
 })
 
 test_that("subgraph_from_edges_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(subgraph_from_edges_impl(
     graph = NULL,
     eids = 1
@@ -2331,7 +2331,7 @@ test_that("subgraph_from_edges_impl errors", {
 # 81. reverse_edges_impl
 
 test_that("reverse_edges_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2348,7 +2348,7 @@ test_that("reverse_edges_impl basic", {
 })
 
 test_that("reverse_edges_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(reverse_edges_impl(
     graph = NULL
   ))
@@ -2361,7 +2361,7 @@ test_that("reverse_edges_impl errors", {
 # 101. path_length_hist_impl
 
 test_that("path_length_hist_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2382,7 +2382,7 @@ test_that("path_length_hist_impl basic", {
 })
 
 test_that("path_length_hist_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(path_length_hist_impl(
     graph = NULL
   ))
@@ -2391,7 +2391,7 @@ test_that("path_length_hist_impl errors", {
 # 102. simplify_impl
 
 test_that("simplify_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2413,7 +2413,7 @@ test_that("simplify_impl basic", {
 })
 
 test_that("simplify_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(simplify_impl(
     graph = NULL
   ))
@@ -2422,7 +2422,7 @@ test_that("simplify_impl errors", {
 # 103. transitivity_undirected_impl
 
 test_that("transitivity_undirected_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2443,7 +2443,7 @@ test_that("transitivity_undirected_impl basic", {
 })
 
 test_that("transitivity_undirected_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(transitivity_undirected_impl(
     graph = NULL
   ))
@@ -2452,7 +2452,7 @@ test_that("transitivity_undirected_impl errors", {
 # 104. transitivity_local_undirected_impl
 
 test_that("transitivity_local_undirected_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2473,7 +2473,7 @@ test_that("transitivity_local_undirected_impl basic", {
 })
 
 test_that("transitivity_local_undirected_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(transitivity_local_undirected_impl(
     graph = NULL
   ))
@@ -2482,7 +2482,7 @@ test_that("transitivity_local_undirected_impl errors", {
 # 105. transitivity_avglocal_undirected_impl
 
 test_that("transitivity_avglocal_undirected_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2503,7 +2503,7 @@ test_that("transitivity_avglocal_undirected_impl basic", {
 })
 
 test_that("transitivity_avglocal_undirected_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(transitivity_avglocal_undirected_impl(
     graph = NULL
   ))
@@ -2512,7 +2512,7 @@ test_that("transitivity_avglocal_undirected_impl errors", {
 # 106. transitivity_barrat_impl
 
 test_that("transitivity_barrat_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2535,7 +2535,7 @@ test_that("transitivity_barrat_impl basic", {
 })
 
 test_that("transitivity_barrat_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(transitivity_barrat_impl(
     graph = NULL
   ))
@@ -2544,7 +2544,7 @@ test_that("transitivity_barrat_impl errors", {
 # 107. ecc_impl
 
 test_that("ecc_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 4
   )
@@ -2567,7 +2567,7 @@ test_that("ecc_impl basic", {
 })
 
 test_that("ecc_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(ecc_impl(
     graph = NULL
   ))
@@ -2576,7 +2576,7 @@ test_that("ecc_impl errors", {
 # 108. reciprocity_impl
 
 test_that("reciprocity_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2598,7 +2598,7 @@ test_that("reciprocity_impl basic", {
 })
 
 test_that("reciprocity_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(reciprocity_impl(
     graph = NULL
   ))
@@ -2607,7 +2607,7 @@ test_that("reciprocity_impl errors", {
 # 109. maxdegree_impl
 
 test_that("maxdegree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2629,7 +2629,7 @@ test_that("maxdegree_impl basic", {
 })
 
 test_that("maxdegree_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(maxdegree_impl(
     graph = NULL
   ))
@@ -2638,7 +2638,7 @@ test_that("maxdegree_impl errors", {
 # 110. density_impl
 
 test_that("density_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2659,7 +2659,7 @@ test_that("density_impl basic", {
 })
 
 test_that("density_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(density_impl(
     graph = NULL
   ))
@@ -2668,7 +2668,7 @@ test_that("density_impl errors", {
 # 111. mean_degree_impl
 
 test_that("mean_degree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2689,7 +2689,7 @@ test_that("mean_degree_impl basic", {
 })
 
 test_that("mean_degree_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(mean_degree_impl(
     graph = NULL
   ))
@@ -2698,7 +2698,7 @@ test_that("mean_degree_impl errors", {
 # 112. feedback_arc_set_impl
 
 test_that("feedback_arc_set_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2719,7 +2719,7 @@ test_that("feedback_arc_set_impl basic", {
 })
 
 test_that("feedback_arc_set_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(feedback_arc_set_impl(
     graph = NULL
   ))
@@ -2728,7 +2728,7 @@ test_that("feedback_arc_set_impl errors", {
 # 113. feedback_vertex_set_impl
 
 test_that("feedback_vertex_set_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2745,7 +2745,7 @@ test_that("feedback_vertex_set_impl basic", {
 })
 
 test_that("feedback_vertex_set_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(feedback_vertex_set_impl(
     graph = NULL
   ))
@@ -2754,7 +2754,7 @@ test_that("feedback_vertex_set_impl errors", {
 # 114. is_loop_impl
 
 test_that("is_loop_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2771,7 +2771,7 @@ test_that("is_loop_impl basic", {
 })
 
 test_that("is_loop_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_loop_impl(
     graph = NULL
   ))
@@ -2780,7 +2780,7 @@ test_that("is_loop_impl errors", {
 # 115. is_dag_impl
 
 test_that("is_dag_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2797,7 +2797,7 @@ test_that("is_dag_impl basic", {
 })
 
 test_that("is_dag_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_dag_impl(
     graph = NULL
   ))
@@ -2806,7 +2806,7 @@ test_that("is_dag_impl errors", {
 # 116. is_acyclic_impl
 
 test_that("is_acyclic_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2823,7 +2823,7 @@ test_that("is_acyclic_impl basic", {
 })
 
 test_that("is_acyclic_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_acyclic_impl(
     graph = NULL
   ))
@@ -2832,7 +2832,7 @@ test_that("is_acyclic_impl errors", {
 # 117. is_simple_impl
 
 test_that("is_simple_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2849,7 +2849,7 @@ test_that("is_simple_impl basic", {
 })
 
 test_that("is_simple_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_simple_impl(
     graph = NULL
   ))
@@ -2858,7 +2858,7 @@ test_that("is_simple_impl errors", {
 # 118. is_multiple_impl
 
 test_that("is_multiple_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2875,7 +2875,7 @@ test_that("is_multiple_impl basic", {
 })
 
 test_that("is_multiple_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_multiple_impl(
     graph = NULL
   ))
@@ -2884,7 +2884,7 @@ test_that("is_multiple_impl errors", {
 # 119. has_loop_impl
 
 test_that("has_loop_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2901,7 +2901,7 @@ test_that("has_loop_impl basic", {
 })
 
 test_that("has_loop_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(has_loop_impl(
     graph = NULL
   ))
@@ -2910,7 +2910,7 @@ test_that("has_loop_impl errors", {
 # 120. has_multiple_impl
 
 test_that("has_multiple_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2927,7 +2927,7 @@ test_that("has_multiple_impl basic", {
 })
 
 test_that("has_multiple_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(has_multiple_impl(
     graph = NULL
   ))
@@ -2936,7 +2936,7 @@ test_that("has_multiple_impl errors", {
 # 121. count_loops_impl
 
 test_that("count_loops_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2953,7 +2953,7 @@ test_that("count_loops_impl basic", {
 })
 
 test_that("count_loops_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(count_loops_impl(
     graph = NULL
   ))
@@ -2962,7 +2962,7 @@ test_that("count_loops_impl errors", {
 # 122. count_multiple_impl
 
 test_that("count_multiple_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -2979,7 +2979,7 @@ test_that("count_multiple_impl basic", {
 })
 
 test_that("count_multiple_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(count_multiple_impl(
     graph = NULL
   ))
@@ -2988,7 +2988,7 @@ test_that("count_multiple_impl errors", {
 # 123. is_perfect_impl
 
 test_that("is_perfect_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3005,7 +3005,7 @@ test_that("is_perfect_impl basic", {
 })
 
 test_that("is_perfect_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_perfect_impl(
     graph = NULL
   ))
@@ -3014,7 +3014,7 @@ test_that("is_perfect_impl errors", {
 # 124. eigenvector_centrality_impl
 
 test_that("eigenvector_centrality_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3036,7 +3036,7 @@ test_that("eigenvector_centrality_impl basic", {
 })
 
 test_that("eigenvector_centrality_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(eigenvector_centrality_impl(
     graph = NULL
   ))
@@ -3045,7 +3045,7 @@ test_that("eigenvector_centrality_impl errors", {
 # 125. hub_and_authority_scores_impl
 
 test_that("hub_and_authority_scores_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_full_graph(5)
   expect_snapshot(hub_and_authority_scores_impl(
     graph = g
@@ -3063,7 +3063,7 @@ test_that("hub_and_authority_scores_impl basic", {
 })
 
 test_that("hub_and_authority_scores_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(hub_and_authority_scores_impl(
     graph = NULL
   ))
@@ -3072,7 +3072,7 @@ test_that("hub_and_authority_scores_impl errors", {
 # 126. unfold_tree_impl
 
 test_that("unfold_tree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3096,7 +3096,7 @@ test_that("unfold_tree_impl basic", {
 })
 
 test_that("unfold_tree_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(unfold_tree_impl(
     graph = NULL,
     roots = 1
@@ -3106,7 +3106,7 @@ test_that("unfold_tree_impl errors", {
 # 127. is_mutual_impl
 
 test_that("is_mutual_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3127,7 +3127,7 @@ test_that("is_mutual_impl basic", {
 })
 
 test_that("is_mutual_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_mutual_impl(
     graph = NULL
   ))
@@ -3136,7 +3136,7 @@ test_that("is_mutual_impl errors", {
 # 128. has_mutual_impl
 
 test_that("has_mutual_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3157,7 +3157,7 @@ test_that("has_mutual_impl basic", {
 })
 
 test_that("has_mutual_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(has_mutual_impl(
     graph = NULL
   ))
@@ -3166,7 +3166,7 @@ test_that("has_mutual_impl errors", {
 # 129. maximum_cardinality_search_impl
 
 test_that("maximum_cardinality_search_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3183,7 +3183,7 @@ test_that("maximum_cardinality_search_impl basic", {
 })
 
 test_that("maximum_cardinality_search_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(maximum_cardinality_search_impl(
     graph = NULL
   ))
@@ -3192,7 +3192,7 @@ test_that("maximum_cardinality_search_impl errors", {
 # 130. avg_nearest_neighbor_degree_impl
 
 test_that("avg_nearest_neighbor_degree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3214,7 +3214,7 @@ test_that("avg_nearest_neighbor_degree_impl basic", {
 })
 
 test_that("avg_nearest_neighbor_degree_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(avg_nearest_neighbor_degree_impl(
     graph = NULL
   ))
@@ -3223,7 +3223,7 @@ test_that("avg_nearest_neighbor_degree_impl errors", {
 # 131. degree_correlation_vector_impl
 
 test_that("degree_correlation_vector_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3246,7 +3246,7 @@ test_that("degree_correlation_vector_impl basic", {
 })
 
 test_that("degree_correlation_vector_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(degree_correlation_vector_impl(
     graph = NULL
   ))
@@ -3255,7 +3255,7 @@ test_that("degree_correlation_vector_impl errors", {
 # 132. rich_club_sequence_impl
 
 test_that("rich_club_sequence_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3281,7 +3281,7 @@ test_that("rich_club_sequence_impl basic", {
 })
 
 test_that("rich_club_sequence_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     rich_club_sequence_impl(
       graph = NULL,
@@ -3293,7 +3293,7 @@ test_that("rich_club_sequence_impl errors", {
 # 133. strength_impl
 
 test_that("strength_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3315,7 +3315,7 @@ test_that("strength_impl basic", {
 })
 
 test_that("strength_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(strength_impl(
     graph = NULL
   ))
@@ -3324,7 +3324,7 @@ test_that("strength_impl errors", {
 # 134. centralization_impl
 
 test_that("centralization_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(centralization_impl(
     scores = c(1, 2, 3)
   ))
@@ -3342,7 +3342,7 @@ test_that("centralization_impl basic", {
 })
 
 test_that("centralization_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(centralization_impl(
     scores = package_version("1.2.3")
   ))
@@ -3351,7 +3351,7 @@ test_that("centralization_impl errors", {
 # 135. centralization_degree_impl
 
 test_that("centralization_degree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3374,7 +3374,7 @@ test_that("centralization_degree_impl basic", {
 })
 
 test_that("centralization_degree_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(centralization_degree_impl(
     graph = NULL
   ))
@@ -3383,7 +3383,7 @@ test_that("centralization_degree_impl errors", {
 # 136. centralization_degree_tmax_impl
 
 test_that("centralization_degree_tmax_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(centralization_degree_tmax_impl(
     nodes = 3,
     loops = TRUE
@@ -3403,7 +3403,7 @@ test_that("centralization_degree_tmax_impl basic", {
 })
 
 test_that("centralization_degree_tmax_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     centralization_degree_tmax_impl(
       nodes = -1,
@@ -3415,7 +3415,7 @@ test_that("centralization_degree_tmax_impl errors", {
 # 137. centralization_betweenness_impl
 
 test_that("centralization_betweenness_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3437,7 +3437,7 @@ test_that("centralization_betweenness_impl basic", {
 })
 
 test_that("centralization_betweenness_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(centralization_betweenness_impl(
     graph = NULL
   ))
@@ -3446,7 +3446,7 @@ test_that("centralization_betweenness_impl errors", {
 # 138. centralization_betweenness_tmax_impl
 
 test_that("centralization_betweenness_tmax_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(centralization_betweenness_tmax_impl(
     nodes = 3,
     directed = TRUE
@@ -3465,7 +3465,7 @@ test_that("centralization_betweenness_tmax_impl basic", {
 })
 
 test_that("centralization_betweenness_tmax_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     centralization_betweenness_tmax_impl(
       nodes = -1,
@@ -3477,7 +3477,7 @@ test_that("centralization_betweenness_tmax_impl errors", {
 # 139. centralization_closeness_impl
 
 test_that("centralization_closeness_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3499,7 +3499,7 @@ test_that("centralization_closeness_impl basic", {
 })
 
 test_that("centralization_closeness_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(centralization_closeness_impl(
     graph = NULL
   ))
@@ -3508,7 +3508,7 @@ test_that("centralization_closeness_impl errors", {
 # 140. centralization_closeness_tmax_impl
 
 test_that("centralization_closeness_tmax_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(centralization_closeness_tmax_impl(
     nodes = 3
   ))
@@ -3525,7 +3525,7 @@ test_that("centralization_closeness_tmax_impl basic", {
 })
 
 test_that("centralization_closeness_tmax_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(centralization_closeness_tmax_impl(
     nodes = -1
   ))
@@ -3534,7 +3534,7 @@ test_that("centralization_closeness_tmax_impl errors", {
 # 141. centralization_eigenvector_centrality_impl
 
 test_that("centralization_eigenvector_centrality_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3556,7 +3556,7 @@ test_that("centralization_eigenvector_centrality_impl basic", {
 })
 
 test_that("centralization_eigenvector_centrality_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     centralization_eigenvector_centrality_impl(
       graph = NULL
@@ -3567,7 +3567,7 @@ test_that("centralization_eigenvector_centrality_impl errors", {
 # 142. centralization_eigenvector_centrality_tmax_impl
 
 test_that("centralization_eigenvector_centrality_tmax_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(centralization_eigenvector_centrality_tmax_impl(
     nodes = 3
   ))
@@ -3584,7 +3584,7 @@ test_that("centralization_eigenvector_centrality_tmax_impl basic", {
 })
 
 test_that("centralization_eigenvector_centrality_tmax_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     centralization_eigenvector_centrality_tmax_impl(
       nodes = -1
@@ -3595,7 +3595,7 @@ test_that("centralization_eigenvector_centrality_tmax_impl errors", {
 # 143. assortativity_nominal_impl
 
 test_that("assortativity_nominal_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3620,7 +3620,7 @@ test_that("assortativity_nominal_impl basic", {
 })
 
 test_that("assortativity_nominal_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(assortativity_nominal_impl(
     graph = NULL,
     types = c(1, 2, 1)
@@ -3630,7 +3630,7 @@ test_that("assortativity_nominal_impl errors", {
 # 144. assortativity_impl
 
 test_that("assortativity_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3655,7 +3655,7 @@ test_that("assortativity_impl basic", {
 })
 
 test_that("assortativity_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(assortativity_impl(
     graph = NULL,
     values = c(1, 2, 1)
@@ -3665,7 +3665,7 @@ test_that("assortativity_impl errors", {
 # 145. assortativity_degree_impl
 
 test_that("assortativity_degree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3686,7 +3686,7 @@ test_that("assortativity_degree_impl basic", {
 })
 
 test_that("assortativity_degree_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(assortativity_degree_impl(
     graph = NULL
   ))
@@ -3695,7 +3695,7 @@ test_that("assortativity_degree_impl errors", {
 # 146. joint_degree_matrix_impl
 
 test_that("joint_degree_matrix_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3717,7 +3717,7 @@ test_that("joint_degree_matrix_impl basic", {
 })
 
 test_that("joint_degree_matrix_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(joint_degree_matrix_impl(
     graph = NULL
   ))
@@ -3726,7 +3726,7 @@ test_that("joint_degree_matrix_impl errors", {
 # 147. joint_degree_distribution_impl
 
 test_that("joint_degree_distribution_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3752,7 +3752,7 @@ test_that("joint_degree_distribution_impl basic", {
 })
 
 test_that("joint_degree_distribution_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(joint_degree_distribution_impl(
     graph = NULL
   ))
@@ -3761,7 +3761,7 @@ test_that("joint_degree_distribution_impl errors", {
 # 148. joint_type_distribution_impl
 
 test_that("joint_type_distribution_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3787,7 +3787,7 @@ test_that("joint_type_distribution_impl basic", {
 })
 
 test_that("joint_type_distribution_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     joint_type_distribution_impl(
       graph = NULL,
@@ -3799,7 +3799,7 @@ test_that("joint_type_distribution_impl errors", {
 # 149. contract_vertices_impl
 
 test_that("contract_vertices_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3818,7 +3818,7 @@ test_that("contract_vertices_impl basic", {
 })
 
 test_that("contract_vertices_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(contract_vertices_impl(
     graph = NULL,
     mapping = c(1, 1, 2)
@@ -3828,7 +3828,7 @@ test_that("contract_vertices_impl errors", {
 # 150. eccentricity_dijkstra_impl
 
 test_that("eccentricity_dijkstra_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3849,7 +3849,7 @@ test_that("eccentricity_dijkstra_impl basic", {
 })
 
 test_that("eccentricity_dijkstra_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(eccentricity_dijkstra_impl(
     graph = NULL
   ))
@@ -3858,7 +3858,7 @@ test_that("eccentricity_dijkstra_impl errors", {
 # 151. graph_center_dijkstra_impl
 
 test_that("graph_center_dijkstra_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3879,7 +3879,7 @@ test_that("graph_center_dijkstra_impl basic", {
 })
 
 test_that("graph_center_dijkstra_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(graph_center_dijkstra_impl(
     graph = NULL
   ))
@@ -3888,7 +3888,7 @@ test_that("graph_center_dijkstra_impl errors", {
 # 152. radius_dijkstra_impl
 
 test_that("radius_dijkstra_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3909,7 +3909,7 @@ test_that("radius_dijkstra_impl basic", {
 })
 
 test_that("radius_dijkstra_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(radius_dijkstra_impl(
     graph = NULL
   ))
@@ -3918,7 +3918,7 @@ test_that("radius_dijkstra_impl errors", {
 # 153. pseudo_diameter_impl
 
 test_that("pseudo_diameter_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3943,7 +3943,7 @@ test_that("pseudo_diameter_impl basic", {
 })
 
 test_that("pseudo_diameter_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(pseudo_diameter_impl(
     graph = NULL,
     start_vid = 1
@@ -3953,7 +3953,7 @@ test_that("pseudo_diameter_impl errors", {
 # 154. pseudo_diameter_dijkstra_impl
 
 test_that("pseudo_diameter_dijkstra_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -3978,7 +3978,7 @@ test_that("pseudo_diameter_dijkstra_impl basic", {
 })
 
 test_that("pseudo_diameter_dijkstra_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     pseudo_diameter_dijkstra_impl(
       graph = NULL,
@@ -3990,7 +3990,7 @@ test_that("pseudo_diameter_dijkstra_impl errors", {
 # 155. diversity_impl
 
 test_that("diversity_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4008,7 +4008,7 @@ test_that("diversity_impl basic", {
 })
 
 test_that("diversity_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(diversity_impl(
     graph = NULL
   ))
@@ -4017,7 +4017,7 @@ test_that("diversity_impl errors", {
 # 156. random_walk_impl
 
 test_that("random_walk_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4045,7 +4045,7 @@ test_that("random_walk_impl basic", {
 })
 
 test_that("random_walk_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(random_walk_impl(
     graph = NULL,
     start = 1,
@@ -4056,7 +4056,7 @@ test_that("random_walk_impl errors", {
 # 157. global_efficiency_impl
 
 test_that("global_efficiency_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4077,7 +4077,7 @@ test_that("global_efficiency_impl basic", {
 })
 
 test_that("global_efficiency_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(global_efficiency_impl(
     graph = NULL
   ))
@@ -4086,7 +4086,7 @@ test_that("global_efficiency_impl errors", {
 # 158. local_efficiency_impl
 
 test_that("local_efficiency_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4108,7 +4108,7 @@ test_that("local_efficiency_impl basic", {
 })
 
 test_that("local_efficiency_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(local_efficiency_impl(
     graph = NULL
   ))
@@ -4117,7 +4117,7 @@ test_that("local_efficiency_impl errors", {
 # 159. average_local_efficiency_impl
 
 test_that("average_local_efficiency_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4139,7 +4139,7 @@ test_that("average_local_efficiency_impl basic", {
 })
 
 test_that("average_local_efficiency_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(average_local_efficiency_impl(
     graph = NULL
   ))
@@ -4148,7 +4148,7 @@ test_that("average_local_efficiency_impl errors", {
 # 160. transitive_closure_dag_impl
 
 test_that("transitive_closure_dag_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3,
     directed = TRUE
@@ -4166,7 +4166,7 @@ test_that("transitive_closure_dag_impl basic", {
 })
 
 test_that("transitive_closure_dag_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(transitive_closure_dag_impl(
     graph = NULL
   ))
@@ -4175,7 +4175,7 @@ test_that("transitive_closure_dag_impl errors", {
 # 161. transitive_closure_impl
 
 test_that("transitive_closure_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4192,7 +4192,7 @@ test_that("transitive_closure_impl basic", {
 })
 
 test_that("transitive_closure_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(transitive_closure_impl(
     graph = NULL
   ))
@@ -4201,7 +4201,7 @@ test_that("transitive_closure_impl errors", {
 # 162. trussness_impl
 
 test_that("trussness_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4218,7 +4218,7 @@ test_that("trussness_impl basic", {
 })
 
 test_that("trussness_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(trussness_impl(
     graph = NULL
   ))
@@ -4227,7 +4227,7 @@ test_that("trussness_impl errors", {
 # 163. is_graphical_impl
 
 test_that("is_graphical_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(is_graphical_impl(
     out_deg = c(2, 2, 2)
   ))
@@ -4245,7 +4245,7 @@ test_that("is_graphical_impl basic", {
 })
 
 test_that("is_graphical_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_graphical_impl(
     out_deg = "a"
   ))
@@ -4254,7 +4254,7 @@ test_that("is_graphical_impl errors", {
 # 164. bfs_simple_impl
 
 test_that("bfs_simple_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4278,7 +4278,7 @@ test_that("bfs_simple_impl basic", {
 })
 
 test_that("bfs_simple_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(bfs_simple_impl(
     graph = NULL,
     root = 1
@@ -4288,7 +4288,7 @@ test_that("bfs_simple_impl errors", {
 # 165. bipartite_projection_size_impl
 
 test_that("bipartite_projection_size_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 4
   )
@@ -4306,7 +4306,7 @@ test_that("bipartite_projection_size_impl basic", {
 })
 
 test_that("bipartite_projection_size_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(bipartite_projection_size_impl(
     graph = NULL
   ))
@@ -4315,7 +4315,7 @@ test_that("bipartite_projection_size_impl errors", {
 # 166. biadjacency_impl
 
 test_that("biadjacency_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   m <- matrix(c(1, 0, 1, 0, 1, 1), nrow = 2)
   expect_snapshot(biadjacency_impl(
     incidence = m
@@ -4335,7 +4335,7 @@ test_that("biadjacency_impl basic", {
 })
 
 test_that("biadjacency_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(biadjacency_impl(
     incidence = "a"
   ))
@@ -4344,7 +4344,7 @@ test_that("biadjacency_impl errors", {
 # 167. get_biadjacency_impl
 
 test_that("get_biadjacency_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4363,7 +4363,7 @@ test_that("get_biadjacency_impl basic", {
 })
 
 test_that("get_biadjacency_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     get_biadjacency_impl(
       graph = NULL,
@@ -4375,7 +4375,7 @@ test_that("get_biadjacency_impl errors", {
 # 168. is_bipartite_impl
 
 test_that("is_bipartite_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4392,7 +4392,7 @@ test_that("is_bipartite_impl basic", {
 })
 
 test_that("is_bipartite_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_bipartite_impl(
     graph = NULL
   ))
@@ -4401,7 +4401,7 @@ test_that("is_bipartite_impl errors", {
 # 169. bipartite_game_gnp_impl
 
 test_that("bipartite_game_gnp_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(bipartite_game_gnp_impl(
     n1 = 2,
     n2 = 2,
@@ -4425,7 +4425,7 @@ test_that("bipartite_game_gnp_impl basic", {
 })
 
 test_that("bipartite_game_gnp_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(bipartite_game_gnp_impl(
     n1 = -1,
     n2 = 2,
@@ -4436,7 +4436,7 @@ test_that("bipartite_game_gnp_impl errors", {
 # 170. bipartite_game_gnm_impl
 
 test_that("bipartite_game_gnm_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(bipartite_game_gnm_impl(
     n1 = 2,
     n2 = 2,
@@ -4460,7 +4460,7 @@ test_that("bipartite_game_gnm_impl basic", {
 })
 
 test_that("bipartite_game_gnm_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(bipartite_game_gnm_impl(
     n1 = -1,
     n2 = 2,
@@ -4471,7 +4471,7 @@ test_that("bipartite_game_gnm_impl errors", {
 # 171. get_laplacian_impl
 
 test_that("get_laplacian_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4494,7 +4494,7 @@ test_that("get_laplacian_impl basic", {
 })
 
 test_that("get_laplacian_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_laplacian_impl(
     graph = NULL
   ))
@@ -4503,7 +4503,7 @@ test_that("get_laplacian_impl errors", {
 # 172. get_laplacian_sparse_impl
 
 test_that("get_laplacian_sparse_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4526,7 +4526,7 @@ test_that("get_laplacian_sparse_impl basic", {
 })
 
 test_that("get_laplacian_sparse_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_laplacian_sparse_impl(
     graph = NULL
   ))
@@ -4535,7 +4535,7 @@ test_that("get_laplacian_sparse_impl errors", {
 # 173. connected_components_impl
 
 test_that("connected_components_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4557,7 +4557,7 @@ test_that("connected_components_impl basic", {
 })
 
 test_that("connected_components_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(connected_components_impl(
     graph = NULL
   ))
@@ -4566,7 +4566,7 @@ test_that("connected_components_impl errors", {
 # 174. is_connected_impl
 
 test_that("is_connected_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4587,7 +4587,7 @@ test_that("is_connected_impl basic", {
 })
 
 test_that("is_connected_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_connected_impl(
     graph = NULL
   ))
@@ -4596,7 +4596,7 @@ test_that("is_connected_impl errors", {
 # 175. articulation_points_impl
 
 test_that("articulation_points_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4613,7 +4613,7 @@ test_that("articulation_points_impl basic", {
 })
 
 test_that("articulation_points_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(articulation_points_impl(
     graph = NULL
   ))
@@ -4622,7 +4622,7 @@ test_that("articulation_points_impl errors", {
 # 176. biconnected_components_impl
 
 test_that("biconnected_components_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4639,7 +4639,7 @@ test_that("biconnected_components_impl basic", {
 })
 
 test_that("biconnected_components_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(biconnected_components_impl(
     graph = NULL
   ))
@@ -4648,7 +4648,7 @@ test_that("biconnected_components_impl errors", {
 # 177. bridges_impl
 
 test_that("bridges_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4665,7 +4665,7 @@ test_that("bridges_impl basic", {
 })
 
 test_that("bridges_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(bridges_impl(
     graph = NULL
   ))
@@ -4674,7 +4674,7 @@ test_that("bridges_impl errors", {
 # 178. is_biconnected_impl
 
 test_that("is_biconnected_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4691,7 +4691,7 @@ test_that("is_biconnected_impl basic", {
 })
 
 test_that("is_biconnected_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_biconnected_impl(
     graph = NULL
   ))
@@ -4700,7 +4700,7 @@ test_that("is_biconnected_impl errors", {
 # 179. count_reachable_impl
 
 test_that("count_reachable_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 5
   )
@@ -4723,7 +4723,7 @@ test_that("count_reachable_impl basic", {
 })
 
 test_that("count_reachable_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(count_reachable_impl(
     graph = NULL,
     mode = "out"
@@ -4733,7 +4733,7 @@ test_that("count_reachable_impl errors", {
 # 180. bond_percolation_impl
 
 test_that("bond_percolation_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4750,7 +4750,7 @@ test_that("bond_percolation_impl basic", {
 })
 
 test_that("bond_percolation_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(bond_percolation_impl(
     graph = NULL
   ))
@@ -4759,7 +4759,7 @@ test_that("bond_percolation_impl errors", {
 # 181. site_percolation_impl
 
 test_that("site_percolation_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4776,7 +4776,7 @@ test_that("site_percolation_impl basic", {
 })
 
 test_that("site_percolation_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(site_percolation_impl(
     graph = NULL
   ))
@@ -4785,7 +4785,7 @@ test_that("site_percolation_impl errors", {
 # 182. edgelist_percolation_impl
 
 test_that("edgelist_percolation_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(edgelist_percolation_impl(
     edges = matrix(c(1, 2, 2, 3), ncol = 2)
   ))
@@ -4798,7 +4798,7 @@ test_that("edgelist_percolation_impl basic", {
 })
 
 test_that("edgelist_percolation_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(edgelist_percolation_impl(
     edges = "a"
   ))
@@ -4807,7 +4807,7 @@ test_that("edgelist_percolation_impl errors", {
 # 183. is_clique_impl
 
 test_that("is_clique_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4831,7 +4831,7 @@ test_that("is_clique_impl basic", {
 })
 
 test_that("is_clique_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_clique_impl(
     graph = NULL,
     candidate = 1:2
@@ -4841,7 +4841,7 @@ test_that("is_clique_impl errors", {
 # 184. cliques_impl
 
 test_that("cliques_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4863,7 +4863,7 @@ test_that("cliques_impl basic", {
 })
 
 test_that("cliques_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(cliques_impl(
     graph = NULL
   ))
@@ -4872,7 +4872,7 @@ test_that("cliques_impl errors", {
 # 185. clique_size_hist_impl
 
 test_that("clique_size_hist_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4894,7 +4894,7 @@ test_that("clique_size_hist_impl basic", {
 })
 
 test_that("clique_size_hist_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(clique_size_hist_impl(
     graph = NULL
   ))
@@ -4903,7 +4903,7 @@ test_that("clique_size_hist_impl errors", {
 # 186. largest_cliques_impl
 
 test_that("largest_cliques_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4920,7 +4920,7 @@ test_that("largest_cliques_impl basic", {
 })
 
 test_that("largest_cliques_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(largest_cliques_impl(
     graph = NULL
   ))
@@ -4929,7 +4929,7 @@ test_that("largest_cliques_impl errors", {
 # 187. maximal_cliques_hist_impl
 
 test_that("maximal_cliques_hist_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4951,7 +4951,7 @@ test_that("maximal_cliques_hist_impl basic", {
 })
 
 test_that("maximal_cliques_hist_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(maximal_cliques_hist_impl(
     graph = NULL
   ))
@@ -4960,7 +4960,7 @@ test_that("maximal_cliques_hist_impl errors", {
 # 188. clique_number_impl
 
 test_that("clique_number_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -4977,7 +4977,7 @@ test_that("clique_number_impl basic", {
 })
 
 test_that("clique_number_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(clique_number_impl(
     graph = NULL
   ))
@@ -4986,7 +4986,7 @@ test_that("clique_number_impl errors", {
 # 189. weighted_cliques_impl
 
 test_that("weighted_cliques_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5010,7 +5010,7 @@ test_that("weighted_cliques_impl basic", {
 })
 
 test_that("weighted_cliques_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(weighted_cliques_impl(
     graph = NULL
   ))
@@ -5019,7 +5019,7 @@ test_that("weighted_cliques_impl errors", {
 # 190. largest_weighted_cliques_impl
 
 test_that("largest_weighted_cliques_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5040,7 +5040,7 @@ test_that("largest_weighted_cliques_impl basic", {
 })
 
 test_that("largest_weighted_cliques_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(largest_weighted_cliques_impl(
     graph = NULL
   ))
@@ -5049,7 +5049,7 @@ test_that("largest_weighted_cliques_impl errors", {
 # 191. weighted_clique_number_impl
 
 test_that("weighted_clique_number_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5070,7 +5070,7 @@ test_that("weighted_clique_number_impl basic", {
 })
 
 test_that("weighted_clique_number_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(weighted_clique_number_impl(
     graph = NULL
   ))
@@ -5079,7 +5079,7 @@ test_that("weighted_clique_number_impl errors", {
 # 192. is_independent_vertex_set_impl
 
 test_that("is_independent_vertex_set_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5098,7 +5098,7 @@ test_that("is_independent_vertex_set_impl basic", {
 })
 
 test_that("is_independent_vertex_set_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_independent_vertex_set_impl(
     graph = NULL,
     candidate = 1:2
@@ -5108,7 +5108,7 @@ test_that("is_independent_vertex_set_impl errors", {
 # 193. layout_random_impl
 
 test_that("layout_random_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5125,7 +5125,7 @@ test_that("layout_random_impl basic", {
 })
 
 test_that("layout_random_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(layout_random_impl(
     graph = NULL
   ))
@@ -5134,7 +5134,7 @@ test_that("layout_random_impl errors", {
 # 194. layout_circle_impl
 
 test_that("layout_circle_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5155,7 +5155,7 @@ test_that("layout_circle_impl basic", {
 })
 
 test_that("layout_circle_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(layout_circle_impl(
     graph = NULL
   ))
@@ -5164,7 +5164,7 @@ test_that("layout_circle_impl errors", {
 # 195. layout_star_impl
 
 test_that("layout_star_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5195,7 +5195,7 @@ test_that("layout_star_impl basic", {
 })
 
 test_that("layout_star_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(layout_star_impl(
     graph = NULL
   ))
@@ -5204,7 +5204,7 @@ test_that("layout_star_impl errors", {
 # 196. layout_grid_impl
 
 test_that("layout_grid_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5225,7 +5225,7 @@ test_that("layout_grid_impl basic", {
 })
 
 test_that("layout_grid_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(layout_grid_impl(
     graph = NULL
   ))
@@ -5234,7 +5234,7 @@ test_that("layout_grid_impl errors", {
 # 197. layout_grid_3d_impl
 
 test_that("layout_grid_3d_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5256,7 +5256,7 @@ test_that("layout_grid_3d_impl basic", {
 })
 
 test_that("layout_grid_3d_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(layout_grid_3d_impl(
     graph = NULL
   ))
@@ -5265,7 +5265,7 @@ test_that("layout_grid_3d_impl errors", {
 # 198. roots_for_tree_layout_impl
 
 test_that("roots_for_tree_layout_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5286,7 +5286,7 @@ test_that("roots_for_tree_layout_impl basic", {
 })
 
 test_that("roots_for_tree_layout_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     roots_for_tree_layout_impl(
       graph = NULL,
@@ -5299,7 +5299,7 @@ test_that("roots_for_tree_layout_impl errors", {
 # 199. layout_random_3d_impl
 
 test_that("layout_random_3d_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5316,7 +5316,7 @@ test_that("layout_random_3d_impl basic", {
 })
 
 test_that("layout_random_3d_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(layout_random_3d_impl(
     graph = NULL
   ))
@@ -5325,7 +5325,7 @@ test_that("layout_random_3d_impl errors", {
 # 200. layout_sphere_impl
 
 test_that("layout_sphere_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5342,7 +5342,7 @@ test_that("layout_sphere_impl basic", {
 })
 
 test_that("layout_sphere_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(layout_sphere_impl(
     graph = NULL
   ))
@@ -5351,7 +5351,7 @@ test_that("layout_sphere_impl errors", {
 # 201. layout_sugiyama_impl
 
 test_that("layout_sugiyama_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5376,7 +5376,7 @@ test_that("layout_sugiyama_impl basic", {
 })
 
 test_that("layout_sugiyama_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(layout_sugiyama_impl(
     graph = NULL
   ))
@@ -5385,7 +5385,7 @@ test_that("layout_sugiyama_impl errors", {
 # 202. layout_mds_impl
 
 test_that("layout_mds_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5407,7 +5407,7 @@ test_that("layout_mds_impl basic", {
 })
 
 test_that("layout_mds_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(layout_mds_impl(
     graph = NULL
   ))
@@ -5416,7 +5416,7 @@ test_that("layout_mds_impl errors", {
 # 203. layout_bipartite_impl
 
 test_that("layout_bipartite_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5442,7 +5442,7 @@ test_that("layout_bipartite_impl basic", {
 })
 
 test_that("layout_bipartite_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     layout_bipartite_impl(
       graph = NULL,
@@ -5454,7 +5454,7 @@ test_that("layout_bipartite_impl errors", {
 # 204. layout_gem_impl
 
 test_that("layout_gem_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5482,7 +5482,7 @@ test_that("layout_gem_impl basic", {
 })
 
 test_that("layout_gem_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     layout_gem_impl(
       graph = NULL,
@@ -5494,7 +5494,7 @@ test_that("layout_gem_impl errors", {
 # 205. layout_davidson_harel_impl
 
 test_that("layout_davidson_harel_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5526,7 +5526,7 @@ test_that("layout_davidson_harel_impl basic", {
 })
 
 test_that("layout_davidson_harel_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     layout_davidson_harel_impl(
       graph = NULL,
@@ -5538,7 +5538,7 @@ test_that("layout_davidson_harel_impl errors", {
 # 206. layout_umap_impl
 
 test_that("layout_umap_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5568,7 +5568,7 @@ test_that("layout_umap_impl basic", {
 })
 
 test_that("layout_umap_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     layout_umap_impl(
       graph = NULL,
@@ -5580,7 +5580,7 @@ test_that("layout_umap_impl errors", {
 # 207. layout_umap_3d_impl
 
 test_that("layout_umap_3d_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5610,7 +5610,7 @@ test_that("layout_umap_3d_impl basic", {
 })
 
 test_that("layout_umap_3d_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     layout_umap_3d_impl(
       graph = NULL,
@@ -5622,7 +5622,7 @@ test_that("layout_umap_3d_impl errors", {
 # 208. layout_umap_compute_weights_impl
 
 test_that("layout_umap_compute_weights_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5643,7 +5643,7 @@ test_that("layout_umap_compute_weights_impl basic", {
 })
 
 test_that("layout_umap_compute_weights_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     layout_umap_compute_weights_impl(
       graph = NULL,
@@ -5656,7 +5656,7 @@ test_that("layout_umap_compute_weights_impl errors", {
 # 209. layout_align_impl
 
 test_that("layout_align_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5675,7 +5675,7 @@ test_that("layout_align_impl basic", {
 })
 
 test_that("layout_align_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     layout_align_impl(
       graph = NULL,
@@ -5687,7 +5687,7 @@ test_that("layout_align_impl errors", {
 # 210. similarity_dice_impl
 
 test_that("similarity_dice_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5710,7 +5710,7 @@ test_that("similarity_dice_impl basic", {
 })
 
 test_that("similarity_dice_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(similarity_dice_impl(
     graph = NULL
   ))
@@ -5719,7 +5719,7 @@ test_that("similarity_dice_impl errors", {
 # 211. similarity_dice_es_impl
 
 test_that("similarity_dice_es_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5742,7 +5742,7 @@ test_that("similarity_dice_es_impl basic", {
 })
 
 test_that("similarity_dice_es_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(similarity_dice_es_impl(
     graph = NULL
   ))
@@ -5751,7 +5751,7 @@ test_that("similarity_dice_es_impl errors", {
 # 212. similarity_dice_pairs_impl
 
 test_that("similarity_dice_pairs_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 4
   )
@@ -5776,7 +5776,7 @@ test_that("similarity_dice_pairs_impl basic", {
 })
 
 test_that("similarity_dice_pairs_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     similarity_dice_pairs_impl(
       graph = NULL,
@@ -5788,7 +5788,7 @@ test_that("similarity_dice_pairs_impl errors", {
 # 213. similarity_inverse_log_weighted_impl
 
 test_that("similarity_inverse_log_weighted_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5810,7 +5810,7 @@ test_that("similarity_inverse_log_weighted_impl basic", {
 })
 
 test_that("similarity_inverse_log_weighted_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(similarity_inverse_log_weighted_impl(
     graph = NULL
   ))
@@ -5819,7 +5819,7 @@ test_that("similarity_inverse_log_weighted_impl errors", {
 # 214. similarity_jaccard_impl
 
 test_that("similarity_jaccard_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5842,7 +5842,7 @@ test_that("similarity_jaccard_impl basic", {
 })
 
 test_that("similarity_jaccard_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(similarity_jaccard_impl(
     graph = NULL
   ))
@@ -5851,7 +5851,7 @@ test_that("similarity_jaccard_impl errors", {
 # 215. similarity_jaccard_es_impl
 
 test_that("similarity_jaccard_es_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5874,7 +5874,7 @@ test_that("similarity_jaccard_es_impl basic", {
 })
 
 test_that("similarity_jaccard_es_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(similarity_jaccard_es_impl(
     graph = NULL
   ))
@@ -5883,7 +5883,7 @@ test_that("similarity_jaccard_es_impl errors", {
 # 216. similarity_jaccard_pairs_impl
 
 test_that("similarity_jaccard_pairs_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 4
   )
@@ -5908,7 +5908,7 @@ test_that("similarity_jaccard_pairs_impl basic", {
 })
 
 test_that("similarity_jaccard_pairs_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     similarity_jaccard_pairs_impl(
       graph = NULL,
@@ -5920,7 +5920,7 @@ test_that("similarity_jaccard_pairs_impl errors", {
 # 217. compare_communities_impl
 
 test_that("compare_communities_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(compare_communities_impl(
     comm1 = c(1, 2, 1),
     comm2 = c(2, 1, 2)
@@ -5940,7 +5940,7 @@ test_that("compare_communities_impl basic", {
 })
 
 test_that("compare_communities_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(compare_communities_impl(
     comm1 = "a",
     comm2 = c(2, 1, 2)
@@ -5950,7 +5950,7 @@ test_that("compare_communities_impl errors", {
 # 218. modularity_impl
 
 test_that("modularity_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -5976,7 +5976,7 @@ test_that("modularity_impl basic", {
 })
 
 test_that("modularity_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(modularity_impl(
     graph = NULL,
     membership = c(1, 2, 1)
@@ -5986,7 +5986,7 @@ test_that("modularity_impl errors", {
 # 219. modularity_matrix_impl
 
 test_that("modularity_matrix_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6009,7 +6009,7 @@ test_that("modularity_matrix_impl basic", {
 })
 
 test_that("modularity_matrix_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(modularity_matrix_impl(
     graph = NULL
   ))
@@ -6018,7 +6018,7 @@ test_that("modularity_matrix_impl errors", {
 # 220. community_fluid_communities_impl
 
 test_that("community_fluid_communities_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6037,7 +6037,7 @@ test_that("community_fluid_communities_impl basic", {
 })
 
 test_that("community_fluid_communities_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     community_fluid_communities_impl(
       graph = NULL,
@@ -6049,7 +6049,7 @@ test_that("community_fluid_communities_impl errors", {
 # 221. community_label_propagation_impl
 
 test_that("community_label_propagation_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6073,7 +6073,7 @@ test_that("community_label_propagation_impl basic", {
 })
 
 test_that("community_label_propagation_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(community_label_propagation_impl(
     graph = NULL
   ))
@@ -6082,7 +6082,7 @@ test_that("community_label_propagation_impl errors", {
 # 222. community_multilevel_impl
 
 test_that("community_multilevel_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6104,7 +6104,7 @@ test_that("community_multilevel_impl basic", {
 })
 
 test_that("community_multilevel_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(community_multilevel_impl(
     graph = NULL
   ))
@@ -6113,7 +6113,7 @@ test_that("community_multilevel_impl errors", {
 # 223. community_optimal_modularity_impl
 
 test_that("community_optimal_modularity_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6134,7 +6134,7 @@ test_that("community_optimal_modularity_impl basic", {
 })
 
 test_that("community_optimal_modularity_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(community_optimal_modularity_impl(
     graph = NULL
   ))
@@ -6143,7 +6143,7 @@ test_that("community_optimal_modularity_impl errors", {
 # 224. community_leiden_impl
 
 test_that("community_leiden_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6174,7 +6174,7 @@ test_that("community_leiden_impl basic", {
 })
 
 test_that("community_leiden_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(community_leiden_impl(
     graph = NULL,
     resolution = 1
@@ -6184,7 +6184,7 @@ test_that("community_leiden_impl errors", {
 # 225. split_join_distance_impl
 
 test_that("split_join_distance_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(split_join_distance_impl(
     comm1 = c(1, 2, 1),
     comm2 = c(2, 1, 2)
@@ -6199,7 +6199,7 @@ test_that("split_join_distance_impl basic", {
 })
 
 test_that("split_join_distance_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(split_join_distance_impl(
     comm1 = "a",
     comm2 = c(2, 1, 2)
@@ -6209,7 +6209,7 @@ test_that("split_join_distance_impl errors", {
 # 226. community_infomap_impl
 
 test_that("community_infomap_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6232,7 +6232,7 @@ test_that("community_infomap_impl basic", {
 })
 
 test_that("community_infomap_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(community_infomap_impl(
     graph = NULL
   ))
@@ -6241,7 +6241,7 @@ test_that("community_infomap_impl errors", {
 # 227. graphlets_impl
 
 test_that("graphlets_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6264,7 +6264,7 @@ test_that("graphlets_impl basic", {
 })
 
 test_that("graphlets_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(graphlets_impl(
     graph = NULL
   ))
@@ -6273,7 +6273,7 @@ test_that("graphlets_impl errors", {
 # 228. hrg_fit_impl
 
 test_that("hrg_fit_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -6290,7 +6290,7 @@ test_that("hrg_fit_impl basic", {
 })
 
 test_that("hrg_fit_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(hrg_fit_impl(
     graph = NULL
   ))
@@ -6300,7 +6300,7 @@ test_that("hrg_fit_impl errors", {
 
 test_that("hrg_sample_impl basic", {
   skip_if(Sys.getenv("R_SANITIZER") == "true")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_full_graph(10)
   hrg_model <- fit_hrg(g, hrg = NULL, start = FALSE, steps = 0)
   expect_snapshot(hrg_sample_impl(
@@ -6316,7 +6316,7 @@ test_that("hrg_sample_impl basic", {
 
 test_that("hrg_sample_impl errors", {
   skip_if(Sys.getenv("R_SANITIZER") == "true")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   # FIXME: This test triggers an assertion failure in the C code when passing
   # NULL/empty HRG. The C code should validate input and return a proper error
   # message instead of an assertion failure.
@@ -6329,7 +6329,7 @@ test_that("hrg_sample_impl errors", {
 
 test_that("hrg_sample_many_impl basic", {
   skip_if(Sys.getenv("R_SANITIZER") == "true")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_full_graph(10)
   hrg_model <- fit_hrg(g, hrg = NULL, start = FALSE, steps = 0)
   expect_snapshot(hrg_sample_many_impl(
@@ -6347,7 +6347,7 @@ test_that("hrg_sample_many_impl basic", {
 
 test_that("hrg_sample_many_impl errors", {
   skip_if(Sys.getenv("R_SANITIZER") == "true")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   # FIXME: This test triggers an assertion failure in the C code when passing
   # NULL/empty HRG. The C code should validate input and return a proper error
   # message instead of an assertion failure.
@@ -6361,7 +6361,7 @@ test_that("hrg_sample_many_impl errors", {
 
 test_that("hrg_game_impl basic", {
   skip_if(Sys.getenv("R_SANITIZER") == "true")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_full_graph(10)
   hrg_model <- fit_hrg(g, hrg = NULL, start = FALSE, steps = 0)
   expect_snapshot(hrg_game_impl(
@@ -6377,7 +6377,7 @@ test_that("hrg_game_impl basic", {
 
 test_that("hrg_game_impl errors", {
   skip_if(Sys.getenv("R_SANITIZER") == "true")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   # FIXME: This test triggers an assertion failure in the C code when passing
   # NULL/empty HRG. The C code should validate input and return a proper error
   # message instead of an assertion failure.
@@ -6389,7 +6389,7 @@ test_that("hrg_game_impl errors", {
 # 232. hrg_consensus_impl
 
 # test_that("hrg_consensus_impl basic", {
-# withr::local_seed(20250909)
+# igraph_local_seed(20250909)
 # oldval <- igraph_opt("print.id")
 # igraph_options(print.id = FALSE)
 #   g <- path_graph_impl(3)
@@ -6398,7 +6398,7 @@ test_that("hrg_game_impl errors", {
 # })
 
 test_that("hrg_consensus_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(hrg_consensus_impl(
     graph = NULL
   ))
@@ -6407,7 +6407,7 @@ test_that("hrg_consensus_impl errors", {
 # 233. hrg_predict_impl
 
 # test_that("hrg_predict_impl basic", {
-# withr::local_seed(20250909)
+# igraph_local_seed(20250909)
 # oldval <- igraph_opt("print.id")
 # igraph_options(print.id = FALSE)
 #   g <- path_graph_impl(3)
@@ -6416,7 +6416,7 @@ test_that("hrg_consensus_impl errors", {
 # })
 
 test_that("hrg_predict_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(hrg_predict_impl(
     graph = NULL
   ))
@@ -6425,7 +6425,7 @@ test_that("hrg_predict_impl errors", {
 # 234. hrg_create_impl
 
 test_that("hrg_create_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_tree(5)
   expect_snapshot(hrg_create_impl(
     graph = g,
@@ -6441,7 +6441,7 @@ test_that("hrg_create_impl basic", {
 })
 
 test_that("hrg_create_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_full_graph(4, directed = TRUE)
   expect_snapshot_igraph_error(hrg_create_impl(
     graph = g,
@@ -6453,7 +6453,7 @@ test_that("hrg_create_impl errors", {
 
 test_that("hrg_resize_impl basic", {
   skip_if(Sys.getenv("R_SANITIZER") == "true")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_full_graph(10)
   hrg_model <- fit_hrg(g, hrg = NULL, start = FALSE, steps = 0)
   expect_snapshot(hrg_resize_impl(
@@ -6471,7 +6471,7 @@ test_that("hrg_resize_impl basic", {
 
 test_that("hrg_resize_impl errors", {
   skip_if(Sys.getenv("R_SANITIZER") == "true")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(hrg_resize_impl(
     hrg = -1,
     newsize = 2
@@ -6482,7 +6482,7 @@ test_that("hrg_resize_impl errors", {
 
 test_that("hrg_size_impl basic", {
   skip_if(Sys.getenv("R_SANITIZER") == "true")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_full_graph(10)
   hrg_model <- fit_hrg(g, hrg = NULL, start = FALSE, steps = 0)
   expect_snapshot(hrg_size_impl(
@@ -6498,7 +6498,7 @@ test_that("hrg_size_impl basic", {
 
 test_that("hrg_size_impl errors", {
   skip_if(Sys.getenv("R_SANITIZER") == "true")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(hrg_size_impl(
     hrg = -1
   ))
@@ -6507,7 +6507,7 @@ test_that("hrg_size_impl errors", {
 # 237. from_hrg_dendrogram_impl
 
 test_that("from_hrg_dendrogram_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_full_graph(10)
   hrg_model <- fit_hrg(g, hrg = NULL, start = FALSE, steps = 0)
   expect_snapshot(from_hrg_dendrogram_impl(
@@ -6522,7 +6522,7 @@ test_that("from_hrg_dendrogram_impl basic", {
 })
 
 test_that("from_hrg_dendrogram_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(from_hrg_dendrogram_impl(
     hrg = -1
   ))
@@ -6531,7 +6531,7 @@ test_that("from_hrg_dendrogram_impl errors", {
 # 238. get_adjacency_sparse_impl
 
 test_that("get_adjacency_sparse_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6554,7 +6554,7 @@ test_that("get_adjacency_sparse_impl basic", {
 })
 
 test_that("get_adjacency_sparse_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_adjacency_sparse_impl(
     graph = NULL
   ))
@@ -6563,7 +6563,7 @@ test_that("get_adjacency_sparse_impl errors", {
 # 239. get_stochastic_impl
 
 test_that("get_stochastic_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6585,7 +6585,7 @@ test_that("get_stochastic_impl basic", {
 })
 
 test_that("get_stochastic_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_stochastic_impl(
     graph = NULL
   ))
@@ -6594,7 +6594,7 @@ test_that("get_stochastic_impl errors", {
 # 240. get_stochastic_sparse_impl
 
 test_that("get_stochastic_sparse_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6616,7 +6616,7 @@ test_that("get_stochastic_sparse_impl basic", {
 })
 
 test_that("get_stochastic_sparse_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(get_stochastic_sparse_impl(
     graph = NULL
   ))
@@ -6625,7 +6625,7 @@ test_that("get_stochastic_sparse_impl errors", {
 # 241. to_directed_impl
 
 test_that("to_directed_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6646,7 +6646,7 @@ test_that("to_directed_impl basic", {
 })
 
 test_that("to_directed_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(to_directed_impl(
     graph = NULL
   ))
@@ -6655,7 +6655,7 @@ test_that("to_directed_impl errors", {
 # 242. to_undirected_impl
 
 test_that("to_undirected_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6677,7 +6677,7 @@ test_that("to_undirected_impl basic", {
 })
 
 test_that("to_undirected_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(to_undirected_impl(
     graph = NULL
   ))
@@ -6686,7 +6686,7 @@ test_that("to_undirected_impl errors", {
 # 243. motifs_randesu_impl
 
 test_that("motifs_randesu_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6708,7 +6708,7 @@ test_that("motifs_randesu_impl basic", {
 })
 
 test_that("motifs_randesu_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(motifs_randesu_impl(
     graph = NULL
   ))
@@ -6717,7 +6717,7 @@ test_that("motifs_randesu_impl errors", {
 # 244. motifs_randesu_estimate_impl
 
 test_that("motifs_randesu_estimate_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 6
   )
@@ -6745,7 +6745,7 @@ test_that("motifs_randesu_estimate_impl basic", {
 })
 
 test_that("motifs_randesu_estimate_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     motifs_randesu_estimate_impl(
       graph = NULL,
@@ -6758,7 +6758,7 @@ test_that("motifs_randesu_estimate_impl errors", {
 # 245. motifs_randesu_no_impl
 
 test_that("motifs_randesu_no_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6780,7 +6780,7 @@ test_that("motifs_randesu_no_impl basic", {
 })
 
 test_that("motifs_randesu_no_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6797,7 +6797,7 @@ test_that("motifs_randesu_no_impl errors", {
 # 246. dyad_census_impl
 
 test_that("dyad_census_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6814,7 +6814,7 @@ test_that("dyad_census_impl basic", {
 })
 
 test_that("dyad_census_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(dyad_census_impl(
     graph = NULL
   ))
@@ -6823,7 +6823,7 @@ test_that("dyad_census_impl errors", {
 # 247. triad_census_impl
 
 test_that("triad_census_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6842,7 +6842,7 @@ test_that("triad_census_impl basic", {
 })
 
 test_that("triad_census_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(triad_census_impl(
     graph = NULL
   ))
@@ -6851,7 +6851,7 @@ test_that("triad_census_impl errors", {
 # 248. count_adjacent_triangles_impl
 
 test_that("count_adjacent_triangles_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6872,7 +6872,7 @@ test_that("count_adjacent_triangles_impl basic", {
 })
 
 test_that("count_adjacent_triangles_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(count_adjacent_triangles_impl(
     graph = NULL
   ))
@@ -6881,7 +6881,7 @@ test_that("count_adjacent_triangles_impl errors", {
 # 249. count_triangles_impl
 
 test_that("count_triangles_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6898,7 +6898,7 @@ test_that("count_triangles_impl basic", {
 })
 
 test_that("count_triangles_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(count_triangles_impl(
     graph = NULL
   ))
@@ -6907,7 +6907,7 @@ test_that("count_triangles_impl errors", {
 # 250. local_scan_0_impl
 
 test_that("local_scan_0_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -6929,7 +6929,7 @@ test_that("local_scan_0_impl basic", {
 })
 
 test_that("local_scan_0_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(local_scan_0_impl(
     graph = NULL
   ))
@@ -6938,7 +6938,7 @@ test_that("local_scan_0_impl errors", {
 # 251. local_scan_0_them_impl
 
 test_that("local_scan_0_them_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -6967,7 +6967,7 @@ test_that("local_scan_0_them_impl basic", {
 })
 
 test_that("local_scan_0_them_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   them <- path_graph_impl(
     n = 3
   )
@@ -6982,7 +6982,7 @@ test_that("local_scan_0_them_impl errors", {
 # 252. local_scan_1_ecount_impl
 
 test_that("local_scan_1_ecount_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7004,7 +7004,7 @@ test_that("local_scan_1_ecount_impl basic", {
 })
 
 test_that("local_scan_1_ecount_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(local_scan_1_ecount_impl(
     graph = NULL
   ))
@@ -7013,7 +7013,7 @@ test_that("local_scan_1_ecount_impl errors", {
 # 253. local_scan_1_ecount_them_impl
 
 test_that("local_scan_1_ecount_them_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -7042,7 +7042,7 @@ test_that("local_scan_1_ecount_them_impl basic", {
 })
 
 test_that("local_scan_1_ecount_them_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   them <- path_graph_impl(
     n = 3
   )
@@ -7057,7 +7057,7 @@ test_that("local_scan_1_ecount_them_impl errors", {
 # 254. local_scan_k_ecount_impl
 
 test_that("local_scan_k_ecount_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7082,7 +7082,7 @@ test_that("local_scan_k_ecount_impl basic", {
 })
 
 test_that("local_scan_k_ecount_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(local_scan_k_ecount_impl(
     graph = NULL,
     k = 1
@@ -7092,7 +7092,7 @@ test_that("local_scan_k_ecount_impl errors", {
 # 255. local_scan_k_ecount_them_impl
 
 test_that("local_scan_k_ecount_them_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -7124,7 +7124,7 @@ test_that("local_scan_k_ecount_them_impl basic", {
 })
 
 test_that("local_scan_k_ecount_them_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   them <- path_graph_impl(
     n = 3
   )
@@ -7140,7 +7140,7 @@ test_that("local_scan_k_ecount_them_impl errors", {
 # 256. local_scan_neighborhood_ecount_impl
 
 test_that("local_scan_neighborhood_ecount_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 4
   )
@@ -7164,7 +7164,7 @@ test_that("local_scan_neighborhood_ecount_impl basic", {
 })
 
 test_that("local_scan_neighborhood_ecount_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     local_scan_neighborhood_ecount_impl(
       graph = NULL,
@@ -7176,7 +7176,7 @@ test_that("local_scan_neighborhood_ecount_impl errors", {
 # 257. local_scan_subset_ecount_impl
 
 test_that("local_scan_subset_ecount_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 4
   )
@@ -7200,7 +7200,7 @@ test_that("local_scan_subset_ecount_impl basic", {
 })
 
 test_that("local_scan_subset_ecount_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 4
   )
@@ -7216,7 +7216,7 @@ test_that("local_scan_subset_ecount_impl errors", {
 # 258. list_triangles_impl
 
 test_that("list_triangles_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7233,7 +7233,7 @@ test_that("list_triangles_impl basic", {
 })
 
 test_that("list_triangles_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(list_triangles_impl(
     graph = NULL
   ))
@@ -7242,7 +7242,7 @@ test_that("list_triangles_impl errors", {
 # 259. join_impl
 
 test_that("join_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -7265,7 +7265,7 @@ test_that("join_impl basic", {
 })
 
 test_that("join_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   right <- path_graph_impl(
     n = 3
   )
@@ -7278,7 +7278,7 @@ test_that("join_impl errors", {
 # 260. induced_subgraph_map_impl
 
 test_that("induced_subgraph_map_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7304,7 +7304,7 @@ test_that("induced_subgraph_map_impl basic", {
 })
 
 test_that("induced_subgraph_map_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     induced_subgraph_map_impl(
       graph = NULL,
@@ -7317,7 +7317,7 @@ test_that("induced_subgraph_map_impl errors", {
 # 261. mycielskian_impl
 
 test_that("mycielskian_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7338,7 +7338,7 @@ test_that("mycielskian_impl basic", {
 })
 
 test_that("mycielskian_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(mycielskian_impl(
     graph = NULL
   ))
@@ -7347,7 +7347,7 @@ test_that("mycielskian_impl errors", {
 # 262. product_impl
 
 test_that("product_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -7375,7 +7375,7 @@ test_that("product_impl basic", {
 })
 
 test_that("product_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g2 <- path_graph_impl(
     n = 3
   )
@@ -7388,7 +7388,7 @@ test_that("product_impl errors", {
 # 263. rooted_product_impl
 
 test_that("rooted_product_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -7413,7 +7413,7 @@ test_that("rooted_product_impl basic", {
 })
 
 test_that("rooted_product_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g2 <- path_graph_impl(
     n = 3
   )
@@ -7429,7 +7429,7 @@ test_that("rooted_product_impl errors", {
 # 264. gomory_hu_tree_impl
 
 test_that("gomory_hu_tree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7450,7 +7450,7 @@ test_that("gomory_hu_tree_impl basic", {
 })
 
 test_that("gomory_hu_tree_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(gomory_hu_tree_impl(
     graph = NULL
   ))
@@ -7459,7 +7459,7 @@ test_that("gomory_hu_tree_impl errors", {
 # 265. maxflow_impl
 
 test_that("maxflow_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7486,7 +7486,7 @@ test_that("maxflow_impl basic", {
 })
 
 test_that("maxflow_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(maxflow_impl(
     graph = NULL,
     source = 1,
@@ -7497,7 +7497,7 @@ test_that("maxflow_impl errors", {
 # 266. residual_graph_impl
 
 test_that("residual_graph_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7518,7 +7518,7 @@ test_that("residual_graph_impl basic", {
 })
 
 test_that("residual_graph_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     residual_graph_impl(
       graph = NULL,
@@ -7531,7 +7531,7 @@ test_that("residual_graph_impl errors", {
 # 267. reverse_residual_graph_impl
 
 test_that("reverse_residual_graph_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7552,7 +7552,7 @@ test_that("reverse_residual_graph_impl basic", {
 })
 
 test_that("reverse_residual_graph_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     reverse_residual_graph_impl(
       graph = NULL,
@@ -7565,7 +7565,7 @@ test_that("reverse_residual_graph_impl errors", {
 # 268. st_mincut_impl
 
 test_that("st_mincut_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7592,7 +7592,7 @@ test_that("st_mincut_impl basic", {
 })
 
 test_that("st_mincut_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(st_mincut_impl(
     graph = NULL,
     source = 1,
@@ -7603,7 +7603,7 @@ test_that("st_mincut_impl errors", {
 # 269. dominator_tree_impl
 
 test_that("dominator_tree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3,
     directed = TRUE
@@ -7628,7 +7628,7 @@ test_that("dominator_tree_impl basic", {
 })
 
 test_that("dominator_tree_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(dominator_tree_impl(
     graph = NULL,
     root = 1
@@ -7638,7 +7638,7 @@ test_that("dominator_tree_impl errors", {
 # 270. all_st_cuts_impl
 
 test_that("all_st_cuts_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3,
     directed = TRUE
@@ -7660,7 +7660,7 @@ test_that("all_st_cuts_impl basic", {
 })
 
 test_that("all_st_cuts_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(all_st_cuts_impl(
     graph = NULL,
     source = 1,
@@ -7671,7 +7671,7 @@ test_that("all_st_cuts_impl errors", {
 # 271. all_st_mincuts_impl
 
 test_that("all_st_mincuts_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3,
     directed = TRUE
@@ -7699,7 +7699,7 @@ test_that("all_st_mincuts_impl basic", {
 })
 
 test_that("all_st_mincuts_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     all_st_mincuts_impl(
       graph = NULL,
@@ -7712,7 +7712,7 @@ test_that("all_st_mincuts_impl errors", {
 # 272. even_tarjan_reduction_impl
 
 test_that("even_tarjan_reduction_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7729,7 +7729,7 @@ test_that("even_tarjan_reduction_impl basic", {
 })
 
 test_that("even_tarjan_reduction_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(even_tarjan_reduction_impl(
     graph = NULL
   ))
@@ -7738,7 +7738,7 @@ test_that("even_tarjan_reduction_impl errors", {
 # 273. is_separator_impl
 
 test_that("is_separator_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7757,7 +7757,7 @@ test_that("is_separator_impl basic", {
 })
 
 test_that("is_separator_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_separator_impl(
     graph = NULL,
     candidate = 1:2
@@ -7767,7 +7767,7 @@ test_that("is_separator_impl errors", {
 # 274. is_minimal_separator_impl
 
 test_that("is_minimal_separator_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7786,7 +7786,7 @@ test_that("is_minimal_separator_impl basic", {
 })
 
 test_that("is_minimal_separator_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_minimal_separator_impl(
     graph = NULL,
     candidate = 1:2
@@ -7796,7 +7796,7 @@ test_that("is_minimal_separator_impl errors", {
 # 275. all_minimal_st_separators_impl
 
 test_that("all_minimal_st_separators_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7813,7 +7813,7 @@ test_that("all_minimal_st_separators_impl basic", {
 })
 
 test_that("all_minimal_st_separators_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(all_minimal_st_separators_impl(
     graph = NULL
   ))
@@ -7822,7 +7822,7 @@ test_that("all_minimal_st_separators_impl errors", {
 # 276. minimum_size_separators_impl
 
 test_that("minimum_size_separators_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7839,7 +7839,7 @@ test_that("minimum_size_separators_impl basic", {
 })
 
 test_that("minimum_size_separators_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(minimum_size_separators_impl(
     graph = NULL
   ))
@@ -7848,7 +7848,7 @@ test_that("minimum_size_separators_impl errors", {
 # 277. isoclass_impl
 
 test_that("isoclass_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -7865,7 +7865,7 @@ test_that("isoclass_impl basic", {
 })
 
 test_that("isoclass_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(isoclass_impl(
     graph = NULL
   ))
@@ -7874,7 +7874,7 @@ test_that("isoclass_impl errors", {
 # 278. isomorphic_impl
 
 test_that("isomorphic_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -7897,7 +7897,7 @@ test_that("isomorphic_impl basic", {
 })
 
 test_that("isomorphic_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   graph2 <- path_graph_impl(
     n = 3
   )
@@ -7910,7 +7910,7 @@ test_that("isomorphic_impl errors", {
 # 279. isoclass_subgraph_impl
 
 test_that("isoclass_subgraph_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 5
   )
@@ -7929,7 +7929,7 @@ test_that("isoclass_subgraph_impl basic", {
 })
 
 test_that("isoclass_subgraph_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(isoclass_subgraph_impl(
     graph = NULL,
     vids = 1:2
@@ -7939,7 +7939,7 @@ test_that("isoclass_subgraph_impl errors", {
 # 280. isoclass_create_impl
 
 test_that("isoclass_create_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(isoclass_create_impl(
     size = 3,
     number = 1
@@ -7959,7 +7959,7 @@ test_that("isoclass_create_impl basic", {
 })
 
 test_that("isoclass_create_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(isoclass_create_impl(
     size = "a",
     number = 1
@@ -7969,7 +7969,7 @@ test_that("isoclass_create_impl errors", {
 # 281. isomorphic_vf2_impl
 
 test_that("isomorphic_vf2_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -8000,7 +8000,7 @@ test_that("isomorphic_vf2_impl basic", {
 })
 
 test_that("isomorphic_vf2_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   graph2 <- path_graph_impl(
     n = 3
   )
@@ -8016,7 +8016,7 @@ test_that("isomorphic_vf2_impl errors", {
 # 283. count_isomorphisms_vf2_impl
 
 test_that("count_isomorphisms_vf2_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -8047,7 +8047,7 @@ test_that("count_isomorphisms_vf2_impl basic", {
 })
 
 test_that("count_isomorphisms_vf2_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   graph2 <- path_graph_impl(
     n = 3
   )
@@ -8062,7 +8062,7 @@ test_that("count_isomorphisms_vf2_impl errors", {
 # 284. get_isomorphisms_vf2_impl
 
 test_that("get_isomorphisms_vf2_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -8093,7 +8093,7 @@ test_that("get_isomorphisms_vf2_impl basic", {
 })
 
 test_that("get_isomorphisms_vf2_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   graph2 <- path_graph_impl(
     n = 3
   )
@@ -8108,7 +8108,7 @@ test_that("get_isomorphisms_vf2_impl errors", {
 # 285. subisomorphic_impl
 
 test_that("subisomorphic_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -8131,7 +8131,7 @@ test_that("subisomorphic_impl basic", {
 })
 
 test_that("subisomorphic_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   graph2 <- path_graph_impl(
     n = 3
   )
@@ -8144,7 +8144,7 @@ test_that("subisomorphic_impl errors", {
 # 286. subisomorphic_vf2_impl
 
 test_that("subisomorphic_vf2_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -8175,7 +8175,7 @@ test_that("subisomorphic_vf2_impl basic", {
 })
 
 test_that("subisomorphic_vf2_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   graph2 <- path_graph_impl(
     n = 3
   )
@@ -8190,7 +8190,7 @@ test_that("subisomorphic_vf2_impl errors", {
 # 287. count_subisomorphisms_vf2_impl
 
 test_that("count_subisomorphisms_vf2_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -8221,7 +8221,7 @@ test_that("count_subisomorphisms_vf2_impl basic", {
 })
 
 test_that("count_subisomorphisms_vf2_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   graph2 <- path_graph_impl(
     n = 3
   )
@@ -8236,7 +8236,7 @@ test_that("count_subisomorphisms_vf2_impl errors", {
 # 288. get_subisomorphisms_vf2_impl
 
 test_that("get_subisomorphisms_vf2_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -8267,7 +8267,7 @@ test_that("get_subisomorphisms_vf2_impl basic", {
 })
 
 test_that("get_subisomorphisms_vf2_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   graph2 <- path_graph_impl(
     n = 3
   )
@@ -8282,7 +8282,7 @@ test_that("get_subisomorphisms_vf2_impl errors", {
 # 289. canonical_permutation_impl
 
 test_that("canonical_permutation_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8304,7 +8304,7 @@ test_that("canonical_permutation_impl basic", {
 })
 
 test_that("canonical_permutation_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(canonical_permutation_impl(
     graph = NULL
   ))
@@ -8313,7 +8313,7 @@ test_that("canonical_permutation_impl errors", {
 # 290. permute_vertices_impl
 
 test_that("permute_vertices_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8332,7 +8332,7 @@ test_that("permute_vertices_impl basic", {
 })
 
 test_that("permute_vertices_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(permute_vertices_impl(
     graph = NULL,
     permutation = 3:1
@@ -8342,7 +8342,7 @@ test_that("permute_vertices_impl errors", {
 # 291. isomorphic_bliss_impl
 
 test_that("isomorphic_bliss_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -8372,7 +8372,7 @@ test_that("isomorphic_bliss_impl basic", {
 })
 
 test_that("isomorphic_bliss_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   graph2 <- path_graph_impl(
     n = 3
   )
@@ -8385,7 +8385,7 @@ test_that("isomorphic_bliss_impl errors", {
 # 292. count_automorphisms_impl
 
 test_that("count_automorphisms_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8407,7 +8407,7 @@ test_that("count_automorphisms_impl basic", {
 })
 
 test_that("count_automorphisms_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(count_automorphisms_impl(
     graph = NULL
   ))
@@ -8416,7 +8416,7 @@ test_that("count_automorphisms_impl errors", {
 # 293. automorphism_group_impl
 
 test_that("automorphism_group_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8439,7 +8439,7 @@ test_that("automorphism_group_impl basic", {
 })
 
 test_that("automorphism_group_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(automorphism_group_impl(
     graph = NULL
   ))
@@ -8448,7 +8448,7 @@ test_that("automorphism_group_impl errors", {
 # 294. simplify_and_colorize_impl
 
 test_that("simplify_and_colorize_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8465,7 +8465,7 @@ test_that("simplify_and_colorize_impl basic", {
 })
 
 test_that("simplify_and_colorize_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(simplify_and_colorize_impl(
     graph = NULL
   ))
@@ -8474,7 +8474,7 @@ test_that("simplify_and_colorize_impl errors", {
 # 295. graph_count_impl
 
 test_that("graph_count_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(graph_count_impl(
     n = 3
   ))
@@ -8491,7 +8491,7 @@ test_that("graph_count_impl basic", {
 })
 
 test_that("graph_count_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(graph_count_impl(
     n = "a"
   ))
@@ -8500,7 +8500,7 @@ test_that("graph_count_impl errors", {
 # 296. is_matching_impl
 
 test_that("is_matching_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8524,7 +8524,7 @@ test_that("is_matching_impl basic", {
 })
 
 test_that("is_matching_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_matching_impl(
     graph = NULL,
     matching = 1:2
@@ -8534,7 +8534,7 @@ test_that("is_matching_impl errors", {
 # 297. is_maximal_matching_impl
 
 test_that("is_maximal_matching_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8558,7 +8558,7 @@ test_that("is_maximal_matching_impl basic", {
 })
 
 test_that("is_maximal_matching_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_maximal_matching_impl(
     graph = NULL,
     matching = 1:2
@@ -8568,7 +8568,7 @@ test_that("is_maximal_matching_impl errors", {
 # 298. maximum_bipartite_matching_impl
 
 test_that("maximum_bipartite_matching_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8593,7 +8593,7 @@ test_that("maximum_bipartite_matching_impl basic", {
 })
 
 test_that("maximum_bipartite_matching_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     maximum_bipartite_matching_impl(
       graph = NULL,
@@ -8605,7 +8605,7 @@ test_that("maximum_bipartite_matching_impl errors", {
 # 299. adjacency_spectral_embedding_impl
 
 test_that("adjacency_spectral_embedding_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8633,7 +8633,7 @@ test_that("adjacency_spectral_embedding_impl basic", {
 })
 
 test_that("adjacency_spectral_embedding_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(adjacency_spectral_embedding_impl(
     graph = NULL,
     no = 2
@@ -8643,7 +8643,7 @@ test_that("adjacency_spectral_embedding_impl errors", {
 # 300. laplacian_spectral_embedding_impl
 
 test_that("laplacian_spectral_embedding_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8662,7 +8662,7 @@ test_that("laplacian_spectral_embedding_impl basic", {
 })
 
 test_that("laplacian_spectral_embedding_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(laplacian_spectral_embedding_impl(
     graph = NULL,
     no = 2
@@ -8672,7 +8672,7 @@ test_that("laplacian_spectral_embedding_impl errors", {
 # 301. eigen_adjacency_impl
 
 test_that("eigen_adjacency_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8697,7 +8697,7 @@ test_that("eigen_adjacency_impl basic", {
 })
 
 test_that("eigen_adjacency_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(eigen_adjacency_impl(
     graph = NULL
   ))
@@ -8706,7 +8706,7 @@ test_that("eigen_adjacency_impl errors", {
 # 302. power_law_fit_impl
 
 test_that("power_law_fit_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(power_law_fit_impl(
     data = c(1, 2, 3)
   ))
@@ -8724,7 +8724,7 @@ test_that("power_law_fit_impl basic", {
 })
 
 test_that("power_law_fit_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(power_law_fit_impl(
     data = "a"
   ))
@@ -8733,7 +8733,7 @@ test_that("power_law_fit_impl errors", {
 # 303. sir_impl
 
 test_that("sir_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8760,7 +8760,7 @@ test_that("sir_impl basic", {
 })
 
 test_that("sir_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(sir_impl(
     graph = NULL,
     beta = 0.1,
@@ -8771,7 +8771,7 @@ test_that("sir_impl errors", {
 # 304. convex_hull_2d_impl
 
 test_that("convex_hull_2d_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(convex_hull_2d_impl(
     data = matrix(1:6, ncol = 2)
   ))
@@ -8784,7 +8784,7 @@ test_that("convex_hull_2d_impl basic", {
 })
 
 test_that("convex_hull_2d_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(convex_hull_2d_impl(
     data = "a"
   ))
@@ -8793,7 +8793,7 @@ test_that("convex_hull_2d_impl errors", {
 # 305. dim_select_impl
 
 test_that("dim_select_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(dim_select_impl(
     sv = c(1, 2, 3)
   ))
@@ -8806,7 +8806,7 @@ test_that("dim_select_impl basic", {
 })
 
 test_that("dim_select_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(dim_select_impl(
     sv = NULL
   ))
@@ -8815,7 +8815,7 @@ test_that("dim_select_impl errors", {
 # 306. solve_lsap_impl
 
 test_that("solve_lsap_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(solve_lsap_impl(
     c = matrix(1:4, ncol = 2),
     n = 2
@@ -8830,7 +8830,7 @@ test_that("solve_lsap_impl basic", {
 })
 
 test_that("solve_lsap_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(solve_lsap_impl(
     c = "a",
     n = 2
@@ -8840,7 +8840,7 @@ test_that("solve_lsap_impl errors", {
 # 307. find_cycle_impl
 
 test_that("find_cycle_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8861,7 +8861,7 @@ test_that("find_cycle_impl basic", {
 })
 
 test_that("find_cycle_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(find_cycle_impl(
     graph = NULL
   ))
@@ -8870,7 +8870,7 @@ test_that("find_cycle_impl errors", {
 # 308. simple_cycles_impl
 
 test_that("simple_cycles_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8893,7 +8893,7 @@ test_that("simple_cycles_impl basic", {
 })
 
 test_that("simple_cycles_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(simple_cycles_impl(
     graph = NULL
   ))
@@ -8902,7 +8902,7 @@ test_that("simple_cycles_impl errors", {
 # 309. is_eulerian_impl
 
 test_that("is_eulerian_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8919,7 +8919,7 @@ test_that("is_eulerian_impl basic", {
 })
 
 test_that("is_eulerian_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_eulerian_impl(
     graph = NULL
   ))
@@ -8928,7 +8928,7 @@ test_that("is_eulerian_impl errors", {
 # 310. eulerian_path_impl
 
 test_that("eulerian_path_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -8945,7 +8945,7 @@ test_that("eulerian_path_impl basic", {
 })
 
 test_that("eulerian_path_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(eulerian_path_impl(
     graph = NULL
   ))
@@ -8954,7 +8954,7 @@ test_that("eulerian_path_impl errors", {
 # 311. eulerian_cycle_impl
 
 test_that("eulerian_cycle_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(
     n = 3
   )
@@ -8978,7 +8978,7 @@ test_that("eulerian_cycle_impl basic", {
 })
 
 test_that("eulerian_cycle_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(eulerian_cycle_impl(
     graph = NULL
   ))
@@ -8987,7 +8987,7 @@ test_that("eulerian_cycle_impl errors", {
 # 312. fundamental_cycles_impl
 
 test_that("fundamental_cycles_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -9012,7 +9012,7 @@ test_that("fundamental_cycles_impl basic", {
 })
 
 test_that("fundamental_cycles_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(fundamental_cycles_impl(
     graph = NULL,
     start = 1
@@ -9022,7 +9022,7 @@ test_that("fundamental_cycles_impl errors", {
 # 313. minimum_cycle_basis_impl
 
 test_that("minimum_cycle_basis_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -9046,7 +9046,7 @@ test_that("minimum_cycle_basis_impl basic", {
 })
 
 test_that("minimum_cycle_basis_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(minimum_cycle_basis_impl(
     graph = NULL
   ))
@@ -9055,7 +9055,7 @@ test_that("minimum_cycle_basis_impl errors", {
 # 314. is_tree_impl
 
 test_that("is_tree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -9077,7 +9077,7 @@ test_that("is_tree_impl basic", {
 })
 
 test_that("is_tree_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_tree_impl(
     graph = NULL
   ))
@@ -9086,7 +9086,7 @@ test_that("is_tree_impl errors", {
 # 315. is_forest_impl
 
 test_that("is_forest_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -9108,7 +9108,7 @@ test_that("is_forest_impl basic", {
 })
 
 test_that("is_forest_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_forest_impl(
     graph = NULL
   ))
@@ -9117,7 +9117,7 @@ test_that("is_forest_impl errors", {
 # 316. from_prufer_impl
 
 test_that("from_prufer_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(from_prufer_impl(
     prufer = 1:2
   ))
@@ -9130,7 +9130,7 @@ test_that("from_prufer_impl basic", {
 })
 
 test_that("from_prufer_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(from_prufer_impl(
     prufer = "a"
   ))
@@ -9139,7 +9139,7 @@ test_that("from_prufer_impl errors", {
 # 317. to_prufer_impl
 
 test_that("to_prufer_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -9156,7 +9156,7 @@ test_that("to_prufer_impl basic", {
 })
 
 test_that("to_prufer_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(to_prufer_impl(
     graph = NULL
   ))
@@ -9165,7 +9165,7 @@ test_that("to_prufer_impl errors", {
 # 318. tree_from_parent_vector_impl
 
 test_that("tree_from_parent_vector_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(tree_from_parent_vector_impl(
     parents = c(-1, 1, 2, 3)
   ))
@@ -9182,7 +9182,7 @@ test_that("tree_from_parent_vector_impl basic", {
 })
 
 test_that("tree_from_parent_vector_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(tree_from_parent_vector_impl(
     parents = "a"
   ))
@@ -9191,7 +9191,7 @@ test_that("tree_from_parent_vector_impl errors", {
 # 319. is_complete_impl
 
 test_that("is_complete_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -9208,7 +9208,7 @@ test_that("is_complete_impl basic", {
 })
 
 test_that("is_complete_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_complete_impl(
     graph = NULL
   ))
@@ -9217,7 +9217,7 @@ test_that("is_complete_impl errors", {
 # 320. random_spanning_tree_impl
 
 test_that("random_spanning_tree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -9236,7 +9236,7 @@ test_that("random_spanning_tree_impl basic", {
 })
 
 test_that("random_spanning_tree_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(random_spanning_tree_impl(
     graph = NULL,
     vid = 1
@@ -9246,7 +9246,7 @@ test_that("random_spanning_tree_impl errors", {
 # 321. tree_game_impl
 
 test_that("tree_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(tree_game_impl(
     n = 3
   ))
@@ -9264,7 +9264,7 @@ test_that("tree_game_impl basic", {
 })
 
 test_that("tree_game_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(tree_game_impl(
     n = "a"
   ))
@@ -9273,7 +9273,7 @@ test_that("tree_game_impl errors", {
 # 322. vertex_coloring_greedy_impl
 
 test_that("vertex_coloring_greedy_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -9294,7 +9294,7 @@ test_that("vertex_coloring_greedy_impl basic", {
 })
 
 test_that("vertex_coloring_greedy_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(vertex_coloring_greedy_impl(
     graph = NULL
   ))
@@ -9303,7 +9303,7 @@ test_that("vertex_coloring_greedy_impl errors", {
 # 323. is_vertex_coloring_impl
 
 test_that("is_vertex_coloring_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- path_graph_impl(
     n = 3
   )
@@ -9322,7 +9322,7 @@ test_that("is_vertex_coloring_impl basic", {
 })
 
 test_that("is_vertex_coloring_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(
     is_vertex_coloring_impl(
       graph = NULL,
@@ -9334,7 +9334,7 @@ test_that("is_vertex_coloring_impl errors", {
 # 324. is_bipartite_coloring_impl
 
 # test_that("is_bipartite_coloring_impl basic", {
-#   withr::local_seed(20250909)
+#   igraph_local_seed(20250909)
 #   oldval <- igraph_opt("print.id")
 # igraph_options(print.id = FALSE)
 #   g <- path_graph_impl(3)
@@ -9344,7 +9344,7 @@ test_that("is_vertex_coloring_impl errors", {
 # 325. is_bipartite_coloring_impl
 
 test_that("is_bipartite_coloring_impl basic", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   g <- path_graph_impl(
     n = 3
   )
@@ -9363,7 +9363,7 @@ test_that("is_bipartite_coloring_impl basic", {
 })
 
 test_that("is_bipartite_coloring_impl errors", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   expect_snapshot_igraph_error(
     is_bipartite_coloring_impl(
       graph = NULL,
@@ -9375,7 +9375,7 @@ test_that("is_bipartite_coloring_impl errors", {
 # 326. is_edge_coloring_impl
 
 test_that("is_edge_coloring_impl basic", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   g <- path_graph_impl(
     n = 3
   )
@@ -9398,7 +9398,7 @@ test_that("is_edge_coloring_impl basic", {
 })
 
 test_that("is_edge_coloring_impl errors", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   expect_snapshot_igraph_error(is_edge_coloring_impl(
     graph = NULL,
     types = c(1, 2)
@@ -9408,7 +9408,7 @@ test_that("is_edge_coloring_impl errors", {
 # 327. deterministic_optimal_imitation_impl
 
 test_that("deterministic_optimal_imitation_impl basic", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   g <- path_graph_impl(
     n = 3
   )
@@ -9439,7 +9439,7 @@ test_that("deterministic_optimal_imitation_impl basic", {
 })
 
 test_that("deterministic_optimal_imitation_impl errors", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   expect_snapshot_igraph_error(
     deterministic_optimal_imitation_impl(
       graph = NULL,
@@ -9453,7 +9453,7 @@ test_that("deterministic_optimal_imitation_impl errors", {
 # 328. moran_process_impl
 
 test_that("moran_process_impl basic", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   g <- path_graph_impl(
     n = 3
   )
@@ -9478,7 +9478,7 @@ test_that("moran_process_impl basic", {
 })
 
 test_that("moran_process_impl errors", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   expect_snapshot_igraph_error(
     moran_process_impl(
       graph = NULL,
@@ -9491,7 +9491,7 @@ test_that("moran_process_impl errors", {
 # 329. roulette_wheel_imitation_impl
 
 test_that("roulette_wheel_imitation_impl basic", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   g <- path_graph_impl(
     n = 3
   )
@@ -9524,7 +9524,7 @@ test_that("roulette_wheel_imitation_impl basic", {
 })
 
 test_that("roulette_wheel_imitation_impl errors", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   expect_snapshot_igraph_error(
     roulette_wheel_imitation_impl(
       graph = NULL,
@@ -9539,7 +9539,7 @@ test_that("roulette_wheel_imitation_impl errors", {
 # 330. stochastic_imitation_impl
 
 test_that("stochastic_imitation_impl basic", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   g <- path_graph_impl(
     n = 3
   )
@@ -9572,7 +9572,7 @@ test_that("stochastic_imitation_impl basic", {
 })
 
 test_that("stochastic_imitation_impl errors", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   expect_snapshot_igraph_error(
     stochastic_imitation_impl(
       graph = NULL,
@@ -9587,7 +9587,7 @@ test_that("stochastic_imitation_impl errors", {
 # 331. invalidate_cache_impl
 
 test_that("invalidate_cache_impl basic", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   g <- path_graph_impl(
     n = 3
   )
@@ -9604,7 +9604,7 @@ test_that("invalidate_cache_impl basic", {
 })
 
 test_that("invalidate_cache_impl errors", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   expect_snapshot_igraph_error(invalidate_cache_impl(
     graph = NULL
   ))
@@ -9613,7 +9613,7 @@ test_that("invalidate_cache_impl errors", {
 # 332. vertex_path_from_edge_path_impl
 
 test_that("vertex_path_from_edge_path_impl basic", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   g <- path_graph_impl(
     n = 3
   )
@@ -9640,7 +9640,7 @@ test_that("vertex_path_from_edge_path_impl basic", {
 })
 
 test_that("vertex_path_from_edge_path_impl errors", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   expect_snapshot_igraph_error(
     vertex_path_from_edge_path_impl(
       graph = NULL,
@@ -9653,7 +9653,7 @@ test_that("vertex_path_from_edge_path_impl errors", {
 # 333. version_impl
 
 test_that("version_impl basic", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   version_impl_clean <- function() {
     v <- version_impl()
 
@@ -9667,7 +9667,7 @@ test_that("version_impl basic", {
 })
 
 test_that("version_impl errors", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   # version_impl() has no parameters, so testing with invalid arguments
   expect_snapshot_igraph_error(version_impl(
     "invalid"
@@ -9677,7 +9677,7 @@ test_that("version_impl errors", {
 # 334. ecount_impl
 
 test_that("ecount_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_empty_graph(5)
   expect_snapshot(ecount_impl(
     graph = g
@@ -9690,7 +9690,7 @@ test_that("ecount_impl basic", {
 })
 
 test_that("ecount_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(ecount_impl(
     graph = NULL
   ))
@@ -9699,7 +9699,7 @@ test_that("ecount_impl errors", {
 # 335. is_directed_impl
 
 test_that("is_directed_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_empty_graph(5, directed = TRUE)
   expect_snapshot(is_directed_impl(
     graph = g
@@ -9712,7 +9712,7 @@ test_that("is_directed_impl basic", {
 })
 
 test_that("is_directed_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(is_directed_impl(
     graph = NULL
   ))
@@ -9721,7 +9721,7 @@ test_that("is_directed_impl errors", {
 # 336. edges_impl
 
 test_that("edges_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_graph(c(1, 2, 2, 3, 3, 4), n = 4, directed = TRUE)
 
   # Get all edges
@@ -9738,7 +9738,7 @@ test_that("edges_impl basic", {
 })
 
 test_that("edges_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(edges_impl(
     graph = NULL,
     eids = 1
@@ -9748,7 +9748,7 @@ test_that("edges_impl errors", {
 # 337. add_vertices_impl
 
 test_that("add_vertices_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_empty_graph(3)
 
   g_new <- add_vertices_impl(
@@ -9759,7 +9759,7 @@ test_that("add_vertices_impl basic", {
 })
 
 test_that("add_vertices_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(add_vertices_impl(
     graph = NULL,
     nv = 1
@@ -9769,7 +9769,7 @@ test_that("add_vertices_impl errors", {
 # 338. delete_edges_impl
 
 test_that("delete_edges_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_graph(c(1, 2, 2, 3, 3, 4), n = 4, directed = TRUE)
 
   g_new <- delete_edges_impl(
@@ -9780,7 +9780,7 @@ test_that("delete_edges_impl basic", {
 })
 
 test_that("delete_edges_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(delete_edges_impl(
     graph = NULL,
     edges = 1
@@ -9790,7 +9790,7 @@ test_that("delete_edges_impl errors", {
 # 339. delete_vertices_impl
 
 test_that("delete_vertices_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_graph(c(1, 2, 2, 3, 3, 4), n = 4, directed = TRUE)
 
   g_new <- delete_vertices_impl(
@@ -9801,7 +9801,7 @@ test_that("delete_vertices_impl basic", {
 })
 
 test_that("delete_vertices_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(delete_vertices_impl(
     graph = NULL,
     vertices = 1
@@ -9811,7 +9811,7 @@ test_that("delete_vertices_impl errors", {
 # 340. incident_impl
 
 test_that("incident_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   local_igraph_options(return.vs_es = FALSE)
   g <- make_graph(c(1, 2, 2, 3, 3, 1), n = 3, directed = TRUE)
 
@@ -9833,7 +9833,7 @@ test_that("incident_impl basic", {
 })
 
 test_that("incident_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(incident_impl(
     graph = NULL,
     vid = 1
@@ -9841,14 +9841,14 @@ test_that("incident_impl errors", {
 })
 
 test_that("famous_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(famous_impl(
     name = "Zachary"
   ))
 })
 
 test_that("famous_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(famous_impl(
     name = "NonexistentGraph"
   ))
@@ -9857,7 +9857,7 @@ test_that("famous_impl errors", {
 # 342. constraint_impl
 
 test_that("constraint_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_graph(c(1, 2, 2, 3, 3, 1), n = 3, directed = FALSE)
   result <- constraint_impl(
     graph = g
@@ -9866,7 +9866,7 @@ test_that("constraint_impl basic", {
 })
 
 test_that("constraint_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(constraint_impl(
     graph = NULL
   ))
@@ -9875,7 +9875,7 @@ test_that("constraint_impl errors", {
 # 343. cocitation_impl
 
 test_that("cocitation_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_graph(c(1, 2, 1, 3, 2, 4, 3, 4), n = 4, directed = TRUE)
   result <- cocitation_impl(
     graph = g
@@ -9884,7 +9884,7 @@ test_that("cocitation_impl basic", {
 })
 
 test_that("cocitation_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(cocitation_impl(
     graph = NULL
   ))
@@ -9893,7 +9893,7 @@ test_that("cocitation_impl errors", {
 # 344. bibcoupling_impl
 
 test_that("bibcoupling_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_graph(c(1, 2, 1, 3, 2, 4, 3, 4), n = 4, directed = TRUE)
   result <- bibcoupling_impl(
     graph = g
@@ -9902,7 +9902,7 @@ test_that("bibcoupling_impl basic", {
 })
 
 test_that("bibcoupling_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(bibcoupling_impl(
     graph = NULL
   ))
@@ -9911,7 +9911,7 @@ test_that("bibcoupling_impl errors", {
 # 345. girth_impl
 
 test_that("girth_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   result <- girth_impl(
     graph = g
@@ -9920,7 +9920,7 @@ test_that("girth_impl basic", {
 })
 
 test_that("girth_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(girth_impl(
     graph = NULL
   ))
@@ -9929,7 +9929,7 @@ test_that("girth_impl errors", {
 # 346. coreness_impl
 
 test_that("coreness_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_graph(c(1, 2, 2, 3, 3, 1, 3, 4), n = 4, directed = FALSE)
   expect_snapshot(coreness_impl(
     graph = g
@@ -9937,7 +9937,7 @@ test_that("coreness_impl basic", {
 })
 
 test_that("coreness_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(coreness_impl(
     graph = NULL
   ))
@@ -9946,7 +9946,7 @@ test_that("coreness_impl errors", {
 # 347. union_impl
 
 test_that("union_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- make_graph(c(1, 2, 2, 3), n = 3)
   g2 <- make_graph(c(1, 3, 3, 4), n = 4)
   expect_snapshot(union_impl(
@@ -9956,7 +9956,7 @@ test_that("union_impl basic", {
 })
 
 test_that("union_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(union_impl(
     left = NULL,
     right = NULL
@@ -9966,7 +9966,7 @@ test_that("union_impl errors", {
 # 348. intersection_impl
 
 test_that("intersection_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- make_graph(c(1, 2, 2, 3, 1, 3), n = 3)
   g2 <- make_graph(c(1, 2, 2, 3), n = 3)
   expect_snapshot(intersection_impl(
@@ -9976,7 +9976,7 @@ test_that("intersection_impl basic", {
 })
 
 test_that("intersection_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot_igraph_error(intersection_impl(
     left = NULL,
     right = NULL
@@ -9989,14 +9989,14 @@ test_that("intersection_impl errors", {
 # Graph constructors
 
 test_that("star_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(star_impl(n = 5, mode = "out", center = 0))
   expect_snapshot(star_impl(n = 6, mode = "in", center = 1))
   expect_snapshot(star_impl(n = 4, mode = "undirected", center = 0))
 })
 
 test_that("ring_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(ring_impl(
     n = 5,
     directed = FALSE,
@@ -10012,13 +10012,13 @@ test_that("ring_impl basic", {
 })
 
 test_that("full_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(full_impl(n = 4, directed = FALSE, loops = FALSE))
   expect_snapshot(full_impl(n = 3, directed = TRUE, loops = FALSE))
 })
 
 test_that("kary_tree_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(kary_tree_impl(
     n = 7,
     children = 2,
@@ -10034,7 +10034,7 @@ test_that("kary_tree_impl basic", {
 # Random graph generators
 
 test_that("barabasi_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(barabasi_game_impl(
     n = 10,
     power = 1,
@@ -10052,7 +10052,7 @@ test_that("barabasi_game_impl basic", {
 })
 
 test_that("growing_random_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(growing_random_game_impl(
     n = 10,
     m = 1,
@@ -10062,12 +10062,12 @@ test_that("growing_random_game_impl basic", {
 })
 
 test_that("grg_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(grg_game_impl(nodes = 10, radius = 0.3, torus = FALSE))
 })
 
 test_that("watts_strogatz_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(watts_strogatz_game_impl(
     dim = 1,
     size = 10,
@@ -10079,7 +10079,7 @@ test_that("watts_strogatz_game_impl basic", {
 # Distance and path functions
 
 test_that("distances_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   expect_snapshot(distances_impl(
     graph = g,
@@ -10090,7 +10090,7 @@ test_that("distances_impl basic", {
 })
 
 test_that("diameter_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(10)
   expect_snapshot(diameter_impl(
     graph = g,
@@ -10100,7 +10100,7 @@ test_that("diameter_impl basic", {
 })
 
 test_that("get_shortest_paths_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   expect_snapshot(get_shortest_paths_impl(
     graph = g,
@@ -10111,7 +10111,7 @@ test_that("get_shortest_paths_impl basic", {
 })
 
 test_that("subcomponent_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_graph(~ A-B-C, D-E-F)
   expect_snapshot(subcomponent_impl(
     graph = g,
@@ -10123,13 +10123,13 @@ test_that("subcomponent_impl basic", {
 # Centrality measures
 
 test_that("betweenness_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_star(5, mode = "undirected")
   expect_snapshot(betweenness_impl(graph = g, vids = V(g), directed = FALSE))
 })
 
 test_that("closeness_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   expect_snapshot(closeness_impl(
     graph = g,
@@ -10139,7 +10139,7 @@ test_that("closeness_impl basic", {
 })
 
 test_that("harmonic_centrality_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_star(5, mode = "undirected")
   expect_snapshot(harmonic_centrality_impl(
     graph = g,
@@ -10149,7 +10149,7 @@ test_that("harmonic_centrality_impl basic", {
 })
 
 test_that("pagerank_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5, directed = TRUE)
   expect_snapshot(pagerank_impl(
     graph = g,
@@ -10160,7 +10160,7 @@ test_that("pagerank_impl basic", {
 })
 
 test_that("hub_score_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_star(5, mode = "undirected")
   out <- hub_score_impl(graph = g, scale = TRUE, weights = NULL)
   # FIXME: out$vector unstable despite random seed
@@ -10171,7 +10171,7 @@ test_that("hub_score_impl basic", {
 })
 
 test_that("authority_score_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_star(5, mode = "undirected")
   out <- authority_score_impl(graph = g, scale = TRUE, weights = NULL)
   # FIXME: out$vector unstable despite random seed
@@ -10184,25 +10184,25 @@ test_that("authority_score_impl basic", {
 # Community detection
 
 test_that("community_walktrap_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_graph(~ A-B-C-A, D-E-F-D, A-D)
   expect_snapshot(community_walktrap_impl(graph = g, steps = 4))
 })
 
 test_that("community_fastgreedy_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_graph(~ A-B-C-A, D-E-F-D, A-D)
   expect_snapshot(community_fastgreedy_impl(graph = g))
 })
 
 test_that("community_edge_betweenness_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_graph(~ A-B-C-A, D-E-F-D, A-D)
   expect_snapshot(community_edge_betweenness_impl(graph = g, directed = FALSE))
 })
 
 test_that("community_leading_eigenvector_callback_closure_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   # Test with a simple graph
   g <- make_graph("Zachary")
@@ -10232,7 +10232,7 @@ test_that("community_leading_eigenvector_callback_closure_impl basic", {
 })
 
 test_that("community_leading_eigenvector_callback_closure_impl with start", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g <- make_graph("Zachary")
   # Create initial membership (0-based for the impl function)
@@ -10257,7 +10257,7 @@ test_that("community_leading_eigenvector_callback_closure_impl with start", {
 })
 
 test_that("community_leading_eigenvector_callback_closure_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g <- make_graph("Zachary")
 
@@ -10273,13 +10273,13 @@ test_that("community_leading_eigenvector_callback_closure_impl errors", {
 # Connectivity
 
 test_that("edge_connectivity_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   expect_snapshot(edge_connectivity_impl(graph = g))
 })
 
 test_that("vertex_connectivity_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   expect_snapshot(vertex_connectivity_impl(graph = g))
 })
@@ -10287,7 +10287,7 @@ test_that("vertex_connectivity_impl basic", {
 # Layout functions
 
 test_that("layout_sphere_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   expect_snapshot(layout_sphere_impl(graph = g))
 })
@@ -10295,7 +10295,7 @@ test_that("layout_sphere_impl basic", {
 # Bipartite functions
 
 test_that("create_bipartite_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(create_bipartite_impl(
     types = c(FALSE, FALSE, TRUE, TRUE),
     edges = c(0, 2, 0, 3, 1, 2, 1, 3),
@@ -10304,7 +10304,7 @@ test_that("create_bipartite_impl basic", {
 })
 
 test_that("bipartite_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(bipartite_game_impl(
     type = "gnp",
     n1 = 5,
@@ -10324,13 +10324,13 @@ test_that("bipartite_game_impl basic", {
 # Other structural functions
 
 test_that("decompose_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_graph(~ A-B-C, D-E)
   expect_snapshot(decompose_impl(graph = g, mode = c("weak", "strong")))
 })
 
 test_that("neighborhood_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   expect_snapshot(neighborhood_impl(
     graph = g,
@@ -10341,7 +10341,7 @@ test_that("neighborhood_impl basic", {
 })
 
 test_that("neighborhood_size_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   expect_snapshot(neighborhood_size_impl(
     graph = g,
@@ -10354,7 +10354,7 @@ test_that("neighborhood_size_impl basic", {
 # Graph properties
 
 test_that("is_chordal_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   # Test with a chordal graph (complete graph is chordal)
   g <- make_full_graph(4)
   # alpha and alpham1 parameters must be provided as vectors matching vertex count
@@ -10379,7 +10379,7 @@ test_that("is_chordal_impl basic", {
 })
 
 test_that("get_adjacency_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(3)
   expect_snapshot(get_adjacency_impl(
     graph = g,
@@ -10390,7 +10390,7 @@ test_that("get_adjacency_impl basic", {
 # IO functions
 
 test_that("write_graph_edgelist_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(3)
   tmp <- tempfile()
   write_graph_edgelist_impl(graph = g, outstream = tmp)
@@ -10400,7 +10400,7 @@ test_that("write_graph_edgelist_impl basic", {
 })
 
 test_that("read_graph_edgelist_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   tmp <- tempfile()
   writeLines(c("0 1", "1 2", "2 0"), tmp)
   expect_snapshot(read_graph_edgelist_impl(
@@ -10414,7 +10414,7 @@ test_that("read_graph_edgelist_impl basic", {
 # Utility functions
 
 test_that("compare_communities_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   comm1 <- c(1, 1, 2, 2, 3, 3)
   comm2 <- c(1, 1, 2, 2, 2, 3)
   expect_snapshot(compare_communities_impl(
@@ -10427,7 +10427,7 @@ test_that("compare_communities_impl basic", {
 # Additional game functions
 
 test_that("degree_sequence_game_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   expect_snapshot(degree_sequence_game_impl(
     out_deg = c(2, 2, 2, 2),
     method = "configuration"
@@ -10439,7 +10439,7 @@ test_that("degree_sequence_game_impl basic", {
 })
 
 test_that("connect_neighborhood_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   expect_snapshot_igraph(connect_neighborhood_impl(
     graph = g,
@@ -10451,7 +10451,7 @@ test_that("connect_neighborhood_impl basic", {
 # Additional distance functions
 
 test_that("eccentricity_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   expect_snapshot(eccentricity_impl(
     graph = g,
@@ -10461,19 +10461,19 @@ test_that("eccentricity_impl basic", {
 })
 
 test_that("radius_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   expect_snapshot(radius_impl(graph = g, mode = c("out", "in", "all")))
 })
 
 test_that("graph_center_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_star(5, mode = "undirected")
   expect_snapshot(graph_center_impl(graph = g, mode = c("out", "in", "all")))
 })
 
 test_that("voronoi_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(10)
   expect_snapshot(voronoi_impl(
     graph = g,
@@ -10485,7 +10485,7 @@ test_that("voronoi_impl basic", {
 # Spanner
 
 test_that("spanner_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   expect_snapshot(spanner_impl(graph = g, stretch = 2))
 })
@@ -10493,7 +10493,7 @@ test_that("spanner_impl basic", {
 # Additional centrality
 
 test_that("edge_betweenness_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_star(5, mode = "undirected")
   expect_snapshot(edge_betweenness_impl(graph = g, directed = FALSE))
 })
@@ -10501,13 +10501,13 @@ test_that("edge_betweenness_impl basic", {
 # Maximal cliques
 
 test_that("maximal_cliques_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_full_graph(4)
   expect_snapshot(maximal_cliques_impl(graph = g, min_size = 1, max_size = 0))
 })
 
 test_that("independent_vertex_sets_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- make_ring(5)
   expect_snapshot(independent_vertex_sets_impl(
     graph = g,
@@ -10521,7 +10521,7 @@ test_that("independent_vertex_sets_impl basic", {
 # bfs_closure_impl
 
 test_that("bfs_closure_impl works", {
-  withr::local_seed(20250125)
+  igraph_local_seed(20250125)
 
   g <- make_ring(10)
 
@@ -10594,7 +10594,7 @@ test_that("bfs_closure_impl works", {
 # dfs_closure_impl
 
 test_that("dfs_closure_impl works", {
-  withr::local_seed(20250125)
+  igraph_local_seed(20250125)
 
   g <- make_ring(10)
 
@@ -10635,7 +10635,7 @@ test_that("dfs_closure_impl works", {
 # motifs_randesu_callback_closure_impl
 
 test_that("motifs_randesu_callback_closure_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g <- make_graph(~ A - B - C - A)
 
@@ -10672,7 +10672,7 @@ test_that("motifs_randesu_callback_closure_impl basic", {
 })
 
 test_that("motifs_randesu_callback_closure_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g <- make_graph(~ A - B - C)
 
@@ -10690,7 +10690,7 @@ test_that("motifs_randesu_callback_closure_impl errors", {
 # cliques_callback_closure_impl
 
 test_that("cliques_callback_closure_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g <- make_full_graph(4)
 
@@ -10723,7 +10723,7 @@ test_that("cliques_callback_closure_impl basic", {
 })
 
 test_that("cliques_callback_closure_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g <- make_full_graph(4)
 
@@ -10741,7 +10741,7 @@ test_that("cliques_callback_closure_impl errors", {
 # maximal_cliques_callback_closure_impl
 
 test_that("maximal_cliques_callback_closure_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g <- sample_gnp(10, 0.3)
 
@@ -10777,7 +10777,7 @@ test_that("maximal_cliques_callback_closure_impl basic", {
 })
 
 test_that("maximal_cliques_callback_closure_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g <- make_full_graph(4)
 
@@ -10795,7 +10795,7 @@ test_that("maximal_cliques_callback_closure_impl errors", {
 # simple_cycles_callback_closure_impl
 
 test_that("simple_cycles_callback_closure_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g <- make_ring(4, directed = TRUE)
 
@@ -10832,7 +10832,7 @@ test_that("simple_cycles_callback_closure_impl basic", {
 })
 
 test_that("simple_cycles_callback_closure_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g <- make_ring(4, directed = TRUE)
 
@@ -10851,7 +10851,7 @@ test_that("simple_cycles_callback_closure_impl errors", {
 # get_isomorphisms_vf2_callback_closure_impl
 
 test_that("get_isomorphisms_vf2_callback_closure_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g1 <- make_ring(5)
   g2 <- make_ring(5)
@@ -10895,7 +10895,7 @@ test_that("get_isomorphisms_vf2_callback_closure_impl basic", {
 })
 
 test_that("get_isomorphisms_vf2_callback_closure_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g1 <- make_ring(5)
   g2 <- make_ring(5)
@@ -10917,7 +10917,7 @@ test_that("get_isomorphisms_vf2_callback_closure_impl errors", {
 # get_subisomorphisms_vf2_callback_closure_impl
 
 test_that("get_subisomorphisms_vf2_callback_closure_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g1 <- make_full_graph(5)
   g2 <- make_ring(3) # triangle
@@ -10961,7 +10961,7 @@ test_that("get_subisomorphisms_vf2_callback_closure_impl basic", {
 })
 
 test_that("get_subisomorphisms_vf2_callback_closure_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   g1 <- make_ring(3)
   g2 <- make_full_graph(5)
@@ -10984,7 +10984,7 @@ test_that("get_subisomorphisms_vf2_callback_closure_impl errors", {
 
 test_that("sparse_adjacency_impl basic", {
   skip_if_not_installed("Matrix")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   # Create a simple sparse matrix
   M <- Matrix::sparseMatrix(
@@ -11028,7 +11028,7 @@ test_that("sparse_adjacency_impl basic", {
 test_that("sparse_adjacency_impl errors", {
   skip_if_not_installed("Matrix")
   skip_if_not(getRversion() >= "4.2")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   # Regular matrices are converted to sparse matrices automatically
   # This should work, not error
@@ -11040,7 +11040,7 @@ test_that("sparse_adjacency_impl errors", {
 
 test_that("sparse_weighted_adjacency_impl basic", {
   skip_if_not_installed("Matrix")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   # Create a weighted sparse matrix
   M <- Matrix::sparseMatrix(
@@ -11080,7 +11080,7 @@ test_that("sparse_weighted_adjacency_impl basic", {
 test_that("sparse_weighted_adjacency_impl errors", {
   skip_if_not_installed("Matrix")
   skip_if_not(getRversion() >= "4.2")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   # Regular matrices are converted to sparse matrices automatically
   # This should work, not error
@@ -11093,7 +11093,7 @@ test_that("sparse_weighted_adjacency_impl errors", {
 
 test_that("weighted_sparsemat_impl basic", {
   skip_if_not_installed("Matrix")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   # Create a weighted sparse matrix
   M <- Matrix::sparseMatrix(
@@ -11127,7 +11127,7 @@ test_that("weighted_sparsemat_impl basic", {
 test_that("weighted_sparsemat_impl errors", {
   skip_if_not_installed("Matrix")
   skip_if_not(getRversion() >= "4.2")
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   # Regular matrices are converted to sparse matrices automatically
   # This should work, not error
@@ -11143,7 +11143,7 @@ test_that("weighted_sparsemat_impl errors", {
 # Tests for newly autogenerated *_many functions
 
 test_that("disjoint_union_many_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- empty_impl(n = 2)
   g2 <- empty_impl(n = 3)
   g3 <- empty_impl(n = 1)
@@ -11161,7 +11161,7 @@ test_that("disjoint_union_many_impl basic", {
 })
 
 test_that("union_many_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- empty_impl(n = 3)
   g2 <- add_edges_impl(g1, c(0, 1, 1, 2) + 1)
   g3 <- add_edges_impl(g1, c(0, 2) + 1)
@@ -11179,7 +11179,7 @@ test_that("union_many_impl basic", {
 })
 
 test_that("intersection_many_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- add_edges_impl(empty_impl(n = 3), c(0, 1, 1, 2, 0, 2) + 1)
   g2 <- add_edges_impl(empty_impl(n = 3), c(0, 1, 1, 2) + 1)
   g3 <- add_edges_impl(empty_impl(n = 3), c(0, 1) + 1)
@@ -11197,7 +11197,7 @@ test_that("intersection_many_impl basic", {
 })
 
 test_that("layout_merge_dla_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g1 <- path_graph_impl(n = 3)
   g2 <- path_graph_impl(n = 3)
   coords1 <- matrix(c(0, 0, 1, 0, 2, 0), ncol = 2, byrow = TRUE)
@@ -11220,7 +11220,7 @@ test_that("layout_merge_dla_impl basic", {
 
 # get_eid_impl
 test_that("get_eid_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- add_edges_impl(empty_impl(n = 5), c(0, 1, 1, 2, 2, 3, 3, 4) + 1)
 
   expect_snapshot(get_eid_impl(
@@ -11255,7 +11255,7 @@ test_that("get_eid_impl basic", {
 })
 
 test_that("get_eid_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- add_edges_impl(empty_impl(n = 3), c(0, 1, 1, 2) + 1)
 
   expect_snapshot_igraph_error(get_eid_impl(
@@ -11280,7 +11280,7 @@ test_that("get_eid_impl errors", {
 
 # community_voronoi_impl
 test_that("community_voronoi_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- add_edges_impl(
     empty_impl(n = 10),
     c(0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9) + 1
@@ -11302,7 +11302,7 @@ test_that("community_voronoi_impl basic", {
 })
 
 test_that("community_voronoi_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   expect_snapshot_igraph_error(community_voronoi_impl(
     graph = NULL
@@ -11311,7 +11311,7 @@ test_that("community_voronoi_impl errors", {
 
 # subisomorphic_lad_impl
 test_that("subisomorphic_lad_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   # FIXME: Add functionality tests once we understand the expected behavior
   # The function requires complex setup with pattern/target graphs and domains
@@ -11324,7 +11324,7 @@ test_that("subisomorphic_lad_impl basic", {
 })
 
 test_that("subisomorphic_lad_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   g <- add_edges_impl(empty_impl(n = 3), c(0, 1, 1, 2) + 1)
 
   expect_snapshot_igraph_error(subisomorphic_lad_impl(
@@ -11347,7 +11347,7 @@ test_that("subisomorphic_lad_impl errors", {
 
 # eigen_matrix_impl
 test_that("eigen_matrix_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   # FIXME: Add functionality tests once we understand the expected behavior
   # The function requires complex matrix setup and understanding of eigenvalue computation
@@ -11360,7 +11360,7 @@ test_that("eigen_matrix_impl basic", {
 })
 
 test_that("eigen_matrix_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   # Test with invalid matrix dimensions
   expect_error(eigen_matrix_impl(
@@ -11375,7 +11375,7 @@ test_that("eigen_matrix_impl errors", {
 
 # eigen_matrix_symmetric_impl
 test_that("eigen_matrix_symmetric_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   # FIXME: Add functionality tests once we understand the expected behavior
   # The function requires complex matrix setup and understanding of eigenvalue computation
@@ -11388,7 +11388,7 @@ test_that("eigen_matrix_symmetric_impl basic", {
 })
 
 test_that("eigen_matrix_symmetric_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
 
   # Test with invalid matrix dimensions
   expect_error(eigen_matrix_symmetric_impl(

--- a/tests/testthat/test-adjacency.R
+++ b/tests/testthat/test-adjacency.R
@@ -891,7 +891,7 @@ test_that("graph_from_adjacency_matrix handles add.colnames and add.rownames = F
 })
 
 test_that("graph_from_adjacency Na check for upper/lower", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   x <- matrix(runif(100), ncol=10, nrow=10)
   x[lower.tri(x)] <- NA
   expect_no_error(

--- a/tests/testthat/test-adjacency.R
+++ b/tests/testthat/test-adjacency.R
@@ -891,6 +891,7 @@ test_that("graph_from_adjacency_matrix handles add.colnames and add.rownames = F
 })
 
 test_that("graph_from_adjacency Na check for upper/lower", {
+  withr::local_seed(42)
   x <- matrix(runif(100), ncol=10, nrow=10)
   x[lower.tri(x)] <- NA
   expect_no_error(

--- a/tests/testthat/test-assortativity.R
+++ b/tests/testthat/test-assortativity.R
@@ -56,7 +56,7 @@ test_that("nominal assortativity works", {
 })
 
 test_that("nominal assortativity works with character types", {
-  set.seed(2)
+  withr::local_seed(2)
   g <- sample_gnm(10, 20)
 
   # Test with numeric types

--- a/tests/testthat/test-assortativity.R
+++ b/tests/testthat/test-assortativity.R
@@ -56,7 +56,7 @@ test_that("nominal assortativity works", {
 })
 
 test_that("nominal assortativity works with character types", {
-  withr::local_seed(2)
+  igraph_local_seed(2)
   g <- sample_gnm(10, 20)
 
   # Test with numeric types

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -284,7 +284,7 @@ test_that("assert_named_list() works", {
 })
 
 test_that("is_bipartite works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   biadj_mat1 <- matrix(
     sample(0:1, 35, replace = TRUE, prob = c(3, 1)),
     ncol = 5
@@ -351,14 +351,14 @@ test_that("handle_vertex_type_arg validates and converts the type attribute", {
 })
 
 test_that("without_attr", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g_stripped <- sample_gnp(10, 2 / 10) %>%
     delete_graph_attr("name") %>%
     delete_graph_attr("type") %>%
     delete_graph_attr("loops") %>%
     delete_graph_attr("p")
 
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g_no_attr <- sample_(gnp(10, 2 / 10), without_attr())
 
   expect_identical_graphs(g_stripped, g_no_attr)
@@ -553,7 +553,7 @@ test_that("good error message when not using character", {
 })
 
 test_that("set_vertex_attrs() works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- make_ring(10)
   g <- set_vertex_attrs(g, color = "blue", size = 10, name = LETTERS[1:10])
   expect_equal(V(g)$color, rep("blue", vcount(g)))

--- a/tests/testthat/test-attributes.R
+++ b/tests/testthat/test-attributes.R
@@ -284,6 +284,7 @@ test_that("assert_named_list() works", {
 })
 
 test_that("is_bipartite works", {
+  withr::local_seed(42)
   biadj_mat1 <- matrix(
     sample(0:1, 35, replace = TRUE, prob = c(3, 1)),
     ncol = 5
@@ -291,7 +292,6 @@ test_that("is_bipartite works", {
   g1 <- graph_from_biadjacency_matrix(biadj_mat1)
   expect_true(bipartite_mapping(g1)$res)
 
-  withr::local_seed(42)
   biadj_mat2 <- matrix(
     sample(0:1, 35, replace = TRUE, prob = c(3, 1)),
     ncol = 5
@@ -553,6 +553,7 @@ test_that("good error message when not using character", {
 })
 
 test_that("set_vertex_attrs() works", {
+  withr::local_seed(42)
   g <- make_ring(10)
   g <- set_vertex_attrs(g, color = "blue", size = 10, name = LETTERS[1:10])
   expect_equal(V(g)$color, rep("blue", vcount(g)))

--- a/tests/testthat/test-bipartite.R
+++ b/tests/testthat/test-bipartite.R
@@ -1,6 +1,5 @@
 test_that("bipartite_projection works", {
-  local_rng_version("3.5.0")
-  withr::local_seed(42)
+  igraph_local_seed(42, rng_version = "3.5.0")
 
   g <- make_full_bipartite_graph(10, 5)
   proj <- bipartite_projection(g)

--- a/tests/testthat/test-bipartite.R
+++ b/tests/testthat/test-bipartite.R
@@ -41,7 +41,7 @@ test_that("bipartite_projection works", {
 })
 
 test_that("bipartite_projection can calculate only one projection", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g <- sample_bipartite_gnp(5, 10, p = 0.3)
   proj <- bipartite_projection(g)

--- a/tests/testthat/test-centrality.R
+++ b/tests/testthat/test-centrality.R
@@ -21,7 +21,7 @@ test_that("subgraph_centrality() works", {
 })
 
 test_that("subgraph_centrality() ignored edge directions", {
-  withr::local_seed(137)
+  igraph_local_seed(137)
   g <- sample_gnm(10, 20, directed = TRUE)
   expect_equal(
     subgraph_centrality((g)),
@@ -146,7 +146,7 @@ test_that("`hub_score()` works", {
 test_that("authority_score survives stress test", {
   skip_on_cran()
 
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   expect_principal <- function(M, lambda) {
     expect_equal(eigen(M)$values[1], lambda)
@@ -761,7 +761,7 @@ test_that("undirected alpha_centrality() works, #653", {
 })
 
 test_that("spectrum() works for symmetric matrices", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   std <- function(x) {
     x <- zapsmall(x)

--- a/tests/testthat/test-centrality.R
+++ b/tests/testthat/test-centrality.R
@@ -30,6 +30,7 @@ test_that("subgraph_centrality() ignored edge directions", {
 })
 
 test_that("`authority_score()` works", {
+  igraph_local_seed(42)
   rlang::local_options(lifecycle_verbosity = "quiet")
   mscale <- function(x) {
     if (sd(x) != 0) {
@@ -86,6 +87,7 @@ test_that("`authority_score()` works", {
 })
 
 test_that("`hub_score()` works", {
+  igraph_local_seed(42)
   rlang::local_options(lifecycle_verbosity = "quiet")
   mscale <- function(x) {
     if (sd(x) != 0) {
@@ -172,6 +174,7 @@ test_that("authority_score survives stress test", {
 })
 
 test_that("`hits_score()` works -- authority", {
+  igraph_local_seed(42)
   mscale <- function(x) {
     if (sd(x) != 0) {
       x <- scale(x)
@@ -220,6 +223,7 @@ test_that("`hits_score()` works -- authority", {
 })
 
 test_that("`hits_scores()` works -- hub", {
+  igraph_local_seed(42)
   mscale <- function(x) {
     if (sd(x) != 0) {
       x <- scale(x)
@@ -366,6 +370,7 @@ test_that("betweenness() -- shortest paths are compared with tolerance when calc
 })
 
 test_that("edge_betweenness() works", {
+  igraph_local_seed(42)
   kite <- graph_from_literal(
     Andre - Beverly:Carol:Diane:Fernando,
     Beverly - Andre:Diane:Ed:Garth,
@@ -550,6 +555,7 @@ test_that("power_centrality() works", {
 })
 
 test_that("eigen_centrality() works", {
+  igraph_local_seed(42)
   kite <- graph_from_literal(
     Andre - Beverly:Carol:Diane:Fernando,
     Beverly - Andre:Diane:Ed:Garth,
@@ -631,6 +637,7 @@ test_that("sparse alpha_centrality() works", {
 ## weighted version
 
 test_that("weighted dense alpha_centrality() works", {
+  igraph_local_seed(42)
   star <- make_star(10)
   E(star)$weight <- sample(ecount(star))
 
@@ -645,6 +652,7 @@ test_that("weighted dense alpha_centrality() works", {
 })
 
 test_that("weighted sparse alpha_centrality() works", {
+  igraph_local_seed(42)
   star <- make_star(10)
   E(star)$weight <- sample(ecount(star))
 
@@ -659,6 +667,7 @@ test_that("weighted sparse alpha_centrality() works", {
 })
 
 test_that("alpha_centrality() works with custom weight attribute names", {
+  igraph_local_seed(42)
   star <- make_star(10)
   E(star)$myweight <- sample(ecount(star))
 
@@ -675,6 +684,7 @@ test_that("alpha_centrality() works with custom weight attribute names", {
 })
 
 test_that("alpha_centrality() accepts a numeric weights vector", {
+  igraph_local_seed(42)
   star <- make_star(10)
   w <- sample(ecount(star))
   E(star)$weight <- w
@@ -689,6 +699,7 @@ test_that("alpha_centrality() accepts a numeric weights vector", {
 })
 
 test_that("alpha_centrality() does not mutate the input graph", {
+  igraph_local_seed(42)
   star <- make_star(10)
   w <- sample(ecount(star))
   alpha_centrality(star, weights = w, sparse = FALSE)
@@ -785,6 +796,7 @@ test_that("spectrum() works for symmetric matrices", {
 })
 
 test_that("arpack lifecycle warning", {
+  igraph_local_seed(42)
   rlang::local_options(lifecycle_verbosity = "warning")
 
   f <- function(x, extra = NULL) x
@@ -799,12 +811,14 @@ test_that("arpack lifecycle warning", {
 })
 
 test_that("arpack works for identity matrix", {
+  igraph_local_seed(42)
   f <- function(x, extra = NULL) x
   res <- arpack(f, options = list(n = 10, nev = 2, ncv = 4), sym = TRUE)
   expect_equal(res$values, c(1, 1))
 })
 
 test_that("arpack works on the Laplacian of a star", {
+  igraph_local_seed(42)
   f <- function(x, extra = NULL) {
     y <- x
     y[1] <- (length(x) - 1) * x[1] - sum(x[-1])
@@ -832,6 +846,7 @@ test_that("arpack works on the Laplacian of a star", {
 # Complex case
 
 test_that("arpack works for non-symmetric matrices", {
+  igraph_local_seed(42)
   A <- structure(
     c(
       -6, -6, 7, 6, 1, -9, -3, 2, -9, -7, 0, 1, -7, 8,
@@ -896,6 +911,7 @@ test_that("arpack works for non-symmetric matrices", {
 # TODO: further tests for typically hard cases
 
 test_that("eigen_centrality() deprecated scale argument", {
+  igraph_local_seed(42)
   g <- make_ring(10, directed = FALSE)
   expect_snapshot({
     invisible(eigen_centrality(g, scale = TRUE))

--- a/tests/testthat/test-centralization.R
+++ b/tests/testthat/test-centralization.R
@@ -21,6 +21,9 @@ test_that("centr_clo works", {
 
 
 test_that("centr_eigen works", {
+  # centr_eigen() runs the ARPACK eigensolver, which draws from the RNG to seed
+  # its starting vector; pin the seed so the global RNG state isn't disturbed.
+  igraph_local_seed(42)
   g <- make_star(2, "undirected")
   g_centr <- centr_eigen(g, normalized = FALSE)
   g_centr_tmax <- centr_eigen_tmax(g)

--- a/tests/testthat/test-cliques.R
+++ b/tests/testthat/test-cliques.R
@@ -1,5 +1,5 @@
 test_that("cliques() works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   is_clique <- function(graph, vids) {
     s <- induced_subgraph(graph, vids)
@@ -71,7 +71,7 @@ test_that("weighted_cliques works", {
 })
 
 test_that("max_cliques() work", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   gnp <- sample_gnm(1000, 1000)
   full10 <- make_full_graph(10)
   for (i in 1:10) {
@@ -198,7 +198,7 @@ test_that("max_cliques() work", {
 })
 
 test_that("max_cliques() work for subsets", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   gnp <- sample_gnp(100, 0.5)
 
   mysort <- function(x) {
@@ -218,7 +218,7 @@ test_that("max_cliques() work for subsets", {
 })
 
 test_that("count_max_cliques works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   gnp <- sample_gnp(100, 0.5)
 
   cl1 <- count_max_cliques(gnp, min = 8)
@@ -307,7 +307,7 @@ test_that("largest_cliques works", {
 })
 
 test_that("is_clique works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g <- make_full_graph(5)
   expect_true(is_clique(g, V(g)))
@@ -319,7 +319,7 @@ test_that("is_clique works", {
 })
 
 test_that("is_ivs works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g <- make_full_bipartite_graph(5, 5)
   expect_true(is_ivs(g, V(g)[V(g)$type]))
@@ -346,7 +346,7 @@ test_that("is_complete works", {
 
 # Tests for callback functions
 test_that("cliques_callback works", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
 
   g <- sample_gnp(20, 0.3)
 
@@ -366,7 +366,7 @@ test_that("cliques_callback works", {
 })
 
 test_that("cliques_callback can stop early", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
 
   g <- sample_gnp(20, 0.3)
 
@@ -410,7 +410,7 @@ test_that("cliques_callback handles errors in callback", {
 })
 
 test_that("max_cliques works with callback", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
 
   g <- sample_gnp(15, 0.3)
 
@@ -429,7 +429,7 @@ test_that("max_cliques works with callback", {
 })
 
 test_that("max_cliques can stop early with callback", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
 
   g <- sample_gnp(15, 0.3)
 

--- a/tests/testthat/test-cliques.R
+++ b/tests/testthat/test-cliques.R
@@ -231,6 +231,7 @@ test_that("count_max_cliques works", {
 })
 
 test_that("ivs() works", {
+  igraph_local_seed(42)
   gnp <- sample_gnp(50, 0.8)
   ivs <- ivs(gnp, min = ivs_size(gnp))
   edges_iv <- sapply(seq_along(ivs), function(x) {
@@ -240,6 +241,7 @@ test_that("ivs() works", {
 })
 
 test_that("ivs() works, cliques of complement", {
+  igraph_local_seed(42)
   # 2385298846 https://github.com/igraph/rigraph/pull/1541#issuecomment-2385298846
   # that the independent vertex sets of G are
   # the same as the cliques of the complement of G (and vice versa)
@@ -278,6 +280,7 @@ test_that("largest_cliques() works", {
 })
 
 test_that("largest_ivs() works", {
+  igraph_local_seed(42)
   g <- sample_gnp(50, 0.8)
   livs <- largest_ivs(g)
   expect_equal(
@@ -294,6 +297,7 @@ test_that("largest_ivs() works", {
 })
 
 test_that("largest_cliques works", {
+  igraph_local_seed(42)
   g <- sample_gnp(50, 20 / 50)
   lc <- largest_cliques(g)
   expect_length(cliques(g, min = length(lc[[1]]) + 1), 0)

--- a/tests/testthat/test-community.R
+++ b/tests/testthat/test-community.R
@@ -307,6 +307,7 @@ test_that("cluster_leading_eigen is deterministic", {
 })
 
 test_that("cut_at works with cluster_leading_eigen partial dendrograms", {
+  igraph_local_seed(42)
   g <- make_full_graph(5) %du% make_full_graph(5) %du% make_full_graph(5)
   g <- add_edges(g, c(1, 6, 1, 11, 6, 11))
   lec <- cluster_leading_eigen(g)
@@ -363,6 +364,7 @@ test_that("cut_at works with cluster_leading_eigen partial dendrograms", {
 })
 
 test_that("cut_at handles cluster_leading_eigen with no merges", {
+  igraph_local_seed(42)
   # Single-community result: nrow(merges) == 0, so no cuts are possible
   lec <- cluster_leading_eigen(make_full_graph(5))
   expect_equal(max(membership(lec)), 1L)
@@ -377,6 +379,7 @@ test_that("cut_at handles cluster_leading_eigen with no merges", {
 })
 
 test_that("cut_at handles cluster_leading_eigen with deeper dendrograms", {
+  igraph_local_seed(42)
   # Ring of 6 cliques: leading eigen finds 6 communities with 5 merges,
   # exercising more than the trivial 3->2->1 chain.
   g <- Reduce(`%du%`, replicate(6, make_full_graph(4), simplify = FALSE))
@@ -534,8 +537,7 @@ test_that("cluster_optimal works", {
 
 test_that("weighted cluster_optimal works", {
   skip_if_no_glpk()
-  local_rng_version("3.5.0")
-  withr::local_seed(42)
+  igraph_local_seed(42, rng_version = "3.5.0")
 
   graph_full_ring <- make_full_graph(5) + make_ring(5)
   E(graph_full_ring)$weight <- sample(
@@ -637,8 +639,7 @@ test_that("voronoi works with weights", {
 })
 
 test_that("contract works", {
-  local_rng_version("3.5.0")
-  withr::local_seed(42)
+  igraph_local_seed(42, rng_version = "3.5.0")
 
   g <- make_ring(10)
   g$name <- "Ring"
@@ -662,6 +663,7 @@ test_that("contract works", {
 })
 
 test_that("modularity() handles NA weights correctly", {
+  igraph_local_seed(42)
   # Create a simple graph for testing
   g <- make_graph("Zachary")
 

--- a/tests/testthat/test-community.R
+++ b/tests/testthat/test-community.R
@@ -1,5 +1,5 @@
 test_that("community detection functions work", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   cluster_algos <- list(
     "cluster_edge_betweenness",
@@ -69,7 +69,7 @@ test_that("community detection functions work", {
 })
 
 test_that("creating communities objects works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   karate <- make_graph("Zachary")
 
@@ -159,7 +159,7 @@ test_that("cluster_edge_betweenness works", {
 })
 
 test_that("cluster_fast_greedy works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   karate <- make_graph("Zachary")
   karate_fc <- cluster_fast_greedy(karate)
@@ -192,7 +192,7 @@ test_that("cluster_fast_greedy works", {
 
 test_that("label.propagation.community works", {
   karate <- make_graph("Zachary")
-  withr::local_seed(20231029)
+  igraph_local_seed(20231029)
   karate_lpc <- cluster_label_prop(karate)
   expect_equal(karate_lpc$modularity, modularity(karate, karate_lpc$membership))
 
@@ -207,7 +207,7 @@ test_that("label.propagation.community works", {
 })
 
 test_that("cluster_leading_eigen works", {
-  withr::local_seed(20230115)
+  igraph_local_seed(20230115)
 
   check_eigen_value <- function(
     membership,
@@ -293,7 +293,7 @@ test_that("cluster_leading_eigen is deterministic", {
 
   skip_if(getRversion() < "3.6")
 
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   for (i in 1:100) {
     g_rand <- sample_gnm(20, sample(5:40, 1))
@@ -403,7 +403,7 @@ test_that("cut_at handles cluster_leading_eigen with deeper dendrograms", {
 })
 
 test_that("cluster_leiden works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   karate <- make_graph("Zachary")
   karate_leiden <- cluster_leiden(karate, resolution = 0.06)
@@ -482,7 +482,7 @@ test_that("modularity_matrix no longer accepts a membership argument for compati
 })
 
 test_that("cluster_louvain works", {
-  withr::local_seed(20231029)
+  igraph_local_seed(20231029)
 
   karate <- make_graph("Zachary")
   karate_mc <- cluster_louvain(karate)
@@ -551,7 +551,7 @@ test_that("weighted cluster_optimal works", {
 })
 
 test_that("cluster_walktrap works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   karate <- make_graph("Zachary")
   karate_walktrap <- cluster_walktrap(karate)

--- a/tests/testthat/test-components.R
+++ b/tests/testthat/test-components.R
@@ -40,6 +40,7 @@ test_that("is_connected returns FALSE for the null graph", {
 })
 
 test_that("decompose works", {
+  igraph_local_seed(42)
   gnp <- sample_gnp(1000, 1 / 1500)
   gnp_decomposed <- decompose(gnp)
   gnp_comps <- components(gnp)

--- a/tests/testthat/test-components.R
+++ b/tests/testthat/test-components.R
@@ -1,5 +1,5 @@
 test_that("components works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   random_largest_component <- function(n) {
     largest_component(sample_gnp(n, 1 / n))

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -662,7 +662,7 @@ test_that("graph_from_adj_list works", {
 })
 
 test_that("graph_from_edgelist works", {
-  withr::local_seed(20230115)
+  igraph_local_seed(20230115)
 
   g <- sample_gnp(50, 5 / 50)
   el <- as_edgelist(g)

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -1,4 +1,5 @@
 test_that("as_directed works", {
+  igraph_local_seed(42)
   gnp_undirected <- sample_gnp(100, 2 / 100)
   gnp_mutual <- as_directed(gnp_undirected, mode = "mutual")
   expect_equal(degree(gnp_undirected), degree(gnp_mutual) / 2)
@@ -45,11 +46,13 @@ test_that("as_directed keeps attributes", {
 })
 
 test_that("as.directed() deprecation", {
+  igraph_local_seed(42)
   g <- sample_gnp(100, 2 / 100)
   expect_snapshot(is_directed(as.directed(g, mode = "mutual")))
 })
 
 test_that("as.undirected() deprecation", {
+  igraph_local_seed(42)
   g <- sample_gnp(100, 2 / 100)
   expect_snapshot(is_directed(as.undirected(g, mode = "collapse")))
 })
@@ -453,6 +456,7 @@ test_that("as_biadjacency_matrix() wires up legacy `attr` recovery", {
 })
 
 test_that("as_adj works", {
+  igraph_local_seed(42)
   g <- sample_gnp(50, 1 / 50)
   A <- as_adjacency_matrix(g, sparse = FALSE)
   g2 <- graph_from_adjacency_matrix(A, mode = "undirected")
@@ -473,6 +477,7 @@ test_that("as_adj works", {
 })
 
 test_that("as_adj_list works", {
+  igraph_local_seed(42)
   g <- sample_gnp(50, 2 / 50)
   adj_list <- as_adj_list(g)
   expect_s3_class(adj_list[[1]], "igraph.vs")
@@ -535,6 +540,7 @@ test_that("as_adj_list works", {
 })
 
 test_that("as_adj_list works when return.vs.es is FALSE", {
+  igraph_local_seed(42)
   on.exit(try(igraph_options(old)), add = TRUE)
   old <- igraph_options(return.vs.es = FALSE)
 
@@ -599,6 +605,7 @@ test_that("as_adj_list works when return.vs.es is FALSE", {
 })
 
 test_that("as_edgelist works", {
+  igraph_local_seed(42)
   g <- sample_gnp(100, 3 / 100)
   el <- as_edgelist(g)
   g2 <- make_graph(t(el), n = vcount(g), dir = FALSE)
@@ -606,6 +613,7 @@ test_that("as_edgelist works", {
 })
 
 test_that("as_biadjacency_matrix() works -- dense", {
+  igraph_local_seed(42)
   biadj_mat <- matrix(sample(0:1, 35, replace = TRUE, prob = c(3, 1)), ncol = 5)
   g <- graph_from_biadjacency_matrix(biadj_mat)
   biadj_mat2 <- as_biadjacency_matrix(g)
@@ -615,6 +623,7 @@ test_that("as_biadjacency_matrix() works -- dense", {
 })
 
 test_that("as_biadjacency_matrix() works -- dense named", {
+  igraph_local_seed(42)
   biadj_mat <- matrix(sample(0:1, 35, replace = TRUE, prob = c(3, 1)), ncol = 5)
   g <- graph_from_biadjacency_matrix(biadj_mat)
   V(g)$name <- letters[seq_along(V(g))]
@@ -628,6 +637,7 @@ test_that("as_biadjacency_matrix() works -- dense named", {
 })
 
 test_that("as_biadjacency_matrix() works -- sparse", {
+  igraph_local_seed(42)
   biadj_mat <- matrix(sample(0:1, 35, replace = TRUE, prob = c(3, 1)), ncol = 5)
   g <- graph_from_biadjacency_matrix(biadj_mat)
   biadj_mat2 <- as_biadjacency_matrix(g, sparse = TRUE)
@@ -637,6 +647,7 @@ test_that("as_biadjacency_matrix() works -- sparse", {
 })
 
 test_that("graph_from_adj_list works", {
+  igraph_local_seed(42)
   g <- sample_gnp(100, 3 / 100)
   adj_list <- as_adj_list(g)
   g2 <- graph_from_adj_list(adj_list, mode = "all")

--- a/tests/testthat/test-cycles.R
+++ b/tests/testthat/test-cycles.R
@@ -46,7 +46,7 @@ test_that("simple_cycle() works undirected", {
 
 # Tests for callback function
 test_that("simple_cycles_callback works", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
 
   g <- graph_from_literal(A -+ B -+ C -+ A -+ D -+ E +- F -+ A)
 
@@ -65,7 +65,7 @@ test_that("simple_cycles_callback works", {
 })
 
 test_that("simple_cycles_callback can stop early", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
 
   g <- graph_from_literal(A -+ B -+ C -+ A -+ D -+ E -+ D)
 

--- a/tests/testthat/test-degseq.R
+++ b/tests/testthat/test-degseq.R
@@ -1,4 +1,5 @@
 test_that("realize_degseq works", {
+  igraph_local_seed(42)
   g <- largest_component(sample_gnp(1000, 2 / 1000))
 
   nG <- realize_degseq(degree(g))

--- a/tests/testthat/test-embedding.R
+++ b/tests/testthat/test-embedding.R
@@ -1,7 +1,7 @@
 # Helper functions used here live in helper-test-functions.R.
 
 test_that("embed_adjacency_matrix -- Undirected, unweighted case works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- sample_gnm(10, 15, directed = FALSE)
 
   no <- 7
@@ -87,7 +87,7 @@ test_that("embed_adjacency_matrix -- Undirected, unweighted case works", {
 })
 
 test_that("embed_adjacency_matrix -- Undirected, weighted case works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- sample_gnm(10, 20, directed = FALSE)
   E(g)$weight <- sample(1:5, ecount(g), replace = TRUE)
 
@@ -172,7 +172,7 @@ test_that("embed_adjacency_matrix -- Undirected, weighted case works", {
 })
 
 test_that("embed_adjacency_matrix -- Directed, unweighted case works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- sample_gnm(10, 20, directed = TRUE)
 
   no <- 3
@@ -272,7 +272,7 @@ test_that("embed_adjacency_matrix -- Directed, unweighted case works", {
 })
 
 test_that("embed_adjacency_matrix -- Directed, weighted case works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- sample_gnm(10, 20, directed = TRUE)
   E(g)$weight <- sample(1:5, ecount(g), replace = TRUE)
 
@@ -367,7 +367,7 @@ test_that("embed_adjacency_matrix -- Directed, weighted case works", {
 })
 
 test_that("embed_adjacency_matrix -- Issue #50 is resolved", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
 
   g <- sample_gnp(15, 0.4)
   w <- -log(runif(ecount(g)))
@@ -380,7 +380,7 @@ test_that("embed_adjacency_matrix -- Issue #50 is resolved", {
 })
 
 test_that("embed_adjacency_matrix -- Issue #51 is resolved", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
 
   pref.matrix <- diag(0.2, 2) + 0.2
   block.sizes <- c(800, 800)
@@ -394,7 +394,7 @@ test_that("embed_adjacency_matrix -- Issue #51 is resolved", {
 })
 
 test_that("embed_laplacian_matrix -- Undirected, unweighted, D-A case works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- sample_gnm(10, 20, directed = FALSE)
 
   no <- 3
@@ -493,7 +493,7 @@ test_that("embed_laplacian_matrix -- Undirected, unweighted, D-A case works", {
 })
 
 test_that("embed_laplacian_matrix -- Undirected, unweighted, DAD case works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- sample_gnm(10, 20, directed = FALSE)
 
   no <- 3
@@ -592,7 +592,7 @@ test_that("embed_laplacian_matrix -- Undirected, unweighted, DAD case works", {
 })
 
 test_that("embed_laplacian_matrix -- Undirected, unweighted, I-DAD case works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- sample_gnm(10, 20, directed = FALSE)
 
   no <- 3
@@ -691,7 +691,7 @@ test_that("embed_laplacian_matrix -- Undirected, unweighted, I-DAD case works", 
 })
 
 test_that("embed_laplacian_matrix -- Undirected, weighted, D-A case works", {
-  withr::local_seed(42 * 42)
+  igraph_local_seed(42 * 42)
   g <- sample_gnm(10, 20, directed = FALSE)
   E(g)$weight <- sample(1:5, ecount(g), replace = TRUE)
 
@@ -788,7 +788,7 @@ test_that("embed_laplacian_matrix -- Undirected, weighted, D-A case works", {
 })
 
 test_that("embed_laplacian_matrix -- Undirected, unweighted, DAD case works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g <- sample_gnm(10, 20, directed = FALSE)
 
@@ -888,7 +888,7 @@ test_that("embed_laplacian_matrix -- Undirected, unweighted, DAD case works", {
 })
 
 test_that("embed_laplacian_matrix -- Undirected, unweighted, I-DAD case works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g <- sample_gnm(10, 20, directed = FALSE)
 
@@ -988,7 +988,7 @@ test_that("embed_laplacian_matrix -- Undirected, unweighted, I-DAD case works", 
 })
 
 test_that("embed_laplacian_matrix -- Directed, unweighted, OAP case works", {
-  withr::local_seed(42 * 42)
+  igraph_local_seed(42 * 42)
 
   g <- sample_gnm(10, 30, directed = TRUE)
 
@@ -1109,7 +1109,7 @@ test_that("embed_laplacian_matrix -- Directed, unweighted, OAP case works", {
 })
 
 test_that("embed_laplacian_matrix -- Directed, weighted case works", {
-  withr::local_seed(42 * 42)
+  igraph_local_seed(42 * 42)
 
   g <- sample_gnm(10, 30, directed = TRUE)
   E(g)$weight <- sample(1:5, ecount(g), replace = TRUE)
@@ -1230,7 +1230,7 @@ test_that("embed_laplacian_matrix -- Directed, weighted case works", {
 })
 
 test_that("Sampling from a Dirichlet distribution works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   samp <- sample_dirichlet(10000, alpha = c(1, 1, 1))
   expect_equal(dim(samp), c(3, 10000))
   expect_equal(colSums(samp), rep(1, 10000))
@@ -1257,7 +1257,7 @@ test_that("Sampling from a Dirichlet distribution works", {
 })
 
 test_that("Sampling sphere surface works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   s1 <- sample_sphere_surface(4, 100, positive = FALSE)
   expect_equal(colSums(s1^2), rep(1, 100))
 
@@ -1270,7 +1270,7 @@ test_that("Sampling sphere surface works", {
 })
 
 test_that("Sampling sphere volume works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   s1 <- sample_sphere_volume(4, 10000, positive = FALSE)
   expect_true(all(colSums(s1^2) < 1))
 
@@ -1283,7 +1283,7 @@ test_that("Sampling sphere volume works", {
 })
 
 test_that("dimensionality selection works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   karate <- make_graph("zachary")
   ev <- eigen(as_adjacency_matrix(karate), only.values = TRUE)$values

--- a/tests/testthat/test-embedding.R
+++ b/tests/testthat/test-embedding.R
@@ -1,21 +1,4 @@
-standardize_eigen_signs <- function(x) {
-  x <- zapsmall(x)
-  apply(x, 2, function(col) {
-    if (any(col < 0) && col[which(col != 0)[1]] < 0) {
-      -col
-    } else {
-      col
-    }
-  })
-}
-
-order_by_magnitude <- function(x) {
-  order(abs(x), sign(x), decreasing = TRUE)
-}
-
-sort_by_magnitude <- function(x) {
-  x[order_by_magnitude(x)]
-}
+# Helper functions used here live in helper-test-functions.R.
 
 test_that("embed_adjacency_matrix -- Undirected, unweighted case works", {
   withr::local_seed(42)

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -1,4 +1,5 @@
 test_that("fit_power_law() works", {
+  igraph_local_seed(42)
   # g <- sample_pa(100) # increase this number to have a better estimate
   # d <- degree(g, mode = "in")
   d <- c(

--- a/tests/testthat/test-games.R
+++ b/tests/testthat/test-games.R
@@ -1,5 +1,5 @@
 test_that("sample_degseq() works -- 'configuration' generator", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   degrees <- rep(2, 100)
   undirected_graph <- sample_degseq(degrees, method = "configuration")
   expect_equal(degree(undirected_graph), degrees)
@@ -10,7 +10,7 @@ test_that("sample_degseq() works -- 'configuration' generator", {
 })
 
 test_that("sample_degseq() works -- sample_gnp()", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   erdos_renyi <- sample_gnp(1000, 1 / 1000)
   new_graph <- sample_degseq(degree(erdos_renyi), method = "configuration")
   expect_equal(degree(new_graph), degree(erdos_renyi))
@@ -32,7 +32,7 @@ test_that("sample_degseq() works -- sample_gnp()", {
 })
 
 test_that("sample_degseq() works -- 'configuration' generator, connected", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   original_graph <- largest_component(sample_gnp(1000, 2 / 1000))
 
   simple_graph <- sample_degseq(
@@ -48,7 +48,7 @@ test_that("sample_degseq() works -- 'configuration' generator, connected", {
 })
 
 test_that("sample_degseq() works -- vl generator", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   degrees <- rep(2, 100)
   vl_graph <- sample_degseq(degrees, method = "vl")
   expect_equal(degree(vl_graph), degrees)
@@ -56,7 +56,7 @@ test_that("sample_degseq() works -- vl generator", {
 })
 
 test_that("sample_degseq() works -- exponential degree ok", {
-  withr::local_seed(1)
+  igraph_local_seed(1)
   exponential_degrees <- sample(
     1:100,
     100,
@@ -68,7 +68,7 @@ test_that("sample_degseq() works -- exponential degree ok", {
 })
 
 test_that("sample_degseq() works -- exponential degree error", {
-  withr::local_seed(11)
+  igraph_local_seed(11)
   exponential_degrees <- sample(
     1:100,
     100,
@@ -81,14 +81,14 @@ test_that("sample_degseq() works -- exponential degree error", {
 })
 
 test_that("sample_degseq() works -- Power-law degree ok", {
-  withr::local_seed(3)
+  igraph_local_seed(3)
   powerlaw_degrees <- sample(1:100, 100, replace = TRUE, prob = (1:100)^-2)
   powerlaw_vl_graph <- sample_degseq(powerlaw_degrees, method = "vl")
   expect_equal(degree(powerlaw_vl_graph), powerlaw_degrees)
 })
 
 test_that("sample_degseq() works -- Power-law degree error", {
-  withr::local_seed(7)
+  igraph_local_seed(7)
   powerlaw_degrees <- sample(1:100, 100, replace = TRUE, prob = (1:100)^-2)
 
   expect_snapshot_igraph_error({
@@ -97,7 +97,7 @@ test_that("sample_degseq() works -- Power-law degree error", {
 })
 
 test_that("sample_degseq() works -- fast.heur.simple", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- sample_gnp(1000, 1 / 1000)
 
   simple_nm_graph <- sample_degseq(
@@ -110,7 +110,7 @@ test_that("sample_degseq() works -- fast.heur.simple", {
 })
 
 test_that("sample_degseq() works -- configuration.simple", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- sample_gnp(1000, 1 / 1000)
   simple_nmu_graph <- sample_degseq(
     degree(g, mode = "out"),
@@ -122,7 +122,7 @@ test_that("sample_degseq() works -- configuration.simple", {
 })
 
 test_that("sample_degseq() works -- edge.switching.simple directed", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- sample_gnp(1000, 1 / 1000, directed = TRUE)
   simple_switch_graph <- sample_degseq(
     degree(g, mode = "out"),
@@ -137,7 +137,7 @@ test_that("sample_degseq() works -- edge.switching.simple directed", {
 })
 
 test_that("sample_degseq() works -- edge.switching.simple undirected", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- sample_gnp(1000, 1 / 1000, directed = FALSE)
   simple_switch_graph <- sample_degseq(
     degree(g, mode = "all"),
@@ -150,7 +150,7 @@ test_that("sample_degseq() works -- edge.switching.simple undirected", {
 })
 
 test_that("sample_degseq supports the sample_(...) syntax", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   degs <- rep(4, 20)
   g1 <- sample_(degseq(degs))
   g2 <- sample_(degseq(degs))
@@ -181,7 +181,7 @@ test_that("sample_degseq works() -- old method names", {
 })
 
 test_that("sample_chung_lu works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   chung_lu_small <- sample_chung_lu(c(3, 3, 2, 2, 1, 1))
   expect_false(any_multiple(chung_lu_small))
 
@@ -208,7 +208,7 @@ test_that("sample_chung_lu works", {
 })
 
 test_that("sample_forestfire() works -- sparse", {
-  withr::local_seed(20231029)
+  igraph_local_seed(20231029)
   N <- 5000
   xv <- log(2:N)
 
@@ -219,7 +219,7 @@ test_that("sample_forestfire() works -- sparse", {
 })
 
 test_that("sample_forestfire() works -- densifying", {
-  withr::local_seed(20231029)
+  igraph_local_seed(20231029)
 
   N <- 5000
   xv <- log(2:N)
@@ -231,7 +231,7 @@ test_that("sample_forestfire() works -- densifying", {
 })
 
 test_that("sample_forestfire() works -- dense", {
-  withr::local_seed(20231029)
+  igraph_local_seed(20231029)
 
   N <- 5000
   xv <- log(2:N)
@@ -243,7 +243,7 @@ test_that("sample_forestfire() works -- dense", {
 })
 
 test_that("Generating stochastic block models works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   pm <- matrix(1, nrow = 2, ncol = 2)
   bs <- c(4, 6)
   sbm_small <- sample_sbm(
@@ -296,7 +296,7 @@ test_that("Generating stochastic block models works", {
 })
 
 test_that("sample_smallworld works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   for (i in 1:50) {
     p <- runif(1)
     d <- sample(1:3, 1)
@@ -307,7 +307,7 @@ test_that("sample_smallworld works", {
 })
 
 test_that("sample_pa() works", {
-  withr::local_seed(20240209)
+  igraph_local_seed(20240209)
 
   g_pa <- sample_pa(100, m = 2)
   expect_ecount(g_pa, 197)
@@ -332,7 +332,7 @@ test_that("sample_pa() works", {
 })
 
 test_that("sample_pa can start from a graph", {
-  withr::local_seed(20231029)
+  igraph_local_seed(20231029)
 
   g_pa1 <- sample_pa(
     10,
@@ -394,7 +394,7 @@ test_that("sample_pa can start from a graph", {
 })
 
 test_that("sample_bipartite works -- undirected gnp", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g_rand_bip <- sample_bipartite_gnp(10, 5, p = 0.1)
   expect_equal(g_rand_bip$name, "Bipartite Gnp random graph")
@@ -405,7 +405,7 @@ test_that("sample_bipartite works -- undirected gnp", {
 })
 
 test_that("sample_bipartite works -- directed gnp", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g_rand_bip_dir <- sample_bipartite_gnp(10, 5, p = 0.1, directed = TRUE)
   expect_vcount(g_rand_bip_dir, 15)
@@ -425,7 +425,7 @@ test_that("sample_bipartite works -- directed gnp", {
 })
 
 test_that("sample_bipartite works -- undirected gnm", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g_rand_bip_gnm <- sample_bipartite_gnm(10, 5, m = 8)
   expect_vcount(g_rand_bip_gnm, 15)
   expect_ecount(g_rand_bip_gnm, 8)
@@ -433,7 +433,7 @@ test_that("sample_bipartite works -- undirected gnm", {
   expect_false(is_directed(g_rand_bip_gnm))
 })
 test_that("sample_bipartite works -- directed gnm", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g_rand_bip_gnm_dir <- sample_bipartite_gnm(10, 5, m = 8, directed = TRUE)
   expect_vcount(g_rand_bip_gnm_dir, 15)
   expect_ecount(g_rand_bip_gnm_dir, 8)
@@ -475,7 +475,7 @@ test_that("sample_bipartite works -- directed gnm", {
 
 
 test_that("sample_correlated_gnp works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   gnp_graph <- sample_gnp(10, 0.1)
   cor_gnp_graph_1 <- sample_correlated_gnp(
@@ -505,7 +505,7 @@ test_that("sample_correlated_gnp works", {
 
 
 test_that("sample_correlated_gnp works even for non-ER graphs", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   grg_graph <- sample_grg(100, 0.2)
   cor_gnp_graph_1 <- sample_correlated_gnp(grg_graph, corr = 1)
@@ -517,7 +517,7 @@ test_that("sample_correlated_gnp works even for non-ER graphs", {
 })
 
 test_that("sample_correlated_gnp_pair works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   cor_gnp_pair <- sample_correlated_gnp_pair(
     10,
@@ -531,7 +531,7 @@ test_that("sample_correlated_gnp_pair works", {
 ## Some corner cases
 
 test_that("sample_correlated_gnp corner cases work", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   is_full <- function(g) {
     g_full <- make_full_graph(vcount(g), directed = is_directed(g))
@@ -572,7 +572,7 @@ test_that("sample_correlated_gnp corner cases work", {
 })
 
 test_that("permutation works for sample_correlated_gnp", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   gnp_graph <- sample_gnp(10, 0.3)
   perm <- sample(vcount(gnp_graph))
@@ -597,7 +597,7 @@ test_that("permutation works for sample_correlated_gnp", {
 })
 
 test_that("HSBM works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   C <- matrix(c(
     1, 1 / 2, 0,
@@ -616,7 +616,7 @@ test_that("HSBM works", {
   expect_vcount(g_hsbm1, 100)
   expect_false(is_directed(g_hsbm1))
 
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g_hsbm2 <- sample_hierarchical_sbm(
     100,
@@ -629,7 +629,7 @@ test_that("HSBM works", {
   expect_vcount(g_hsbm2, 100)
   expect_true(is_simple(g_hsbm2))
 
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g_hsbm3 <- sample_hierarchical_sbm(
     100,
@@ -642,7 +642,7 @@ test_that("HSBM works", {
   expect_vcount(g_hsbm3, 100)
   expect_true(is_simple(g_hsbm3))
 
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g_hsbm4 <- sample_hierarchical_sbm(
     100,
@@ -673,7 +673,7 @@ test_that("HSBM with list arguments works", {
   vertices_per_block <- 10
   rho <- c(3, 3, 4) / 10
 
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g_hsbm1 <- sample_hierarchical_sbm(
     blocks * vertices_per_block,
     vertices_per_block,
@@ -682,7 +682,7 @@ test_that("HSBM with list arguments works", {
     p = 0
   )
 
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g_hsbm2 <- sample_hierarchical_sbm(
     blocks * vertices_per_block,
     rep(vertices_per_block, blocks),
@@ -692,7 +692,7 @@ test_that("HSBM with list arguments works", {
   )
   expect_equal(g_hsbm1[], g_hsbm2[])
 
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g_hsbm3 <- sample_hierarchical_sbm(
     blocks * vertices_per_block,
     vertices_per_block,
@@ -702,7 +702,7 @@ test_that("HSBM with list arguments works", {
   )
   expect_equal(g_hsbm1[], g_hsbm3[])
 
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g_hsbm4 <- sample_hierarchical_sbm(
     blocks * vertices_per_block,
     vertices_per_block,
@@ -745,7 +745,7 @@ test_that("HSBM with list arguments works", {
   )
   expect_true(is_simple(g_hsbm5))
 
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g_hsbm6 <- sample_hierarchical_sbm(
     21,
     m = c(3, 10, 5, 3),
@@ -783,7 +783,7 @@ test_that("HSBM with list arguments works", {
 })
 
 test_that("Dot product rng works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   vecs <- cbind(
     c(0, 1, 1, 1, 0) / 3,
     c(0, 1, 1, 0, 1) / 3,
@@ -811,7 +811,7 @@ test_that("Dot product rng works", {
 })
 
 test_that("sample_dot_product generates edges with correct probabilities", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   latent_features <- cbind(
     c(0, 1, 1, 1, 0) / 3,
     c(0, 1, 1, 0, 1) / 3,
@@ -835,7 +835,7 @@ test_that("sample_dot_product generates edges with correct probabilities", {
 })
 
 test_that("Dot product rng gives warnings", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   vecs <- cbind(c(1, 1, 1) / 3, -c(1, 1, 1) / 3)
   expect_warning(
     g <- sample_dot_product(vecs),

--- a/tests/testthat/test-glet.R
+++ b/tests/testthat/test-glet.R
@@ -1,8 +1,4 @@
-sortgl <- function(x) {
-  cl <- lapply(x$cliques, sort)
-  n <- lengths(cl)
-  list(cliques = cl[order(n)], thresholds = x$thresholds[order(n)])
-}
+# Helper functions used here live in helper-test-functions.R.
 
 test_that("Graphlets work for some simple graphs", {
   full <- make_full_graph(5)
@@ -49,43 +45,6 @@ test_that("Graphlets filtering works", {
   expect_equal(glet$thresholds, c(8, 5))
 })
 
-threshold.net <- function(graph, level) {
-  N <- vcount(graph)
-  graph.t <- delete_edges(graph, which(E(graph)$weight < level))
-
-  clqt <- unvs(max_cliques(graph.t))
-  clqt <- lapply(clqt, sort)
-  clqt[order(lengths(clqt), decreasing = TRUE)]
-}
-
-graphlets.old <- function(graph) {
-  if (!is_weighted(graph)) {
-    cli::cli_abort("Graph not weighted")
-  }
-  if (min(E(graph)$weight) <= 0 || !all(is.finite(E(graph)$weight))) {
-    cli::cli_abort("Edge weights must be non-negative and finite")
-  }
-
-  ## Do all thresholds
-  cl <- lapply(sort(unique(E(graph)$weight)), function(w) {
-    threshold.net(graph, w)
-  })
-
-  ## Put the cliques in one long list
-  clv <- unlist(cl, recursive = FALSE)
-
-  ## Sort the vertices within the cliques
-  cls <- lapply(clv, sort)
-
-  ## Delete duplicate cliques
-  clu <- unique(cls)
-
-  ## Delete cliques that consist of single vertices
-  clf <- clu[lengths(clu) != 1]
-
-  clf
-}
-
 test_that("Graphlets work for a bigger graph", {
   withr::local_seed(42)
   g <- make_graph("zachary")
@@ -99,72 +58,6 @@ test_that("Graphlets work for a bigger graph", {
 
   expect_equal(glo, gl2o)
 })
-
-graphlets.project.old <- function(graph, cliques, iter, Mu = NULL) {
-  if (!is_weighted(graph)) {
-    cli::cli_abort("Graph not weighted")
-  }
-  if (min(E(graph)$weight) <= 0 || !all(is.finite(E(graph)$weight))) {
-    cli::cli_abort("Edge weights must be non-negative and finite")
-  }
-  if (
-    length(iter) != 1 ||
-      !is.numeric(iter) ||
-      !is.finite(iter) ||
-      iter != as.integer(iter)
-  ) {
-    cli::cli_abort("`iter' must be a non-negative finite integer scalar")
-  }
-
-  clf <- cliques
-
-  ## Create vertex-clique list first
-  vcl <- vector(length = vcount(graph), mode = "list")
-  for (i in seq_along(clf)) {
-    for (j in clf[[i]]) {
-      vcl[[j]] <- c(vcl[[j]], i)
-    }
-  }
-
-  ## Create edge-clique list from this, it is useful to have the edge list
-  ## of the graph at hand
-  el <- as_edgelist(graph, names = FALSE)
-  ecl <- vector(length = ecount(graph), mode = "list")
-  for (i in 1:ecount(graph)) {
-    edge <- el[i, ]
-    ecl[[i]] <- intersect(vcl[[edge[1]]], vcl[[edge[2]]])
-  }
-
-  ## We will also need a clique-edge list, the edges in the cliques
-  system.time({
-    cel <- vector(length = length(clf), mode = "list")
-    for (i in seq_along(ecl)) {
-      for (j in ecl[[i]]) {
-        cel[[j]] <- c(cel[[j]], i)
-      }
-    }
-  })
-
-  ## OK, we are ready to do the projection now
-  if (is.null(Mu)) {
-    Mu <- rep(1, length(clf))
-  }
-  origw <- E(graph)$weight
-  w <- numeric(length(ecl))
-  a <- sapply(clf, function(x) length(x) * (length(x) + 1) / 2)
-  for (i in 1:iter) {
-    for (j in seq_along(ecl)) {
-      w[j] <- sum(Mu[ecl[[j]]])
-    }
-    for (j in seq_along(clf)) {
-      Mu[j] <- Mu[j] * sum(origw[cel[[j]]] / (w[cel[[j]]] + 0.0001)) / a[j]
-    }
-  }
-
-  ## Sort the cliques according to their weights
-  Smb <- sort(Mu, decreasing = TRUE, index.return = TRUE)
-  list(cliques = clf[Smb$ix], Mu = Mu[Smb$ix])
-}
 
 test_that("Graphlet projection works", {
   D1 <- matrix(0, 5, 5)

--- a/tests/testthat/test-glet.R
+++ b/tests/testthat/test-glet.R
@@ -46,7 +46,7 @@ test_that("Graphlets filtering works", {
 })
 
 test_that("Graphlets work for a bigger graph", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- make_graph("zachary")
   E(g)$weight <- sample(1:5, ecount(g), replace = TRUE)
 

--- a/tests/testthat/test-hrg.R
+++ b/tests/testthat/test-hrg.R
@@ -1,5 +1,5 @@
 test_that("Starting from state works (#225)", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g <- sample_gnp(10, p = 1 / 2) + sample_gnp(10, p = 1 / 2)
   hrg <- fit_hrg(g)
@@ -8,7 +8,7 @@ test_that("Starting from state works (#225)", {
 })
 
 test_that("as.hclust.igraphHRG() works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g <- make_graph("zachary")
   hrg <- fit_hrg(g)
@@ -31,7 +31,7 @@ test_that("hrg_tree() checks its argument", {
 })
 
 test_that("print.igrapHRG() works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   small_g <- sample_gnp(10, p = 1 / 2) + sample_gnp(10, p = 1 / 2)
   small_g <- fit_hrg(small_g)

--- a/tests/testthat/test-incidence.R
+++ b/tests/testthat/test-incidence.R
@@ -1,5 +1,5 @@
 test_that("graph_from_biadjacency_matrix() works -- dense", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   inc <- matrix(sample(0:1, 15, repl = TRUE), 3, 5)
   colnames(inc) <- letters[1:5]
@@ -16,7 +16,7 @@ test_that("graph_from_biadjacency_matrix() works -- dense", {
 
 
 test_that("graph_from_biadjacency_matrix() works -- dense + multiple", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   inc <- matrix(sample(0:2, 15, repl = TRUE), 3, 5)
   colnames(inc) <- letters[1:5]
@@ -28,7 +28,7 @@ test_that("graph_from_biadjacency_matrix() works -- dense + multiple", {
 
 
 test_that("graph_from_biadjacency_matrix() works - dense, modes", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   inc <- matrix(sample(0:1, 15, repl = TRUE), 3, 5)
   colnames(inc) <- letters[1:5]
@@ -54,7 +54,7 @@ test_that("graph_from_biadjacency_matrix() works - dense, modes", {
 })
 
 test_that("graph_from_biadjacency_matrix() works - dense, modes, weighted", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   inc <- matrix(sample(0:2, 15, repl = TRUE), 3, 5)
   colnames(inc) <- letters[1:5]
@@ -106,7 +106,7 @@ test_that("graph_from_biadjacency_matrix() works - dense, modes, weighted", {
 })
 
 test_that("graph_from_biadjacency_matrix() works -- sparse", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   inc <- matrix(sample(0:1, 15, repl = TRUE), 3, 5)
   inc <- Matrix::Matrix(inc, sparse = TRUE)
@@ -123,7 +123,7 @@ test_that("graph_from_biadjacency_matrix() works -- sparse", {
 })
 
 test_that("graph_from_biadjacency_matrix() works -- sparse + multiple", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   inc <- matrix(sample(0:2, 15, repl = TRUE), 3, 5)
   inc <- Matrix::Matrix(inc, sparse = TRUE)
@@ -135,7 +135,7 @@ test_that("graph_from_biadjacency_matrix() works -- sparse + multiple", {
 })
 
 test_that("graph_from_biadjacency_matrix() works - sparse, modes", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   inc <- matrix(sample(0:1, 15, repl = TRUE), 3, 5)
   inc <- Matrix::Matrix(inc, sparse = TRUE)
@@ -162,7 +162,7 @@ test_that("graph_from_biadjacency_matrix() works - sparse, modes", {
 })
 
 test_that("graph_from_biadjacency_matrix() works - sparse, modes, weighted", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   inc <- matrix(sample(0:2, 15, repl = TRUE), 3, 5)
   inc <- Matrix::Matrix(inc, sparse = TRUE)

--- a/tests/testthat/test-incidence.R
+++ b/tests/testthat/test-incidence.R
@@ -204,6 +204,7 @@ test_that("graph_from_biadjacency_matrix() works - sparse, modes, weighted", {
 })
 
 test_that("graph_from_biadjacency_matrix() errors well", {
+  igraph_local_seed(42)
   inc <- matrix(sample(0:1, 15, repl = TRUE), 3, 5)
   colnames(inc) <- letters[1:5]
   rownames(inc) <- LETTERS[1:3]

--- a/tests/testthat/test-interface.R
+++ b/tests/testthat/test-interface.R
@@ -76,6 +76,7 @@ test_that("delete_vertices works", {
 })
 
 test_that("neighbors works", {
+  igraph_local_seed(42)
   g <- sample_gnp(100, 20 / 100)
   al <- as_adj_list(g, mode = "all")
   expect_s3_class(neighbors(g, v = 1, mode = "out"), "igraph.vs")
@@ -104,6 +105,7 @@ test_that("neighbors prints an error for an empty input vector", {
 
 
 test_that("adjacent_vertices works", {
+  igraph_local_seed(42)
   g <- sample_gnp(100, 20 / 100)
   al <- as_adj_list(g, mode = "all")
   test_vertices <- c(1, 7, 38, 75, 99)
@@ -128,6 +130,7 @@ test_that("adjacent_vertices works", {
 
 
 test_that("incident_edges works", {
+  igraph_local_seed(42)
   g <- sample_gnp(100, 20 / 100)
   el <- as_adj_edge_list(g, mode = "all")
   test_vertices <- c(1, 7, 38, 75, 99)
@@ -172,6 +175,7 @@ test_that("delete_edges works", {
 })
 
 test_that("ends works", {
+  igraph_local_seed(42)
   g <- sample_gnp(100, 3 / 100)
   edges <- unlist(lapply(seq_len(ecount(g)), ends, graph = g))
   g2 <- make_graph(edges, dir = FALSE, n = vcount(g))

--- a/tests/testthat/test-iterators.R
+++ b/tests/testthat/test-iterators.R
@@ -187,6 +187,7 @@ test_that("identical_graphs works", {
 })
 
 test_that("identical_graphs considers attributes", {
+  igraph_local_seed(42)
   g <- sample_pa(10)
   g2 <- g
 

--- a/tests/testthat/test-iterators.R
+++ b/tests/testthat/test-iterators.R
@@ -5,7 +5,7 @@ test_that("iterators work", {
   expect_equal(sort(E(ring)[weight < 4]$weight), 1:3)
   expect_equal(V(ring)[c("A", "C")]$name, c("A", "C"))
 
-  withr::with_seed(42, {
+  igraph_with_seed(42, {
     g_pa <- sample_pa(100, power = 0.3)
   })
 

--- a/tests/testthat/test-layout.R
+++ b/tests/testthat/test-layout.R
@@ -1,13 +1,13 @@
 test_that("layout_with_fr() works", {
   skip_on_os("solaris")
 
-  withr::with_seed(42, {
+  igraph_with_seed(42, {
     g <- make_ring(10)
     l <- layout_with_fr(g, niter = 50, start.temp = sqrt(10) / 10)
   })
   expect_equal(sum(l), 4.57228, tolerance = 0.1)
 
-  withr::with_seed(42, {
+  igraph_with_seed(42, {
     g <- make_star(30)
     l <- layout_with_fr(g, niter = 500, dim = 3, start.temp = 20)
   })

--- a/tests/testthat/test-layout.R
+++ b/tests/testthat/test-layout.R
@@ -160,7 +160,7 @@ test_that("layout algorithms work for singleton graphs", {
 
 test_that("Kamada-Kawai layout generator works", {
   skip_on_cran()
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   center_layout <- function(layout) {
     t(t(layout) - colMeans(layout))
@@ -236,7 +236,7 @@ test_that("layout_with_sugiyama() does not demote matrices to vectors in res$lay
 })
 
 test_that("merge_coords() works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g <- list(make_ring(10), make_ring(5))
   l <- lapply(g, layout_with_mds)
@@ -277,7 +277,7 @@ test_that("`layout_with_mds()` works", {
 })
 
 test_that("`layout_with_mds()` stress test, graph with multiple components", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- make_ring(10) + make_ring(3)
   expect_equal(ncol(layout_with_mds(g)), 2)
 

--- a/tests/testthat/test-layout.R
+++ b/tests/testthat/test-layout.R
@@ -31,18 +31,21 @@ test_that("layout_with_fr() deprecated argument", {
 })
 
 test_that("layout_nicely() works with proper weights and small trees", {
+  igraph_local_seed(42)
   g <- make_star(12, mode = "out")
   E(g)$weight <- 5:15
   expect_warning(layout_nicely(g), NA)
 })
 
 test_that("layout_nicely() works with negative weights", {
+  igraph_local_seed(42)
   g <- make_graph("petersen")
   E(g)$weight <- -5:9
   expect_warning(layout_nicely(g), regexp = "ignoring all weights")
 })
 
 test_that("layout_nicely() does not recurse into itself", {
+  igraph_local_seed(42)
   g <- make_graph("petersen")
   g$layout <- layout_nicely
   expect_silent(layout_nicely(g)) # should not recurse infinitely
@@ -101,6 +104,7 @@ test_that("layout algorithms work for null graphs", {
 })
 
 test_that("layout algorithms work for singleton graphs", {
+  igraph_local_seed(42)
   g <- make_empty_graph(1)
 
   check_matrix <- function(mat, nrow = 1, ncol = 2) {
@@ -377,6 +381,7 @@ test_that("layout normalization handles all-NaN coordinates correctly", {
 })
 
 test_that("generic modifier mechanism works with existing modifiers", {
+  igraph_local_seed(42)
   # Test that component_wise modifier still works
   g <- make_ring(10) + make_ring(5)
   l1 <- layout_(g, in_circle(), component_wise())

--- a/tests/testthat/test-make.R
+++ b/tests/testthat/test-make.R
@@ -366,6 +366,7 @@ test_that("make_de_bruijn_graph works", {
 })
 
 test_that("make_bipartite_graph works", {
+  igraph_local_seed(42)
   inc_mat_rand <- matrix(sample(0:1, 35, replace = TRUE, prob = c(3, 1)), ncol = 5)
   bip_from_inc <- graph_from_biadjacency_matrix(inc_mat_rand)
 

--- a/tests/testthat/test-migration-fixture.R
+++ b/tests/testthat/test-migration-fixture.R
@@ -118,23 +118,8 @@ test_that("error message snapshots", {
 
 # ---- migrate_recover_args() helper (the engine behind the blocks) ----------
 
-# Config equivalent to the fixture, for exercising the helper directly.
-fixture_args <- function(
-  dots,
-  current = list(weights = NULL, type = "out", directed = FALSE)
-) {
-  migrate_recover_args(
-    dots,
-    current = current,
-    recover_new = c("weights", "type", "directed"),
-    recover_old = c("weight", "kind", "directed"),
-    match_names = c("weight", "kind", "weights", "type", "directed"),
-    match_to = c("weights", "type", "weights", "type", "directed"),
-    defaults = list(weights = NULL, type = "out", directed = FALSE),
-    head_args = c("graph", "n"),
-    fn_name = "migration_fixture"
-  )
-}
+# `fixture_args()` (the config-equivalent wrapper) lives in
+# helper-test-functions.R.
 
 test_that("migrate_recover_args() returns NULL when there is nothing to recover", {
   expect_null(fixture_args(list()))

--- a/tests/testthat/test-minimum.spanning.tree.R
+++ b/tests/testthat/test-minimum.spanning.tree.R
@@ -33,6 +33,7 @@ test_that("mst works", {
 })
 
 test_that("mst error works", {
+  igraph_local_seed(42)
   g <- sample_gnp(10, 0.4)
   expect_snapshot_igraph_error(
     mst(g, algorithm = "undefined")

--- a/tests/testthat/test-motifs.R
+++ b/tests/testthat/test-motifs.R
@@ -1,5 +1,5 @@
 test_that("count_motifs works", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
 
   gnp <- sample_gnp(10000, 4 / 10000, directed = TRUE)
 
@@ -23,7 +23,7 @@ test_that("count_motifs works", {
 })
 
 test_that("motifs works", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
   gnp <- sample_gnp(10000, 4 / 10000, directed = TRUE)
 
   m <- motifs(gnp)
@@ -132,7 +132,7 @@ test_that("motifs works", {
 })
 
 test_that("sample_motifs works", {
-  withr::local_seed(20041103)
+  igraph_local_seed(20041103)
 
   g <- make_graph(~ A - B - C - A - D - E - F - D - C - F)
   n <- vcount(g)
@@ -179,7 +179,7 @@ test_that("dyad_census works with celegansneural", {
 })
 
 test_that("motifs with callback works", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
 
   g <- make_graph(~ A - B - C - A - D - E - F - D - C - F)
 
@@ -199,7 +199,7 @@ test_that("motifs with callback works", {
 })
 
 test_that("motifs with callback can stop early", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
 
   g <- make_graph(~ A - B - C - A - D - E - F - D - C - F)
 
@@ -220,7 +220,7 @@ test_that("motifs with callback can stop early", {
 
 
 test_that("motifs with callback receives correct arguments", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
 
   g <- make_graph(~ A - B - C - A)
 
@@ -235,7 +235,7 @@ test_that("motifs with callback receives correct arguments", {
 })
 
 test_that("motifs with callback handles errors in callback", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
 
   g <- make_graph(~ A - B - C - A - D - E - F - D - C - F)
 
@@ -249,7 +249,7 @@ test_that("motifs with callback handles errors in callback", {
 })
 
 test_that("motifs with callback output matches expected", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g <- make_graph(~ A - B - C - A - D - E - F - D - C - F)
 

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -1,6 +1,4 @@
 test_that("union() works", {
-  order_by_two_first_columns <- function(x) x[order(x[, 1], x[, 2]), ]
-
   g1 <- make_ring(10)
   g2 <- make_star(11, center = 11, mode = "undirected")
   gu <- union(g1, g2)
@@ -16,8 +14,6 @@ test_that("union() works", {
 })
 
 test_that("disjoint_union() works", {
-  order_by_two_first_columns <- function(x) x[order(x[, 1], x[, 2]), ]
-
   g1 <- make_ring(10)
   g2 <- make_star(11, center = 11, mode = "undirected")
   gdu <- disjoint_union(g1, g2)
@@ -75,6 +71,7 @@ test_that("intersection() works", {
 })
 
 test_that("complementer() works", {
+  igraph_local_seed(42)
   g2 <- make_star(11, center = 11, mode = "undirected")
 
   x <- complementer(complementer(g2))
@@ -88,6 +85,7 @@ test_that("complementer() works", {
 
 
 test_that("compose() works", {
+  igraph_local_seed(42)
   g1 <- make_ring(10)
   g2 <- make_star(11, center = 11, mode = "undirected")
   gu <- union(g1, g2)
@@ -664,11 +662,6 @@ test_that("intersection of non-named graphs keeps attributes properly", {
 
   gi <- intersection(g, g2)
 
-  rn <- function(D) {
-    rownames(D) <- paste(D[, 1], D[, 2], sep = "-")
-    D
-  }
-
   df <- rn(as_data_frame(g))
   df2 <- rn(as_data_frame(g2))
   dfi <- rn(as_data_frame(gi))
@@ -686,11 +679,6 @@ test_that("union of non-named graphs keeps attributes properly", {
   E(g2)$weight <- sample(ecount(g2))
 
   gu <- union.igraph(g, g2)
-
-  rn <- function(D) {
-    rownames(D) <- paste(D[, 1], D[, 2], sep = "-")
-    D
-  }
 
   df <- rn(as_data_frame(g))
   df2 <- rn(as_data_frame(g2))
@@ -1258,15 +1246,8 @@ test_that("rev on detached vs, names", {
   }
 })
 
-unique_tests <- list(
-  list(1:5, 1:5),
-  list(c(1, 1, 2:5), 1:5),
-  list(c(1, 1, 1, 1), 1),
-  list(c(1, 2, 2, 2), 1:2),
-  list(c(2, 2, 1, 1), 2:1),
-  list(c(1, 2, 1, 2), 1:2),
-  list(c(), c())
-)
+# `unique_tests` (the input/expected pairs used below) lives in
+# helper-test-functions.R.
 
 test_that("unique on attached vs", {
   sapply(unique_tests, function(d) {

--- a/tests/testthat/test-operators.R
+++ b/tests/testthat/test-operators.R
@@ -653,7 +653,7 @@ test_that("difference of named graphs works", {
 
 
 test_that("intersection of non-named graphs keeps attributes properly", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g <- sample_gnp(10, 1 / 2)
   g2 <- sample_gnp(10, 1 / 2)
@@ -671,7 +671,7 @@ test_that("intersection of non-named graphs keeps attributes properly", {
 })
 
 test_that("union of non-named graphs keeps attributes properly", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g <- sample_gnp(10, 1 / 2)
   g2 <- sample_gnp(10, 1 / 2)

--- a/tests/testthat/test-other.R
+++ b/tests/testthat/test-other.R
@@ -63,108 +63,19 @@ test_that("serialization works", {
   })
 })
 
-names <- c(
-  "Mr Hi", "Actor 2", "Actor 3", "Actor 4",
-  "Actor 5", "Actor 6", "Actor 7", "Actor 8", "Actor 9", "Actor 10",
-  "Actor 11", "Actor 12", "Actor 13", "Actor 14", "Actor 15", "Actor 16",
-  "Actor 17", "Actor 18", "Actor 19", "Actor 20", "Actor 21", "Actor 22",
-  "Actor 23", "Actor 24", "Actor 25", "Actor 26", "Actor 27", "Actor 28",
-  "Actor 29", "Actor 30", "Actor 31", "Actor 32", "Actor 33", "John A"
-)
-
-karate <- structure(
-  list(
-    34,
-    FALSE,
-    c(
-      1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12,
-      13, 17, 19, 21, 31, 2, 3, 7, 13, 17, 19, 21, 30, 3, 7, 8, 9,
-      13, 27, 28, 32, 7, 12, 13, 6, 10, 6, 10, 16, 16, 30, 32, 33,
-      33, 33, 32, 33, 32, 33, 32, 33, 33, 32, 33, 32, 33, 25, 27, 29,
-      32, 33, 25, 27, 31, 31, 29, 33, 33, 31, 33, 32, 33, 32, 33, 32,
-      33, 33
-    ),
-    c(
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-      1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 4, 4, 5,
-      5, 5, 6, 8, 8, 8, 9, 13, 14, 14, 15, 15, 18, 18, 19, 20, 20,
-      22, 22, 23, 23, 23, 23, 23, 24, 24, 24, 25, 26, 26, 27, 28, 28,
-      29, 29, 30, 30, 31, 31, 32
-    ),
-    c(
-      0, 1, 16, 2, 17, 24, 3, 4, 5,
-      35, 37, 6, 18, 25, 32, 7, 26, 27, 8, 36, 38, 9, 10, 33, 11, 19,
-      28, 34, 39, 40, 12, 20, 13, 21, 14, 22, 57, 62, 29, 58, 63, 30,
-      59, 66, 23, 41, 15, 64, 65, 69, 31, 42, 46, 48, 50, 53, 55, 60,
-      71, 73, 75, 43, 44, 45, 47, 49, 51, 52, 54, 56, 61, 67, 68, 70,
-      72, 74, 76, 77
-    ),
-    c(
-      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
-      13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-      29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
-      45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
-      61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76,
-      77
-    ),
-    c(
-      0, 0, 1, 3, 6, 7, 8, 11, 15, 17, 18, 21, 22, 24, 28, 28,
-      28, 30, 32, 32, 34, 34, 36, 36, 36, 36, 38, 38, 41, 42, 44, 46,
-      50, 61, 78
-    ),
-    c(
-      0, 16, 24, 32, 35, 37, 40, 41, 41, 44, 45, 45,
-      45, 45, 46, 48, 50, 50, 50, 52, 53, 55, 55, 57, 62, 65, 66, 68,
-      69, 71, 73, 75, 77, 78, 78
-    ),
-    list(
-      c(1, 0, 1),
-      structure(
-        list(
-          name = "Zachary's karate club network",
-          Citation = "Wayne W. Zachary. An Information Flow Model for Conflict and Fission in Small Groups. Journal of Anthropological Research Vol. 33, No. 4 452-473",
-          Author = "Wayne W. Zachary"
-        ),
-        .Names = c("name", "Citation", "Author")
-      ),
-      structure(
-        list(
-          Faction = c(
-            1, 1, 1, 1, 1, 1, 1, 1,
-            2, 2, 1, 1, 1, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 2, 2, 2, 2, 2, 2,
-            2, 2, 2, 2, 2
-          ),
-          name = names
-        ),
-        .Names = c("Faction", "name")
-      ),
-      structure(
-        list(
-          weight = c(
-            4,
-            5, 3, 3, 3, 3, 2, 2, 2, 3, 1, 3, 2, 2, 2, 2, 6, 3, 4, 5, 1, 2,
-            2, 2, 3, 4, 5, 1, 3, 2, 2, 2, 3, 3, 3, 2, 3, 5, 3, 3, 3, 3, 3,
-            4, 2, 3, 3, 2, 3, 4, 1, 2, 1, 3, 1, 2, 3, 5, 4, 3, 5, 4, 2, 3,
-            2, 7, 4, 2, 4, 2, 2, 4, 2, 3, 3, 4, 4, 5
-          )
-        ),
-        .Names = "weight"
-      )
-    )
-  ),
-  class = "igraph"
-)
+# The old-format `karate_oldstyle` fixture (and its `karate_oldstyle_names`)
+# used below live in helper-test-functions.R.
 
 test_that("VS/ES require explicit conversion", {
   expect_snapshot_igraph_error({
-    V(karate)
+    V(karate_oldstyle)
   })
 })
 
 test_that("VS/ES work with old data type", {
-  karate2 <- upgrade_graph(karate)
+  karate2 <- upgrade_graph(karate_oldstyle)
   vs2 <- V(karate2)
 
   expect_length(vs2, 34)
-  expect_equal(vs2$name, names)
+  expect_equal(vs2$name, karate_oldstyle_names)
 })

--- a/tests/testthat/test-other.R
+++ b/tests/testthat/test-other.R
@@ -9,7 +9,7 @@ test_that("convex_hull works", {
 })
 
 test_that("convex_hull uses 1-based indexing, #613", {
-  withr::local_seed(45)
+  igraph_local_seed(45)
   n <- 10
   xy <- cbind(runif(n), runif(n))
   vp <- convex_hull(xy)

--- a/tests/testthat/test-paths.R
+++ b/tests/testthat/test-paths.R
@@ -1,5 +1,5 @@
 test_that("radius() works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- make_tree(10, 2)
 
   expect_equal(radius(g), 3)
@@ -16,14 +16,14 @@ test_that("radius() works -- weights", {
 })
 
 test_that("radius() works -- lifecycle", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- make_tree(10, 2)
 
   expect_snapshot(radius(g, "out"))
 })
 
 test_that("eccentricity() works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- make_tree(10, 2)
 
   expect_equal(eccentricity(g), c(3, 3, 4, 4, 4, 5, 5, 5, 5, 5))
@@ -40,14 +40,14 @@ test_that("eccentricity() works -- weights", {
 })
 
 test_that("eccentricity() works -- lifecycle", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- make_tree(10, 2)
 
   expect_snapshot(eccentricity(g, vids = V(g), "out"))
 })
 
 test_that("graph_center() works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- make_tree(100, 7)
   expect_equal(as.numeric(graph_center(g)), c(1, 2))
   expect_equal(as.numeric(graph_center(g, mode = "in")), 1)

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -77,7 +77,7 @@ test_that("rglplot() works", {
 
   # https://stackoverflow.com/a/46320771/5489251
   withr::local_envvar(RGL_USE_NULL = TRUE)
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   el <- cbind(sample(1:5), sample(1:5))
   g <- graph_from_edgelist(el)

--- a/tests/testthat/test-print-classic.R
+++ b/tests/testthat/test-print-classic.R
@@ -11,7 +11,7 @@ test_that("classic: print.igraph() works", {
   expect_output(summary(g), "name[ ]*[(]v/c[)]")
   expect_output(print(g), "a--b")
 
-  withr::with_seed(42, {
+  igraph_with_seed(42, {
     E(g)$weight <- sample(ecount(g))
   })
   expect_output(summary(g), "weight[\n |]*[(]e/n[)]")
@@ -21,27 +21,27 @@ test_that("classic: print.igraph() works", {
   expect_output(print(g, v = T), "vertex attributes")
   expect_output(print(g, e = T), "edges [(]vertex names[)] and")
 
-  withr::with_seed(42, {
+  igraph_with_seed(42, {
     g2 <- sample_gnp(13, p = 0.6, directed = TRUE)
   })
   expect_output(print(g2), "1 ->")
 
-  withr::with_seed(42, {
+  igraph_with_seed(42, {
     g3 <- sample_gnp(20, p = 0.8)
   })
   expect_output(print(g3), "1 --")
 
-  withr::with_seed(42, {
+  igraph_with_seed(42, {
     g4 <- make_star(100)
   })
   expect_output(print(g4), "2->1")
 
-  withr::with_seed(42, {
+  igraph_with_seed(42, {
     g5 <- make_star(100, mode = "out")
   })
   expect_output(print(g5), "1->")
 
-  withr::with_seed(42, {
+  igraph_with_seed(42, {
     g6 <- sample_pa(100, m = 6, directed = FALSE)
   })
   expect_output(print(g6), "     ")

--- a/tests/testthat/test-print-classic.R
+++ b/tests/testthat/test-print-classic.R
@@ -137,8 +137,7 @@ test_that("classic: print.igraph.es() uses vertex names", {
 
 
 test_that("classic: vs printing", {
-  local_rng_version("3.5.0")
-  withr::local_seed(42)
+  igraph_local_seed(42, rng_version = "3.5.0")
   g <- make_graph(~ A - A:B:C, B - A:B:C) %>%
     set_vertex_attr("color", value = "red") %>%
     set_vertex_attr("weight", value = sample(1:10, 3))
@@ -152,8 +151,7 @@ test_that("classic: vs printing", {
 })
 
 test_that("classic: vs printing, complex attributes", {
-  local_rng_version("3.5.0")
-  withr::local_seed(42)
+  igraph_local_seed(42, rng_version = "3.5.0")
   g <- make_graph(~ A - A:B:C, B - A:B:C) %>%
     set_vertex_attr("color", value = "red") %>%
     set_vertex_attr("weight", value = sample(1:10, 3)) %>%
@@ -166,8 +164,7 @@ test_that("classic: vs printing, complex attributes", {
 })
 
 test_that("classic: es printing", {
-  local_rng_version("3.5.0")
-  withr::local_seed(42)
+  igraph_local_seed(42, rng_version = "3.5.0")
   g <- make_graph(~ A - A:B:C, B - A:B:C) %>%
     set_edge_attr("color", value = "red") %>%
     set_edge_attr("weight", value = sample(1:10, 3))
@@ -179,8 +176,7 @@ test_that("classic: es printing", {
 })
 
 test_that("classic: es printing, complex attributes", {
-  local_rng_version("3.5.0")
-  withr::local_seed(42)
+  igraph_local_seed(42, rng_version = "3.5.0")
   g <- make_graph(~ A - A:B:C, B - A:B:C) %>%
     set_edge_attr("color", value = "red") %>%
     set_edge_attr("weight", value = sample(1:10, 3)) %>%

--- a/tests/testthat/test-random_walk.R
+++ b/tests/testthat/test-random_walk.R
@@ -1,5 +1,5 @@
 test_that("undirected random_walk works", {
-  withr::local_seed(20231029)
+  igraph_local_seed(20231029)
   g <- make_ring(10)
   w <- random_walk(g, start = 1, steps = 10)
   expect_length(w, 11)
@@ -7,7 +7,7 @@ test_that("undirected random_walk works", {
 })
 
 test_that("directed random_walk works", {
-  withr::local_seed(20231029)
+  igraph_local_seed(20231029)
   g <- make_ring(10, directed = TRUE)
   w <- as_ids(random_walk(g, start = 1, steps = 5))
   expect_equal(w, 1:6)
@@ -21,7 +21,7 @@ test_that("directed random_walk works", {
 })
 
 test_that("directed random_walk can return wtih an error when stuck", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- make_star(11, mode = "out")
   expect_error(
     random_walk(g, start = 7, steps = 10, stuck = "error"),
@@ -30,7 +30,7 @@ test_that("directed random_walk can return wtih an error when stuck", {
 })
 
 test_that("undirected random_edge_walk works", {
-  withr::local_seed(20231029)
+  igraph_local_seed(20231029)
   g <- make_star(11, mode = "undirected")
   w <- random_edge_walk(g, start = 1, steps = 10)
   expect_equal(rle(as.numeric(w))$lengths, rep(2, 5))
@@ -44,7 +44,7 @@ test_that("undirected random_edge_walk works", {
 test_that("directed random_edge_walk works", {
   g <- make_star(11, mode = "out")
 
-  withr::local_seed(20231029)
+  igraph_local_seed(20231029)
   w <- random_edge_walk(g, start = 1, steps = 10)
   expect_length(w, 1)
 
@@ -72,7 +72,7 @@ test_that("directed random_edge_walk works", {
 })
 
 test_that("directed random_edge_walk can return wtih an error when stuck", {
-  withr::local_seed(20231029)
+  igraph_local_seed(20231029)
   g <- make_star(11, mode = "out")
   expect_error(
     random_edge_walk(g, start = 7, steps = 10, stuck = "error"),

--- a/tests/testthat/test-rewire.R
+++ b/tests/testthat/test-rewire.R
@@ -1,4 +1,5 @@
 test_that("rewire(each_edge(mode='in')) keeps the in-degree distribution", {
+  igraph_local_seed(42)
   g <- sample_pa(1000)
 
   g2 <- g %>% rewire(each_edge(mode = "in", multiple = T, prob = 0.2))
@@ -7,6 +8,7 @@ test_that("rewire(each_edge(mode='in')) keeps the in-degree distribution", {
 })
 
 test_that("rewire(each_edge(mode='out')) keeps the out-degree distribution", {
+  igraph_local_seed(42)
   g <- sample_pa(1000)
 
   g2 <- g %>% rewire(each_edge(mode = "out", multiple = T, prob = 0.2))
@@ -15,6 +17,7 @@ test_that("rewire(each_edge(mode='out')) keeps the out-degree distribution", {
 })
 
 test_that("rewire() with zero probability does not do anything", {
+  igraph_local_seed(42)
   g <- sample_pa(100)
   g2 <- g %>% rewire(each_edge(prob = 0))
   expect_identical_graphs(g, g2)

--- a/tests/testthat/test-scan.R
+++ b/tests/testthat/test-scan.R
@@ -161,7 +161,7 @@ test_that("Issue 18 is really resolved", {
 })
 
 test_that("Issue 20 is resolved", {
-  withr::local_seed(12345)
+  igraph_local_seed(12345)
   g1 <- sample_gnp(n = 20, p = 0.1, directed = TRUE)
   g2 <- sample_gnp(n = 20, p = 0.1, directed = TRUE)
   ls <- local_scan(g2, g1, k = 1, mode = "all")

--- a/tests/testthat/test-sgm.R
+++ b/tests/testthat/test-sgm.R
@@ -1,6 +1,5 @@
 test_that("SGM works", {
-  local_rng_version("3.5.0")
-  withr::local_seed(42)
+  igraph_local_seed(42, rng_version = "3.5.0")
 
   vc <- 10
   nos <- 3

--- a/tests/testthat/test-sgm.R
+++ b/tests/testthat/test-sgm.R
@@ -23,7 +23,7 @@ test_that("SGM works", {
   )
 
   ## Slightly bigger
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   vc <- 100
   nos <- 10

--- a/tests/testthat/test-sir.R
+++ b/tests/testthat/test-sir.R
@@ -1,5 +1,5 @@
 test_that("SIR works", {
-  withr::local_seed(20231029)
+  igraph_local_seed(20231029)
 
   g <- sample_gnm(50, 50)
   res <- sir(g, beta = 5, gamma = 1, no.sim = 10)

--- a/tests/testthat/test-structural-properties.R
+++ b/tests/testthat/test-structural-properties.R
@@ -500,7 +500,7 @@ test_that("k_shortest_paths() works with weights", {
 })
 
 test_that("transitivity() works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- sample_gnp(100, p = 10 / 100)
 
   t1 <- transitivity(g, type = "global")
@@ -528,7 +528,7 @@ test_that("transitivity() works", {
 })
 
 test_that("no integer overflow", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
   g <- make_star(80000, mode = "undirected") + edges(sample(2:1000), 100)
   mtr <- min(transitivity(g, type = "local"), na.rm = TRUE)
   expect_true(mtr > 0)
@@ -585,7 +585,7 @@ test_that("constraint() works", {
   c2 <- constraint.orig(karate)
   expect_equal(c1, c2)
 
-  withr::local_seed(42)
+  igraph_local_seed(42)
   E(karate)$weight <- sample(1:10, replace = TRUE, ecount(karate))
   wc1 <- constraint(karate)
   wc2 <- constraint.orig(karate, weights = "weight")
@@ -1020,7 +1020,7 @@ test_that("edge_density works", {
 })
 
 test_that("knn works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   ## Some trivial ones
   g <- make_ring(10)

--- a/tests/testthat/test-structural-properties.R
+++ b/tests/testthat/test-structural-properties.R
@@ -32,6 +32,7 @@ test_that("dfs() deprecated arguments", {
 })
 
 test_that("degree() works", {
+  igraph_local_seed(42)
   gnp1 <- sample_gnp(100, 1 / 100)
   gnp1_deg <- degree(gnp1)
   el <- as_edgelist(gnp1)
@@ -73,6 +74,7 @@ test_that("max_degree() works", {
 })
 
 test_that("mean_degree() works", {
+  igraph_local_seed(42)
   # Undirected graph: formula is 2 * edges / vertices
   g_undirected <- make_ring(10)
   expect_equal(mean_degree(g_undirected), 2)
@@ -267,6 +269,7 @@ test_that("bfs() does not pad order", {
 })
 
 test_that("diameter() works -- undirected", {
+  igraph_local_seed(42)
   g <- largest_component(sample_gnp(30, 3 / 30))
   sp <- distances(g)
   expect_equal(max(sp), diameter(g))
@@ -278,6 +281,7 @@ test_that("diameter() works -- undirected", {
 })
 
 test_that("diameter() works -- directed", {
+  igraph_local_seed(42)
   g <- sample_gnp(30, 3 / 30, directed = TRUE)
   sp <- distances(g, mode = "out")
   sp[sp == Inf] <- NA
@@ -285,6 +289,7 @@ test_that("diameter() works -- directed", {
 })
 
 test_that("diameter() works -- weighted", {
+  igraph_local_seed(42)
   g <- sample_gnp(30, 3 / 30, directed = TRUE)
   E(g)$weight <- sample(1:10, ecount(g), replace = TRUE)
   sp <- distances(g, mode = "out")
@@ -308,6 +313,7 @@ test_that("diameter() correctly handles disconnected graphs", {
 })
 
 test_that("get_diameter() works", {
+  igraph_local_seed(42)
   g <- make_ring(10)
   E(g)$weight <- sample(seq_len(ecount(g)))
   d <- diameter(g)
@@ -587,6 +593,7 @@ test_that("constraint() works", {
 })
 
 test_that("ego() works", {
+  igraph_local_seed(42)
   neig <- function(graph, order, vertices) {
     sp <- distances(graph)
     v <- unique(unlist(lapply(vertices, function(x) {
@@ -848,6 +855,7 @@ test_that("laplacian_matrix() works", {
 })
 
 test_that("mean_distance works", {
+  igraph_local_seed(42)
   avg_path_length <- function(graph) {
     sp <- distances(graph, mode = "out")
     if (is_directed(graph)) {
@@ -889,6 +897,7 @@ test_that("mean_distance works correctly for disconnected graphs", {
 })
 
 test_that("mean_distance can provide details", {
+  igraph_local_seed(42)
   avg_path_length <- function(graph) {
     sp <- distances(graph, mode = "out")
     if (is_directed(graph)) {
@@ -996,6 +1005,7 @@ test_that("any_loop(), which_loop(), count_loops() works", {
 })
 
 test_that("edge_density works", {
+  igraph_local_seed(42)
   g <- sample_gnp(50, 4 / 50)
   gd <- edge_density(g)
   gd2 <- ecount(g) / vcount(g) / (vcount(g) - 1) * 2

--- a/tests/testthat/test-topology.R
+++ b/tests/testthat/test-topology.R
@@ -172,7 +172,7 @@ test_that("LAD stress test", {
     expect_true(iso)
   }
 
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   for (i in 1:N) {
     target <- sample_gnp(20, 1 / 20)
@@ -184,7 +184,7 @@ test_that("LAD stress test", {
 })
 
 test_that("graph.subisomorphic.vf2 works", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   gnp1 <- sample_gnp(20, 6 / 20)
   gnp2 <- sample_gnp(20, 6 / 20)
@@ -431,7 +431,7 @@ test_that("transitive_closure preserves isolated vertices", {
 
 # Tests for isomorphism callback functions
 test_that("isomorphisms works with callback", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
 
   # Create two isomorphic graphs
   g1 <- make_ring(8)
@@ -506,7 +506,7 @@ test_that("isomorphisms handles errors in callback", {
 })
 
 test_that("subisomorphisms works with callback works", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
 
   # Find triangles in a larger graph
   g1 <- make_ring(3) # triangle

--- a/tests/testthat/test-topology.R
+++ b/tests/testthat/test-topology.R
@@ -92,6 +92,7 @@ test_that("VF2 isomorphism considers colors", {
 })
 
 test_that("canonical_permutation works", {
+  igraph_local_seed(42)
   g1 <- sample_gnm(10, 20)
   cp1 <- canonical_permutation(g1)
   cf1 <- permute(g1, cp1$labeling)
@@ -160,8 +161,7 @@ test_that("graph.subisomorphic, method = 'lad' works", {
 })
 
 test_that("LAD stress test", {
-  local_rng_version("3.5.0")
-  withr::local_seed(42)
+  igraph_local_seed(42, rng_version = "3.5.0")
   N <- 100
 
   for (i in 1:N) {
@@ -453,6 +453,7 @@ test_that("isomorphisms works with callback", {
 })
 
 test_that("isomorphisms can stop early", {
+  igraph_local_seed(42)
   # Create two isomorphic graphs
   g1 <- make_ring(6)
   g2 <- permute(g1, sample(vcount(g1)))
@@ -473,6 +474,7 @@ test_that("isomorphisms can stop early", {
 })
 
 test_that("isomorphisms receives correct arguments", {
+  igraph_local_seed(42)
   g1 <- make_ring(5)
   g2 <- permute(g1, sample(vcount(g1)))
 

--- a/tests/testthat/test-trees.R
+++ b/tests/testthat/test-trees.R
@@ -221,7 +221,7 @@ test_that("sample_spanning_tree works for disconnected graphs", {
 })
 
 test_that("subgraph.edges deprecation", {
-  withr::local_seed(42)
+  igraph_local_seed(42)
 
   g <- make_full_graph(8) %du% make_full_graph(5)
   edges <- sample_spanning_tree(g)

--- a/tests/testthat/test-trees.R
+++ b/tests/testthat/test-trees.R
@@ -1,4 +1,5 @@
 test_that("is_tree works for non-trees", {
+  igraph_local_seed(42)
   g <- make_graph("zachary")
   expect_false(is_tree(g))
   expect_equal(
@@ -120,6 +121,7 @@ test_that("to_prufer prints an error for non-trees", {
 })
 
 test_that("sample_tree works", {
+  igraph_local_seed(42)
   g <- sample_tree(100)
   expect_false(is_directed(g))
   expect_ecount(g, 99)
@@ -146,6 +148,7 @@ test_that("sample_tree works", {
 })
 
 test_that("sample_(tree(...)) works", {
+  igraph_local_seed(42)
   g <- sample_(tree(200, method = "prufer"))
   expect_false(is_directed(g))
   expect_ecount(g, 199)
@@ -181,6 +184,7 @@ test_that("sample_tree throws an error for the Prufer method with directed graph
 })
 
 test_that("sample_spanning_tree works for connected graphs", {
+  igraph_local_seed(42)
   g <- make_full_graph(8)
 
   edges <- sample_spanning_tree(g)
@@ -193,6 +197,7 @@ test_that("sample_spanning_tree works for connected graphs", {
 })
 
 test_that("sample_spanning_tree works for disconnected graphs", {
+  igraph_local_seed(42)
   g <- make_full_graph(8) %du% make_full_graph(5)
 
   edges <- sample_spanning_tree(g, vid = 8)

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -228,7 +228,7 @@ Add tests in two locations:
 
 ```r
 test_that("cliques_callback_closure_impl basic", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   local_igraph_options(print.id = FALSE)
 
   g <- make_full_graph(4)
@@ -262,7 +262,7 @@ test_that("cliques_callback_closure_impl basic", {
 })
 
 test_that("cliques_callback_closure_impl errors", {
-  withr::local_seed(20250909)
+  igraph_local_seed(20250909)
   local_igraph_options(print.id = FALSE)
 
   g <- make_full_graph(4)
@@ -282,7 +282,7 @@ test_that("cliques_callback_closure_impl errors", {
 
 ```r
 test_that("cliques_callback works", {
-  withr::local_seed(123)
+  igraph_local_seed(123)
   g <- sample_gnp(20, 0.3)
 
   count <- 0
@@ -318,7 +318,7 @@ test_that("cliques_callback handles errors in callback", {
 
 ### Testing Pattern
 
-- Use `withr::local_seed(20250909)` for reproducibility
+- Use `igraph_local_seed(20250909)` for reproducibility
 - Use `local_igraph_options(print.id = FALSE)` for stable snapshots
 - Both snapshot tests (`expect_snapshot`) and structured tests (`expect_*`)
 - Test basic functionality, early stopping, error handling, and argument types


### PR DESCRIPTION
Fix #2713

## What & why

The test suite has an opt-in check (gated behind `IGRAPH_CHECK_RNG_STATE=true` in
`tests/testthat/setup.R`) that fails any test which leaves the global
`.Random.seed` changed. This PR makes the whole suite pass that check and moves
the suite's RNG-seed handling off `withr` onto in-house helpers.

Running the suite with `IGRAPH_CHECK_RNG_STATE=true`: **0 seed leaks, 0
failures, 0 warnings** (9739 passing).

## New helpers (`tests/testthat/helper.R`)

**`igraph_local_seed()`** — drop-in for `withr::local_seed()`. Sets the seed for
the current scope and restores the previous global RNG state when that scope
exits.
- Self-contained: snapshots and restores `RNGkind` + `.Random.seed` itself
  (uses `withr::defer` only as the deferral primitive), so it doesn't inherit
  `withr::local_seed`'s past seed-handling bugs.
- Restores **RNGkind first, then `.Random.seed` last** — changing the kind
  discards the seed, so the seed write must come last for an exact round-trip.
- Optional `rng_version` (e.g. `"3.5.0"`), folding in what used to be a separate
  `local_rng_version()` call. Pairing two independent deferred restores (kind +
  seed) ran them in the wrong order and leaked; a single ordered restore fixes it.

**`igraph_with_seed()`** — block form mirroring `withr::with_seed()`: set the
seed, evaluate the block, restore. Needed where a single test has several
independently seeded blocks with code between them (e.g. `test-print-classic.R`),
which a frame-scoped `igraph_local_seed()` can't express.

## setup.R

- Set a baseline seed (`set.seed(42)`) so `.Random.seed` always exists before
  tests run. Otherwise the first RNG-touching test *creates* it from nothing
  (many igraph C functions initialise the RNG without drawing from it, e.g.
  `voronoi_cells()`), which the check flagged — and restoring that absent state
  just shoved the "first creation" onto the next test (whack-a-mole).
- The seed-leak override now forwards the test block via
  `substitute()` + `eval(as.call(...))` instead of
  `rlang::inject(testthat::test_that(name, !!code))`. `inject()` eagerly
  processed **any** injection operator in the test body (`!!`, `!!!`, `{{`),
  e.g. `set_vertex_attrs(g, !!!attr_list)`, evaluating it in the wrong frame and
  erroring with `object 'attr_list' not found`.
- The check stays gated behind `IGRAPH_CHECK_RNG_STATE=true` (opt-in for CI).

## Test files

- Moved helper functions that were defined inside test files into a shared
  `helper-test-functions.R` (the override re-scopes test code, so file-local
  helpers were no longer reachable from the test body).
- Added `igraph_local_seed()` to tests that genuinely advance the RNG (unseeded
  `sample_*` fixtures and ARPACK eigensolvers).
- Replaced **all 875** `withr::local_seed()` call sites with
  `igraph_local_seed()` (including the 732 in `test-aaa-auto.R`).
- Replaced the **9** `withr::with_seed()` call sites with `igraph_with_seed()`
  (`test-print-classic.R`, `test-layout.R`, `test-iterators.R`). These never
  leaked — consistency cleanup; snapshots unchanged.
- Replaced every `local_rng_version("3.5.0")` + seed pairing with
  `igraph_local_seed(seed, rng_version = "3.5.0")`, then removed the now-unused
  `local_rng_version()` helper.
- `restore_rng_state()` suppresses warnings around the `RNGkind` restore so
  putting back the older `"Rounding"` sampler (`RNGversion("3.5.0")`) doesn't
  emit R's "non-uniform 'Rounding' sampler used" note.

## tools/AGENTS.md

Updated the test-writing guidance to use `igraph_local_seed`, so newly added
`test-aaa-auto.R` tests follow the convention.

## Notes
- `igraph_local_seed()`/`igraph_with_seed()` live in `helper.R` (not `setup.R`)
  so helper functions like `make_scan_graphs()` can see them.
- The suite no longer uses `withr` for any RNG-seed handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
