### PR TITLE
fix: remove generated `src/Makevars` in cleanup scripts

### DIFF
--- a/cleanup
+++ b/cleanup
@@ -1,6 +1,12 @@
 #! /bin/sh
 
+# 'configure' generates 'src/Makevars' from 'src/Makevars.in'. Remove the
+# generated file in the cleanup step so that the package sources never contain
+# both 'src/Makevars.in' and 'src/Makevars' (R CMD check reports a NOTE about
+# installation with '--no-configure' otherwise).
+rm -f src/Makevars
+
 # Object files cause problems on Github Actions where they get included
 # in the source package that is re-generated from the original source, so
 # we remove them here in the cleanup step
-find src -name *.o | xargs rm
+find src -name '*.o' -exec rm -f {} +

--- a/cleanup.win
+++ b/cleanup.win
@@ -1,6 +1,12 @@
 #! /bin/sh
 
+# 'configure' generates 'src/Makevars' from 'src/Makevars.in'. Remove the
+# generated file in the cleanup step so that the package sources never contain
+# both 'src/Makevars.in' and 'src/Makevars' (R CMD check reports a NOTE about
+# installation with '--no-configure' otherwise).
+rm -f src/Makevars
+
 # Object files cause problems on Github Actions where they get included
 # in the source package that is re-generated from the original source, so
 # we remove them here in the cleanup step
-find src -name *.o | xargs rm
+find src -name '*.o' -exec rm -f {} +


### PR DESCRIPTION
## Summary

Fixes the R-devel `R CMD check` NOTE:

```
checking compilation flags in Makevars ... NOTE
  Package has both 'src/Makevars.in' and 'src/Makevars'.
  Installation with --no-configure' is unlikely to work. ...
  If 'configure' created 'src/Makevars', you need a 'cleanup' script.
```

`configure` generates `src/Makevars` from `src/Makevars.in`. When that generated file lingers in the package sources — e.g. after an in-place install, as CRAN's `r-devel-linux-x86_64-debian-{gcc,clang}` flavors do before checking — `tools:::.check_make_vars()` sees both `src/Makevars.in` and `src/Makevars` and emits the NOTE.

The published CRAN tarball is already clean (it ships only `Makevars.in`, `Makevars.win`, `Makevars.ucrt`), which is why the repo's own `rcc dev` workflow passes — it builds a fresh tarball into a clean tree. The NOTE only appears in CRAN flows that leave the configure-generated `src/Makevars` behind.

The existing `cleanup` script removed only `*.o` files, never the generated `src/Makevars` — exactly the gap the check's message points at. This follows the same pattern comparable CRAN packages use (e.g. `nloptr`, whose cleanup runs `rm -fr … src/Makevars …`).

## Changes

- `cleanup` / `cleanup.win`: `rm -f src/Makevars` so `src/Makevars.in` and `src/Makevars` never coexist.
- Hardened the object-file removal (`find src -name '*.o' -exec rm -f {} +`) so cleanup exits successfully when there is nothing to delete; the previous `find … *.o | xargs rm` errored on empty input.

## Verification

- `cleanup` stays executable with LF line endings.
- Running it removes a stray `src/Makevars` and `*.o` files, and exits `0` as a no-op when nothing matches.
- After an in-place `./configure` (which creates `src/Makevars`), `R CMD build` still produces a clean tarball containing only `Makevars.in`, `Makevars.win`, `Makevars.ucrt`.

<!-- LLM disclosure: this PR was prepared with the assistance of Claude Code. -->

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G73R8wHvRgefet7feu6Q8E

---
_Generated by [Claude Code](https://claude.ai/code/session_01G73R8wHvRgefet7feu6Q8E)_