### PR TITLE
docs: zoning rules for arguments around the ellipsis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ All new functions must include:
 - A concept so that it exists in the pkgdown reference index
 - An "experimental" badge via `r lifecycle::badge("experimental")`
 - All arguments in `snake_case`, with documentation and suitable defaults
-- An ellipsis guarded with `check_dots_empty()` separating mandatory and optional arguments
+- An ellipsis guarded with `check_dots_empty()` separating the head (required and defining arguments) from keyword-only options, following the zoning rules in [CONTRIBUTING.md](CONTRIBUTING.md#argument-order-and-the-ellipsis)
 - Argument validation using built-in `check_*()` functions or `igraph_arg_match()`
 
 **For callback functions:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,10 @@ Which arguments go before the ellipsis (the "head")?
 
    As a rule of thumb, the head should not exceed three or four arguments;
    when in doubt, put an argument after the ellipsis.
+   The head must never be empty, though:
+   at least the function's primary argument stays positional,
+   and a signature whose arguments *all* sit behind the ellipsis
+   is a sign that the function should not carry an ellipsis at all.
 
 Everything else goes after the ellipsis (the "tail"),
 roughly in this order:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,75 @@ style to the code (see also the [lintr package](https://lintr.r-lib.org/)).
 Look at the style (indentation, braces, etc.) of some recently committed bigger
 change, and try to mimic that.
 
+### Argument Order and the Ellipsis
+
+Every exported function separates its arguments into two zones
+with an ellipsis (`...`):
+arguments *before* the ellipsis may be passed by position,
+arguments *after* it are keyword-only.
+This lets us add, reorder, and rename keyword-only arguments
+in later releases without breaking user code,
+and it keeps user code readable
+because rarely-used options must be spelled out.
+
+Which arguments go before the ellipsis (the "head")?
+
+1. **All required arguments** (arguments without a default),
+   with the graph or other primary data first.
+   This holds even when a function has three or more required arguments:
+   a required argument after `...` could still only be passed by name,
+   which hides it from the signature-reading eye
+   and produces worse error messages when it is forgotten.
+2. **Defining optional arguments** may follow —
+   but only when they answer *what* is computed rather than *how*:
+   - the vertices, edges, or other objects the function operates on,
+     such as `v` in `degree()` or `nodes` in `ego()`;
+   - the parameters of a model or generator,
+     such as `power` and `m` in `sample_pa()`;
+   - an enum that selects the essential variant of the operation,
+     such as `type` in `as_adjacency_matrix()`.
+
+   As a rule of thumb, the head should not exceed three or four arguments;
+   when in doubt, put an argument after the ellipsis.
+
+Everything else goes after the ellipsis (the "tail"),
+roughly in this order:
+
+1. interpretation modifiers, such as `mode`, `directed`, `weights`, `loops`;
+2. output shape and format, such as `normalized`, `names`, `sparse`;
+3. algorithm selection and tuning, such as `algorithm`, `options`, callbacks;
+4. deprecated arguments, always last.
+
+This follows the tidyverse design guide
+([required args before `...`, optional after](https://design.tidyverse.org/dots-after-required.html),
+[important args first](https://design.tidyverse.org/important-args-first.html),
+[required args have no defaults](https://design.tidyverse.org/required-no-defaults.html))
+with one deliberate deviation:
+the tidyverse places `...` directly after the *required* arguments,
+whereas we allow a small number of *defining optional* arguments
+to stay ahead of it (rule 2 above).
+igraph's API predates these conventions by two decades,
+and idiomatic calls like `degree(g, 1:3)` or `sample_pa(100, 1.5)`
+are pervasive in scripts, books, and teaching material.
+Deprecating the idiomatic form of a function
+would generate warning noise without a safety benefit;
+the value of keyword-only arguments lies in the long tail of options,
+not in the one or two arguments everyone knows by heart.
+
+New functions follow the same zoning,
+with `rlang::check_dots_empty()` guarding the ellipsis
+(no migration machinery needed);
+document the ellipsis with `@inheritParams rlang::args_dots_empty`.
+
+For existing functions, the signature change is *migrated*:
+a generated block recovers legacy positional or abbreviated calls
+and emits a single soft deprecation,
+so old code keeps working during a transition period.
+See [Argument-migration blocks](tools/README.md#argument-migration-blocks)
+for the mechanics,
+and declare migrations in a per-topic registry file
+under `tools/migrations/`.
+
 ### Documentation
 
 - Install roxygen2 but also [igraph.r2cdocs](https://github.com/igraph/igraph.r2cdocs).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,20 @@ would generate warning noise without a safety benefit;
 the value of keyword-only arguments lies in the long tail of options,
 not in the one or two arguments everyone knows by heart.
 
+Defaults on either side of the ellipsis
+must be *constant expressions* --
+literals, `NULL`/`TRUE`/`FALSE`/`NA`,
+`c()` or `list()` of constants,
+or the `deprecated()` sentinel.
+A complex default -- an option lookup, `V(graph)`,
+a reference to another argument, a random draw --
+is evaluated lazily at an unpredictable time
+and hides the real behavior from the signature:
+declare the formal as `NULL`
+and resolve it in the body
+after all arguments are available.
+The migration generator enforces this rule for migrated signatures.
+
 New functions follow the same zoning,
 with `rlang::check_dots_empty()` guarding the ellipsis
 (no migration machinery needed);

--- a/tools/README.md
+++ b/tools/README.md
@@ -154,6 +154,10 @@ that, the migrated function carries a small **generated block** in its body that
 recovers the legacy call — by position **or by (partial) name** — and emits one
 soft-deprecation.
 
+Which arguments belong before and after the `...` is a design decision,
+documented in
+[CONTRIBUTING.md](../CONTRIBUTING.md#argument-order-and-the-ellipsis).
+
 The block is **generated in place**, not written by hand:
 
 - **`tools/migrations/<topic>.R`** are the source of truth: one registry file

--- a/tools/migrations/README.md
+++ b/tools/migrations/README.md
@@ -11,6 +11,10 @@ for the mechanics.
 A function may be declared in only one registry file;
 the generator stops with an error on duplicates.
 
+The design rules for choosing which arguments go before and after `...`
+are documented in
+[CONTRIBUTING.md](../../CONTRIBUTING.md#argument-order-and-the-ellipsis).
+
 Regenerate the spliced blocks after editing any registry file:
 
 ```sh


### PR DESCRIPTION
# Central PR: moving optional arguments past the ellipsis, repo-wide

Coordination point for applying the argument-migration pattern
(#2684, #2686, #2743) across all exported functions with optional arguments.
After #2779 landed the registry-split logic on `main`, this PR is **docs-only**:
the design rationale in `CONTRIBUTING.md`
(section *Argument Order and the Ellipsis*),
with pointers from `AGENTS.md`, `tools/README.md`,
and `tools/migrations/README.md`.

## The zoning rules (summary)

**Head (before `...`, positional):**

1. All required arguments, data first.
   This includes functions with three or more required arguments:
   a required argument after `...` would be keyword-only but still required,
   which hides it from the signature and worsens error messages.
2. At most a few *defining* optional arguments — those that say **what**
   is computed, not **how**:
   the objects operated on (`v` in `degree()`),
   model parameters (`power`, `m` in `sample_pa()`),
   or a variant-selecting enum (`type` in `as_adjacency_matrix()`).

**Tail (after `...`, keyword-only):** everything else, roughly ordered as
interpretation modifiers (`mode`, `directed`, `weights`, `loops`) →
output shape (`normalized`, `names`, `sparse`) →
algorithm/tuning (`algorithm`, `options`, callbacks) →
deprecated arguments last.

**Deliberate deviation from the tidyverse design guide:**
[dots-after-required](https://design.tidyverse.org/dots-after-required.html)
puts `...` immediately after the required arguments.
We allow a small head of defining optional arguments because idiomatic
positional calls (`degree(g, 1:3)`, `sample_pa(100, 1.5)`) are pervasive in
20 years of scripts, books, and teaching material; deprecating the idiomatic
form would create warning noise without a safety benefit.
The safety value of keyword-only arguments lies in the long tail of options.

**Invariants of the sweep:**

- No behavior changes: defaults stay untouched, no renames in this wave
  (renames remain expressible in the registry via the bare-symbol convention
  and can be layered per function family later).
- Old positional/abbreviated calls keep working through the generated
  ARG_HANDLE recovery, with a single `lifecycle::deprecate_soft("3.0.0", …)`.
- Deprecated functions are not touched.

## Topic PRs (226 functions, 21 PRs)

Each topic PR is a single commit on `main` (the split logic landed via #2779).

| PR | topic | functions |
|---|---|---|
| #2759 | structural-properties (incl. components, paths) | 37 |
| #2760 | games | 36 |
| #2761 | make | 23 |
| #2762 | layout | 17 |
| #2766 | conversion (incl. adjacency, incidence) | 11 |
| #2763 | centrality | 10 |
| #2768 | topology / isomorphism | 10 |
| #2765 | community | 9 |
| #2767 | flow (incl. cohesive blocks) | 9 |
| #2770 | interface / iterators | 8 |
| #2771 | hrg + embedding | 7 |
| #2777 | plotting / tkplot / par | 7 |
| #2764 | centralization | 6 |
| #2769 | cliques | 6 |
| #2772 | motifs + graphlets | 6 |
| #2776 | similarity / efficiency / assortativity | 6 |
| #2778 | misc (foreign, sir, coloring, …) | 5 |
| #2758 | trees / decomposition | 4 |
| #2773 | operators / rewire | 4 |
| #2775 | walks + cycles | 3 |
| #2774 | bipartite + degseq | 2 |

## Not in this sweep (and why)

- `simplify()`, `as_undirected()`, `contract()` — already migrated in #2742.
- Deprecated functions (`erdos.renyi.game()`, `sample_bipartite()`, …) — never changed.
- Replacement functions (`E<-`, `vertex_attr<-`, …) — `value` handling is special.
- Shape-API contract functions (`shapes()`, `shape_noclip()`) — positional calls are the contract.
- `sample_correlated_gnp_pair()` (`p` ~ `permutation`), `lattice()` (`dimvector` ~ `dim`) —
  head/recoverable prefix clashes the #2743 guard rightly rejects; need manual treatment.
- ~20 functions whose optional arguments are all *defining* (nothing to move).
- The trailing-pass-through-dots family (`mst()`, `read_graph()`, `isomorphic()`,
  `local_scan()`, `power.law.fit()`, `layout_nicely()`, …) — their `...` forwards
  to other functions, which the recovery machinery cannot disambiguate;
  needs a dedicated design.