### PR TITLE
ci: let `pak` ignore Bioconductor `graph` on R < 4.4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -73,6 +73,13 @@ Config/build/compilation-database: false
 Config/build/never-clean: true
 Config/comment/compilation-database: Generate manually with
     pkgload:::generate_db() for faster pkgload::load_all()
+Config/gha/extra-packages: graph=?ignore-before-r=4.4.0
+Config/comment/gha/extra-packages: graph is an optional Enhances
+    dependency published only on Bioconductor. The Bioconductor releases
+    matching R 4.2 and R 4.3 (graph 3.16 / 3.18) are archived and return
+    HTTP 404, which aborts pak dependency resolution on those jobs. The
+    ?ignore-before-r pak parameter makes pak ignore graph on R older than
+    4.4.0, where a published release still exists.
 Config/Needs/build: devtools, irlba, pkgconfig
 Config/Needs/coverage: covr
 Config/Needs/roxygen2: r-lib/roxygen2, igraph/igraph.r2cdocs,


### PR DESCRIPTION
LLM disclosure: this PR was prepared with Claude Code (Claude Opus 4.8).

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

## Problem

`graph` is an optional `Enhances:` dependency published only on Bioconductor. The Bioconductor releases matching R 4.2 / 4.3 (`graph` 3.16 / 3.18) are archived and return **HTTP 404**, so `pak` dependency resolution aborts on the `rcc: … (4.2)` / `(4.3)` jobs, in the `install` step, before anything is built.

## Fix

Use pak's documented **downstream-package parameter**, in `DESCRIPTION` — no workflow changes at all:

```
Config/gha/extra-packages: graph=?ignore-before-r=4.4.0
```

The `install` composite action already forwards `Config/gha/extra-packages` to `setup-r-dependencies`. Per `?pak_package_sources`, `<package>=?<params>` is the special **`param`** reference type, whose purpose is "to add a parameter to a downstream dependency", and `ignore-before-r` "will be ignored on R versions that are older than the specified one". So the parameter attaches to the `graph` dependency pulled in via `deps::.`.

Verified locally against pak's vendored `pkgdepends`:

- `parse_pkg_refs("graph=?ignore-before-r=4.4.0")` → `type = "param"`, `package = "graph"`, `ignore-before-r = 4.4.0`.
- Solver semantics (`pkgplan_i_lp_dependencies`): ignored when `4.4.0 > R` → dropped on R 4.2 / 4.3, kept on 4.4 / 4.5 / 4.6.
- The action's own `grep Config/gha/extra-packages DESCRIPTION | cut -d " " -f 2-` extracts exactly `graph=?ignore-before-r=4.4.0` (the adjacent `Config/comment/gha/extra-packages` note does not match the grep).
- `DESCRIPTION` remains valid DCF.

## Why the previous approach was replaced

An earlier revision set `PKG_USE_BIOCONDUCTOR=false` from a workflow step. **That did not work**, as the CI showed:

- On R 4.2 / 4.3 the env var *was* set, but resolution still failed — it only turned the 404 into `graph: Can't find package called graph.` pak does **not** drop an unavailable soft dependency unless it is explicitly ignored (`ignore`, `ignore-before-r`, or `ignore-unavailable`).
- It also **broke the Windows jobs** (4.5 / 4.6 / devel), which died at the multi-line `Rscript -e '…'` invocation — those jobs had been passing.

Both problems disappear here: the workflow is untouched, and the ignore is explicit.

## Scope

`DESCRIPTION` only. Related: **#2754** (run `R-CMD-check` on `claude/**`, stacked on this), **#2749** (the `R_getRegisteredNamespace` C23 sanitizer error — a stale CSAN Docker image, not a package bug). The `structure()` code fixes merged in #2755.

🤖 Generated with [Claude Code](https://claude.com/claude-code)