### PR TITLE
refactor: move optional arguments of make functions behind the ellipsis

### DIFF
--- a/R/cycles.R
+++ b/R/cycles.R
@@ -31,6 +31,7 @@
 #' a specific cycle.
 #'
 #' @param graph The input graph.
+#' @inheritParams rlang::args_dots_empty
 #' @param mode Character constant specifying how to handle directed graphs.
 #'   `out` follows edge directions, `in` follows edges in the reverse direction,
 #'   and `all` ignores edge directions. Ignored in undirected graphs.

--- a/R/make.R
+++ b/R/make.R
@@ -1584,6 +1584,7 @@ undirected_graph <- function(...) constructor_spec(make_undirected_graph, ...)
 #'
 #' @concept Empty graph.
 #' @param n Number of vertices.
+#' @inheritParams rlang::args_dots_empty
 #' @param directed Whether to create a directed graph.
 #' @return An igraph graph.
 #'
@@ -1592,7 +1593,33 @@ undirected_graph <- function(...) constructor_spec(make_undirected_graph, ...)
 #' @examples
 #' make_empty_graph(n = 10)
 #' make_empty_graph(n = 5, directed = FALSE)
-make_empty_graph <- function(n = 0, directed = TRUE) {
+make_empty_graph <- function(
+  n = 0,
+  ...,
+  directed = TRUE
+) {
+  # BEGIN GENERATED ARG_HANDLE: make_empty_graph, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed),
+      recover_new = c("directed"),
+      recover_old = c("directed"),
+      match_names = c("directed"),
+      match_to = c("directed"),
+      defaults = list(directed = TRUE),
+      head_args = c("n"),
+      fn_name = "make_empty_graph"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   if (!is.numeric(n)) {
     cli::cli_abort("{.arg n} must be numeric, not {.obj_type_friendly {n}}.")
   }
@@ -1608,8 +1635,35 @@ make_empty_graph <- function(n = 0, directed = TRUE) {
 }
 
 #' @rdname make_empty_graph
+#' @inheritParams rlang::args_dots_empty
 #' @export
-empty_graph <- function(n = 0, directed = TRUE) {
+empty_graph <- function(
+  n = 0,
+  ...,
+  directed = TRUE
+) {
+  # BEGIN GENERATED ARG_HANDLE: empty_graph, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed),
+      recover_new = c("directed"),
+      recover_old = c("directed"),
+      match_names = c("directed"),
+      match_to = c("directed"),
+      defaults = list(directed = TRUE),
+      head_args = c("n"),
+      fn_name = "empty_graph"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(make_empty_graph, n = n, directed = directed)
 }
 
@@ -1855,6 +1909,7 @@ from_literal <- function(...) {
 #'
 #' @concept Star graph
 #' @param n Number of vertices.
+#' @inheritParams rlang::args_dots_empty
 #' @param mode It defines the direction of the
 #'   edges, `in`: the edges point *to* the center, `out`:
 #'   the edges point *from* the center, `mutual`: a directed
@@ -1870,9 +1925,35 @@ from_literal <- function(...) {
 #' make_star(5, mode = "undirected")
 make_star <- function(
   n,
+  ...,
   mode = c("in", "out", "mutual", "undirected"),
   center = 1
 ) {
+  # BEGIN GENERATED ARG_HANDLE: make_star, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(mode = mode, center = center),
+      recover_new = c("mode", "center"),
+      recover_old = c("mode", "center"),
+      match_names = c("mode", "center"),
+      match_to = c("mode", "center"),
+      defaults = list(
+        mode = c("in", "out", "mutual", "undirected"),
+        center = 1
+      ),
+      head_args = c("n"),
+      fn_name = "make_star"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   mode <- igraph_match_arg(mode)
 
   res <- star_impl(
@@ -1889,8 +1970,39 @@ make_star <- function(
 }
 
 #' @rdname make_star
+#' @inheritParams rlang::args_dots_empty
 #' @export
-star <- function(n, mode = c("in", "out", "mutual", "undirected"), center = 1) {
+star <- function(
+  n,
+  ...,
+  mode = c("in", "out", "mutual", "undirected"),
+  center = 1
+) {
+  # BEGIN GENERATED ARG_HANDLE: star, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(mode = mode, center = center),
+      recover_new = c("mode", "center"),
+      recover_old = c("mode", "center"),
+      match_names = c("mode", "center"),
+      match_to = c("mode", "center"),
+      defaults = list(
+        mode = c("in", "out", "mutual", "undirected"),
+        center = 1
+      ),
+      head_args = c("n"),
+      fn_name = "star"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(make_star, n = n, mode = mode, center = center)
 }
 
@@ -1900,6 +2012,7 @@ star <- function(n, mode = c("in", "out", "mutual", "undirected"), center = 1) {
 #'
 #' @concept Full graph
 #' @param n Number of vertices.
+#' @inheritParams rlang::args_dots_empty
 #' @param directed Whether to create a directed graph.
 #' @param loops Whether to add self-loops to the graph.
 #' @return An igraph graph
@@ -1909,7 +2022,34 @@ star <- function(n, mode = c("in", "out", "mutual", "undirected"), center = 1) {
 #' @examples
 #' make_full_graph(5)
 #' print_all(make_full_graph(4, directed = TRUE))
-make_full_graph <- function(n, directed = FALSE, loops = FALSE) {
+make_full_graph <- function(
+  n,
+  ...,
+  directed = FALSE,
+  loops = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: make_full_graph, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, loops = loops),
+      recover_new = c("directed", "loops"),
+      recover_old = c("directed", "loops"),
+      match_names = c("directed", "loops"),
+      match_to = c("directed", "loops"),
+      defaults = list(directed = FALSE, loops = FALSE),
+      head_args = c("n"),
+      fn_name = "make_full_graph"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   res <- full_impl(
     n,
     directed,
@@ -1923,8 +2063,36 @@ make_full_graph <- function(n, directed = FALSE, loops = FALSE) {
 }
 
 #' @rdname make_full_graph
+#' @inheritParams rlang::args_dots_empty
 #' @export
-full_graph <- function(n, directed = FALSE, loops = FALSE) {
+full_graph <- function(
+  n,
+  ...,
+  directed = FALSE,
+  loops = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: full_graph, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, loops = loops),
+      recover_new = c("directed", "loops"),
+      recover_old = c("directed", "loops"),
+      match_names = c("directed", "loops"),
+      match_to = c("directed", "loops"),
+      defaults = list(directed = FALSE, loops = FALSE),
+      head_args = c("n"),
+      fn_name = "full_graph"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(make_full_graph, n = n, directed = directed, loops = loops)
 }
 
@@ -2043,6 +2211,7 @@ lattice <- function(
 #' of [make_lattice()].
 #'
 #' @param n Number of vertices.
+#' @inheritParams rlang::args_dots_empty
 #' @param directed Whether the graph is directed.
 #' @param mutual Whether directed edges are mutual. It is ignored in
 #'   undirected graphs.
@@ -2056,7 +2225,35 @@ lattice <- function(
 #' @examples
 #' print_all(make_ring(10))
 #' print_all(make_ring(10, directed = TRUE, mutual = TRUE))
-make_ring <- function(n, directed = FALSE, mutual = FALSE, circular = TRUE) {
+make_ring <- function(
+  n,
+  ...,
+  directed = FALSE,
+  mutual = FALSE,
+  circular = TRUE
+) {
+  # BEGIN GENERATED ARG_HANDLE: make_ring, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, mutual = mutual, circular = circular),
+      recover_new = c("directed", "mutual", "circular"),
+      recover_old = c("directed", "mutual", "circular"),
+      match_names = c("directed", "mutual", "circular"),
+      match_to = c("directed", "mutual", "circular"),
+      defaults = list(directed = FALSE, mutual = FALSE, circular = TRUE),
+      head_args = c("n"),
+      fn_name = "make_ring"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   res <- ring_impl(
     n,
     directed,
@@ -2072,8 +2269,37 @@ make_ring <- function(n, directed = FALSE, mutual = FALSE, circular = TRUE) {
 }
 
 #' @rdname make_ring
+#' @inheritParams rlang::args_dots_empty
 #' @export
-ring <- function(n, directed = FALSE, mutual = FALSE, circular = TRUE) {
+ring <- function(
+  n,
+  ...,
+  directed = FALSE,
+  mutual = FALSE,
+  circular = TRUE
+) {
+  # BEGIN GENERATED ARG_HANDLE: ring, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, mutual = mutual, circular = circular),
+      recover_new = c("directed", "mutual", "circular"),
+      recover_old = c("directed", "mutual", "circular"),
+      match_names = c("directed", "mutual", "circular"),
+      match_to = c("directed", "mutual", "circular"),
+      defaults = list(directed = FALSE, mutual = FALSE, circular = TRUE),
+      head_args = c("n"),
+      fn_name = "ring"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     make_ring,
     n,
@@ -2164,6 +2390,7 @@ wheel <- function(
 #' @param n Number of vertices.
 #' @param children Integer scalar, the number of children of a vertex
 #'   (except for leafs)
+#' @inheritParams rlang::args_dots_empty
 #' @param mode Defines the direction of the
 #'   edges. `out` indicates that the edges point from the parent to
 #'   the children, `in` indicates that they point from the children
@@ -2176,7 +2403,34 @@ wheel <- function(
 #' @examples
 #' make_tree(10, 2)
 #' make_tree(10, 3, mode = "undirected")
-make_tree <- function(n, children = 2, mode = c("out", "in", "undirected")) {
+make_tree <- function(
+  n,
+  children = 2,
+  ...,
+  mode = c("out", "in", "undirected")
+) {
+  # BEGIN GENERATED ARG_HANDLE: make_tree, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(mode = mode),
+      recover_new = c("mode"),
+      recover_old = c("mode"),
+      match_names = c("mode"),
+      match_to = c("mode"),
+      defaults = list(mode = c("out", "in", "undirected")),
+      head_args = c("n", "children"),
+      fn_name = "make_tree"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   mode <- igraph_match_arg(mode)
 
   res <- kary_tree_impl(
@@ -2201,6 +2455,7 @@ make_tree <- function(n, children = 2, mode = c("out", "in", "undirected")) {
 #' given number of nodes with the same probability.
 #'
 #' @param n The number of nodes in the tree
+#' @inheritParams rlang::args_dots_empty
 #' @param directed Whether to create a directed tree. The edges of the tree are
 #'   oriented away from the root.
 #' @param method The algorithm to use to generate the tree. \sQuote{prufer}
@@ -2218,7 +2473,34 @@ make_tree <- function(n, children = 2, mode = c("out", "in", "undirected")) {
 #' g <- sample_tree(100, method = "lerw")
 #'
 #' @export
-sample_tree <- function(n, directed = FALSE, method = c("lerw", "prufer")) {
+sample_tree <- function(
+  n,
+  ...,
+  directed = FALSE,
+  method = c("lerw", "prufer")
+) {
+  # BEGIN GENERATED ARG_HANDLE: sample_tree, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, method = method),
+      recover_new = c("directed", "method"),
+      recover_old = c("directed", "method"),
+      match_names = c("directed", "method"),
+      match_to = c("directed", "method"),
+      defaults = list(directed = FALSE, method = c("lerw", "prufer")),
+      head_args = c("n"),
+      fn_name = "sample_tree"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   tree_game_impl(
     n = n,
     directed = directed,
@@ -2335,6 +2617,7 @@ atlas <- function(n) {
 #' @param n The number of vertices.
 #' @param w A matrix which specifies the extended chordal ring. See
 #'   details below.
+#' @inheritParams rlang::args_dots_empty
 #' @param directed Logical, whether or not to create a directed graph.
 #' @return An igraph graph.
 #'
@@ -2345,7 +2628,34 @@ atlas <- function(n) {
 #'   15,
 #'   matrix(c(3, 12, 4, 7, 8, 11), nr = 2)
 #' )
-make_chordal_ring <- function(n, w, directed = FALSE) {
+make_chordal_ring <- function(
+  n,
+  w,
+  ...,
+  directed = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: make_chordal_ring, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed),
+      recover_new = c("directed"),
+      recover_old = c("directed"),
+      match_names = c("directed"),
+      match_to = c("directed"),
+      defaults = list(directed = FALSE),
+      head_args = c("n", "w"),
+      fn_name = "make_chordal_ring"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   res <- extended_chordal_ring_impl(
     nodes = n,
     W = as.matrix(w),
@@ -2359,8 +2669,36 @@ make_chordal_ring <- function(n, w, directed = FALSE) {
 }
 
 #' @rdname make_chordal_ring
+#' @inheritParams rlang::args_dots_empty
 #' @export
-chordal_ring <- function(n, w, directed = FALSE) {
+chordal_ring <- function(
+  n,
+  w,
+  ...,
+  directed = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: chordal_ring, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed),
+      recover_new = c("directed"),
+      recover_old = c("directed"),
+      match_names = c("directed"),
+      match_to = c("directed"),
+      defaults = list(directed = FALSE),
+      head_args = c("n", "w"),
+      fn_name = "chordal_ring"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(make_chordal_ring, n = n, w = w, directed = directed)
 }
 
@@ -2377,6 +2715,7 @@ chordal_ring <- function(n, w, directed = FALSE) {
 #'
 #' @param n Integer, the number of vertices in the circulant graph.
 #' @param shifts Integer vector, a list of the offsets within the circulant graph.
+#' @inheritParams rlang::args_dots_empty
 #' @param directed Logical, whether to create a directed graph.
 #' @return An igraph graph.
 #'
@@ -2390,7 +2729,34 @@ chordal_ring <- function(n, w, directed = FALSE) {
 #' # A directed circulant graph
 #' g2 <- make_circulant(10, c(1, 3), directed = TRUE)
 #' plot(g2, layout = layout_in_circle)
-make_circulant <- function(n, shifts, directed = FALSE) {
+make_circulant <- function(
+  n,
+  shifts,
+  ...,
+  directed = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: make_circulant, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed),
+      recover_new = c("directed"),
+      recover_old = c("directed"),
+      match_names = c("directed"),
+      match_to = c("directed"),
+      defaults = list(directed = FALSE),
+      head_args = c("n", "shifts"),
+      fn_name = "make_circulant"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   circulant_impl(
     n = n,
     shifts = shifts,
@@ -2399,8 +2765,36 @@ make_circulant <- function(n, shifts, directed = FALSE) {
 }
 
 #' @rdname make_circulant
+#' @inheritParams rlang::args_dots_empty
 #' @export
-circulant <- function(n, shifts, directed = FALSE) {
+circulant <- function(
+  n,
+  shifts,
+  ...,
+  directed = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: circulant, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed),
+      recover_new = c("directed"),
+      recover_old = c("directed"),
+      match_names = c("directed"),
+      match_to = c("directed"),
+      defaults = list(directed = FALSE),
+      head_args = c("n", "shifts"),
+      fn_name = "circulant"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(make_circulant, n = n, shifts = shifts, directed = directed)
 }
 
@@ -2566,6 +2960,7 @@ kautz_graph <- function(m, n) {
 #'
 #' @param n1 The number of vertices of the first kind.
 #' @param n2 The number of vertices of the second kind.
+#' @inheritParams rlang::args_dots_empty
 #' @param directed Logical, whether the graphs is directed.
 #' @param mode Scalar giving the kind of edges to create for directed graphs.
 #'   If this is \sQuote{`out`} then all vertices of the first kind are
@@ -2587,9 +2982,32 @@ kautz_graph <- function(m, n) {
 make_full_bipartite_graph <- function(
   n1,
   n2,
+  ...,
   directed = FALSE,
   mode = c("all", "out", "in")
 ) {
+  # BEGIN GENERATED ARG_HANDLE: make_full_bipartite_graph, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, mode = mode),
+      recover_new = c("directed", "mode"),
+      recover_old = c("directed", "mode"),
+      match_names = c("directed", "mode"),
+      match_to = c("directed", "mode"),
+      defaults = list(directed = FALSE, mode = c("all", "out", "in")),
+      head_args = c("n1", "n2"),
+      fn_name = "make_full_bipartite_graph"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   n1 <- as.numeric(n1)
   n2 <- as.numeric(n2)
   directed <- as.logical(directed)
@@ -2610,13 +3028,37 @@ make_full_bipartite_graph <- function(
 }
 
 #' @rdname make_full_bipartite_graph
+#' @inheritParams rlang::args_dots_empty
 #' @export
 full_bipartite_graph <- function(
   n1,
   n2,
+  ...,
   directed = FALSE,
   mode = c("all", "out", "in")
 ) {
+  # BEGIN GENERATED ARG_HANDLE: full_bipartite_graph, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, mode = mode),
+      recover_new = c("directed", "mode"),
+      recover_old = c("directed", "mode"),
+      match_names = c("directed", "mode"),
+      match_to = c("directed", "mode"),
+      defaults = list(directed = FALSE, mode = c("all", "out", "in")),
+      head_args = c("n1", "n2"),
+      fn_name = "full_bipartite_graph"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     make_full_bipartite_graph,
     n1 = n1,
@@ -2652,6 +3094,7 @@ full_bipartite_graph <- function(
 #'   regular [make_graph()] function. It is checked that the edges indeed
 #'   connect vertices of different kind, according to the supplied `types`
 #'   vector. The vector may be a string vector if `types` is a named vector.
+#' @inheritParams rlang::args_dots_empty
 #' @param directed Logical, whether to create a directed graph. Note
 #'   that by default undirected graphs are created, as this is more common for
 #'   bipartite graphs.
@@ -2669,7 +3112,34 @@ full_bipartite_graph <- function(
 #' print(g, v = TRUE)
 #'
 #' @export
-make_bipartite_graph <- function(types, edges, directed = FALSE) {
+make_bipartite_graph <- function(
+  types,
+  edges,
+  ...,
+  directed = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: make_bipartite_graph, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed),
+      recover_new = c("directed"),
+      recover_old = c("directed"),
+      match_names = c("directed"),
+      match_to = c("directed"),
+      defaults = list(directed = FALSE),
+      head_args = c("types", "edges"),
+      fn_name = "make_bipartite_graph"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   vertex.names <- names(types)
 
   if (is.character(edges)) {
@@ -2705,8 +3175,36 @@ make_bipartite_graph <- function(types, edges, directed = FALSE) {
 }
 
 #' @rdname make_bipartite_graph
+#' @inheritParams rlang::args_dots_empty
 #' @export
-bipartite_graph <- function(types, edges, directed = FALSE) {
+bipartite_graph <- function(
+  types,
+  edges,
+  ...,
+  directed = FALSE
+) {
+  # BEGIN GENERATED ARG_HANDLE: bipartite_graph, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed),
+      recover_new = c("directed"),
+      recover_old = c("directed"),
+      match_names = c("directed"),
+      match_to = c("directed"),
+      defaults = list(directed = FALSE),
+      head_args = c("types", "edges"),
+      fn_name = "bipartite_graph"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     make_bipartite_graph,
     types = types,
@@ -2725,6 +3223,7 @@ bipartite_graph <- function(types, edges, directed = FALSE) {
 #' different partitions are present.
 #'
 #' @param n A numeric vector giving the number of vertices in each partition.
+#' @inheritParams rlang::args_dots_empty
 #' @param directed Logical, whether to create a directed graph.
 #' @param mode Character scalar, the type of connections for directed graphs.
 #'   If `"out"`, then edges point from vertices of partitions with lower
@@ -2746,9 +3245,32 @@ bipartite_graph <- function(types, edges, directed = FALSE) {
 #' plot(g2)
 make_full_multipartite <- function(
   n,
+  ...,
   directed = FALSE,
   mode = c("all", "out", "in")
 ) {
+  # BEGIN GENERATED ARG_HANDLE: make_full_multipartite, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, mode = mode),
+      recover_new = c("directed", "mode"),
+      recover_old = c("directed", "mode"),
+      match_names = c("directed", "mode"),
+      match_to = c("directed", "mode"),
+      defaults = list(directed = FALSE, mode = c("all", "out", "in")),
+      head_args = c("n"),
+      fn_name = "make_full_multipartite"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   n <- as.numeric(n)
   directed <- as.logical(directed)
   mode <- igraph_match_arg(mode)
@@ -2770,12 +3292,36 @@ make_full_multipartite <- function(
 }
 
 #' @rdname make_full_multipartite
+#' @inheritParams rlang::args_dots_empty
 #' @export
 full_multipartite <- function(
   n,
+  ...,
   directed = FALSE,
   mode = c("all", "out", "in")
 ) {
+  # BEGIN GENERATED ARG_HANDLE: full_multipartite, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed, mode = mode),
+      recover_new = c("directed", "mode"),
+      recover_old = c("directed", "mode"),
+      match_names = c("directed", "mode"),
+      match_to = c("directed", "mode"),
+      defaults = list(directed = FALSE, mode = c("all", "out", "in")),
+      head_args = c("n"),
+      fn_name = "full_multipartite"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(
     make_full_multipartite,
     n = n,
@@ -2847,6 +3393,7 @@ turan <- function(n, r) {
 #' \eqn{j<i}. If `directed=FALSE` then the graph is just a full graph.
 #'
 #' @param n The number of vertices.
+#' @inheritParams rlang::args_dots_empty
 #' @param directed Whether to create a directed graph.
 #' @return An igraph graph.
 #'
@@ -2854,7 +3401,33 @@ turan <- function(n, r) {
 #' @export
 #' @examples
 #' print_all(make_full_citation_graph(10))
-make_full_citation_graph <- function(n, directed = TRUE) {
+make_full_citation_graph <- function(
+  n,
+  ...,
+  directed = TRUE
+) {
+  # BEGIN GENERATED ARG_HANDLE: make_full_citation_graph, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed),
+      recover_new = c("directed"),
+      recover_old = c("directed"),
+      match_names = c("directed"),
+      match_to = c("directed"),
+      defaults = list(directed = TRUE),
+      head_args = c("n"),
+      fn_name = "make_full_citation_graph"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   # Function call
   res <- full_citation_impl(
     n = n,
@@ -2866,8 +3439,35 @@ make_full_citation_graph <- function(n, directed = TRUE) {
 }
 
 #' @rdname make_full_citation_graph
+#' @inheritParams rlang::args_dots_empty
 #' @export
-full_citation_graph <- function(n, directed = TRUE) {
+full_citation_graph <- function(
+  n,
+  ...,
+  directed = TRUE
+) {
+  # BEGIN GENERATED ARG_HANDLE: full_citation_graph, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(directed = directed),
+      recover_new = c("directed"),
+      recover_old = c("directed"),
+      match_names = c("directed"),
+      match_to = c("directed"),
+      defaults = list(directed = TRUE),
+      head_args = c("n"),
+      fn_name = "full_citation_graph"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   constructor_spec(make_full_citation_graph, n = n, directed = directed)
 }
 
@@ -2971,6 +3571,7 @@ graph_from_lcf <- function(
 #' @param in.deg For directed graph, the in-degree sequence. By default this is
 #'   `NULL` and an undirected graph is created.
 #' @param method Character, the method for generating the graph; see below.
+#' @inheritParams rlang::args_dots_empty
 #' @param allowed.edge.types Character, specifies the types of allowed edges.
 #'   \dQuote{simple} allows simple graphs only (no loops, no multiple edges).
 #'   \dQuote{multiple} allows multiple edges but disallows loop.
@@ -3028,9 +3629,35 @@ graph_from_lcf <- function(
 realize_degseq <- function(
   out.deg,
   in.deg = NULL,
+  ...,
   allowed.edge.types = c("simple", "loops", "multi", "all"),
   method = c("smallest", "largest", "index")
 ) {
+  # BEGIN GENERATED ARG_HANDLE: realize_degseq, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(allowed.edge.types = allowed.edge.types, method = method),
+      recover_new = c("allowed.edge.types", "method"),
+      recover_old = c("allowed.edge.types", "method"),
+      match_names = c("allowed.edge.types", "method"),
+      match_to = c("allowed.edge.types", "method"),
+      defaults = list(
+        allowed.edge.types = c("simple", "loops", "multi", "all"),
+        method = c("smallest", "largest", "index")
+      ),
+      head_args = c("out.deg", "in.deg"),
+      fn_name = "realize_degseq"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   res <- realize_degree_sequence_impl(
     out_deg = out.deg,
     in_deg = in.deg,

--- a/man/make_bipartite_graph.Rd
+++ b/man/make_bipartite_graph.Rd
@@ -5,9 +5,9 @@
 \alias{bipartite_graph}
 \title{Create a bipartite graph}
 \usage{
-make_bipartite_graph(types, edges, directed = FALSE)
+make_bipartite_graph(types, edges, ..., directed = FALSE)
 
-bipartite_graph(types, edges, directed = FALSE)
+bipartite_graph(types, edges, ..., directed = FALSE)
 }
 \arguments{
 \item{types}{A vector giving the vertex types. It will be coerced into
@@ -19,6 +19,8 @@ as the \code{name} vertex attribute.}
 regular \code{\link[=make_graph]{make_graph()}} function. It is checked that the edges indeed
 connect vertices of different kind, according to the supplied \code{types}
 vector. The vector may be a string vector if \code{types} is a named vector.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Logical, whether to create a directed graph. Note
 that by default undirected graphs are created, as this is more common for

--- a/man/make_chordal_ring.Rd
+++ b/man/make_chordal_ring.Rd
@@ -5,15 +5,17 @@
 \alias{chordal_ring}
 \title{Create an extended chordal ring graph}
 \usage{
-make_chordal_ring(n, w, directed = FALSE)
+make_chordal_ring(n, w, ..., directed = FALSE)
 
-chordal_ring(n, w, directed = FALSE)
+chordal_ring(n, w, ..., directed = FALSE)
 }
 \arguments{
 \item{n}{The number of vertices.}
 
 \item{w}{A matrix which specifies the extended chordal ring. See
 details below.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Logical, whether or not to create a directed graph.}
 }

--- a/man/make_circulant.Rd
+++ b/man/make_circulant.Rd
@@ -5,14 +5,16 @@
 \alias{circulant}
 \title{Create a circulant graph}
 \usage{
-make_circulant(n, shifts, directed = FALSE)
+make_circulant(n, shifts, ..., directed = FALSE)
 
-circulant(n, shifts, directed = FALSE)
+circulant(n, shifts, ..., directed = FALSE)
 }
 \arguments{
 \item{n}{Integer, the number of vertices in the circulant graph.}
 
 \item{shifts}{Integer vector, a list of the offsets within the circulant graph.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Logical, whether to create a directed graph.}
 }

--- a/man/make_empty_graph.Rd
+++ b/man/make_empty_graph.Rd
@@ -5,12 +5,14 @@
 \alias{empty_graph}
 \title{A graph with no edges}
 \usage{
-make_empty_graph(n = 0, directed = TRUE)
+make_empty_graph(n = 0, ..., directed = TRUE)
 
-empty_graph(n = 0, directed = TRUE)
+empty_graph(n = 0, ..., directed = TRUE)
 }
 \arguments{
 \item{n}{Number of vertices.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Whether to create a directed graph.}
 }

--- a/man/make_full_bipartite_graph.Rd
+++ b/man/make_full_bipartite_graph.Rd
@@ -8,16 +8,25 @@
 make_full_bipartite_graph(
   n1,
   n2,
+  ...,
   directed = FALSE,
   mode = c("all", "out", "in")
 )
 
-full_bipartite_graph(n1, n2, directed = FALSE, mode = c("all", "out", "in"))
+full_bipartite_graph(
+  n1,
+  n2,
+  ...,
+  directed = FALSE,
+  mode = c("all", "out", "in")
+)
 }
 \arguments{
 \item{n1}{The number of vertices of the first kind.}
 
 \item{n2}{The number of vertices of the second kind.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Logical, whether the graphs is directed.}
 

--- a/man/make_full_citation_graph.Rd
+++ b/man/make_full_citation_graph.Rd
@@ -5,12 +5,14 @@
 \alias{full_citation_graph}
 \title{Create a complete (full) citation graph}
 \usage{
-make_full_citation_graph(n, directed = TRUE)
+make_full_citation_graph(n, ..., directed = TRUE)
 
-full_citation_graph(n, directed = TRUE)
+full_citation_graph(n, ..., directed = TRUE)
 }
 \arguments{
 \item{n}{The number of vertices.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Whether to create a directed graph.}
 }

--- a/man/make_full_graph.Rd
+++ b/man/make_full_graph.Rd
@@ -5,12 +5,14 @@
 \alias{full_graph}
 \title{Create a full graph}
 \usage{
-make_full_graph(n, directed = FALSE, loops = FALSE)
+make_full_graph(n, ..., directed = FALSE, loops = FALSE)
 
-full_graph(n, directed = FALSE, loops = FALSE)
+full_graph(n, ..., directed = FALSE, loops = FALSE)
 }
 \arguments{
 \item{n}{Number of vertices.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Whether to create a directed graph.}
 

--- a/man/make_full_multipartite.Rd
+++ b/man/make_full_multipartite.Rd
@@ -5,12 +5,14 @@
 \alias{full_multipartite}
 \title{Create a full multipartite graph}
 \usage{
-make_full_multipartite(n, directed = FALSE, mode = c("all", "out", "in"))
+make_full_multipartite(n, ..., directed = FALSE, mode = c("all", "out", "in"))
 
-full_multipartite(n, directed = FALSE, mode = c("all", "out", "in"))
+full_multipartite(n, ..., directed = FALSE, mode = c("all", "out", "in"))
 }
 \arguments{
 \item{n}{A numeric vector giving the number of vertices in each partition.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Logical, whether to create a directed graph.}
 

--- a/man/make_ring.Rd
+++ b/man/make_ring.Rd
@@ -5,12 +5,14 @@
 \alias{ring}
 \title{Create a ring graph}
 \usage{
-make_ring(n, directed = FALSE, mutual = FALSE, circular = TRUE)
+make_ring(n, ..., directed = FALSE, mutual = FALSE, circular = TRUE)
 
-ring(n, directed = FALSE, mutual = FALSE, circular = TRUE)
+ring(n, ..., directed = FALSE, mutual = FALSE, circular = TRUE)
 }
 \arguments{
 \item{n}{Number of vertices.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Whether the graph is directed.}
 

--- a/man/make_star.Rd
+++ b/man/make_star.Rd
@@ -5,12 +5,14 @@
 \alias{star}
 \title{Create a star graph, a tree with n vertices and n - 1 leaves}
 \usage{
-make_star(n, mode = c("in", "out", "mutual", "undirected"), center = 1)
+make_star(n, ..., mode = c("in", "out", "mutual", "undirected"), center = 1)
 
-star(n, mode = c("in", "out", "mutual", "undirected"), center = 1)
+star(n, ..., mode = c("in", "out", "mutual", "undirected"), center = 1)
 }
 \arguments{
 \item{n}{Number of vertices.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{mode}{It defines the direction of the
 edges, \verb{in}: the edges point \emph{to} the center, \code{out}:

--- a/man/make_tree.Rd
+++ b/man/make_tree.Rd
@@ -5,7 +5,7 @@
 \alias{tree}
 \title{Create tree graphs}
 \usage{
-make_tree(n, children = 2, mode = c("out", "in", "undirected"))
+make_tree(n, children = 2, ..., mode = c("out", "in", "undirected"))
 
 tree(...)
 }
@@ -15,13 +15,13 @@ tree(...)
 \item{children}{Integer scalar, the number of children of a vertex
 (except for leafs)}
 
+\item{...}{Passed to \code{make_tree()} or \code{sample_tree()}.}
+
 \item{mode}{Defines the direction of the
 edges. \code{out} indicates that the edges point from the parent to
 the children, \verb{in} indicates that they point from the children
 to their parents, while \code{undirected} creates an undirected
 graph.}
-
-\item{...}{Passed to \code{make_tree()} or \code{sample_tree()}.}
 }
 \value{
 An igraph graph

--- a/man/realize_degseq.Rd
+++ b/man/realize_degseq.Rd
@@ -7,6 +7,7 @@
 realize_degseq(
   out.deg,
   in.deg = NULL,
+  ...,
   allowed.edge.types = c("simple", "loops", "multi", "all"),
   method = c("smallest", "largest", "index")
 )
@@ -19,6 +20,8 @@ should be even. For directed graphs its sum should be the same as the sum of
 
 \item{in.deg}{For directed graph, the in-degree sequence. By default this is
 \code{NULL} and an undirected graph is created.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{allowed.edge.types}{Character, specifies the types of allowed edges.
 \dQuote{simple} allows simple graphs only (no loops, no multiple edges).

--- a/man/sample_tree.Rd
+++ b/man/sample_tree.Rd
@@ -4,10 +4,12 @@
 \alias{sample_tree}
 \title{Sample trees randomly and uniformly}
 \usage{
-sample_tree(n, directed = FALSE, method = c("lerw", "prufer"))
+sample_tree(n, ..., directed = FALSE, method = c("lerw", "prufer"))
 }
 \arguments{
 \item{n}{The number of nodes in the tree}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{directed}{Whether to create a directed tree. The edges of the tree are
 oriented away from the root.}

--- a/tests/testthat/_snaps/make.md
+++ b/tests/testthat/_snaps/make.md
@@ -168,7 +168,7 @@
 ---
 
     Code
-      make_empty_graph(10, "spam")
+      make_empty_graph(10, directed = "spam")
     Condition
       Error in `make_empty_graph()`:
       ! `directed` must be a logical, not a string.

--- a/tests/testthat/test-centralization.R
+++ b/tests/testthat/test-centralization.R
@@ -1,19 +1,19 @@
 test_that("centr_degree works", {
-  g <- make_star(5, "undirected")
+  g <- make_star(5, mode = "undirected")
   g_centr <- centr_degree(g, normalized = FALSE)
   g_centr_tmax <- centr_degree_tmax(g, loops = FALSE)
   expect_equal(g_centr$centralization, g_centr_tmax)
 })
 
 test_that("centr_betw works", {
-  g <- make_star(5, "undirected")
+  g <- make_star(5, mode = "undirected")
   g_centr <- centr_betw(g, normalized = FALSE)
   g_centr_tmax <- centr_betw_tmax(g)
   expect_equal(g_centr$centralization, g_centr_tmax)
 })
 
 test_that("centr_clo works", {
-  g <- make_star(5, "undirected")
+  g <- make_star(5, mode = "undirected")
   g_centr <- centr_clo(g, normalized = FALSE)
   g_centr_tmax <- centr_clo_tmax(g)
   expect_equal(g_centr$centralization, g_centr_tmax)
@@ -24,7 +24,7 @@ test_that("centr_eigen works", {
   # centr_eigen() runs the ARPACK eigensolver, which draws from the RNG to seed
   # its starting vector; pin the seed so the global RNG state isn't disturbed.
   igraph_local_seed(42)
-  g <- make_star(2, "undirected")
+  g <- make_star(2, mode = "undirected")
   g_centr <- centr_eigen(g, normalized = FALSE)
   g_centr_tmax <- centr_eigen_tmax(g)
   expect_equal(g_centr$centralization, g_centr_tmax)

--- a/tests/testthat/test-components.R
+++ b/tests/testthat/test-components.R
@@ -92,7 +92,7 @@ test_that("component_distribution() finds correct distribution", {
 })
 
 test_that("largest component is actually the largest", {
-  star <- make_star(20, "undirected")
+  star <- make_star(20, mode = "undirected")
   ring <- make_ring(10)
 
   dis_union <- disjoint_union(star, ring)

--- a/tests/testthat/test-layout.R
+++ b/tests/testthat/test-layout.R
@@ -255,7 +255,7 @@ test_that("merge_coords() works", {
 })
 
 test_that("`layout_with_mds()` works", {
-  g <- make_tree(10, 2, "undirected")
+  g <- make_tree(10, 2, mode = "undirected")
 
   mymds <- function(g) {
     sp <- distances(g)

--- a/tests/testthat/test-make.R
+++ b/tests/testthat/test-make.R
@@ -559,3 +559,198 @@ test_that("make_turan() works", {
   g5 <- make_(turan(10, 2))
   expect_vcount(g5, 10)
 })
+
+# ---- ellipsis migration: argument coverage ----------------------------
+
+test_that("make_empty_graph() tail arguments and positional recovery", {
+  g <- make_empty_graph(3, directed = FALSE)
+  expect_false(is_directed(g))
+  expect_vcount(g, 3)
+  expect_ecount(g, 0)
+
+  lifecycle::expect_deprecated(res <- make_empty_graph(3, FALSE))
+  expect_identical_graphs(res, g)
+})
+
+test_that("empty_graph() twin forwards tail arguments", {
+  expect_identical_graphs(
+    make_(empty_graph(4, directed = FALSE)),
+    make_empty_graph(4, directed = FALSE)
+  )
+})
+
+test_that("make_star() tail arguments and positional recovery", {
+  g <- make_star(5, mode = "out", center = 3)
+  expect_equal(degree(g, mode = "out"), c(0, 0, 4, 0, 0))
+
+  lifecycle::expect_deprecated(res <- make_star(4, "undirected"))
+  expect_identical_graphs(res, make_star(4, mode = "undirected"))
+})
+
+test_that("star() twin forwards tail arguments", {
+  expect_identical_graphs(
+    make_(star(5, mode = "out", center = 3)),
+    make_star(5, mode = "out", center = 3)
+  )
+})
+
+test_that("make_full_graph() tail arguments and positional recovery", {
+  # directed is exercised above, loops is the remaining tail argument.
+  g <- make_full_graph(3, directed = TRUE, loops = TRUE)
+  expect_ecount(g, 9)
+  expect_equal(sum(which_loop(g)), 3)
+
+  lifecycle::expect_deprecated(res <- make_full_graph(3, TRUE))
+  expect_identical_graphs(res, make_full_graph(3, directed = TRUE))
+})
+
+test_that("full_graph() twin forwards tail arguments", {
+  expect_identical_graphs(
+    make_(full_graph(4, directed = TRUE, loops = TRUE)),
+    make_full_graph(4, directed = TRUE, loops = TRUE)
+  )
+})
+
+test_that("make_ring() tail arguments and positional recovery", {
+  g <- make_ring(5, directed = TRUE, mutual = TRUE, circular = FALSE)
+  expect_true(is_directed(g))
+  expect_ecount(g, 8)
+  expect_true(all(which_mutual(g)))
+
+  lifecycle::expect_deprecated(res <- make_ring(5, TRUE))
+  expect_identical_graphs(res, make_ring(5, directed = TRUE))
+})
+
+test_that("ring() twin forwards tail arguments", {
+  expect_identical_graphs(
+    make_(ring(5, directed = TRUE, mutual = TRUE, circular = FALSE)),
+    make_ring(5, directed = TRUE, mutual = TRUE, circular = FALSE)
+  )
+})
+
+test_that("make_tree() recovers the positional mode argument", {
+  # The mode values are exercised in test-trees.R, only recovery is needed here.
+  lifecycle::expect_deprecated(res <- make_tree(7, 2, "in"))
+  expect_identical_graphs(res, make_tree(7, 2, mode = "in"))
+})
+
+test_that("sample_tree() recovers positional tail arguments", {
+  # directed and method are exercised in test-trees.R, only recovery is needed here.
+  igraph_with_seed(42, {
+    lifecycle::expect_deprecated(res <- sample_tree(20, TRUE))
+  })
+  igraph_with_seed(42, {
+    expected <- sample_tree(20, directed = TRUE)
+  })
+  expect_identical_graphs(res, expected)
+})
+
+test_that("make_chordal_ring() tail arguments and positional recovery", {
+  w <- matrix(c(3, 12, 4, 7, 8, 11), nrow = 2)
+  g <- make_chordal_ring(15, w, directed = TRUE)
+  expect_true(is_directed(g))
+  expect_vcount(g, 15)
+
+  lifecycle::expect_deprecated(res <- make_chordal_ring(15, w, TRUE))
+  expect_identical_graphs(res, g)
+})
+
+test_that("chordal_ring() twin forwards tail arguments", {
+  w <- matrix(c(3, 12, 4, 7, 8, 11), nrow = 2)
+  expect_identical_graphs(
+    make_(chordal_ring(15, w, directed = TRUE)),
+    make_chordal_ring(15, w, directed = TRUE)
+  )
+})
+
+test_that("make_circulant() recovers the positional directed argument", {
+  # directed is exercised above, only recovery is needed here.
+  lifecycle::expect_deprecated(res <- make_circulant(5, c(1, 2), TRUE))
+  expect_identical_graphs(res, make_circulant(5, c(1, 2), directed = TRUE))
+})
+
+test_that("circulant() twin forwards tail arguments", {
+  expect_identical_graphs(
+    make_(circulant(6, c(1, 2), directed = TRUE)),
+    make_circulant(6, c(1, 2), directed = TRUE)
+  )
+})
+
+test_that("make_full_bipartite_graph() tail arguments and positional recovery", {
+  g <- make_full_bipartite_graph(2, 3, directed = TRUE, mode = "in")
+  expect_true(is_directed(g))
+  expect_ecount(g, 6)
+  # With mode = "in" all edges point from the second partition to the first.
+  expect_equal(degree(g, mode = "in"), c(3, 3, 0, 0, 0))
+
+  lifecycle::expect_deprecated(res <- make_full_bipartite_graph(2, 3, TRUE))
+  expect_identical_graphs(res, make_full_bipartite_graph(2, 3, directed = TRUE))
+})
+
+test_that("full_bipartite_graph() twin forwards tail arguments", {
+  expect_identical_graphs(
+    make_(full_bipartite_graph(2, 3, directed = TRUE, mode = "in")),
+    make_full_bipartite_graph(2, 3, directed = TRUE, mode = "in")
+  )
+})
+
+test_that("make_bipartite_graph() tail arguments and positional recovery", {
+  types <- c(FALSE, FALSE, TRUE)
+  edges <- c(1, 3, 2, 3)
+  g <- make_bipartite_graph(types, edges, directed = TRUE)
+  expect_true(is_directed(g))
+  expect_ecount(g, 2)
+
+  lifecycle::expect_deprecated(res <- make_bipartite_graph(types, edges, TRUE))
+  expect_identical_graphs(res, g)
+})
+
+test_that("bipartite_graph() twin forwards tail arguments", {
+  types <- c(FALSE, FALSE, TRUE)
+  edges <- c(1, 3, 2, 3)
+  expect_identical_graphs(
+    make_(bipartite_graph(types, edges, directed = TRUE)),
+    make_bipartite_graph(types, edges, directed = TRUE)
+  )
+})
+
+test_that("make_full_multipartite() recovers the positional directed argument", {
+  # directed and mode are exercised above, only recovery is needed here.
+  lifecycle::expect_deprecated(res <- make_full_multipartite(c(2, 2), TRUE))
+  expect_identical_graphs(res, make_full_multipartite(c(2, 2), directed = TRUE))
+})
+
+test_that("full_multipartite() twin forwards tail arguments", {
+  expect_identical_graphs(
+    make_(full_multipartite(c(2, 3), directed = TRUE, mode = "out")),
+    make_full_multipartite(c(2, 3), directed = TRUE, mode = "out")
+  )
+})
+
+test_that("make_full_citation_graph() tail arguments and positional recovery", {
+  g <- make_full_citation_graph(4, directed = FALSE)
+  expect_false(is_directed(g))
+  expect_ecount(g, 6)
+
+  lifecycle::expect_deprecated(res <- make_full_citation_graph(4, FALSE))
+  expect_identical_graphs(res, g)
+})
+
+test_that("full_citation_graph() twin forwards tail arguments", {
+  expect_identical_graphs(
+    make_(full_citation_graph(4, directed = FALSE)),
+    make_full_citation_graph(4, directed = FALSE)
+  )
+})
+
+test_that("realize_degseq() recovers positional tail arguments", {
+  # allowed.edge.types and method are exercised in test-degseq.R,
+  # only recovery is needed here.
+  # The degree sequence c(4, 2) is only realizable with loops and multi-edges,
+  # so the recovered value has a visible effect.
+  lifecycle::expect_deprecated(res <- realize_degseq(c(4, 2), NULL, "all"))
+  expect_identical_graphs(
+    res,
+    realize_degseq(c(4, 2), allowed.edge.types = "all")
+  )
+})

--- a/tests/testthat/test-make.R
+++ b/tests/testthat/test-make.R
@@ -113,15 +113,15 @@ test_that("make_star works", {
   adj_mat <- matrix(0, 3, 3)
   adj_mat[2:3, 1] <- 1
   expect_isomorphic(
-    make_star(3, "in"),
+    make_star(3, mode = "in"),
     graph_from_adjacency_matrix(adj_mat)
   )
   expect_isomorphic(
-    make_star(3, "out"),
+    make_star(3, mode = "out"),
     graph_from_adjacency_matrix(t(adj_mat))
   )
   expect_isomorphic(
-    make_star(3, "undirected"),
+    make_star(3, mode = "undirected"),
     graph_from_adjacency_matrix(adj_mat, mode = "max")
   )
 })
@@ -288,7 +288,7 @@ test_that("compatibility when arguments are not named", {
 test_that("make_empty_graph gives an error for invalid arguments", {
   expect_snapshot_igraph_error(make_empty_graph(NULL))
   expect_snapshot_igraph_error(make_empty_graph("spam"))
-  expect_snapshot_igraph_error(make_empty_graph(10, "spam"))
+  expect_snapshot_igraph_error(make_empty_graph(10, directed = "spam"))
 })
 
 test_that("make_graph_atlas works", {
@@ -411,7 +411,7 @@ test_that("make_bipartite_graph works with vertex names", {
 
 test_that("make_full_bipartite_graph works", {
   full_bip_star <- make_full_bipartite_graph(5, 1)
-  expect_isomorphic(full_bip_star, make_star(6, "undirected"))
+  expect_isomorphic(full_bip_star, make_star(6, mode = "undirected"))
 
   full_bip <- make_full_bipartite_graph(5, 5)
   expect_vcount(full_bip, 10)

--- a/tests/testthat/test-stochastic_matrix.R
+++ b/tests/testthat/test-stochastic_matrix.R
@@ -1,5 +1,5 @@
 test_that("stochastic_matrix works", {
-  g <- make_star(5, "undirected")
+  g <- make_star(5, mode = "undirected")
   adj_mat <- as_adjacency_matrix(g)
   stoch_mat_manual <- adj_mat / degree(g)
   stoch_mat_calc <- stochastic_matrix(g)

--- a/tests/testthat/test-structural-properties.R
+++ b/tests/testthat/test-structural-properties.R
@@ -758,7 +758,7 @@ test_that("unfold_tree() works", {
 })
 
 test_that("count_components() counts correctly", {
-  g <- make_star(20, "undirected")
+  g <- make_star(20, mode = "undirected")
   h <- make_ring(10)
 
   G <- disjoint_union(g, h)

--- a/tools/migrations/make.R
+++ b/tools/migrations/make.R
@@ -1,0 +1,259 @@
+# Argument-signature migrations: make
+# Schema: see tools/migrations.R. Regenerate with:
+#   Rscript tools/generate-migrations.R
+
+migrations <- list(
+  bipartite_graph = list(
+    old = function(types, edges, directed) {},
+    new = function(
+      types,
+      edges,
+      ...,
+      directed = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  chordal_ring = list(
+    old = function(n, w, directed) {},
+    new = function(
+      n,
+      w,
+      ...,
+      directed = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  circulant = list(
+    old = function(n, shifts, directed) {},
+    new = function(
+      n,
+      shifts,
+      ...,
+      directed = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  empty_graph = list(
+    old = function(n, directed) {},
+    new = function(
+      n = 0,
+      ...,
+      directed = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  full_bipartite_graph = list(
+    old = function(n1, n2, directed, mode) {},
+    new = function(
+      n1,
+      n2,
+      ...,
+      directed = FALSE,
+      mode = c("all", "out", "in")
+    ) {},
+    when = "3.0.0"
+  ),
+
+  full_citation_graph = list(
+    old = function(n, directed) {},
+    new = function(
+      n,
+      ...,
+      directed = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  full_graph = list(
+    old = function(n, directed, loops) {},
+    new = function(
+      n,
+      ...,
+      directed = FALSE,
+      loops = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  full_multipartite = list(
+    old = function(n, directed, mode) {},
+    new = function(
+      n,
+      ...,
+      directed = FALSE,
+      mode = c("all", "out", "in")
+    ) {},
+    when = "3.0.0"
+  ),
+
+  make_bipartite_graph = list(
+    old = function(types, edges, directed) {},
+    new = function(
+      types,
+      edges,
+      ...,
+      directed = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  make_chordal_ring = list(
+    old = function(n, w, directed) {},
+    new = function(
+      n,
+      w,
+      ...,
+      directed = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  make_circulant = list(
+    old = function(n, shifts, directed) {},
+    new = function(
+      n,
+      shifts,
+      ...,
+      directed = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  make_empty_graph = list(
+    old = function(n, directed) {},
+    new = function(
+      n = 0,
+      ...,
+      directed = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  make_full_bipartite_graph = list(
+    old = function(n1, n2, directed, mode) {},
+    new = function(
+      n1,
+      n2,
+      ...,
+      directed = FALSE,
+      mode = c("all", "out", "in")
+    ) {},
+    when = "3.0.0"
+  ),
+
+  make_full_citation_graph = list(
+    old = function(n, directed) {},
+    new = function(
+      n,
+      ...,
+      directed = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  make_full_graph = list(
+    old = function(n, directed, loops) {},
+    new = function(
+      n,
+      ...,
+      directed = FALSE,
+      loops = FALSE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  make_full_multipartite = list(
+    old = function(n, directed, mode) {},
+    new = function(
+      n,
+      ...,
+      directed = FALSE,
+      mode = c("all", "out", "in")
+    ) {},
+    when = "3.0.0"
+  ),
+
+  make_ring = list(
+    old = function(n, directed, mutual, circular) {},
+    new = function(
+      n,
+      ...,
+      directed = FALSE,
+      mutual = FALSE,
+      circular = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  make_star = list(
+    old = function(n, mode, center) {},
+    new = function(
+      n,
+      ...,
+      mode = c("in", "out", "mutual", "undirected"),
+      center = 1
+    ) {},
+    when = "3.0.0"
+  ),
+
+  make_tree = list(
+    old = function(n, children, mode) {},
+    new = function(
+      n,
+      children = 2,
+      ...,
+      mode = c("out", "in", "undirected")
+    ) {},
+    when = "3.0.0"
+  ),
+
+  realize_degseq = list(
+    old = function(out.deg, in.deg, allowed.edge.types, method) {},
+    new = function(
+      out.deg,
+      in.deg = NULL,
+      ...,
+      allowed.edge.types = c("simple", "loops", "multi", "all"),
+      method = c("smallest", "largest", "index")
+    ) {},
+    when = "3.0.0"
+  ),
+
+  ring = list(
+    old = function(n, directed, mutual, circular) {},
+    new = function(
+      n,
+      ...,
+      directed = FALSE,
+      mutual = FALSE,
+      circular = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_tree = list(
+    old = function(n, directed, method) {},
+    new = function(
+      n,
+      ...,
+      directed = FALSE,
+      method = c("lerw", "prufer")
+    ) {},
+    when = "3.0.0"
+  ),
+
+  star = list(
+    old = function(n, mode, center) {},
+    new = function(
+      n,
+      ...,
+      mode = c("in", "out", "mutual", "undirected"),
+      center = 1
+    ) {},
+    when = "3.0.0"
+  )
+)


### PR DESCRIPTION
Part of the repo-wide ellipsis migration coordinated in #2757 —
see that PR for the full rationale (CONTRIBUTING.md, *Argument Order and the Ellipsis*).
Based directly on `main` (the registry split landed via #2779); a single topic commit.

## What this does

Inserts `...` between the *defining* arguments (head) and the *optional
modifiers* (tail) of **23 exported make functions**.
Arguments after `...` become keyword-only.

- Legacy positional or abbreviated calls are **recovered** by the generated
  ARG_HANDLE block and emit a single `lifecycle::deprecate_soft("3.0.0", …)` —
  behavior is unchanged.
- No defaults change, no arguments are renamed, deprecated functions untouched.
- Registry: `tools/migrations/make.R`; blocks regenerated via
  `Rscript tools/generate-migrations.R` (idempotent, CI-checked).
- Rd usage/arguments updated mechanically (see note below).

## New signatures

| function | head (positional) | keyword-only tail |
|---|---|---|
| `bipartite_graph()` | `types, edges` | `directed` |
| `chordal_ring()` | `n, w` | `directed` |
| `circulant()` | `n, shifts` | `directed` |
| `empty_graph()` | `n` | `directed` |
| `full_bipartite_graph()` | `n1, n2` | `directed, mode` |
| `full_citation_graph()` | `n` | `directed` |
| `full_graph()` | `n` | `directed, loops` |
| `full_multipartite()` | `n` | `directed, mode` |
| `make_bipartite_graph()` | `types, edges` | `directed` |
| `make_chordal_ring()` | `n, w` | `directed` |
| `make_circulant()` | `n, shifts` | `directed` |
| `make_empty_graph()` | `n` | `directed` |
| `make_full_bipartite_graph()` | `n1, n2` | `directed, mode` |
| `make_full_citation_graph()` | `n` | `directed` |
| `make_full_graph()` | `n` | `directed, loops` |
| `make_full_multipartite()` | `n` | `directed, mode` |
| `make_ring()` | `n` | `directed, mutual, circular` |
| `make_star()` | `n` | `mode, center` |
| `make_tree()` | `n, children` | `mode` |
| `realize_degseq()` | `out.deg, in.deg` | `allowed.edge.types, method` |
| `ring()` | `n` | `directed, mutual, circular` |
| `sample_tree()` | `n` | `directed, method` |
| `star()` | `n` | `mode, center` |

## Notes for review

- The environment used to prepare this PR cannot install `igraph.r2cdocs`
  (GitHub API unreachable), so `man/*.Rd` files were updated **mechanically**
  (usage + `...` argument item) instead of via `devtools::document()`.
  R CMD check's usage↔formals validation passes; a follow-up
  `devtools::document()` run may reflow whitespace but should produce no
  semantic diff.
- Package tests that called these functions positionally were updated to
  named arguments (they are the same soft-deprecation user code will see).
