### PR TITLE
refactor: move optional arguments of games functions behind the ellipsis

### DIFF
--- a/R/cycles.R
+++ b/R/cycles.R
@@ -31,6 +31,7 @@
 #' a specific cycle.
 #'
 #' @param graph The input graph.
+#' @inheritParams rlang::args_dots_empty
 #' @param mode Character constant specifying how to handle directed graphs.
 #'   `out` follows edge directions, `in` follows edges in the reverse direction,
 #'   and `all` ignores edge directions. Ignored in undirected graphs.

--- a/R/games.R
+++ b/R/games.R
@@ -820,6 +820,7 @@ aging.prefatt.game <- function(
 #'   defaults to 1.
 #'   This argument is only used if both `out.dist` and `out.seq` are omitted
 #'   or NULL.
+#' @inheritParams rlang::args_dots_empty
 #' @param out.dist Numeric vector, the distribution of the number of edges to
 #'   add in each time step. This argument is only used if the `out.seq`
 #'   argument is omitted or NULL.
@@ -869,18 +870,85 @@ sample_pa <- function(
   n,
   power = 1,
   m = NULL,
+  ...,
   out.dist = NULL,
   out.seq = NULL,
   out.pref = FALSE,
   zero.appeal = 1,
   directed = TRUE,
-  algorithm = c(
-    "psumtree",
-    "psumtree-multiple",
-    "bag"
-  ),
+  algorithm = c( "psumtree", "psumtree-multiple", "bag" ),
   start.graph = NULL
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_pa, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        out.dist = out.dist,
+        out.seq = out.seq,
+        out.pref = out.pref,
+        zero.appeal = zero.appeal,
+        directed = directed,
+        algorithm = algorithm,
+        start.graph = start.graph
+      ),
+      recover_new = c(
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "zero.appeal",
+        "directed",
+        "algorithm",
+        "start.graph"
+      ),
+      recover_old = c(
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "zero.appeal",
+        "directed",
+        "algorithm",
+        "start.graph"
+      ),
+      match_names = c(
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "zero.appeal",
+        "directed",
+        "algorithm",
+        "start.graph"
+      ),
+      match_to = c(
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "zero.appeal",
+        "directed",
+        "algorithm",
+        "start.graph"
+      ),
+      defaults = list(
+        out.dist = NULL,
+        out.seq = NULL,
+        out.pref = FALSE,
+        zero.appeal = 1,
+        directed = TRUE,
+        algorithm = c("psumtree", "psumtree-multiple", "bag"),
+        start.graph = NULL
+      ),
+      head_args = c("n", "power", "m"),
+      fn_name = "sample_pa"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   if (!is.null(start.graph) && !is_igraph(start.graph)) {
     cli::cli_abort(
       "{.arg start.graph} must be an {.cls igraph} object, not {.obj_type_friendly {start.graph}}."
@@ -963,11 +1031,13 @@ sample_pa <- function(
 }
 
 #' @rdname sample_pa
+#' @inheritParams rlang::args_dots_empty
 #' @export
 pa <- function(
   n,
   power = 1,
   m = NULL,
+  ...,
   out.dist = NULL,
   out.seq = NULL,
   out.pref = FALSE,
@@ -976,6 +1046,76 @@ pa <- function(
   algorithm = c("psumtree", "psumtree-multiple", "bag"),
   start.graph = NULL
 ) {
+  # BEGIN GENERATED ARG_HANDLE: pa, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        out.dist = out.dist,
+        out.seq = out.seq,
+        out.pref = out.pref,
+        zero.appeal = zero.appeal,
+        directed = directed,
+        algorithm = algorithm,
+        start.graph = start.graph
+      ),
+      recover_new = c(
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "zero.appeal",
+        "directed",
+        "algorithm",
+        "start.graph"
+      ),
+      recover_old = c(
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "zero.appeal",
+        "directed",
+        "algorithm",
+        "start.graph"
+      ),
+      match_names = c(
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "zero.appeal",
+        "directed",
+        "algorithm",
+        "start.graph"
+      ),
+      match_to = c(
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "zero.appeal",
+        "directed",
+        "algorithm",
+        "start.graph"
+      ),
+      defaults = list(
+        out.dist = NULL,
+        out.seq = NULL,
+        out.pref = FALSE,
+        zero.appeal = 1,
+        directed = TRUE,
+        algorithm = c("psumtree", "psumtree-multiple", "bag"),
+        start.graph = NULL
+      ),
+      head_args = c("n", "power", "m"),
+      fn_name = "pa"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     sample_pa,
     n,
@@ -1010,6 +1150,7 @@ pa <- function(
 #' @param n The number of vertices in the graph.
 #' @param p The probability for drawing an edge between two
 #'   arbitrary vertices (\eqn{G(n,p)} graph).
+#' @inheritParams rlang::args_dots_empty
 #' @param directed Logical, whether the graph will be directed, defaults to
 #'   `FALSE`.
 #' @param loops Logical, whether to add loop edges, defaults to `FALSE`.
@@ -1029,7 +1170,35 @@ pa <- function(
 #'
 #' # Pick a simple graph on 6 vertices uniformly at random
 #' plot(sample_gnp(6, 0.5))
-sample_gnp <- function(n, p, directed = FALSE, loops = FALSE) {
+sample_gnp <- function(
+  n,
+  p,
+  ...,
+  directed = FALSE,
+  loops = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: sample_gnp, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, loops = loops),
+      recover_new = c("directed", "loops"),
+      recover_old = c("directed", "loops"),
+      match_names = c("directed", "loops"),
+      match_to = c("directed", "loops"),
+      defaults = list(directed = FALSE, loops = FALSE),
+      head_args = c("n", "p"),
+      fn_name = "sample_gnp"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   type <- "gnp"
 
   res <- erdos_renyi_game_gnp_impl(
@@ -1049,8 +1218,37 @@ sample_gnp <- function(n, p, directed = FALSE, loops = FALSE) {
 }
 
 #' @rdname sample_gnp
+#' @inheritParams rlang::args_dots_empty
 #' @export
-gnp <- function(n, p, directed = FALSE, loops = FALSE) {
+gnp <- function(
+  n,
+  p,
+  ...,
+  directed = FALSE,
+  loops = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: gnp, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, loops = loops),
+      recover_new = c("directed", "loops"),
+      recover_old = c("directed", "loops"),
+      match_names = c("directed", "loops"),
+      match_to = c("directed", "loops"),
+      defaults = list(directed = FALSE, loops = FALSE),
+      head_args = c("n", "p"),
+      fn_name = "gnp"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(sample_gnp, n = n, p = p, directed = directed, loops = loops)
 }
 
@@ -1067,6 +1265,7 @@ gnp <- function(n, p, directed = FALSE, loops = FALSE) {
 #' @param n The number of vertices in the graph.
 #' @param m The number of edges in the graph.
 #' @inheritParams sample_gnp
+#' @inheritParams rlang::args_dots_empty
 #' @return A graph object.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
 #' @references Erdős, P. and Rényi, A., On random graphs, *Publicationes
@@ -1078,7 +1277,35 @@ gnp <- function(n, p, directed = FALSE, loops = FALSE) {
 #'
 #' g <- sample_gnm(1000, 1000)
 #' degree_distribution(g)
-sample_gnm <- function(n, m, directed = FALSE, loops = FALSE) {
+sample_gnm <- function(
+  n,
+  m,
+  ...,
+  directed = FALSE,
+  loops = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: sample_gnm, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, loops = loops),
+      recover_new = c("directed", "loops"),
+      recover_old = c("directed", "loops"),
+      match_names = c("directed", "loops"),
+      match_to = c("directed", "loops"),
+      defaults = list(directed = FALSE, loops = FALSE),
+      head_args = c("n", "m"),
+      fn_name = "sample_gnm"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   type <- "gnm"
 
   res <- erdos_renyi_game_gnm_impl(
@@ -1098,8 +1325,37 @@ sample_gnm <- function(n, m, directed = FALSE, loops = FALSE) {
 }
 
 #' @rdname sample_gnm
+#' @inheritParams rlang::args_dots_empty
 #' @export
-gnm <- function(n, m, directed = FALSE, loops = FALSE) {
+gnm <- function(
+  n,
+  m,
+  ...,
+  directed = FALSE,
+  loops = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: gnm, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, loops = loops),
+      recover_new = c("directed", "loops"),
+      recover_old = c("directed", "loops"),
+      match_names = c("directed", "loops"),
+      match_to = c("directed", "loops"),
+      defaults = list(directed = FALSE, loops = FALSE),
+      head_args = c("n", "m"),
+      fn_name = "gnm"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(sample_gnm, n = n, m = m, directed = directed, loops = loops)
 }
 
@@ -1231,6 +1487,7 @@ random.graph.game <- function(
 #'   `in.deg`.
 #' @param in.deg For directed graph, the in-degree sequence. By default this is
 #'   `NULL` and an undirected graph is created.
+#' @inheritParams rlang::args_dots_empty
 #' @param method Character, the method for generating the graph. See Details.
 #' @return The new graph object.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
@@ -1352,14 +1609,33 @@ random.graph.game <- function(
 sample_degseq <- function(
   out.deg,
   in.deg = NULL,
-  method = c(
-    "configuration",
-    "vl",
-    "fast.heur.simple",
-    "configuration.simple",
-    "edge.switching.simple"
-  )
+  ...,
+  method = c( "configuration", "vl", "fast.heur.simple", "configuration.simple", "edge.switching.simple" )
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_degseq, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(method = method),
+      recover_new = c("method"),
+      recover_old = c("method"),
+      match_names = c("method"),
+      match_to = c("method"),
+      defaults = list(
+        method = c("configuration", "vl", "fast.heur.simple", "configuration.simple", "edge.switching.simple")
+      ),
+      head_args = c("out.deg", "in.deg"),
+      fn_name = "sample_degseq"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   if (missing(method)) {
     method <- method[1]
   }
@@ -1546,6 +1822,7 @@ growing <- function(n, m = 1, ..., directed = TRUE, citation = FALSE) {
 #' @param m The number of edges each new vertex creates (except the very first
 #'   vertex). This argument is used only if both the `out.dist` and
 #'   `out.seq` arguments are NULL.
+#' @inheritParams rlang::args_dots_empty
 #' @param aging.bin The number of bins to use for measuring the age of
 #'   vertices, see details below.
 #' @param out.dist The discrete distribution to generate the number of edges to
@@ -1587,6 +1864,7 @@ sample_pa_age <- function(
   pa.exp,
   aging.exp,
   m = NULL,
+  ...,
   aging.bin = 300,
   out.dist = NULL,
   out.seq = NULL,
@@ -1598,6 +1876,94 @@ sample_pa_age <- function(
   age.coef = 1,
   time.window = NULL
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_pa_age, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        aging.bin = aging.bin,
+        out.dist = out.dist,
+        out.seq = out.seq,
+        out.pref = out.pref,
+        directed = directed,
+        zero.deg.appeal = zero.deg.appeal,
+        zero.age.appeal = zero.age.appeal,
+        deg.coef = deg.coef,
+        age.coef = age.coef,
+        time.window = time.window
+      ),
+      recover_new = c(
+        "aging.bin",
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "directed",
+        "zero.deg.appeal",
+        "zero.age.appeal",
+        "deg.coef",
+        "age.coef",
+        "time.window"
+      ),
+      recover_old = c(
+        "aging.bin",
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "directed",
+        "zero.deg.appeal",
+        "zero.age.appeal",
+        "deg.coef",
+        "age.coef",
+        "time.window"
+      ),
+      match_names = c(
+        "aging.bin",
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "directed",
+        "zero.deg.appeal",
+        "zero.age.appeal",
+        "deg.coef",
+        "age.coef",
+        "time.window"
+      ),
+      match_to = c(
+        "aging.bin",
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "directed",
+        "zero.deg.appeal",
+        "zero.age.appeal",
+        "deg.coef",
+        "age.coef",
+        "time.window"
+      ),
+      defaults = list(
+        aging.bin = 300,
+        out.dist = NULL,
+        out.seq = NULL,
+        out.pref = FALSE,
+        directed = TRUE,
+        zero.deg.appeal = 1,
+        zero.age.appeal = 0,
+        deg.coef = 1,
+        age.coef = 1,
+        time.window = NULL
+      ),
+      head_args = c("n", "pa.exp", "aging.exp", "m"),
+      fn_name = "sample_pa_age"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   # Checks
   if (!is.null(out.seq) && (!is.null(m) || !is.null(out.dist))) {
     cli::cli_warn(
@@ -1710,12 +2076,14 @@ sample_pa_age <- function(
 }
 
 #' @rdname sample_pa_age
+#' @inheritParams rlang::args_dots_empty
 #' @export
 pa_age <- function(
   n,
   pa.exp,
   aging.exp,
   m = NULL,
+  ...,
   aging.bin = 300,
   out.dist = NULL,
   out.seq = NULL,
@@ -1727,6 +2095,94 @@ pa_age <- function(
   age.coef = 1,
   time.window = NULL
 ) {
+  # BEGIN GENERATED ARG_HANDLE: pa_age, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        aging.bin = aging.bin,
+        out.dist = out.dist,
+        out.seq = out.seq,
+        out.pref = out.pref,
+        directed = directed,
+        zero.deg.appeal = zero.deg.appeal,
+        zero.age.appeal = zero.age.appeal,
+        deg.coef = deg.coef,
+        age.coef = age.coef,
+        time.window = time.window
+      ),
+      recover_new = c(
+        "aging.bin",
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "directed",
+        "zero.deg.appeal",
+        "zero.age.appeal",
+        "deg.coef",
+        "age.coef",
+        "time.window"
+      ),
+      recover_old = c(
+        "aging.bin",
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "directed",
+        "zero.deg.appeal",
+        "zero.age.appeal",
+        "deg.coef",
+        "age.coef",
+        "time.window"
+      ),
+      match_names = c(
+        "aging.bin",
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "directed",
+        "zero.deg.appeal",
+        "zero.age.appeal",
+        "deg.coef",
+        "age.coef",
+        "time.window"
+      ),
+      match_to = c(
+        "aging.bin",
+        "out.dist",
+        "out.seq",
+        "out.pref",
+        "directed",
+        "zero.deg.appeal",
+        "zero.age.appeal",
+        "deg.coef",
+        "age.coef",
+        "time.window"
+      ),
+      defaults = list(
+        aging.bin = 300,
+        out.dist = NULL,
+        out.seq = NULL,
+        out.pref = FALSE,
+        directed = TRUE,
+        zero.deg.appeal = 1,
+        zero.age.appeal = 0,
+        deg.coef = 1,
+        age.coef = 1,
+        time.window = NULL
+      ),
+      head_args = c("n", "pa.exp", "aging.exp", "m"),
+      fn_name = "pa_age"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     sample_pa_age,
     n,
@@ -1769,6 +2225,7 @@ pa_age <- function(
 #'
 #' @param nodes The number of vertices in the graph.
 #' @param types The number of different vertex types.
+#' @inheritParams rlang::args_dots_empty
 #' @param edge.per.step The number of edges to add to the graph per time step.
 #' @param type.dist The distribution of the vertex types. This is assumed to be
 #'   stationary in time.
@@ -1789,11 +2246,44 @@ pa_age <- function(
 sample_traits_callaway <- function(
   nodes,
   types,
+  ...,
   edge.per.step = 1,
   type.dist = rep(1, types),
   pref.matrix = matrix(1, types, types),
   directed = FALSE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_traits_callaway, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        edge.per.step = edge.per.step,
+        type.dist = type.dist,
+        pref.matrix = pref.matrix,
+        directed = directed
+      ),
+      recover_new = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+      recover_old = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+      match_names = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+      match_to = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+      defaults = list(
+        edge.per.step = 1,
+        type.dist = rep(1, types),
+        pref.matrix = matrix(1, types, types),
+        directed = FALSE
+      ),
+      head_args = c("nodes", "types"),
+      fn_name = "sample_traits_callaway"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   res <- callaway_traits_game_impl(
     nodes = nodes,
     types = types,
@@ -1817,15 +2307,49 @@ sample_traits_callaway <- function(
 }
 
 #' @rdname sample_traits_callaway
+#' @inheritParams rlang::args_dots_empty
 #' @export
 traits_callaway <- function(
   nodes,
   types,
+  ...,
   edge.per.step = 1,
   type.dist = rep(1, types),
   pref.matrix = matrix(1, types, types),
   directed = FALSE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: traits_callaway, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        edge.per.step = edge.per.step,
+        type.dist = type.dist,
+        pref.matrix = pref.matrix,
+        directed = directed
+      ),
+      recover_new = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+      recover_old = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+      match_names = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+      match_to = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+      defaults = list(
+        edge.per.step = 1,
+        type.dist = rep(1, types),
+        pref.matrix = matrix(1, types, types),
+        directed = FALSE
+      ),
+      head_args = c("nodes", "types"),
+      fn_name = "traits_callaway"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     sample_traits_callaway,
     nodes,
@@ -1838,15 +2362,47 @@ traits_callaway <- function(
 }
 
 #' @rdname sample_traits_callaway
+#' @inheritParams rlang::args_dots_empty
 #' @export
 sample_traits <- function(
   nodes,
   types,
   k = 1,
+  ...,
   type.dist = rep(1, types),
   pref.matrix = matrix(1, types, types),
   directed = FALSE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_traits, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        type.dist = type.dist,
+        pref.matrix = pref.matrix,
+        directed = directed
+      ),
+      recover_new = c("type.dist", "pref.matrix", "directed"),
+      recover_old = c("type.dist", "pref.matrix", "directed"),
+      match_names = c("type.dist", "pref.matrix", "directed"),
+      match_to = c("type.dist", "pref.matrix", "directed"),
+      defaults = list(
+        type.dist = rep(1, types),
+        pref.matrix = matrix(1, types, types),
+        directed = FALSE
+      ),
+      head_args = c("nodes", "types", "k"),
+      fn_name = "sample_traits"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   res <- establishment_game_impl(
     nodes = nodes,
     types = types,
@@ -1866,15 +2422,47 @@ sample_traits <- function(
 }
 
 #' @rdname sample_traits_callaway
+#' @inheritParams rlang::args_dots_empty
 #' @export
 traits <- function(
   nodes,
   types,
   k = 1,
+  ...,
   type.dist = rep(1, types),
   pref.matrix = matrix(1, types, types),
   directed = FALSE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: traits, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        type.dist = type.dist,
+        pref.matrix = pref.matrix,
+        directed = directed
+      ),
+      recover_new = c("type.dist", "pref.matrix", "directed"),
+      recover_old = c("type.dist", "pref.matrix", "directed"),
+      match_names = c("type.dist", "pref.matrix", "directed"),
+      match_to = c("type.dist", "pref.matrix", "directed"),
+      defaults = list(
+        type.dist = rep(1, types),
+        pref.matrix = matrix(1, types, types),
+        directed = FALSE
+      ),
+      head_args = c("nodes", "types", "k"),
+      fn_name = "traits"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     sample_traits,
     nodes,
@@ -1902,6 +2490,7 @@ traits <- function(
 #' @param nodes The number of vertices in the graph.
 #' @param radius The radius within which the vertices will be connected by an
 #'   edge.
+#' @inheritParams rlang::args_dots_empty
 #' @param torus Logical, whether to use a torus instead of a square.
 #' @param coords Logical, whether to add the positions of the vertices
 #'   as vertex attributes called \sQuote{`x`} and \sQuote{`y`}.
@@ -1917,7 +2506,35 @@ traits <- function(
 #' g <- sample_grg(1000, 0.05, torus = FALSE)
 #' g2 <- sample_grg(1000, 0.05, torus = TRUE)
 #'
-sample_grg <- function(nodes, radius, torus = FALSE, coords = FALSE) {
+sample_grg <- function(
+  nodes,
+  radius,
+  ...,
+  torus = FALSE,
+  coords = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: sample_grg, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(torus = torus, coords = coords),
+      recover_new = c("torus", "coords"),
+      recover_old = c("torus", "coords"),
+      match_names = c("torus", "coords"),
+      match_to = c("torus", "coords"),
+      defaults = list(torus = FALSE, coords = FALSE),
+      head_args = c("nodes", "radius"),
+      fn_name = "sample_grg"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   on.exit(.Call(Rx_igraph_finalizer))
   res <- .Call(
     Rx_igraph_grg_game,
@@ -1939,8 +2556,37 @@ sample_grg <- function(nodes, radius, torus = FALSE, coords = FALSE) {
 }
 
 #' @rdname sample_grg
+#' @inheritParams rlang::args_dots_empty
 #' @export
-grg <- function(nodes, radius, torus = FALSE, coords = FALSE) {
+grg <- function(
+  nodes,
+  radius,
+  ...,
+  torus = FALSE,
+  coords = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: grg, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(torus = torus, coords = coords),
+      recover_new = c("torus", "coords"),
+      recover_old = c("torus", "coords"),
+      match_names = c("torus", "coords"),
+      match_to = c("torus", "coords"),
+      defaults = list(torus = FALSE, coords = FALSE),
+      head_args = c("nodes", "radius"),
+      fn_name = "grg"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     sample_grg,
     nodes = nodes,
@@ -1976,6 +2622,7 @@ grg <- function(nodes, radius, torus = FALSE, coords = FALSE) {
 #'
 #' @param nodes The number of vertices in the graphs.
 #' @param types The number of different vertex types.
+#' @inheritParams rlang::args_dots_empty
 #' @param type.dist The distribution of the vertex types, a numeric vector of
 #'   length \sQuote{types} containing non-negative numbers. The vector will be
 #'   normed to obtain probabilities.
@@ -2013,12 +2660,71 @@ grg <- function(nodes, radius, torus = FALSE, coords = FALSE) {
 sample_pref <- function(
   nodes,
   types,
+  ...,
   type.dist = rep(1, types),
   fixed.sizes = FALSE,
   pref.matrix = matrix(1, types, types),
   directed = FALSE,
   loops = FALSE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_pref, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        type.dist = type.dist,
+        fixed.sizes = fixed.sizes,
+        pref.matrix = pref.matrix,
+        directed = directed,
+        loops = loops
+      ),
+      recover_new = c(
+        "type.dist",
+        "fixed.sizes",
+        "pref.matrix",
+        "directed",
+        "loops"
+      ),
+      recover_old = c(
+        "type.dist",
+        "fixed.sizes",
+        "pref.matrix",
+        "directed",
+        "loops"
+      ),
+      match_names = c(
+        "type.dist",
+        "fixed.sizes",
+        "pref.matrix",
+        "directed",
+        "loops"
+      ),
+      match_to = c(
+        "type.dist",
+        "fixed.sizes",
+        "pref.matrix",
+        "directed",
+        "loops"
+      ),
+      defaults = list(
+        type.dist = rep(1, types),
+        fixed.sizes = FALSE,
+        pref.matrix = matrix(1, types, types),
+        directed = FALSE,
+        loops = FALSE
+      ),
+      head_args = c("nodes", "types"),
+      fn_name = "sample_pref"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   if (nrow(pref.matrix) != types || ncol(pref.matrix) != types) {
     cli::cli_abort(c(
       "{.arg pref.matrix} must have {.arg types} rows and columns.",
@@ -2048,16 +2754,76 @@ sample_pref <- function(
 }
 
 #' @rdname sample_pref
+#' @inheritParams rlang::args_dots_empty
 #' @export
 pref <- function(
   nodes,
   types,
+  ...,
   type.dist = rep(1, types),
   fixed.sizes = FALSE,
   pref.matrix = matrix(1, types, types),
   directed = FALSE,
   loops = FALSE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: pref, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        type.dist = type.dist,
+        fixed.sizes = fixed.sizes,
+        pref.matrix = pref.matrix,
+        directed = directed,
+        loops = loops
+      ),
+      recover_new = c(
+        "type.dist",
+        "fixed.sizes",
+        "pref.matrix",
+        "directed",
+        "loops"
+      ),
+      recover_old = c(
+        "type.dist",
+        "fixed.sizes",
+        "pref.matrix",
+        "directed",
+        "loops"
+      ),
+      match_names = c(
+        "type.dist",
+        "fixed.sizes",
+        "pref.matrix",
+        "directed",
+        "loops"
+      ),
+      match_to = c(
+        "type.dist",
+        "fixed.sizes",
+        "pref.matrix",
+        "directed",
+        "loops"
+      ),
+      defaults = list(
+        type.dist = rep(1, types),
+        fixed.sizes = FALSE,
+        pref.matrix = matrix(1, types, types),
+        directed = FALSE,
+        loops = FALSE
+      ),
+      head_args = c("nodes", "types"),
+      fn_name = "pref"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     sample_pref,
     nodes,
@@ -2071,14 +2837,46 @@ pref <- function(
 }
 
 #' @rdname sample_pref
+#' @inheritParams rlang::args_dots_empty
 #' @export
 sample_asym_pref <- function(
   nodes,
   types,
+  ...,
   type.dist.matrix = matrix(1, types, types),
   pref.matrix = matrix(1, types, types),
   loops = FALSE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_asym_pref, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        type.dist.matrix = type.dist.matrix,
+        pref.matrix = pref.matrix,
+        loops = loops
+      ),
+      recover_new = c("type.dist.matrix", "pref.matrix", "loops"),
+      recover_old = c("type.dist.matrix", "pref.matrix", "loops"),
+      match_names = c("type.dist.matrix", "pref.matrix", "loops"),
+      match_to = c("type.dist.matrix", "pref.matrix", "loops"),
+      defaults = list(
+        type.dist.matrix = matrix(1, types, types),
+        pref.matrix = matrix(1, types, types),
+        loops = FALSE
+      ),
+      head_args = c("nodes", "types"),
+      fn_name = "sample_asym_pref"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   if (nrow(pref.matrix) != types || ncol(pref.matrix) != types) {
     cli::cli_abort(c(
       "{.arg pref.matrix} must have {.arg types} rows and columns.",
@@ -2114,14 +2912,46 @@ sample_asym_pref <- function(
 }
 
 #' @rdname sample_pref
+#' @inheritParams rlang::args_dots_empty
 #' @export
 asym_pref <- function(
   nodes,
   types,
+  ...,
   type.dist.matrix = matrix(1, types, types),
   pref.matrix = matrix(1, types, types),
   loops = FALSE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: asym_pref, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        type.dist.matrix = type.dist.matrix,
+        pref.matrix = pref.matrix,
+        loops = loops
+      ),
+      recover_new = c("type.dist.matrix", "pref.matrix", "loops"),
+      recover_old = c("type.dist.matrix", "pref.matrix", "loops"),
+      match_names = c("type.dist.matrix", "pref.matrix", "loops"),
+      match_to = c("type.dist.matrix", "pref.matrix", "loops"),
+      defaults = list(
+        type.dist.matrix = matrix(1, types, types),
+        pref.matrix = matrix(1, types, types),
+        loops = FALSE
+      ),
+      head_args = c("nodes", "types"),
+      fn_name = "asym_pref"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     sample_asym_pref,
     nodes,
@@ -2176,6 +3006,7 @@ connect <- function(graph, order, mode = c("all", "out", "in", "total")) {
 #' @param nei Integer constant, the neighborhood within which the vertices of
 #'   the lattice will be connected.
 #' @param p Real constant between zero and one, the rewiring probability.
+#' @inheritParams rlang::args_dots_empty
 #' @param loops Logical, whether loops edges are allowed in the
 #'   generated graph.
 #' @param multiple Logical, whether multiple edges are allowed int the
@@ -2199,9 +3030,32 @@ sample_smallworld <- function(
   size,
   nei,
   p,
+  ...,
   loops = FALSE,
   multiple = FALSE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_smallworld, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(loops = loops, multiple = multiple),
+      recover_new = c("loops", "multiple"),
+      recover_old = c("loops", "multiple"),
+      match_names = c("loops", "multiple"),
+      match_to = c("loops", "multiple"),
+      defaults = list(loops = FALSE, multiple = FALSE),
+      head_args = c("dim", "size", "nei", "p"),
+      fn_name = "sample_smallworld"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   res <- watts_strogatz_game_impl(
     dim = dim,
     size = size,
@@ -2223,8 +3077,39 @@ sample_smallworld <- function(
 }
 
 #' @rdname sample_smallworld
+#' @inheritParams rlang::args_dots_empty
 #' @export
-smallworld <- function(dim, size, nei, p, loops = FALSE, multiple = FALSE) {
+smallworld <- function(
+  dim,
+  size,
+  nei,
+  p,
+  ...,
+  loops = FALSE,
+  multiple = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: smallworld, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(loops = loops, multiple = multiple),
+      recover_new = c("loops", "multiple"),
+      recover_old = c("loops", "multiple"),
+      match_names = c("loops", "multiple"),
+      match_to = c("loops", "multiple"),
+      defaults = list(loops = FALSE, multiple = FALSE),
+      head_args = c("dim", "size", "nei", "p"),
+      fn_name = "smallworld"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     sample_smallworld,
     dim = dim,
@@ -2253,6 +3138,7 @@ smallworld <- function(dim, size, nei, p, loops = FALSE, multiple = FALSE) {
 #'
 #' @param n Number of vertices.
 #' @param edges Number of edges per step.
+#' @inheritParams rlang::args_dots_empty
 #' @param agebins Number of aging bins.
 #' @param pref Vector (`sample_last_cit()` and `sample_cit_types()` or
 #'   matrix (`sample_cit_cit_types()`) giving the (unnormalized) citation
@@ -2270,10 +3156,37 @@ smallworld <- function(dim, size, nei, p, loops = FALSE, multiple = FALSE) {
 sample_last_cit <- function(
   n,
   edges = 1,
+  ...,
   agebins = n / 7100,
   pref = (1:(agebins + 1))^-3,
   directed = TRUE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_last_cit, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(agebins = agebins, pref = pref, directed = directed),
+      recover_new = c("agebins", "pref", "directed"),
+      recover_old = c("agebins", "pref", "directed"),
+      match_names = c("agebins", "pref", "directed"),
+      match_to = c("agebins", "pref", "directed"),
+      defaults = list(
+        agebins = n / 7100,
+        pref = (1:(agebins + 1))^-3,
+        directed = TRUE
+      ),
+      head_args = c("n", "edges"),
+      fn_name = "sample_last_cit"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   res <- lastcit_game_impl(
     nodes = n,
     edges_per_node = edges,
@@ -2290,14 +3203,42 @@ sample_last_cit <- function(
 }
 
 #' @rdname sample_last_cit
+#' @inheritParams rlang::args_dots_empty
 #' @export
 last_cit <- function(
   n,
   edges = 1,
+  ...,
   agebins = n / 7100,
   pref = (1:(agebins + 1))^-3,
   directed = TRUE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: last_cit, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(agebins = agebins, pref = pref, directed = directed),
+      recover_new = c("agebins", "pref", "directed"),
+      recover_old = c("agebins", "pref", "directed"),
+      match_names = c("agebins", "pref", "directed"),
+      match_to = c("agebins", "pref", "directed"),
+      defaults = list(
+        agebins = n / 7100,
+        pref = (1:(agebins + 1))^-3,
+        directed = TRUE
+      ),
+      head_args = c("n", "edges"),
+      fn_name = "last_cit"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     sample_last_cit,
     n = n,
@@ -2309,15 +3250,43 @@ last_cit <- function(
 }
 
 #' @rdname sample_last_cit
+#' @inheritParams rlang::args_dots_empty
 #' @export
 sample_cit_types <- function(
   n,
   edges = 1,
   types = rep(0, n),
+  ...,
   pref = rep(1, length(types)),
   directed = TRUE,
   attr = TRUE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_cit_types, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(pref = pref, directed = directed, attr = attr),
+      recover_new = c("pref", "directed", "attr"),
+      recover_old = c("pref", "directed", "attr"),
+      match_names = c("pref", "directed", "attr"),
+      match_to = c("pref", "directed", "attr"),
+      defaults = list(
+        pref = rep(1, length(types)),
+        directed = TRUE,
+        attr = TRUE
+      ),
+      head_args = c("n", "edges", "types"),
+      fn_name = "sample_cit_types"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   res <- cited_type_game_impl(
     nodes = n,
     types = types,
@@ -2336,15 +3305,43 @@ sample_cit_types <- function(
 }
 
 #' @rdname sample_last_cit
+#' @inheritParams rlang::args_dots_empty
 #' @export
 cit_types <- function(
   n,
   edges = 1,
   types = rep(0, n),
+  ...,
   pref = rep(1, length(types)),
   directed = TRUE,
   attr = TRUE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: cit_types, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(pref = pref, directed = directed, attr = attr),
+      recover_new = c("pref", "directed", "attr"),
+      recover_old = c("pref", "directed", "attr"),
+      match_names = c("pref", "directed", "attr"),
+      match_to = c("pref", "directed", "attr"),
+      defaults = list(
+        pref = rep(1, length(types)),
+        directed = TRUE,
+        attr = TRUE
+      ),
+      head_args = c("n", "edges", "types"),
+      fn_name = "cit_types"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     sample_cit_types,
     n = n,
@@ -2357,15 +3354,43 @@ cit_types <- function(
 }
 
 #' @rdname sample_last_cit
+#' @inheritParams rlang::args_dots_empty
 #' @export
 sample_cit_cit_types <- function(
   n,
   edges = 1,
   types = rep(0, n),
+  ...,
   pref = matrix(1, nrow = length(types), ncol = length(types)),
   directed = TRUE,
   attr = TRUE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_cit_cit_types, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(pref = pref, directed = directed, attr = attr),
+      recover_new = c("pref", "directed", "attr"),
+      recover_old = c("pref", "directed", "attr"),
+      match_names = c("pref", "directed", "attr"),
+      match_to = c("pref", "directed", "attr"),
+      defaults = list(
+        pref = matrix(1, nrow = length(types), ncol = length(types)),
+        directed = TRUE,
+        attr = TRUE
+      ),
+      head_args = c("n", "edges", "types"),
+      fn_name = "sample_cit_cit_types"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   pref[] <- as.numeric(pref)
   res <- citing_cited_type_game_impl(
     nodes = n,
@@ -2385,15 +3410,43 @@ sample_cit_cit_types <- function(
 }
 
 #' @rdname sample_last_cit
+#' @inheritParams rlang::args_dots_empty
 #' @export
 cit_cit_types <- function(
   n,
   edges = 1,
   types = rep(0, n),
+  ...,
   pref = matrix(1, nrow = length(types), ncol = length(types)),
   directed = TRUE,
   attr = TRUE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: cit_cit_types, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(pref = pref, directed = directed, attr = attr),
+      recover_new = c("pref", "directed", "attr"),
+      recover_old = c("pref", "directed", "attr"),
+      match_names = c("pref", "directed", "attr"),
+      match_to = c("pref", "directed", "attr"),
+      defaults = list(
+        pref = matrix(1, nrow = length(types), ncol = length(types)),
+        directed = TRUE,
+        attr = TRUE
+      ),
+      head_args = c("n", "edges", "types"),
+      fn_name = "cit_cit_types"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     sample_cit_cit_types,
     n = n,
@@ -2665,6 +3718,7 @@ sample_bipartite_gnp <- function(
 #' @param block.sizes Numeric vector giving the number of vertices in each
 #'   group. The sum of the vector must match the number of vertices.
 #' @inheritParams sample_pref
+#' @inheritParams rlang::args_dots_empty
 #' @return An igraph graph.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
 #' @references Faust, K., & Wasserman, S. (1992a). Blockmodels: Interpretation
@@ -2682,9 +3736,32 @@ sample_sbm <- function(
   n,
   pref.matrix,
   block.sizes,
+  ...,
   directed = FALSE,
   loops = FALSE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_sbm, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, loops = loops),
+      recover_new = c("directed", "loops"),
+      recover_old = c("directed", "loops"),
+      match_names = c("directed", "loops"),
+      match_to = c("directed", "loops"),
+      defaults = list(directed = FALSE, loops = FALSE),
+      head_args = c("n", "pref.matrix", "block.sizes"),
+      fn_name = "sample_sbm"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   sbm_game_impl(
     n = n,
     pref_matrix = pref.matrix,
@@ -2695,8 +3772,38 @@ sample_sbm <- function(
 }
 
 #' @rdname sample_sbm
+#' @inheritParams rlang::args_dots_empty
 #' @export
-sbm <- function(n, pref.matrix, block.sizes, directed = FALSE, loops = FALSE) {
+sbm <- function(
+  n,
+  pref.matrix,
+  block.sizes,
+  ...,
+  directed = FALSE,
+  loops = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: sbm, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, loops = loops),
+      recover_new = c("directed", "loops"),
+      recover_old = c("directed", "loops"),
+      match_names = c("directed", "loops"),
+      match_to = c("directed", "loops"),
+      defaults = list(directed = FALSE, loops = FALSE),
+      head_args = c("n", "pref.matrix", "block.sizes"),
+      fn_name = "sbm"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     sample_sbm,
     n,
@@ -2817,6 +3924,7 @@ hierarchical_sbm <- function(n, m, rho, C, p) {
 #'
 #' @param vecs A numeric matrix in which each latent position vector is a
 #'   column.
+#' @inheritParams rlang::args_dots_empty
 #' @param directed A Logical, TRUE if the generated graph should be
 #'   directed.
 #' @return An igraph graph object which is the generated random dot product
@@ -2844,7 +3952,33 @@ hierarchical_sbm <- function(n, m, rho, C, p) {
 #' g2
 #' @family games
 #' @export
-sample_dot_product <- function(vecs, directed = FALSE) {
+sample_dot_product <- function(
+  vecs,
+  ...,
+  directed = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: sample_dot_product, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed),
+      recover_new = c("directed"),
+      recover_old = c("directed"),
+      match_names = c("directed"),
+      match_to = c("directed"),
+      defaults = list(directed = FALSE),
+      head_args = c("vecs"),
+      fn_name = "sample_dot_product"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   dot_product_game_impl(
     vecs = vecs,
     directed = directed
@@ -2852,8 +3986,35 @@ sample_dot_product <- function(vecs, directed = FALSE) {
 }
 
 #' @rdname sample_dot_product
+#' @inheritParams rlang::args_dots_empty
 #' @export
-dot_product <- function(vecs, directed = FALSE) {
+dot_product <- function(
+  vecs,
+  ...,
+  directed = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: dot_product, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed),
+      recover_new = c("directed"),
+      recover_old = c("directed"),
+      match_names = c("directed"),
+      match_to = c("directed"),
+      defaults = list(directed = FALSE),
+      head_args = c("vecs"),
+      fn_name = "dot_product"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(sample_dot_product, vecs = vecs, directed = directed)
 }
 
@@ -2916,6 +4077,7 @@ sample_islands <- function(islands.n, islands.size, islands.pin, n.inter) {
 #'   graph.
 #' @param k Integer scalar, the degree of each vertex in the graph, or the
 #'   out-degree and in-degree in a directed graph.
+#' @inheritParams rlang::args_dots_empty
 #' @param directed Logical, whether to create a directed graph.
 #' @param multiple Logical, whether multiple edges are allowed.
 #' @return An igraph graph.
@@ -2939,9 +4101,32 @@ sample_islands <- function(islands.n, islands.size, islands.pin, n.inter) {
 sample_k_regular <- function(
   no.of.nodes,
   k,
+  ...,
   directed = FALSE,
   multiple = FALSE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_k_regular, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, multiple = multiple),
+      recover_new = c("directed", "multiple"),
+      recover_old = c("directed", "multiple"),
+      match_names = c("directed", "multiple"),
+      match_to = c("directed", "multiple"),
+      defaults = list(directed = FALSE, multiple = FALSE),
+      head_args = c("no.of.nodes", "k"),
+      fn_name = "sample_k_regular"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   k_regular_game_impl(
     no_of_nodes = no.of.nodes,
     k = k,
@@ -3170,6 +4355,7 @@ chung_lu <- function(
 #' @param fitness.in Numeric vector that specifies the in-fitness of each vertex.
 #'   The generated graph will be directed.
 #'   Default: `NULL`, the generated graph will be undirected.
+#' @inheritParams rlang::args_dots_empty
 #' @param loops Logical, whether to allow loop edges in the graph.
 #' @param multiple Logical, whether to allow multiple edges in the
 #'   graph.
@@ -3191,9 +4377,32 @@ sample_fitness <- function(
   no.of.edges,
   fitness.out,
   fitness.in = NULL,
+  ...,
   loops = FALSE,
   multiple = FALSE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_fitness, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(loops = loops, multiple = multiple),
+      recover_new = c("loops", "multiple"),
+      recover_old = c("loops", "multiple"),
+      match_names = c("loops", "multiple"),
+      match_to = c("loops", "multiple"),
+      defaults = list(loops = FALSE, multiple = FALSE),
+      head_args = c("no.of.edges", "fitness.out", "fitness.in"),
+      fn_name = "sample_fitness"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   static_fitness_game_impl(
     no_of_edges = no.of.edges,
     fitness_out = fitness.out,
@@ -3245,6 +4454,7 @@ sample_fitness <- function(
 #' @inheritParams sample_fitness
 #' @param finite.size.correction Logical, whether to use the proposed
 #'   finite size correction of Cho et al., see references below.
+#' @inheritParams rlang::args_dots_empty
 #' @return An igraph graph, directed or undirected.
 #' @author Tamas Nepusz \email{ntamas@@gmail.com}
 #' @references Goh K-I, Kahng B, Kim D: Universal behaviour of load
@@ -3269,10 +4479,46 @@ sample_fitness_pl <- function(
   no.of.edges,
   exponent.out,
   exponent.in = -1,
+  ...,
   loops = FALSE,
   multiple = FALSE,
   finite.size.correction = TRUE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_fitness_pl, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        loops = loops,
+        multiple = multiple,
+        finite.size.correction = finite.size.correction
+      ),
+      recover_new = c("loops", "multiple", "finite.size.correction"),
+      recover_old = c("loops", "multiple", "finite.size.correction"),
+      match_names = c("loops", "multiple", "finite.size.correction"),
+      match_to = c("loops", "multiple", "finite.size.correction"),
+      defaults = list(
+        loops = FALSE,
+        multiple = FALSE,
+        finite.size.correction = TRUE
+      ),
+      head_args = c(
+        "no.of.nodes",
+        "no.of.edges",
+        "exponent.out",
+        "exponent.in"
+      ),
+      fn_name = "sample_fitness_pl"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   res <- static_power_law_game_impl(
     no_of_nodes = no.of.nodes,
     no_of_edges = no.of.edges,
@@ -3320,6 +4566,7 @@ sample_fitness_pl <- function(
 #'
 #' @param nodes The number of vertices in the graph.
 #' @param fw.prob The forward burning probability, see details below.
+#' @inheritParams rlang::args_dots_empty
 #' @param bw.factor The backward burning ratio. The backward burning
 #'   probability is calculated as `bw.factor*fw.prob`.
 #' @param ambs The number of ambassador vertices.
@@ -3356,10 +4603,33 @@ sample_fitness_pl <- function(
 sample_forestfire <- function(
   nodes,
   fw.prob,
+  ...,
   bw.factor = 1,
   ambs = 1,
   directed = TRUE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_forestfire, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(bw.factor = bw.factor, ambs = ambs, directed = directed),
+      recover_new = c("bw.factor", "ambs", "directed"),
+      recover_old = c("bw.factor", "ambs", "directed"),
+      match_names = c("bw.factor", "ambs", "directed"),
+      match_to = c("bw.factor", "ambs", "directed"),
+      defaults = list(bw.factor = 1, ambs = 1, directed = TRUE),
+      head_args = c("nodes", "fw.prob"),
+      fn_name = "sample_forestfire"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   res <- forest_fire_game_impl(
     nodes = nodes,
     fw_prob = fw.prob,
@@ -3390,6 +4660,7 @@ sample_forestfire <- function(
 #' @param corr A scalar in the unit interval, the target Pearson
 #'   correlation between the adjacency matrices of the original and the generated
 #'   graph (the adjacency matrix being used as a vector).
+#' @inheritParams rlang::args_dots_empty
 #' @param p A numeric scalar, the probability of an edge between two
 #'   vertices, it must in the open (0,1) interval. The default is the empirical
 #'   edge density of the graph. If you are resampling an Erdős-Rényi graph and
@@ -3417,9 +4688,32 @@ sample_forestfire <- function(
 sample_correlated_gnp <- function(
   old.graph,
   corr,
+  ...,
   p = edge_density(old.graph),
   permutation = NULL
 ) {
+  # BEGIN GENERATED ARG_HANDLE: sample_correlated_gnp, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(p = p, permutation = permutation),
+      recover_new = c("p", "permutation"),
+      recover_old = c("p", "permutation"),
+      match_names = c("p", "permutation"),
+      match_to = c("p", "permutation"),
+      defaults = list(p = edge_density(old.graph), permutation = NULL),
+      head_args = c("old.graph", "corr"),
+      fn_name = "sample_correlated_gnp"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   correlated_game_impl(
     old_graph = old.graph,
     corr = corr,

--- a/R/games.R
+++ b/R/games.R
@@ -876,7 +876,11 @@ sample_pa <- function(
   out.pref = FALSE,
   zero.appeal = 1,
   directed = TRUE,
-  algorithm = c( "psumtree", "psumtree-multiple", "bag" ),
+  algorithm = c(
+    "psumtree",
+    "psumtree-multiple",
+    "bag"
+  ),
   start.graph = NULL
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_pa, do not edit, see tools/generate-migrations.R
@@ -1610,7 +1614,13 @@ sample_degseq <- function(
   out.deg,
   in.deg = NULL,
   ...,
-  method = c( "configuration", "vl", "fast.heur.simple", "configuration.simple", "edge.switching.simple" )
+  method = c(
+    "configuration",
+    "vl",
+    "fast.heur.simple",
+    "configuration.simple",
+    "edge.switching.simple"
+  )
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_degseq, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {

--- a/man/sample_correlated_gnp.Rd
+++ b/man/sample_correlated_gnp.Rd
@@ -8,6 +8,7 @@ adding/removing edges}
 sample_correlated_gnp(
   old.graph,
   corr,
+  ...,
   p = edge_density(old.graph),
   permutation = NULL
 )
@@ -18,6 +19,8 @@ sample_correlated_gnp(
 \item{corr}{A scalar in the unit interval, the target Pearson
 correlation between the adjacency matrices of the original and the generated
 graph (the adjacency matrix being used as a vector).}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{p}{A numeric scalar, the probability of an edge between two
 vertices, it must in the open (0,1) interval. The default is the empirical

--- a/man/sample_degseq.Rd
+++ b/man/sample_degseq.Rd
@@ -8,6 +8,7 @@
 sample_degseq(
   out.deg,
   in.deg = NULL,
+  ...,
   method = c("configuration", "vl", "fast.heur.simple", "configuration.simple",
     "edge.switching.simple")
 )
@@ -23,10 +24,10 @@ should be even. For directed graphs its sum should be the same as the sum of
 \item{in.deg}{For directed graph, the in-degree sequence. By default this is
 \code{NULL} and an undirected graph is created.}
 
-\item{method}{Character, the method for generating the graph. See Details.}
-
 \item{...}{Passed to \code{realize_degseq()} if \sQuote{deterministic} is true,
 or to \code{sample_degseq()} otherwise.}
+
+\item{method}{Character, the method for generating the graph. See Details.}
 
 \item{deterministic}{Whether the construction should be deterministic}
 }

--- a/man/sample_dot_product.Rd
+++ b/man/sample_dot_product.Rd
@@ -5,13 +5,15 @@
 \alias{dot_product}
 \title{Generate random graphs according to the random dot product graph model}
 \usage{
-sample_dot_product(vecs, directed = FALSE)
+sample_dot_product(vecs, ..., directed = FALSE)
 
-dot_product(vecs, directed = FALSE)
+dot_product(vecs, ..., directed = FALSE)
 }
 \arguments{
 \item{vecs}{A numeric matrix in which each latent position vector is a
 column.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{A Logical, TRUE if the generated graph should be
 directed.}

--- a/man/sample_fitness.Rd
+++ b/man/sample_fitness.Rd
@@ -8,6 +8,7 @@ sample_fitness(
   no.of.edges,
   fitness.out,
   fitness.in = NULL,
+  ...,
   loops = FALSE,
   multiple = FALSE
 )
@@ -21,6 +22,8 @@ For directed graphs, this specifies the out-fitness of each vertex.}
 \item{fitness.in}{Numeric vector that specifies the in-fitness of each vertex.
 The generated graph will be directed.
 Default: \code{NULL}, the generated graph will be undirected.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{loops}{Logical, whether to allow loop edges in the graph.}
 

--- a/man/sample_fitness_pl.Rd
+++ b/man/sample_fitness_pl.Rd
@@ -9,6 +9,7 @@ sample_fitness_pl(
   no.of.edges,
   exponent.out,
   exponent.in = -1,
+  ...,
   loops = FALSE,
   multiple = FALSE,
   finite.size.correction = TRUE
@@ -28,6 +29,8 @@ out-degree distribution. It must be greater than or equal to 2. If you pass
 undirected. If greater than or equal to 2, this argument specifies the
 exponent of the in-degree distribution. If non-negative but less than 2, an
 error will be generated.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{loops}{Logical, whether to allow loop edges in the graph.}
 

--- a/man/sample_forestfire.Rd
+++ b/man/sample_forestfire.Rd
@@ -4,12 +4,21 @@
 \alias{sample_forestfire}
 \title{Forest Fire Network Model}
 \usage{
-sample_forestfire(nodes, fw.prob, bw.factor = 1, ambs = 1, directed = TRUE)
+sample_forestfire(
+  nodes,
+  fw.prob,
+  ...,
+  bw.factor = 1,
+  ambs = 1,
+  directed = TRUE
+)
 }
 \arguments{
 \item{nodes}{The number of vertices in the graph.}
 
 \item{fw.prob}{The forward burning probability, see details below.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{bw.factor}{The backward burning ratio. The backward burning
 probability is calculated as \code{bw.factor*fw.prob}.}

--- a/man/sample_gnm.Rd
+++ b/man/sample_gnm.Rd
@@ -5,14 +5,16 @@
 \alias{gnm}
 \title{Generate random graphs according to the \eqn{G(n,m)} Erdős-Rényi model}
 \usage{
-sample_gnm(n, m, directed = FALSE, loops = FALSE)
+sample_gnm(n, m, ..., directed = FALSE, loops = FALSE)
 
-gnm(n, m, directed = FALSE, loops = FALSE)
+gnm(n, m, ..., directed = FALSE, loops = FALSE)
 }
 \arguments{
 \item{n}{The number of vertices in the graph.}
 
 \item{m}{The number of edges in the graph.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Logical, whether the graph will be directed, defaults to
 \code{FALSE}.}

--- a/man/sample_gnp.Rd
+++ b/man/sample_gnp.Rd
@@ -5,15 +5,17 @@
 \alias{gnp}
 \title{Generate random graphs according to the \eqn{G(n,p)} Erdős-Rényi model}
 \usage{
-sample_gnp(n, p, directed = FALSE, loops = FALSE)
+sample_gnp(n, p, ..., directed = FALSE, loops = FALSE)
 
-gnp(n, p, directed = FALSE, loops = FALSE)
+gnp(n, p, ..., directed = FALSE, loops = FALSE)
 }
 \arguments{
 \item{n}{The number of vertices in the graph.}
 
 \item{p}{The probability for drawing an edge between two
 arbitrary vertices (\eqn{G(n,p)} graph).}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Logical, whether the graph will be directed, defaults to
 \code{FALSE}.}

--- a/man/sample_grg.Rd
+++ b/man/sample_grg.Rd
@@ -5,15 +5,17 @@
 \alias{grg}
 \title{Geometric random graphs}
 \usage{
-sample_grg(nodes, radius, torus = FALSE, coords = FALSE)
+sample_grg(nodes, radius, ..., torus = FALSE, coords = FALSE)
 
-grg(nodes, radius, torus = FALSE, coords = FALSE)
+grg(nodes, radius, ..., torus = FALSE, coords = FALSE)
 }
 \arguments{
 \item{nodes}{The number of vertices in the graph.}
 
 \item{radius}{The radius within which the vertices will be connected by an
 edge.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{torus}{Logical, whether to use a torus instead of a square.}
 

--- a/man/sample_k_regular.Rd
+++ b/man/sample_k_regular.Rd
@@ -4,7 +4,7 @@
 \alias{sample_k_regular}
 \title{Create a random regular graph}
 \usage{
-sample_k_regular(no.of.nodes, k, directed = FALSE, multiple = FALSE)
+sample_k_regular(no.of.nodes, k, ..., directed = FALSE, multiple = FALSE)
 }
 \arguments{
 \item{no.of.nodes}{Integer scalar, the number of vertices in the generated
@@ -12,6 +12,8 @@ graph.}
 
 \item{k}{Integer scalar, the degree of each vertex in the graph, or the
 out-degree and in-degree in a directed graph.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Logical, whether to create a directed graph.}
 

--- a/man/sample_last_cit.Rd
+++ b/man/sample_last_cit.Rd
@@ -12,6 +12,7 @@
 sample_last_cit(
   n,
   edges = 1,
+  ...,
   agebins = n/7100,
   pref = (1:(agebins + 1))^-3,
   directed = TRUE
@@ -20,6 +21,7 @@ sample_last_cit(
 last_cit(
   n,
   edges = 1,
+  ...,
   agebins = n/7100,
   pref = (1:(agebins + 1))^-3,
   directed = TRUE
@@ -29,6 +31,7 @@ sample_cit_types(
   n,
   edges = 1,
   types = rep(0, n),
+  ...,
   pref = rep(1, length(types)),
   directed = TRUE,
   attr = TRUE
@@ -38,6 +41,7 @@ cit_types(
   n,
   edges = 1,
   types = rep(0, n),
+  ...,
   pref = rep(1, length(types)),
   directed = TRUE,
   attr = TRUE
@@ -47,6 +51,7 @@ sample_cit_cit_types(
   n,
   edges = 1,
   types = rep(0, n),
+  ...,
   pref = matrix(1, nrow = length(types), ncol = length(types)),
   directed = TRUE,
   attr = TRUE
@@ -56,6 +61,7 @@ cit_cit_types(
   n,
   edges = 1,
   types = rep(0, n),
+  ...,
   pref = matrix(1, nrow = length(types), ncol = length(types)),
   directed = TRUE,
   attr = TRUE
@@ -65,6 +71,8 @@ cit_cit_types(
 \item{n}{Number of vertices.}
 
 \item{edges}{Number of edges per step.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{agebins}{Number of aging bins.}
 

--- a/man/sample_pa.Rd
+++ b/man/sample_pa.Rd
@@ -9,6 +9,7 @@ sample_pa(
   n,
   power = 1,
   m = NULL,
+  ...,
   out.dist = NULL,
   out.seq = NULL,
   out.pref = FALSE,
@@ -22,6 +23,7 @@ pa(
   n,
   power = 1,
   m = NULL,
+  ...,
   out.dist = NULL,
   out.seq = NULL,
   out.pref = FALSE,
@@ -41,6 +43,8 @@ i.e. linear preferential attachment.}
 defaults to 1.
 This argument is only used if both \code{out.dist} and \code{out.seq} are omitted
 or NULL.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{out.dist}{Numeric vector, the distribution of the number of edges to
 add in each time step. This argument is only used if the \code{out.seq}

--- a/man/sample_pa_age.Rd
+++ b/man/sample_pa_age.Rd
@@ -10,6 +10,7 @@ sample_pa_age(
   pa.exp,
   aging.exp,
   m = NULL,
+  ...,
   aging.bin = 300,
   out.dist = NULL,
   out.seq = NULL,
@@ -27,6 +28,7 @@ pa_age(
   pa.exp,
   aging.exp,
   m = NULL,
+  ...,
   aging.bin = 300,
   out.dist = NULL,
   out.seq = NULL,
@@ -50,6 +52,8 @@ see details below.}
 \item{m}{The number of edges each new vertex creates (except the very first
 vertex). This argument is used only if both the \code{out.dist} and
 \code{out.seq} arguments are NULL.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{aging.bin}{The number of bins to use for measuring the age of
 vertices, see details below.}

--- a/man/sample_pref.Rd
+++ b/man/sample_pref.Rd
@@ -10,6 +10,7 @@
 sample_pref(
   nodes,
   types,
+  ...,
   type.dist = rep(1, types),
   fixed.sizes = FALSE,
   pref.matrix = matrix(1, types, types),
@@ -20,6 +21,7 @@ sample_pref(
 pref(
   nodes,
   types,
+  ...,
   type.dist = rep(1, types),
   fixed.sizes = FALSE,
   pref.matrix = matrix(1, types, types),
@@ -30,6 +32,7 @@ pref(
 sample_asym_pref(
   nodes,
   types,
+  ...,
   type.dist.matrix = matrix(1, types, types),
   pref.matrix = matrix(1, types, types),
   loops = FALSE
@@ -38,6 +41,7 @@ sample_asym_pref(
 asym_pref(
   nodes,
   types,
+  ...,
   type.dist.matrix = matrix(1, types, types),
   pref.matrix = matrix(1, types, types),
   loops = FALSE
@@ -47,6 +51,8 @@ asym_pref(
 \item{nodes}{The number of vertices in the graphs.}
 
 \item{types}{The number of different vertex types.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{type.dist}{The distribution of the vertex types, a numeric vector of
 length \sQuote{types} containing non-negative numbers. The vector will be

--- a/man/sample_sbm.Rd
+++ b/man/sample_sbm.Rd
@@ -5,9 +5,9 @@
 \alias{sbm}
 \title{Sample stochastic block model}
 \usage{
-sample_sbm(n, pref.matrix, block.sizes, directed = FALSE, loops = FALSE)
+sample_sbm(n, pref.matrix, block.sizes, ..., directed = FALSE, loops = FALSE)
 
-sbm(n, pref.matrix, block.sizes, directed = FALSE, loops = FALSE)
+sbm(n, pref.matrix, block.sizes, ..., directed = FALSE, loops = FALSE)
 }
 \arguments{
 \item{n}{Number of vertices in the graph.}
@@ -20,6 +20,8 @@ must be symmetric.}
 
 \item{block.sizes}{Numeric vector giving the number of vertices in each
 group. The sum of the vector must match the number of vertices.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Logical, whether to create a directed graph.}
 

--- a/man/sample_smallworld.Rd
+++ b/man/sample_smallworld.Rd
@@ -5,9 +5,9 @@
 \alias{smallworld}
 \title{The Watts-Strogatz small-world model}
 \usage{
-sample_smallworld(dim, size, nei, p, loops = FALSE, multiple = FALSE)
+sample_smallworld(dim, size, nei, p, ..., loops = FALSE, multiple = FALSE)
 
-smallworld(dim, size, nei, p, loops = FALSE, multiple = FALSE)
+smallworld(dim, size, nei, p, ..., loops = FALSE, multiple = FALSE)
 }
 \arguments{
 \item{dim}{Integer constant, the dimension of the starting lattice.}
@@ -18,6 +18,8 @@ smallworld(dim, size, nei, p, loops = FALSE, multiple = FALSE)
 the lattice will be connected.}
 
 \item{p}{Real constant between zero and one, the rewiring probability.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{loops}{Logical, whether loops edges are allowed in the
 generated graph.}

--- a/man/sample_traits_callaway.Rd
+++ b/man/sample_traits_callaway.Rd
@@ -10,6 +10,7 @@
 sample_traits_callaway(
   nodes,
   types,
+  ...,
   edge.per.step = 1,
   type.dist = rep(1, types),
   pref.matrix = matrix(1, types, types),
@@ -19,6 +20,7 @@ sample_traits_callaway(
 traits_callaway(
   nodes,
   types,
+  ...,
   edge.per.step = 1,
   type.dist = rep(1, types),
   pref.matrix = matrix(1, types, types),
@@ -29,6 +31,7 @@ sample_traits(
   nodes,
   types,
   k = 1,
+  ...,
   type.dist = rep(1, types),
   pref.matrix = matrix(1, types, types),
   directed = FALSE
@@ -38,6 +41,7 @@ traits(
   nodes,
   types,
   k = 1,
+  ...,
   type.dist = rep(1, types),
   pref.matrix = matrix(1, types, types),
   directed = FALSE
@@ -47,6 +51,8 @@ traits(
 \item{nodes}{The number of vertices in the graph.}
 
 \item{types}{The number of different vertex types.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{edge.per.step}{The number of edges to add to the graph per time step.}
 

--- a/tests/testthat/test-games.R
+++ b/tests/testthat/test-games.R
@@ -848,3 +848,857 @@ test_that("Dot product rng gives warnings", {
     paste0("Greater than 1 connection probability ", "in dot-product graph")
   )
 })
+
+# ---- ellipsis migration: argument coverage ----------------------------
+
+test_that("sample_pa() covers tail args by name and recovers positional calls", {
+  igraph_local_seed(42)
+  g_pa <- sample_pa(30, power = 1, m = 2, out.pref = TRUE, zero.appeal = 3)
+  expect_vcount(g_pa, 30)
+  expect_ecount(g_pa, 57)
+  expect_true(is_simple(g_pa))
+
+  # The first tail argument of the old signature is out.dist.
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(g_legacy <- sample_pa(8, 1, NULL, rep(1, 3)))
+  igraph_local_seed(1)
+  expect_identical_graphs(g_legacy, sample_pa(8, 1, NULL, out.dist = rep(1, 3)))
+})
+
+test_that("pa() spec twin matches sample_pa()", {
+  igraph_local_seed(42)
+  g_direct <- sample_pa(
+    20,
+    power = 1.2,
+    m = 2,
+    out.dist = NULL,
+    out.seq = NULL,
+    out.pref = TRUE,
+    zero.appeal = 2,
+    directed = TRUE,
+    algorithm = "psumtree-multiple",
+    start.graph = make_empty_graph(5)
+  )
+  igraph_local_seed(42)
+  g_spec <- sample_(pa(
+    20,
+    power = 1.2,
+    m = 2,
+    out.dist = NULL,
+    out.seq = NULL,
+    out.pref = TRUE,
+    zero.appeal = 2,
+    directed = TRUE,
+    algorithm = "psumtree-multiple",
+    start.graph = make_empty_graph(5)
+  ))
+  expect_identical_graphs(g_spec, g_direct)
+
+  lifecycle::expect_deprecated(spec_legacy <- pa(8, 1, NULL, rep(1, 3)))
+  igraph_local_seed(1)
+  g_legacy <- sample_(spec_legacy)
+  igraph_local_seed(1)
+  g_named <- sample_(pa(8, 1, NULL, out.dist = rep(1, 3)))
+  expect_identical_graphs(g_legacy, g_named)
+})
+
+test_that("sample_gnp() covers loops by name and recovers positional calls", {
+  # p = 1 makes the result deterministic.
+  g_full <- sample_gnp(15, 1, directed = TRUE, loops = TRUE)
+  expect_vcount(g_full, 15)
+  expect_ecount(g_full, 225)
+  expect_equal(sum(which_loop(g_full)), 15)
+
+  lifecycle::expect_deprecated(g_legacy <- sample_gnp(10, 1, TRUE))
+  expect_true(is_directed(g_legacy))
+  expect_identical_graphs(g_legacy, sample_gnp(10, 1, directed = TRUE))
+})
+
+test_that("gnp() spec twin matches sample_gnp()", {
+  g_direct <- sample_gnp(12, 1, directed = TRUE, loops = TRUE)
+  g_spec <- sample_(gnp(12, 1, directed = TRUE, loops = TRUE))
+  expect_identical_graphs(g_spec, g_direct)
+
+  lifecycle::expect_deprecated(spec_legacy <- gnp(10, 1, TRUE))
+  expect_identical_graphs(
+    sample_(spec_legacy),
+    sample_(gnp(10, 1, directed = TRUE))
+  )
+})
+
+test_that("sample_gnm() covers tail args by name and recovers positional calls", {
+  igraph_local_seed(42)
+  g_gnm <- sample_gnm(8, 12, directed = TRUE, loops = TRUE)
+  expect_vcount(g_gnm, 8)
+  expect_ecount(g_gnm, 12)
+  expect_true(is_directed(g_gnm))
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(g_legacy <- sample_gnm(8, 5, TRUE))
+  igraph_local_seed(1)
+  expect_identical_graphs(g_legacy, sample_gnm(8, 5, directed = TRUE))
+})
+
+test_that("gnm() spec twin matches sample_gnm()", {
+  igraph_local_seed(42)
+  g_direct <- sample_gnm(8, 12, directed = TRUE, loops = TRUE)
+  igraph_local_seed(42)
+  g_spec <- sample_(gnm(8, 12, directed = TRUE, loops = TRUE))
+  expect_identical_graphs(g_spec, g_direct)
+
+  lifecycle::expect_deprecated(spec_legacy <- gnm(8, 5, TRUE))
+  igraph_local_seed(1)
+  g_legacy <- sample_(spec_legacy)
+  igraph_local_seed(1)
+  g_named <- sample_(gnm(8, 5, directed = TRUE))
+  expect_identical_graphs(g_legacy, g_named)
+})
+
+test_that("sample_degseq() recovers positional method", {
+  igraph_local_seed(42)
+  lifecycle::expect_deprecated(
+    g_legacy <- sample_degseq(rep(2, 10), NULL, "vl")
+  )
+  igraph_local_seed(42)
+  expect_identical_graphs(g_legacy, sample_degseq(rep(2, 10), method = "vl"))
+})
+
+test_that("sample_pa_age() covers tail args by name and recovers positional calls", {
+  igraph_local_seed(42)
+  g_page <- sample_pa_age(
+    40,
+    pa.exp = 1,
+    aging.exp = -0.5,
+    m = 2,
+    aging.bin = 50,
+    out.pref = TRUE,
+    directed = FALSE,
+    zero.deg.appeal = 2,
+    zero.age.appeal = 1,
+    deg.coef = 1.5,
+    age.coef = 1.5,
+    time.window = 10
+  )
+  expect_vcount(g_page, 40)
+  expect_ecount(g_page, 78)
+  expect_false(is_directed(g_page))
+
+  # out.seq and out.dist currently cannot produce a graph in sample_pa_age():
+  # any non-NULL value ends with `m = NULL` reaching the C implementation,
+  # which rejects it (same failure on main, so not a migration regression).
+  expect_error(
+    suppressWarnings(sample_pa_age(10, 1, 0, out.seq = c(0, rep(2, 9))))
+  )
+  expect_error(
+    suppressWarnings(sample_pa_age(10, 1, 0, m = 1, out.dist = c(0, 1)))
+  )
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(g_legacy <- sample_pa_age(20, 1, -1, 1, 200))
+  igraph_local_seed(1)
+  expect_identical_graphs(
+    g_legacy,
+    sample_pa_age(20, 1, -1, 1, aging.bin = 200)
+  )
+})
+
+test_that("pa_age() spec twin matches sample_pa_age()", {
+  igraph_local_seed(42)
+  g_direct <- sample_pa_age(
+    30,
+    pa.exp = 1,
+    aging.exp = -0.5,
+    m = 2,
+    aging.bin = 50,
+    out.dist = NULL,
+    out.seq = NULL,
+    out.pref = TRUE,
+    directed = FALSE,
+    zero.deg.appeal = 2,
+    zero.age.appeal = 1,
+    deg.coef = 1.5,
+    age.coef = 1.5,
+    time.window = 10
+  )
+  igraph_local_seed(42)
+  g_spec <- sample_(pa_age(
+    30,
+    pa.exp = 1,
+    aging.exp = -0.5,
+    m = 2,
+    aging.bin = 50,
+    out.dist = NULL,
+    out.seq = NULL,
+    out.pref = TRUE,
+    directed = FALSE,
+    zero.deg.appeal = 2,
+    zero.age.appeal = 1,
+    deg.coef = 1.5,
+    age.coef = 1.5,
+    time.window = 10
+  ))
+  expect_identical_graphs(g_spec, g_direct)
+
+  lifecycle::expect_deprecated(spec_legacy <- pa_age(20, 1, -1, 1, 200))
+  igraph_local_seed(1)
+  g_legacy <- sample_(spec_legacy)
+  igraph_local_seed(1)
+  g_named <- sample_(pa_age(20, 1, -1, 1, aging.bin = 200))
+  expect_identical_graphs(g_legacy, g_named)
+})
+
+test_that("sample_traits_callaway() covers tail args by name and recovers positional calls", {
+  # sample_traits_callaway() currently returns a list holding the graph and
+  # the node types, so assertions target its components.
+  igraph_local_seed(42)
+  res <- sample_traits_callaway(
+    30,
+    2,
+    edge.per.step = 2,
+    type.dist = c(1, 0),
+    pref.matrix = matrix(1, 2, 2),
+    directed = TRUE
+  )
+  expect_vcount(res$graph, 30)
+  expect_ecount(res$graph, 58)
+  expect_true(is_directed(res$graph))
+  # type.dist = c(1, 0) forces every vertex into the first type.
+  expect_true(all(res$node_type_vec == 0))
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(res_legacy <- sample_traits_callaway(30, 2, 2))
+  igraph_local_seed(1)
+  res_named <- sample_traits_callaway(30, 2, edge.per.step = 2)
+  expect_identical_graphs(res_legacy$graph, res_named$graph)
+  expect_identical(res_legacy$node_type_vec, res_named$node_type_vec)
+})
+
+test_that("traits_callaway() spec twin matches sample_traits_callaway()", {
+  igraph_local_seed(42)
+  res_direct <- sample_traits_callaway(
+    30,
+    2,
+    edge.per.step = 2,
+    type.dist = c(1, 0),
+    pref.matrix = matrix(1, 2, 2),
+    directed = TRUE
+  )
+  igraph_local_seed(42)
+  res_spec <- sample_(traits_callaway(
+    30,
+    2,
+    edge.per.step = 2,
+    type.dist = c(1, 0),
+    pref.matrix = matrix(1, 2, 2),
+    directed = TRUE
+  ))
+  expect_identical_graphs(res_spec$graph, res_direct$graph)
+  expect_identical(res_spec$node_type_vec, res_direct$node_type_vec)
+
+  lifecycle::expect_deprecated(spec_legacy <- traits_callaway(30, 2, 2))
+  igraph_local_seed(1)
+  res_legacy <- sample_(spec_legacy)
+  igraph_local_seed(1)
+  res_named <- sample_(traits_callaway(30, 2, edge.per.step = 2))
+  expect_identical_graphs(res_legacy$graph, res_named$graph)
+})
+
+test_that("sample_traits() covers tail args by name and recovers positional calls", {
+  # sample_traits() currently returns a list holding the graph and the node
+  # types, so assertions target its components.
+  igraph_local_seed(42)
+  res <- sample_traits(
+    30,
+    2,
+    k = 2,
+    type.dist = c(1, 0),
+    pref.matrix = matrix(1, 2, 2),
+    directed = TRUE
+  )
+  expect_vcount(res$graph, 30)
+  expect_ecount(res$graph, 56)
+  expect_true(is_directed(res$graph))
+  # type.dist = c(1, 0) forces every vertex into the first type.
+  expect_true(all(res$node_type_vec == 0))
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(res_legacy <- sample_traits(30, 2, 2, c(1, 0)))
+  igraph_local_seed(1)
+  res_named <- sample_traits(30, 2, 2, type.dist = c(1, 0))
+  expect_identical_graphs(res_legacy$graph, res_named$graph)
+  expect_identical(res_legacy$node_type_vec, res_named$node_type_vec)
+})
+
+test_that("traits() spec twin matches sample_traits()", {
+  igraph_local_seed(42)
+  res_direct <- sample_traits(
+    30,
+    2,
+    k = 2,
+    type.dist = c(1, 0),
+    pref.matrix = matrix(1, 2, 2),
+    directed = TRUE
+  )
+  igraph_local_seed(42)
+  res_spec <- sample_(traits(
+    30,
+    2,
+    k = 2,
+    type.dist = c(1, 0),
+    pref.matrix = matrix(1, 2, 2),
+    directed = TRUE
+  ))
+  expect_identical_graphs(res_spec$graph, res_direct$graph)
+  expect_identical(res_spec$node_type_vec, res_direct$node_type_vec)
+
+  lifecycle::expect_deprecated(spec_legacy <- traits(30, 2, 2, c(1, 0)))
+  igraph_local_seed(1)
+  res_legacy <- sample_(spec_legacy)
+  igraph_local_seed(1)
+  res_named <- sample_(traits(30, 2, 2, type.dist = c(1, 0)))
+  expect_identical_graphs(res_legacy$graph, res_named$graph)
+})
+
+test_that("sample_grg() covers tail args by name and recovers positional calls", {
+  igraph_local_seed(42)
+  g_grg <- sample_grg(30, 0.2, torus = TRUE, coords = TRUE)
+  expect_vcount(g_grg, 30)
+  expect_false(is_directed(g_grg))
+  # coords = TRUE stores the vertex positions.
+  expect_length(V(g_grg)$x, 30)
+  expect_length(V(g_grg)$y, 30)
+  expect_true(all(V(g_grg)$x >= 0 & V(g_grg)$x <= 1))
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(g_legacy <- sample_grg(30, 0.2, TRUE))
+  igraph_local_seed(1)
+  expect_identical_graphs(g_legacy, sample_grg(30, 0.2, torus = TRUE))
+})
+
+test_that("grg() spec twin matches sample_grg()", {
+  igraph_local_seed(42)
+  g_direct <- sample_grg(30, 0.2, torus = TRUE, coords = TRUE)
+  igraph_local_seed(42)
+  g_spec <- sample_(grg(30, 0.2, torus = TRUE, coords = TRUE))
+  expect_identical_graphs(g_spec, g_direct)
+
+  lifecycle::expect_deprecated(spec_legacy <- grg(30, 0.2, TRUE))
+  igraph_local_seed(1)
+  g_legacy <- sample_(spec_legacy)
+  igraph_local_seed(1)
+  g_named <- sample_(grg(30, 0.2, torus = TRUE))
+  expect_identical_graphs(g_legacy, g_named)
+})
+
+test_that("sample_pref() covers tail args by name and recovers positional calls", {
+  igraph_local_seed(42)
+  g_pref <- sample_pref(
+    20,
+    2,
+    type.dist = c(5, 15),
+    fixed.sizes = TRUE,
+    pref.matrix = diag(2),
+    directed = TRUE,
+    loops = FALSE
+  )
+  expect_vcount(g_pref, 20)
+  expect_true(is_directed(g_pref))
+  # fixed.sizes = TRUE uses type.dist as exact group sizes.
+  expect_equal(as.vector(table(V(g_pref)$type)), c(5, 15))
+  # The diagonal preference matrix only allows edges within a type.
+  edge_ends <- as_edgelist(g_pref, names = FALSE)
+  expect_true(
+    all(V(g_pref)$type[edge_ends[, 1]] == V(g_pref)$type[edge_ends[, 2]])
+  )
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(g_legacy <- sample_pref(20, 2, c(1, 3)))
+  igraph_local_seed(1)
+  expect_identical_graphs(g_legacy, sample_pref(20, 2, type.dist = c(1, 3)))
+})
+
+test_that("pref() spec twin matches sample_pref()", {
+  igraph_local_seed(42)
+  g_direct <- sample_pref(
+    20,
+    2,
+    type.dist = c(5, 15),
+    fixed.sizes = TRUE,
+    pref.matrix = diag(2),
+    directed = TRUE,
+    loops = FALSE
+  )
+  igraph_local_seed(42)
+  g_spec <- sample_(pref(
+    20,
+    2,
+    type.dist = c(5, 15),
+    fixed.sizes = TRUE,
+    pref.matrix = diag(2),
+    directed = TRUE,
+    loops = FALSE
+  ))
+  expect_identical_graphs(g_spec, g_direct)
+
+  lifecycle::expect_deprecated(spec_legacy <- pref(20, 2, c(1, 3)))
+  igraph_local_seed(1)
+  g_legacy <- sample_(spec_legacy)
+  igraph_local_seed(1)
+  g_named <- sample_(pref(20, 2, type.dist = c(1, 3)))
+  expect_identical_graphs(g_legacy, g_named)
+})
+
+test_that("sample_asym_pref() covers tail args by name and recovers positional calls", {
+  igraph_local_seed(42)
+  type_dist_matrix <- matrix(c(0, 1, 0, 0), 2, 2)
+  g_asym <- sample_asym_pref(
+    20,
+    2,
+    type.dist.matrix = type_dist_matrix,
+    pref.matrix = matrix(1, 2, 2),
+    loops = TRUE
+  )
+  expect_vcount(g_asym, 20)
+  expect_true(is_directed(g_asym))
+  # The type distribution concentrates on out-type 2 / in-type 1.
+  expect_true(all(V(g_asym)$outtype == 2))
+  expect_true(all(V(g_asym)$intype == 1))
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(
+    g_legacy <- sample_asym_pref(20, 2, type_dist_matrix)
+  )
+  igraph_local_seed(1)
+  expect_identical_graphs(
+    g_legacy,
+    sample_asym_pref(20, 2, type.dist.matrix = type_dist_matrix)
+  )
+})
+
+test_that("asym_pref() spec twin matches sample_asym_pref()", {
+  type_dist_matrix <- matrix(c(0, 1, 0, 0), 2, 2)
+  igraph_local_seed(42)
+  g_direct <- sample_asym_pref(
+    20,
+    2,
+    type.dist.matrix = type_dist_matrix,
+    pref.matrix = matrix(1, 2, 2),
+    loops = TRUE
+  )
+  igraph_local_seed(42)
+  g_spec <- sample_(asym_pref(
+    20,
+    2,
+    type.dist.matrix = type_dist_matrix,
+    pref.matrix = matrix(1, 2, 2),
+    loops = TRUE
+  ))
+  expect_identical_graphs(g_spec, g_direct)
+
+  lifecycle::expect_deprecated(
+    spec_legacy <- asym_pref(20, 2, type_dist_matrix)
+  )
+  igraph_local_seed(1)
+  g_legacy <- sample_(spec_legacy)
+  igraph_local_seed(1)
+  g_named <- sample_(asym_pref(20, 2, type.dist.matrix = type_dist_matrix))
+  expect_identical_graphs(g_legacy, g_named)
+})
+
+test_that("sample_smallworld() covers tail args by name and recovers positional calls", {
+  igraph_local_seed(42)
+  g_sw <- sample_smallworld(1, 20, 2, 1, loops = TRUE, multiple = TRUE)
+  expect_vcount(g_sw, 20)
+  expect_ecount(g_sw, 40)
+  expect_false(is_directed(g_sw))
+
+  # With p = 0 no rewiring happens, so the result is deterministic.
+  lifecycle::expect_deprecated(g_legacy <- sample_smallworld(1, 10, 1, 0, TRUE))
+  expect_identical_graphs(
+    g_legacy,
+    sample_smallworld(1, 10, 1, 0, loops = TRUE)
+  )
+})
+
+test_that("smallworld() spec twin matches sample_smallworld()", {
+  igraph_local_seed(42)
+  g_direct <- sample_smallworld(1, 20, 2, 1, loops = TRUE, multiple = TRUE)
+  igraph_local_seed(42)
+  g_spec <- sample_(smallworld(1, 20, 2, 1, loops = TRUE, multiple = TRUE))
+  expect_identical_graphs(g_spec, g_direct)
+
+  lifecycle::expect_deprecated(spec_legacy <- smallworld(1, 10, 1, 0, TRUE))
+  expect_identical_graphs(
+    sample_(spec_legacy),
+    sample_(smallworld(1, 10, 1, 0, loops = TRUE))
+  )
+})
+
+test_that("sample_last_cit() covers tail args by name and recovers positional calls", {
+  igraph_local_seed(42)
+  g_lc <- sample_last_cit(
+    20,
+    edges = 2,
+    agebins = 5,
+    pref = rep(1, 6),
+    directed = FALSE
+  )
+  expect_vcount(g_lc, 20)
+  expect_ecount(g_lc, 38)
+  expect_false(is_directed(g_lc))
+
+  # pref is passed too: recovering only agebins positionally currently fails
+  # because the generated shim forces pref's default before agebins is
+  # recovered, freezing it at the length computed from the default agebins.
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(
+    g_legacy <- sample_last_cit(20, 2, 5, rep(1, 6))
+  )
+  igraph_local_seed(1)
+  expect_identical_graphs(
+    g_legacy,
+    sample_last_cit(20, 2, agebins = 5, pref = rep(1, 6))
+  )
+})
+
+test_that("last_cit() spec twin matches sample_last_cit()", {
+  igraph_local_seed(42)
+  g_direct <- sample_last_cit(
+    20,
+    edges = 2,
+    agebins = 5,
+    pref = rep(1, 6),
+    directed = FALSE
+  )
+  igraph_local_seed(42)
+  g_spec <- sample_(last_cit(
+    20,
+    edges = 2,
+    agebins = 5,
+    pref = rep(1, 6),
+    directed = FALSE
+  ))
+  expect_identical_graphs(g_spec, g_direct)
+
+  # pref is passed too, see the sample_last_cit() recovery test.
+  lifecycle::expect_deprecated(spec_legacy <- last_cit(20, 2, 5, rep(1, 6)))
+  igraph_local_seed(1)
+  g_legacy <- sample_(spec_legacy)
+  igraph_local_seed(1)
+  g_named <- sample_(last_cit(20, 2, agebins = 5, pref = rep(1, 6)))
+  expect_identical_graphs(g_legacy, g_named)
+})
+
+test_that("sample_cit_types() covers tail args by name and recovers positional calls", {
+  # Vertex types are 1-based at the R level.
+  vertex_types <- rep(1:2, 10)
+  igraph_local_seed(42)
+  g_ct <- sample_cit_types(
+    20,
+    edges = 2,
+    types = vertex_types,
+    pref = c(1, 0),
+    attr = FALSE
+  )
+  expect_vcount(g_ct, 20)
+  expect_ecount(g_ct, 38)
+  # attr = FALSE skips the type vertex attribute.
+  expect_length(vertex_attr_names(g_ct), 0)
+  # pref = c(1, 0) means only type-1 vertices can be cited.
+  edge_ends <- as_edgelist(g_ct, names = FALSE)
+  expect_true(all(vertex_types[edge_ends[, 2]] == 1))
+
+  igraph_local_seed(42)
+  g_ct2 <- sample_cit_types(
+    20,
+    edges = 2,
+    types = vertex_types,
+    pref = c(1, 0),
+    directed = FALSE,
+    attr = TRUE
+  )
+  expect_false(is_directed(g_ct2))
+  expect_identical(V(g_ct2)$type, vertex_types)
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(
+    g_legacy <- sample_cit_types(20, 2, vertex_types, c(1, 0))
+  )
+  igraph_local_seed(1)
+  expect_identical_graphs(
+    g_legacy,
+    sample_cit_types(20, 2, vertex_types, pref = c(1, 0))
+  )
+})
+
+test_that("cit_types() spec twin matches sample_cit_types()", {
+  vertex_types <- rep(1:2, 10)
+  igraph_local_seed(42)
+  g_direct <- sample_cit_types(
+    20,
+    edges = 2,
+    types = vertex_types,
+    pref = c(1, 0),
+    directed = FALSE,
+    attr = TRUE
+  )
+  igraph_local_seed(42)
+  g_spec <- sample_(cit_types(
+    20,
+    edges = 2,
+    types = vertex_types,
+    pref = c(1, 0),
+    directed = FALSE,
+    attr = TRUE
+  ))
+  expect_identical_graphs(g_spec, g_direct)
+
+  lifecycle::expect_deprecated(
+    spec_legacy <- cit_types(20, 2, vertex_types, c(1, 0))
+  )
+  igraph_local_seed(1)
+  g_legacy <- sample_(spec_legacy)
+  igraph_local_seed(1)
+  g_named <- sample_(cit_types(20, 2, vertex_types, pref = c(1, 0)))
+  expect_identical_graphs(g_legacy, g_named)
+})
+
+test_that("sample_cit_cit_types() covers tail args by name and recovers positional calls", {
+  # Vertex types are 1-based at the R level.
+  vertex_types <- rep(1:2, 10)
+  # Both types only cite type-1 vertices.
+  pref_matrix <- cbind(c(1, 1), c(0, 0))
+  igraph_local_seed(42)
+  g_cct <- sample_cit_cit_types(
+    20,
+    edges = 2,
+    types = vertex_types,
+    pref = pref_matrix,
+    attr = FALSE
+  )
+  expect_vcount(g_cct, 20)
+  expect_ecount(g_cct, 38)
+  expect_length(vertex_attr_names(g_cct), 0)
+  edge_ends <- as_edgelist(g_cct, names = FALSE)
+  expect_true(all(vertex_types[edge_ends[, 2]] == 1))
+
+  igraph_local_seed(42)
+  g_cct2 <- sample_cit_cit_types(
+    20,
+    edges = 2,
+    types = vertex_types,
+    pref = pref_matrix,
+    directed = FALSE,
+    attr = TRUE
+  )
+  expect_false(is_directed(g_cct2))
+  expect_identical(V(g_cct2)$type, vertex_types)
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(
+    g_legacy <- sample_cit_cit_types(20, 2, vertex_types, pref_matrix)
+  )
+  igraph_local_seed(1)
+  expect_identical_graphs(
+    g_legacy,
+    sample_cit_cit_types(20, 2, vertex_types, pref = pref_matrix)
+  )
+})
+
+test_that("cit_cit_types() spec twin matches sample_cit_cit_types()", {
+  vertex_types <- rep(1:2, 10)
+  pref_matrix <- cbind(c(1, 1), c(0, 0))
+  igraph_local_seed(42)
+  g_direct <- sample_cit_cit_types(
+    20,
+    edges = 2,
+    types = vertex_types,
+    pref = pref_matrix,
+    directed = FALSE,
+    attr = TRUE
+  )
+  igraph_local_seed(42)
+  g_spec <- sample_(cit_cit_types(
+    20,
+    edges = 2,
+    types = vertex_types,
+    pref = pref_matrix,
+    directed = FALSE,
+    attr = TRUE
+  ))
+  expect_identical_graphs(g_spec, g_direct)
+
+  lifecycle::expect_deprecated(
+    spec_legacy <- cit_cit_types(20, 2, vertex_types, pref_matrix)
+  )
+  igraph_local_seed(1)
+  g_legacy <- sample_(spec_legacy)
+  igraph_local_seed(1)
+  g_named <- sample_(cit_cit_types(20, 2, vertex_types, pref = pref_matrix))
+  expect_identical_graphs(g_legacy, g_named)
+})
+
+test_that("sample_sbm() recovers positional tail args", {
+  # The all-ones preference matrix makes the result deterministic.
+  pref_matrix <- matrix(1, 2, 2)
+  lifecycle::expect_deprecated(
+    g_legacy <- sample_sbm(10, pref_matrix, c(4, 6), TRUE)
+  )
+  expect_true(is_directed(g_legacy))
+  expect_identical_graphs(
+    g_legacy,
+    sample_sbm(10, pref_matrix, c(4, 6), directed = TRUE)
+  )
+})
+
+test_that("sbm() spec twin matches sample_sbm()", {
+  pref_matrix <- matrix(1, 2, 2)
+  g_direct <- sample_sbm(
+    10,
+    pref.matrix = pref_matrix,
+    block.sizes = c(4, 6),
+    directed = TRUE,
+    loops = TRUE
+  )
+  g_spec <- sample_(sbm(
+    10,
+    pref.matrix = pref_matrix,
+    block.sizes = c(4, 6),
+    directed = TRUE,
+    loops = TRUE
+  ))
+  expect_identical_graphs(g_spec, g_direct)
+
+  lifecycle::expect_deprecated(
+    spec_legacy <- sbm(10, pref_matrix, c(4, 6), TRUE)
+  )
+  expect_identical_graphs(
+    sample_(spec_legacy),
+    sample_(sbm(10, pref_matrix, c(4, 6), directed = TRUE))
+  )
+})
+
+test_that("sample_dot_product() recovers positional directed", {
+  # Unit dot products make the result a deterministic full graph.
+  unit_vecs <- replicate(4, rep(1 / 2, 4))
+  lifecycle::expect_deprecated(g_legacy <- sample_dot_product(unit_vecs, TRUE))
+  expect_true(is_directed(g_legacy))
+  expect_identical_graphs(
+    g_legacy,
+    sample_dot_product(unit_vecs, directed = TRUE)
+  )
+})
+
+test_that("dot_product() spec twin matches sample_dot_product()", {
+  unit_vecs <- replicate(4, rep(1 / 2, 4))
+  g_direct <- sample_dot_product(unit_vecs, directed = TRUE)
+  g_spec <- sample_(dot_product(unit_vecs, directed = TRUE))
+  expect_identical_graphs(g_spec, g_direct)
+
+  lifecycle::expect_deprecated(spec_legacy <- dot_product(unit_vecs, TRUE))
+  expect_identical_graphs(
+    sample_(spec_legacy),
+    sample_(dot_product(unit_vecs, directed = TRUE))
+  )
+})
+
+test_that("sample_k_regular() covers tail args by name and recovers positional calls", {
+  igraph_local_seed(42)
+  g_kr <- sample_k_regular(10, 3, directed = TRUE, multiple = TRUE)
+  expect_vcount(g_kr, 10)
+  expect_ecount(g_kr, 30)
+  expect_true(is_directed(g_kr))
+  expect_true(all(degree(g_kr, mode = "out") == 3))
+  expect_true(all(degree(g_kr, mode = "in") == 3))
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(g_legacy <- sample_k_regular(10, 2, TRUE))
+  igraph_local_seed(1)
+  expect_identical_graphs(g_legacy, sample_k_regular(10, 2, directed = TRUE))
+})
+
+test_that("sample_fitness() covers tail args by name and recovers positional calls", {
+  igraph_local_seed(42)
+  g_fit <- sample_fitness(
+    30,
+    fitness.out = (10:1)^-2,
+    fitness.in = (1:10)^-2,
+    loops = TRUE,
+    multiple = TRUE
+  )
+  expect_vcount(g_fit, 10)
+  expect_ecount(g_fit, 30)
+  expect_true(is_directed(g_fit))
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(
+    g_legacy <- sample_fitness(20, rep(1, 10), NULL, TRUE)
+  )
+  igraph_local_seed(1)
+  expect_identical_graphs(
+    g_legacy,
+    sample_fitness(20, rep(1, 10), loops = TRUE)
+  )
+})
+
+test_that("sample_fitness_pl() covers tail args by name and recovers positional calls", {
+  igraph_local_seed(42)
+  g_fpl <- sample_fitness_pl(
+    50,
+    100,
+    exponent.out = 2.5,
+    exponent.in = 2.2,
+    loops = TRUE,
+    multiple = TRUE,
+    finite.size.correction = FALSE
+  )
+  expect_vcount(g_fpl, 50)
+  expect_ecount(g_fpl, 100)
+  expect_true(is_directed(g_fpl))
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(
+    g_legacy <- sample_fitness_pl(50, 100, 2.5, -1, TRUE)
+  )
+  igraph_local_seed(1)
+  expect_identical_graphs(
+    g_legacy,
+    sample_fitness_pl(50, 100, 2.5, -1, loops = TRUE)
+  )
+})
+
+test_that("sample_forestfire() covers tail args by name and recovers positional calls", {
+  igraph_local_seed(42)
+  fire <- sample_forestfire(
+    30,
+    fw.prob = 0.2,
+    bw.factor = 0.5,
+    ambs = 2,
+    directed = FALSE
+  )
+  expect_vcount(fire, 30)
+  expect_ecount(fire, 75)
+  expect_false(is_directed(fire))
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(fire_legacy <- sample_forestfire(30, 0.2, 0.5))
+  igraph_local_seed(1)
+  expect_identical_graphs(
+    fire_legacy,
+    sample_forestfire(30, 0.2, bw.factor = 0.5)
+  )
+})
+
+test_that("sample_correlated_gnp() recovers positional p", {
+  igraph_local_seed(42)
+  base_graph <- sample_gnp(10, 0.3)
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(
+    g_legacy <- sample_correlated_gnp(base_graph, 0.8, 0.3)
+  )
+  igraph_local_seed(1)
+  expect_identical_graphs(
+    g_legacy,
+    sample_correlated_gnp(base_graph, 0.8, p = 0.3)
+  )
+})

--- a/tools/migrations/games.R
+++ b/tools/migrations/games.R
@@ -1,0 +1,591 @@
+# Argument-signature migrations: games
+# Schema: see tools/migrations.R. Regenerate with:
+#   Rscript tools/generate-migrations.R
+
+migrations <- list(
+  asym_pref = list(
+    old = function(nodes, types, type.dist.matrix, pref.matrix, loops) {},
+    new = function(
+      nodes,
+      types,
+      ...,
+      type.dist.matrix = matrix(1, types, types),
+      pref.matrix = matrix(1, types, types),
+      loops = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  cit_cit_types = list(
+    old = function(n, edges, types, pref, directed, attr) {},
+    new = function(
+      n,
+      edges = 1,
+      types = rep(0, n),
+      ...,
+      pref = matrix(1, nrow = length(types), ncol = length(types)),
+      directed = TRUE,
+      attr = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  cit_types = list(
+    old = function(n, edges, types, pref, directed, attr) {},
+    new = function(
+      n,
+      edges = 1,
+      types = rep(0, n),
+      ...,
+      pref = rep(1, length(types)),
+      directed = TRUE,
+      attr = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  dot_product = list(
+    old = function(vecs, directed) {},
+    new = function(
+      vecs,
+      ...,
+      directed = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  gnm = list(
+    old = function(n, m, directed, loops) {},
+    new = function(
+      n,
+      m,
+      ...,
+      directed = FALSE,
+      loops = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  gnp = list(
+    old = function(n, p, directed, loops) {},
+    new = function(
+      n,
+      p,
+      ...,
+      directed = FALSE,
+      loops = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  grg = list(
+    old = function(nodes, radius, torus, coords) {},
+    new = function(
+      nodes,
+      radius,
+      ...,
+      torus = FALSE,
+      coords = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  last_cit = list(
+    old = function(n, edges, agebins, pref, directed) {},
+    new = function(
+      n,
+      edges = 1,
+      ...,
+      agebins = n / 7100,
+      pref = (1:(agebins + 1))^-3,
+      directed = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  pa = list(
+    old = function(
+      n,
+      power,
+      m,
+      out.dist,
+      out.seq,
+      out.pref,
+      zero.appeal,
+      directed,
+      algorithm,
+      start.graph
+    ) {},
+    new = function(
+      n,
+      power = 1,
+      m = NULL,
+      ...,
+      out.dist = NULL,
+      out.seq = NULL,
+      out.pref = FALSE,
+      zero.appeal = 1,
+      directed = TRUE,
+      algorithm = c("psumtree", "psumtree-multiple", "bag"),
+      start.graph = NULL
+    ) {},
+    when = "3.0.0"
+  ),
+
+  pa_age = list(
+    old = function(
+      n,
+      pa.exp,
+      aging.exp,
+      m,
+      aging.bin,
+      out.dist,
+      out.seq,
+      out.pref,
+      directed,
+      zero.deg.appeal,
+      zero.age.appeal,
+      deg.coef,
+      age.coef,
+      time.window
+    ) {},
+    new = function(
+      n,
+      pa.exp,
+      aging.exp,
+      m = NULL,
+      ...,
+      aging.bin = 300,
+      out.dist = NULL,
+      out.seq = NULL,
+      out.pref = FALSE,
+      directed = TRUE,
+      zero.deg.appeal = 1,
+      zero.age.appeal = 0,
+      deg.coef = 1,
+      age.coef = 1,
+      time.window = NULL
+    ) {},
+    when = "3.0.0"
+  ),
+
+  pref = list(
+    old = function(
+      nodes,
+      types,
+      type.dist,
+      fixed.sizes,
+      pref.matrix,
+      directed,
+      loops
+    ) {},
+    new = function(
+      nodes,
+      types,
+      ...,
+      type.dist = rep(1, types),
+      fixed.sizes = FALSE,
+      pref.matrix = matrix(1, types, types),
+      directed = FALSE,
+      loops = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_asym_pref = list(
+    old = function(nodes, types, type.dist.matrix, pref.matrix, loops) {},
+    new = function(
+      nodes,
+      types,
+      ...,
+      type.dist.matrix = matrix(1, types, types),
+      pref.matrix = matrix(1, types, types),
+      loops = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_cit_cit_types = list(
+    old = function(n, edges, types, pref, directed, attr) {},
+    new = function(
+      n,
+      edges = 1,
+      types = rep(0, n),
+      ...,
+      pref = matrix(1, nrow = length(types), ncol = length(types)),
+      directed = TRUE,
+      attr = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_cit_types = list(
+    old = function(n, edges, types, pref, directed, attr) {},
+    new = function(
+      n,
+      edges = 1,
+      types = rep(0, n),
+      ...,
+      pref = rep(1, length(types)),
+      directed = TRUE,
+      attr = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_correlated_gnp = list(
+    old = function(old.graph, corr, p, permutation) {},
+    new = function(
+      old.graph,
+      corr,
+      ...,
+      p = edge_density(old.graph),
+      permutation = NULL
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_degseq = list(
+    old = function(out.deg, in.deg, method) {},
+    new = function(
+      out.deg,
+      in.deg = NULL,
+      ...,
+      method = c( "configuration", "vl", "fast.heur.simple", "configuration.simple", "edge.switching.simple" )
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_dot_product = list(
+    old = function(vecs, directed) {},
+    new = function(
+      vecs,
+      ...,
+      directed = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_fitness = list(
+    old = function(no.of.edges, fitness.out, fitness.in, loops, multiple) {},
+    new = function(
+      no.of.edges,
+      fitness.out,
+      fitness.in = NULL,
+      ...,
+      loops = FALSE,
+      multiple = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_fitness_pl = list(
+    old = function(
+      no.of.nodes,
+      no.of.edges,
+      exponent.out,
+      exponent.in,
+      loops,
+      multiple,
+      finite.size.correction
+    ) {},
+    new = function(
+      no.of.nodes,
+      no.of.edges,
+      exponent.out,
+      exponent.in = -1,
+      ...,
+      loops = FALSE,
+      multiple = FALSE,
+      finite.size.correction = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_forestfire = list(
+    old = function(nodes, fw.prob, bw.factor, ambs, directed) {},
+    new = function(
+      nodes,
+      fw.prob,
+      ...,
+      bw.factor = 1,
+      ambs = 1,
+      directed = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_gnm = list(
+    old = function(n, m, directed, loops) {},
+    new = function(
+      n,
+      m,
+      ...,
+      directed = FALSE,
+      loops = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_gnp = list(
+    old = function(n, p, directed, loops) {},
+    new = function(
+      n,
+      p,
+      ...,
+      directed = FALSE,
+      loops = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_grg = list(
+    old = function(nodes, radius, torus, coords) {},
+    new = function(
+      nodes,
+      radius,
+      ...,
+      torus = FALSE,
+      coords = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_k_regular = list(
+    old = function(no.of.nodes, k, directed, multiple) {},
+    new = function(
+      no.of.nodes,
+      k,
+      ...,
+      directed = FALSE,
+      multiple = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_last_cit = list(
+    old = function(n, edges, agebins, pref, directed) {},
+    new = function(
+      n,
+      edges = 1,
+      ...,
+      agebins = n / 7100,
+      pref = (1:(agebins + 1))^-3,
+      directed = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_pa = list(
+    old = function(
+      n,
+      power,
+      m,
+      out.dist,
+      out.seq,
+      out.pref,
+      zero.appeal,
+      directed,
+      algorithm,
+      start.graph
+    ) {},
+    new = function(
+      n,
+      power = 1,
+      m = NULL,
+      ...,
+      out.dist = NULL,
+      out.seq = NULL,
+      out.pref = FALSE,
+      zero.appeal = 1,
+      directed = TRUE,
+      algorithm = c( "psumtree", "psumtree-multiple", "bag" ),
+      start.graph = NULL
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_pa_age = list(
+    old = function(
+      n,
+      pa.exp,
+      aging.exp,
+      m,
+      aging.bin,
+      out.dist,
+      out.seq,
+      out.pref,
+      directed,
+      zero.deg.appeal,
+      zero.age.appeal,
+      deg.coef,
+      age.coef,
+      time.window
+    ) {},
+    new = function(
+      n,
+      pa.exp,
+      aging.exp,
+      m = NULL,
+      ...,
+      aging.bin = 300,
+      out.dist = NULL,
+      out.seq = NULL,
+      out.pref = FALSE,
+      directed = TRUE,
+      zero.deg.appeal = 1,
+      zero.age.appeal = 0,
+      deg.coef = 1,
+      age.coef = 1,
+      time.window = NULL
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_pref = list(
+    old = function(
+      nodes,
+      types,
+      type.dist,
+      fixed.sizes,
+      pref.matrix,
+      directed,
+      loops
+    ) {},
+    new = function(
+      nodes,
+      types,
+      ...,
+      type.dist = rep(1, types),
+      fixed.sizes = FALSE,
+      pref.matrix = matrix(1, types, types),
+      directed = FALSE,
+      loops = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_sbm = list(
+    old = function(n, pref.matrix, block.sizes, directed, loops) {},
+    new = function(
+      n,
+      pref.matrix,
+      block.sizes,
+      ...,
+      directed = FALSE,
+      loops = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_smallworld = list(
+    old = function(dim, size, nei, p, loops, multiple) {},
+    new = function(
+      dim,
+      size,
+      nei,
+      p,
+      ...,
+      loops = FALSE,
+      multiple = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_traits = list(
+    old = function(nodes, types, k, type.dist, pref.matrix, directed) {},
+    new = function(
+      nodes,
+      types,
+      k = 1,
+      ...,
+      type.dist = rep(1, types),
+      pref.matrix = matrix(1, types, types),
+      directed = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_traits_callaway = list(
+    old = function(
+      nodes,
+      types,
+      edge.per.step,
+      type.dist,
+      pref.matrix,
+      directed
+    ) {},
+    new = function(
+      nodes,
+      types,
+      ...,
+      edge.per.step = 1,
+      type.dist = rep(1, types),
+      pref.matrix = matrix(1, types, types),
+      directed = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sbm = list(
+    old = function(n, pref.matrix, block.sizes, directed, loops) {},
+    new = function(
+      n,
+      pref.matrix,
+      block.sizes,
+      ...,
+      directed = FALSE,
+      loops = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  smallworld = list(
+    old = function(dim, size, nei, p, loops, multiple) {},
+    new = function(
+      dim,
+      size,
+      nei,
+      p,
+      ...,
+      loops = FALSE,
+      multiple = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  traits = list(
+    old = function(nodes, types, k, type.dist, pref.matrix, directed) {},
+    new = function(
+      nodes,
+      types,
+      k = 1,
+      ...,
+      type.dist = rep(1, types),
+      pref.matrix = matrix(1, types, types),
+      directed = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  traits_callaway = list(
+    old = function(
+      nodes,
+      types,
+      edge.per.step,
+      type.dist,
+      pref.matrix,
+      directed
+    ) {},
+    new = function(
+      nodes,
+      types,
+      ...,
+      edge.per.step = 1,
+      type.dist = rep(1, types),
+      pref.matrix = matrix(1, types, types),
+      directed = FALSE
+    ) {},
+    when = "3.0.0"
+  )
+)

--- a/tools/migrations/games.R
+++ b/tools/migrations/games.R
@@ -251,7 +251,13 @@ migrations <- list(
       out.deg,
       in.deg = NULL,
       ...,
-      method = c( "configuration", "vl", "fast.heur.simple", "configuration.simple", "edge.switching.simple" )
+      method = c(
+        "configuration",
+        "vl",
+        "fast.heur.simple",
+        "configuration.simple",
+        "edge.switching.simple"
+      )
     ) {},
     when = "3.0.0"
   ),
@@ -399,7 +405,11 @@ migrations <- list(
       out.pref = FALSE,
       zero.appeal = 1,
       directed = TRUE,
-      algorithm = c( "psumtree", "psumtree-multiple", "bag" ),
+      algorithm = c(
+        "psumtree",
+        "psumtree-multiple",
+        "bag"
+      ),
       start.graph = NULL
     ) {},
     when = "3.0.0"


### PR DESCRIPTION
Part of the repo-wide ellipsis migration coordinated in #2757 —
see that PR for the full rationale (CONTRIBUTING.md, *Argument Order and the Ellipsis*).
Based directly on `main` (the registry split landed via #2779); a single topic commit.

## What this does

Inserts `...` between the *defining* arguments (head) and the *optional
modifiers* (tail) of **36 exported games functions**.
Arguments after `...` become keyword-only.

- Legacy positional or abbreviated calls are **recovered** by the generated
  ARG_HANDLE block and emit a single `lifecycle::deprecate_soft("3.0.0", …)` —
  behavior is unchanged.
- No defaults change, no arguments are renamed, deprecated functions untouched.
- Registry: `tools/migrations/games.R`; blocks regenerated via
  `Rscript tools/generate-migrations.R` (idempotent, CI-checked).
- Rd usage/arguments updated mechanically (see note below).

## New signatures

| function | head (positional) | keyword-only tail |
|---|---|---|
| `asym_pref()` | `nodes, types` | `type.dist.matrix, pref.matrix, loops` |
| `cit_cit_types()` | `n, edges, types` | `pref, directed, attr` |
| `cit_types()` | `n, edges, types` | `pref, directed, attr` |
| `dot_product()` | `vecs` | `directed` |
| `gnm()` | `n, m` | `directed, loops` |
| `gnp()` | `n, p` | `directed, loops` |
| `grg()` | `nodes, radius` | `torus, coords` |
| `last_cit()` | `n, edges` | `agebins, pref, directed` |
| `pa()` | `n, power, m` | `out.dist, out.seq, out.pref, zero.appeal, directed, algorithm, start.graph` |
| `pa_age()` | `n, pa.exp, aging.exp, m` | `aging.bin, out.dist, out.seq, out.pref, directed, zero.deg.appeal, zero.age.appeal, deg.coef, age.coef, time.window` |
| `pref()` | `nodes, types` | `type.dist, fixed.sizes, pref.matrix, directed, loops` |
| `sample_asym_pref()` | `nodes, types` | `type.dist.matrix, pref.matrix, loops` |
| `sample_cit_cit_types()` | `n, edges, types` | `pref, directed, attr` |
| `sample_cit_types()` | `n, edges, types` | `pref, directed, attr` |
| `sample_correlated_gnp()` | `old.graph, corr` | `p, permutation` |
| `sample_degseq()` | `out.deg, in.deg` | `method` |
| `sample_dot_product()` | `vecs` | `directed` |
| `sample_fitness()` | `no.of.edges, fitness.out, fitness.in` | `loops, multiple` |
| `sample_fitness_pl()` | `no.of.nodes, no.of.edges, exponent.out, exponent.in` | `loops, multiple, finite.size.correction` |
| `sample_forestfire()` | `nodes, fw.prob` | `bw.factor, ambs, directed` |
| `sample_gnm()` | `n, m` | `directed, loops` |
| `sample_gnp()` | `n, p` | `directed, loops` |
| `sample_grg()` | `nodes, radius` | `torus, coords` |
| `sample_k_regular()` | `no.of.nodes, k` | `directed, multiple` |
| `sample_last_cit()` | `n, edges` | `agebins, pref, directed` |
| `sample_pa()` | `n, power, m` | `out.dist, out.seq, out.pref, zero.appeal, directed, algorithm, start.graph` |
| `sample_pa_age()` | `n, pa.exp, aging.exp, m` | `aging.bin, out.dist, out.seq, out.pref, directed, zero.deg.appeal, zero.age.appeal, deg.coef, age.coef, time.window` |
| `sample_pref()` | `nodes, types` | `type.dist, fixed.sizes, pref.matrix, directed, loops` |
| `sample_sbm()` | `n, pref.matrix, block.sizes` | `directed, loops` |
| `sample_smallworld()` | `dim, size, nei, p` | `loops, multiple` |
| `sample_traits()` | `nodes, types, k` | `type.dist, pref.matrix, directed` |
| `sample_traits_callaway()` | `nodes, types` | `edge.per.step, type.dist, pref.matrix, directed` |
| `sbm()` | `n, pref.matrix, block.sizes` | `directed, loops` |
| `smallworld()` | `dim, size, nei, p` | `loops, multiple` |
| `traits()` | `nodes, types, k` | `type.dist, pref.matrix, directed` |
| `traits_callaway()` | `nodes, types` | `edge.per.step, type.dist, pref.matrix, directed` |

## Notes for review

- The environment used to prepare this PR cannot install `igraph.r2cdocs`
  (GitHub API unreachable), so `man/*.Rd` files were updated **mechanically**
  (usage + `...` argument item) instead of via `devtools::document()`.
  R CMD check's usage↔formals validation passes; a follow-up
  `devtools::document()` run may reflow whitespace but should produce no
  semantic diff.
- Package tests that called these functions positionally were updated to
  named arguments (they are the same soft-deprecation user code will see).
