### PR TITLE
ci: run R-CMD-check on `claude/**` branches

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,10 +12,12 @@ on:
       - release
       - next
       - cran-*
+      - claude/**
   pull_request:
     branches:
       - main
       - master
+      - claude/**
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/build-and-check.yml
+++ b/.github/workflows/build-and-check.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - cran-*
+      - claude/**
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:

--- a/.github/workflows/build-and-check.yml
+++ b/.github/workflows/build-and-check.yml
@@ -21,7 +21,7 @@ jobs:
     name: Sanitizer
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -34,7 +34,11 @@ jobs:
       - name: run sanitizer
         uses: addnab/docker-run-action@v3
         with:
-          image: ghcr.io/cynkra/docker-images/r-debug-csan-igraph:latest
+          # Built daily from https://github.com/cynkra/r-debug, so R-devel is
+          # at most a day old.
+          # The images under ghcr.io/cynkra/docker-images are no longer
+          # rebuilt; their R-devel is stale.
+          image: ghcr.io/cynkra/r-debug/r-debug-csan-igraph:latest
           options: --rm --platform linux/amd64 -v ${{ github.workspace }}:/rigraph
           run: |
             set -e

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -6157,8 +6157,14 @@ SEXP Rx_igraph_is_chordal(SEXP graph, SEXP alpha, SEXP alpham1,
   SEXP result, names;
                                         /* Convert input */
   Rz_SEXP_to_igraph(graph, &c_graph);
-  if (!Rf_isNull(alpha)) { Rz_SEXP_to_vector_int_copy(alpha, &c_alpha); }
-  if (!Rf_isNull(alpham1)) { Rz_SEXP_to_vector_int_copy(alpham1, &c_alpham1); }
+  if (!Rf_isNull(alpha)) {
+    IGRAPH_R_CHECK(Rz_SEXP_to_vector_int_copy(alpha, &c_alpha));
+    IGRAPH_FINALLY_PV(igraph_vector_int_destroy, &c_alpha);
+  }
+  if (!Rf_isNull(alpham1)) {
+    IGRAPH_R_CHECK(Rz_SEXP_to_vector_int_copy(alpham1, &c_alpham1));
+    IGRAPH_FINALLY_PV(igraph_vector_int_destroy, &c_alpham1);
+  }
   if (LOGICAL(pfillin)[0]) {
     if (0 != igraph_vector_int_init(&c_fillin, 0)) {
       igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
@@ -6186,6 +6192,16 @@ SEXP Rx_igraph_is_chordal(SEXP graph, SEXP alpha, SEXP alpham1,
     IGRAPH_FINALLY_CLEAN(1);
   } else {
     PROTECT(newgraph=R_NilValue);
+  }
+  /* Unwound in reverse order of registration, so that IGRAPH_FINALLY_CLEAN()
+   * pops the entry that belongs to the vector being destroyed. */
+  if (!Rf_isNull(alpham1)) {
+    igraph_vector_int_destroy(&c_alpham1);
+    IGRAPH_FINALLY_CLEAN(1);
+  }
+  if (!Rf_isNull(alpha)) {
+    igraph_vector_int_destroy(&c_alpha);
+    IGRAPH_FINALLY_CLEAN(1);
   }
   SET_VECTOR_ELT(result, 0, chordal);
   SET_VECTOR_ELT(result, 1, fillin);

--- a/tests/testthat/test-foreign.R
+++ b/tests/testthat/test-foreign.R
@@ -63,7 +63,7 @@ test_that("graph_from_graphdb works", {
   skip_on_cran()
 
   # Bug in base R? Checked with 2024-11-01 r87285:
-  # docker run --rm -ti -v $PWD:/rigraph -e MAKEFLAGS=-j4 ghcr.io/cynkra/docker-images/rigraph-san:latest RDcsan -q -e 'filename <- "/rigraph/DESCRIPTION"; gz_file_con <- file(filename, open = "rb"); file_con <- gzcon(gz_file_con); close(file_con); gc()'
+  # docker run --rm -ti -v $PWD:/rigraph -e MAKEFLAGS=-j4 ghcr.io/cynkra/r-debug/r-debug-csan-igraph:latest RDcsan -q -e 'filename <- "/rigraph/DESCRIPTION"; gz_file_con <- file(filename, open = "rb"); file_con <- gzcon(gz_file_con); close(file_con); gc()'
   skip_if(Sys.getenv("R_SANITIZER") == "true")
 
   expect_silent(graph_from_graphdb(nodes = 1000))


### PR DESCRIPTION
This can be reused to check the full matrix which is omitted by default for maintainers (=PRs from the igraph/rigraph repo). Retarget to the appropriate claude/** branch.

---

LLM disclosure: this PR was prepared with Claude Code (Claude Opus 4.8).

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

## What (draft)

`R-CMD-check.yaml` only triggered on `push` to `main`/`master`/`release`/`next`/`cran-*` and on `pull_request` against `main`/`master`. A PR based on another `claude/**` branch (like this one, stacked on #2753) therefore got **no CI runs at all**.

This adds `claude/**` to both branch filters — a two-line change:

```yaml
  push:
    branches:
      …
      - claude/**
  pull_request:
    branches:
      …
      - claude/**
```

The `push` trigger is the one that matters for coverage: the `versions-matrix` step is skipped for same-repo pull requests (its `if:` requires a fork PR or a `cran-*` branch), but it *does* run for `push` events. So pushing a `claude/**` branch generates the full version matrix and exercises the `rcc-full` job.

## Not included

An earlier revision of this PR also widened the matrix in `.github/workflows/versions-matrix/action.R` (full R range on macOS/Windows/arm64). That was a misunderstanding of "test the full matrix" and has been **reverted** — the matrix definition is unchanged, including its deliberately ragged arm64/macOS coverage and the rationale comments.

## Stacking

Based on **#2753** (`claude/fix-names-deprecation-graph`), not `main`. Review/merge #2753 first; this then reduces to the two-line trigger diff.

## Note

The `claude/**` trigger runs CI on every push to any `claude/*` branch. That's what makes these stacked PRs testable, but you may want to narrow or drop it before it lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)