### PR TITLE
fix(migrations): guard against head/recoverable prefix clashes

### DIFF
--- a/tests/testthat/test-migration-fixture.R
+++ b/tests/testthat/test-migration-fixture.R
@@ -173,6 +173,54 @@ test_that("the generated block is in sync with the registry", {
   expect_identical(spliced$lines, lines)
 })
 
+test_that("normalise_migration() rejects head/recoverable prefix clashes", {
+  # Head args are matched by base R (with partial matching) before `...`, so a
+  # head arg in a prefix relationship with a recoverable name would silently
+  # capture it before the recovery layer runs. The generator must reject this.
+  generator <- testthat::test_path("..", "..", "tools", "generate-migrations.R")
+  skip_if_not(file.exists(generator))
+  gen_env <- new.env()
+  sys.source(generator, envir = gen_env)
+
+  # Head arg `type` is a prefix of the recoverable `typeof`.
+  expect_error(
+    gen_env$normalise_migration(
+      "bad_head_prefix",
+      list(
+        old = function(graph, typeof) {},
+        new = function(graph, type = "x", ..., typeof = NULL) {},
+        when = "3.0.0"
+      )
+    ),
+    "prefix relationship"
+  )
+
+  # Recoverable `type` is a prefix of the head arg `typeof`.
+  expect_error(
+    gen_env$normalise_migration(
+      "bad_recover_prefix",
+      list(
+        old = function(graph, type) {},
+        new = function(graph, typeof = "x", ..., type = NULL) {},
+        when = "3.0.0"
+      )
+    ),
+    "prefix relationship"
+  )
+
+  # Merely sharing a leading letter (`graph` vs `groups`) is allowed.
+  expect_no_error(
+    gen_env$normalise_migration(
+      "ok_shared_letter",
+      list(
+        old = function(graph, groups) {},
+        new = function(graph, ..., groups = NULL) {},
+        when = "3.0.0"
+      )
+    )
+  )
+})
+
 test_that("the BEGIN marker may carry a trailing note", {
   generator <- testthat::test_path("..", "..", "tools", "generate-migrations.R")
   skip_if_not(file.exists(generator))

--- a/tools/generate-migrations.R
+++ b/tools/generate-migrations.R
@@ -174,6 +174,36 @@ normalise_migration <- function(fn, entry) {
   entry$match_names <- c(entry$recover_old[renamed], entry$tail)
   entry$match_to <- c(entry$recover_new[renamed], entry$tail)
 
+  # Head args are matched by base R *before* `...`, with base R partial matching,
+  # so they are resolved before the recovery layer ever runs. If a head arg name
+  # and a recoverable name are in a prefix relationship, base R silently captures
+  # the abbreviation (or even the full name) for the head arg and it never
+  # reaches `...`: e.g. head `type` swallows `ty=` meant for a recoverable
+  # `typeof`, and a recoverable `type` is swallowed whole by a head `typeof`. The
+  # recovery layer cannot see or defend against this, so reject it here rather
+  # than ship a silent hole. (Merely sharing a leading letter -- `graph` vs a
+  # recoverable `groups` -- is a weaker base-R hazard the two-layer scheme can't
+  # fully eliminate and is left unguarded.)
+  clashes <- character(0)
+  for (h in entry$head) {
+    for (r in entry$match_names) {
+      if (startsWith(h, r) || startsWith(r, h)) {
+        clashes <- c(clashes, paste0(h, " <-> ", r))
+      }
+    }
+  }
+  if (length(clashes)) {
+    stop(
+      "Migration `",
+      fn,
+      "`: head arg(s) and recoverable name(s) are in a prefix relationship, ",
+      "so base R partial matching would capture them before recovery runs: ",
+      paste(unique(clashes), collapse = ", "),
+      ". Rename to remove the prefix overlap.",
+      call. = FALSE
+    )
+  }
+
   entry
 }
 


### PR DESCRIPTION
## What & why

The argument-migration compat layer (`tools/migrations.R` → `tools/generate-migrations.R` → the generated `ARG_HANDLE` blocks → `migrate_recover_args()`) resolves arguments in two layers:

- **Head args** (before `...`) are matched by **base R**, including base R partial matching.
- **Everything landing in `...`** is matched by the recovery layer via `charmatch()`.

The core mechanism is already robust against the important partial-matching cases: `charmatch()` correctly prefers an exact old name over a longer new name it prefixes (`weight` vs `weights`), genuinely ambiguous abbreviations error cleanly, and double-supply is caught via the `current`/`defaults` conflict check.

There was one structural blind spot, though: base R resolves the head args **before** the recovery layer runs. If a head arg name and a recoverable name are in a **prefix relationship**, base R silently captures the abbreviation — or even the full name — for the head arg, and it never reaches `...`. For example, a head `type` swallows `ty=` meant for a recoverable `typeof`, and a recoverable `type` is swallowed whole by a head `typeof`. The recovery layer cannot see or defend against this.

The two current migrations (`as_adjacency_matrix`, `as_biadjacency_matrix`) and the test fixture have no such clash, so this was latent — but nothing stopped a future registry entry from opening the hole.

## Change

- `normalise_migration()` now rejects any migration where a head arg name and a recoverable name are in a prefix relationship (either direction), with a clear, actionable error naming the clashing pair. This runs at generation time and via the existing in-sync test, so drift is caught in CI.
- Merely sharing a leading letter (e.g. head `graph` vs recoverable `groups`) is a weaker base-R hazard the two-layer scheme can't fully eliminate; it is deliberately left unguarded and documented as such in the code comment.
- Added generator-level tests covering both clash directions and the allowed shared-leading-letter case.

Regenerating (`Rscript tools/generate-migrations.R`) produces no drift, `air` leaves both files unchanged, and the migration-fixture test file passes.

<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->
Prepared with the assistance of Claude Code.

<!-- The following text must be left intact and the box checked before the PR can be merged. -->

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EduCkKvjkGLZddcSCDHwk5

---
_Generated by [Claude Code](https://claude.ai/code/session_01EduCkKvjkGLZddcSCDHwk5)_