### PR TITLE
refactor: move optional arguments of community functions behind the ellipsis

### DIFF
--- a/R/community.R
+++ b/R/community.R
@@ -745,6 +745,7 @@ print.communities <- function(x, ...) {
 #' @param membership The membership vector of the community structure, a
 #'   numeric vector denoting the ID of the community for each vertex. It
 #'   might be `NULL` for hierarchical community structures.
+#' @inheritParams rlang::args_dots_empty
 #' @param algorithm Character string, the algorithm that generated
 #'   the community structure, it can be arbitrary.
 #' @param merges A merge matrix, for hierarchical community structures (or
@@ -772,10 +773,37 @@ print.communities <- function(x, ...) {
 make_clusters <- function(
   graph,
   membership = NULL,
+  ...,
   algorithm = NULL,
   merges = NULL,
   modularity = TRUE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: make_clusters, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        algorithm = algorithm,
+        merges = merges,
+        modularity = modularity
+      ),
+      recover_new = c("algorithm", "merges", "modularity"),
+      recover_old = c("algorithm", "merges", "modularity"),
+      match_names = c("algorithm", "merges", "modularity"),
+      match_to = c("algorithm", "merges", "modularity"),
+      defaults = list(algorithm = NULL, merges = NULL, modularity = TRUE),
+      head_args = c("graph", "membership"),
+      fn_name = "make_clusters"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   stopifnot(is.null(membership) || is.numeric(membership))
   stopifnot(
     is.null(algorithm) ||
@@ -938,14 +966,42 @@ modularity.communities <- function(x, ...) {
 }
 
 #' @rdname modularity.igraph
+#' @inheritParams rlang::args_dots_empty
 #' @export
 modularity_matrix <- function(
   graph,
   membership = lifecycle::deprecated(),
+  ...,
   weights = NULL,
   resolution = 1,
   directed = TRUE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: modularity_matrix, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        weights = weights,
+        resolution = resolution,
+        directed = directed
+      ),
+      recover_new = c("weights", "resolution", "directed"),
+      recover_old = c("weights", "resolution", "directed"),
+      match_names = c("weights", "resolution", "directed"),
+      match_to = c("weights", "resolution", "directed"),
+      defaults = list(weights = NULL, resolution = 1, directed = TRUE),
+      head_args = c("graph", "membership"),
+      fn_name = "modularity_matrix"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   # Argument checks
   ensure_igraph(graph)
 
@@ -1376,6 +1432,7 @@ community.to.membership2 <- function(merges, vcount, steps) {
 #' community of the the given vertex. See also the examples below.
 #'
 #' @param graph The input graph. Edge directions are ignored in directed graphs.
+#' @inheritParams rlang::args_dots_empty
 #' @param weights The weights of the edges. It must be a positive numeric vector,
 #'   `NULL` or `NA`. If it is `NULL` and the input graph has a
 #'   \sQuote{weight} edge attribute, then that attribute will be used. If
@@ -1478,6 +1535,7 @@ community.to.membership2 <- function(merges, vcount, steps) {
 #'
 cluster_spinglass <- function(
   graph,
+  ...,
   weights = NULL,
   vertex = NULL,
   spins = 25,
@@ -1490,6 +1548,100 @@ cluster_spinglass <- function(
   implementation = c("orig", "neg"),
   gamma.minus = 1.0
 ) {
+  # BEGIN GENERATED ARG_HANDLE: cluster_spinglass, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        weights = weights,
+        vertex = vertex,
+        spins = spins,
+        parupdate = parupdate,
+        start.temp = start.temp,
+        stop.temp = stop.temp,
+        cool.fact = cool.fact,
+        update.rule = update.rule,
+        gamma = gamma,
+        implementation = implementation,
+        gamma.minus = gamma.minus
+      ),
+      recover_new = c(
+        "weights",
+        "vertex",
+        "spins",
+        "parupdate",
+        "start.temp",
+        "stop.temp",
+        "cool.fact",
+        "update.rule",
+        "gamma",
+        "implementation",
+        "gamma.minus"
+      ),
+      recover_old = c(
+        "weights",
+        "vertex",
+        "spins",
+        "parupdate",
+        "start.temp",
+        "stop.temp",
+        "cool.fact",
+        "update.rule",
+        "gamma",
+        "implementation",
+        "gamma.minus"
+      ),
+      match_names = c(
+        "weights",
+        "vertex",
+        "spins",
+        "parupdate",
+        "start.temp",
+        "stop.temp",
+        "cool.fact",
+        "update.rule",
+        "gamma",
+        "implementation",
+        "gamma.minus"
+      ),
+      match_to = c(
+        "weights",
+        "vertex",
+        "spins",
+        "parupdate",
+        "start.temp",
+        "stop.temp",
+        "cool.fact",
+        "update.rule",
+        "gamma",
+        "implementation",
+        "gamma.minus"
+      ),
+      defaults = list(
+        weights = NULL,
+        vertex = NULL,
+        spins = 25,
+        parupdate = FALSE,
+        start.temp = 1,
+        stop.temp = 0.01,
+        cool.fact = 0.99,
+        update.rule = c("config", "random", "simple"),
+        gamma = 1,
+        implementation = c("orig", "neg"),
+        gamma.minus = 1
+      ),
+      head_args = c("graph"),
+      fn_name = "cluster_spinglass"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   ensure_igraph(graph)
 
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
@@ -1825,6 +1977,7 @@ cluster_fluid_communities <- function(graph, no.of.communities) {
 #'
 #' @param graph The input graph. Edge directions are ignored in directed
 #'   graphs.
+#' @inheritParams rlang::args_dots_empty
 #' @param weights The weights of the edges. It must be a positive numeric vector,
 #'   `NULL` or `NA`. If it is `NULL` and the input graph has a
 #'   \sQuote{weight} edge attribute, then that attribute will be used. If
@@ -1867,12 +2020,47 @@ cluster_fluid_communities <- function(graph, no.of.communities) {
 #'
 cluster_walktrap <- function(
   graph,
+  ...,
   weights = NULL,
   steps = 4,
   merges = TRUE,
   modularity = TRUE,
   membership = TRUE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: cluster_walktrap, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        weights = weights,
+        steps = steps,
+        merges = merges,
+        modularity = modularity,
+        membership = membership
+      ),
+      recover_new = c("weights", "steps", "merges", "modularity", "membership"),
+      recover_old = c("weights", "steps", "merges", "modularity", "membership"),
+      match_names = c("weights", "steps", "merges", "modularity", "membership"),
+      match_to = c("weights", "steps", "merges", "modularity", "membership"),
+      defaults = list(
+        weights = NULL,
+        steps = 4,
+        merges = TRUE,
+        modularity = TRUE,
+        membership = TRUE
+      ),
+      head_args = c("graph"),
+      fn_name = "cluster_walktrap"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   ensure_igraph(graph)
 
   if (membership && !modularity) {
@@ -1937,6 +2125,7 @@ cluster_walktrap <- function(
 #' `bridges` contains the IDs of edges whose removal caused a split.
 #'
 #' @param graph The graph to analyze.
+#' @inheritParams rlang::args_dots_empty
 #' @param weights The weights of the edges. It must be a positive numeric vector,
 #'   `NULL` or `NA`. If it is `NULL` and the input graph has a
 #'   \sQuote{weight} edge attribute, then that attribute will be used. If
@@ -1997,6 +2186,7 @@ cluster_walktrap <- function(
 #'
 cluster_edge_betweenness <- function(
   graph,
+  ...,
   weights = NULL,
   directed = TRUE,
   edge.betweenness = TRUE,
@@ -2005,6 +2195,76 @@ cluster_edge_betweenness <- function(
   modularity = TRUE,
   membership = TRUE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: cluster_edge_betweenness, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        weights = weights,
+        directed = directed,
+        edge.betweenness = edge.betweenness,
+        merges = merges,
+        bridges = bridges,
+        modularity = modularity,
+        membership = membership
+      ),
+      recover_new = c(
+        "weights",
+        "directed",
+        "edge.betweenness",
+        "merges",
+        "bridges",
+        "modularity",
+        "membership"
+      ),
+      recover_old = c(
+        "weights",
+        "directed",
+        "edge.betweenness",
+        "merges",
+        "bridges",
+        "modularity",
+        "membership"
+      ),
+      match_names = c(
+        "weights",
+        "directed",
+        "edge.betweenness",
+        "merges",
+        "bridges",
+        "modularity",
+        "membership"
+      ),
+      match_to = c(
+        "weights",
+        "directed",
+        "edge.betweenness",
+        "merges",
+        "bridges",
+        "modularity",
+        "membership"
+      ),
+      defaults = list(
+        weights = NULL,
+        directed = TRUE,
+        edge.betweenness = TRUE,
+        merges = TRUE,
+        bridges = TRUE,
+        modularity = TRUE,
+        membership = TRUE
+      ),
+      head_args = c("graph"),
+      fn_name = "cluster_edge_betweenness"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   ensure_igraph(graph)
 
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
@@ -2053,6 +2313,7 @@ cluster_edge_betweenness <- function(
 #'
 #' @param graph The input graph. It must be undirected and must not have
 #'   multi-edges.
+#' @inheritParams rlang::args_dots_empty
 #' @param merges Logical, whether to return the merge matrix.
 #' @param modularity Logical, whether to return a vector containing the
 #'   modularity after each merge.
@@ -2092,11 +2353,44 @@ cluster_edge_betweenness <- function(
 #'
 cluster_fast_greedy <- function(
   graph,
+  ...,
   merges = TRUE,
   modularity = TRUE,
   membership = TRUE,
   weights = NULL
 ) {
+  # BEGIN GENERATED ARG_HANDLE: cluster_fast_greedy, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        merges = merges,
+        modularity = modularity,
+        membership = membership,
+        weights = weights
+      ),
+      recover_new = c("merges", "modularity", "membership", "weights"),
+      recover_old = c("merges", "modularity", "membership", "weights"),
+      match_names = c("merges", "modularity", "membership", "weights"),
+      match_to = c("merges", "modularity", "membership", "weights"),
+      defaults = list(
+        merges = TRUE,
+        modularity = TRUE,
+        membership = TRUE,
+        weights = NULL
+      ),
+      head_args = c("graph"),
+      fn_name = "cluster_fast_greedy"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   ensure_igraph(graph)
 
   if (is.null(weights) && "weight" %in% edge_attr_names(graph)) {
@@ -2477,6 +2771,7 @@ cluster_label_prop0 <- function(
 #' This function was contributed by Tom Gregorovic.
 #'
 #' @param graph The input graph. It must be undirected.
+#' @inheritParams rlang::args_dots_empty
 #' @param weights The weights of the edges. It must be a positive numeric vector,
 #'   `NULL` or `NA`. If it is `NULL` and the input graph has a
 #'   \sQuote{weight} edge attribute, then that attribute will be used. If
@@ -2515,7 +2810,34 @@ cluster_label_prop0 <- function(
 #' g <- add_edges(g, c(1, 6, 1, 11, 6, 11))
 #' cluster_louvain(g)
 #'
-cluster_louvain <- function(graph, weights = NULL, resolution = 1) {
+cluster_louvain <- function(
+  graph,
+  ...,
+  weights = NULL,
+  resolution = 1
+) {
+  # BEGIN GENERATED ARG_HANDLE: cluster_louvain, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(weights = weights, resolution = resolution),
+      recover_new = c("weights", "resolution"),
+      recover_old = c("weights", "resolution"),
+      match_names = c("weights", "resolution"),
+      match_to = c("weights", "resolution"),
+      defaults = list(weights = NULL, resolution = 1),
+      head_args = c("graph"),
+      fn_name = "cluster_louvain"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   # Argument checks
   ensure_igraph(graph)
 
@@ -2587,6 +2909,7 @@ cluster_louvain <- function(graph, weights = NULL, resolution = 1) {
 #' }
 #'
 #' @param graph The input graph. It may be undirected or directed.
+#' @inheritParams rlang::args_dots_empty
 #' @param weights The weights of the edges. It must be a positive numeric
 #'   vector, `NULL` or `NA`. If it is `NULL` and the input graph has a
 #'   \sQuote{weight} edge attribute, then that attribute will be used. If
@@ -2607,7 +2930,33 @@ cluster_louvain <- function(graph, weights = NULL, resolution = 1) {
 #' @family community
 #' @export
 #' @keywords graphs
-cluster_optimal <- function(graph, weights = NULL) {
+cluster_optimal <- function(
+  graph,
+  ...,
+  weights = NULL
+) {
+  # BEGIN GENERATED ARG_HANDLE: cluster_optimal, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(weights = weights),
+      recover_new = c("weights"),
+      recover_old = c("weights"),
+      match_names = c("weights"),
+      match_to = c("weights"),
+      defaults = list(weights = NULL),
+      head_args = c("graph"),
+      fn_name = "cluster_optimal"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   # Argument checks
   ensure_igraph(graph)
 
@@ -2646,6 +2995,7 @@ cluster_optimal <- function(graph, weights = NULL) {
 #' Please see the details of this method in the references given below.
 #'
 #' @param graph The input graph. Edge directions will be taken into account.
+#' @inheritParams rlang::args_dots_empty
 #' @param e.weights Numeric vector of edge weights.
 #'   The length must match the number of edges in the graph.  By default (`NULL`) the
 #'   \sQuote{`weight`} edge attribute is used as weights. If it is not
@@ -2688,11 +3038,44 @@ cluster_optimal <- function(graph, weights = NULL) {
 #'
 cluster_infomap <- function(
   graph,
+  ...,
   e.weights = NULL,
   v.weights = NULL,
   nb.trials = 10,
   modularity = TRUE
 ) {
+  # BEGIN GENERATED ARG_HANDLE: cluster_infomap, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        e.weights = e.weights,
+        v.weights = v.weights,
+        nb.trials = nb.trials,
+        modularity = modularity
+      ),
+      recover_new = c("e.weights", "v.weights", "nb.trials", "modularity"),
+      recover_old = c("e.weights", "v.weights", "nb.trials", "modularity"),
+      match_names = c("e.weights", "v.weights", "nb.trials", "modularity"),
+      match_to = c("e.weights", "v.weights", "nb.trials", "modularity"),
+      defaults = list(
+        e.weights = NULL,
+        v.weights = NULL,
+        nb.trials = 10,
+        modularity = TRUE
+      ),
+      head_args = c("graph"),
+      fn_name = "cluster_infomap"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   res <- community_infomap_impl(
     graph = graph,
     e_weights = e.weights,

--- a/R/cycles.R
+++ b/R/cycles.R
@@ -31,6 +31,7 @@
 #' a specific cycle.
 #'
 #' @param graph The input graph.
+#' @inheritParams rlang::args_dots_empty
 #' @param mode Character constant specifying how to handle directed graphs.
 #'   `out` follows edge directions, `in` follows edges in the reverse direction,
 #'   and `all` ignores edge directions. Ignored in undirected graphs.

--- a/man/cluster_edge_betweenness.Rd
+++ b/man/cluster_edge_betweenness.Rd
@@ -6,6 +6,7 @@
 \usage{
 cluster_edge_betweenness(
   graph,
+  ...,
   weights = NULL,
   directed = TRUE,
   edge.betweenness = TRUE,
@@ -17,6 +18,8 @@ cluster_edge_betweenness(
 }
 \arguments{
 \item{graph}{The graph to analyze.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{weights}{The weights of the edges. It must be a positive numeric vector,
 \code{NULL} or \code{NA}. If it is \code{NULL} and the input graph has a

--- a/man/cluster_fast_greedy.Rd
+++ b/man/cluster_fast_greedy.Rd
@@ -6,6 +6,7 @@
 \usage{
 cluster_fast_greedy(
   graph,
+  ...,
   merges = TRUE,
   modularity = TRUE,
   membership = TRUE,
@@ -15,6 +16,8 @@ cluster_fast_greedy(
 \arguments{
 \item{graph}{The input graph. It must be undirected and must not have
 multi-edges.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{merges}{Logical, whether to return the merge matrix.}
 

--- a/man/cluster_infomap.Rd
+++ b/man/cluster_infomap.Rd
@@ -6,6 +6,7 @@
 \usage{
 cluster_infomap(
   graph,
+  ...,
   e.weights = NULL,
   v.weights = NULL,
   nb.trials = 10,
@@ -14,6 +15,8 @@ cluster_infomap(
 }
 \arguments{
 \item{graph}{The input graph. Edge directions will be taken into account.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{e.weights}{Numeric vector of edge weights.
 The length must match the number of edges in the graph.  By default (\code{NULL}) the

--- a/man/cluster_louvain.Rd
+++ b/man/cluster_louvain.Rd
@@ -4,10 +4,12 @@
 \alias{cluster_louvain}
 \title{Finding community structure by multi-level optimization of modularity}
 \usage{
-cluster_louvain(graph, weights = NULL, resolution = 1)
+cluster_louvain(graph, ..., weights = NULL, resolution = 1)
 }
 \arguments{
 \item{graph}{The input graph. It must be undirected.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{weights}{The weights of the edges. It must be a positive numeric vector,
 \code{NULL} or \code{NA}. If it is \code{NULL} and the input graph has a

--- a/man/cluster_optimal.Rd
+++ b/man/cluster_optimal.Rd
@@ -4,10 +4,12 @@
 \alias{cluster_optimal}
 \title{Optimal community structure}
 \usage{
-cluster_optimal(graph, weights = NULL)
+cluster_optimal(graph, ..., weights = NULL)
 }
 \arguments{
 \item{graph}{The input graph. It may be undirected or directed.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{weights}{The weights of the edges. It must be a positive numeric
 vector, \code{NULL} or \code{NA}. If it is \code{NULL} and the input graph has a

--- a/man/cluster_spinglass.Rd
+++ b/man/cluster_spinglass.Rd
@@ -6,6 +6,7 @@
 \usage{
 cluster_spinglass(
   graph,
+  ...,
   weights = NULL,
   vertex = NULL,
   spins = 25,
@@ -21,6 +22,8 @@ cluster_spinglass(
 }
 \arguments{
 \item{graph}{The input graph. Edge directions are ignored in directed graphs.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{weights}{The weights of the edges. It must be a positive numeric vector,
 \code{NULL} or \code{NA}. If it is \code{NULL} and the input graph has a

--- a/man/cluster_walktrap.Rd
+++ b/man/cluster_walktrap.Rd
@@ -6,6 +6,7 @@
 \usage{
 cluster_walktrap(
   graph,
+  ...,
   weights = NULL,
   steps = 4,
   merges = TRUE,
@@ -16,6 +17,8 @@ cluster_walktrap(
 \arguments{
 \item{graph}{The input graph. Edge directions are ignored in directed
 graphs.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{weights}{The weights of the edges. It must be a positive numeric vector,
 \code{NULL} or \code{NA}. If it is \code{NULL} and the input graph has a

--- a/man/make_clusters.Rd
+++ b/man/make_clusters.Rd
@@ -7,6 +7,7 @@
 make_clusters(
   graph,
   membership = NULL,
+  ...,
   algorithm = NULL,
   merges = NULL,
   modularity = TRUE
@@ -18,6 +19,8 @@ make_clusters(
 \item{membership}{The membership vector of the community structure, a
 numeric vector denoting the ID of the community for each vertex. It
 might be \code{NULL} for hierarchical community structures.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{algorithm}{Character string, the algorithm that generated
 the community structure, it can be arbitrary.}

--- a/man/modularity.igraph.Rd
+++ b/man/modularity.igraph.Rd
@@ -11,6 +11,7 @@
 modularity_matrix(
   graph,
   membership = lifecycle::deprecated(),
+  ...,
   weights = NULL,
   resolution = 1,
   directed = TRUE

--- a/tools/migrations/community.R
+++ b/tools/migrations/community.R
@@ -1,0 +1,150 @@
+# Argument-signature migrations: community
+# Schema: see tools/migrations.R. Regenerate with:
+#   Rscript tools/generate-migrations.R
+
+migrations <- list(
+  cluster_edge_betweenness = list(
+    old = function(
+      graph,
+      weights,
+      directed,
+      edge.betweenness,
+      merges,
+      bridges,
+      modularity,
+      membership
+    ) {},
+    new = function(
+      graph,
+      ...,
+      weights = NULL,
+      directed = TRUE,
+      edge.betweenness = TRUE,
+      merges = TRUE,
+      bridges = TRUE,
+      modularity = TRUE,
+      membership = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  cluster_fast_greedy = list(
+    old = function(graph, merges, modularity, membership, weights) {},
+    new = function(
+      graph,
+      ...,
+      merges = TRUE,
+      modularity = TRUE,
+      membership = TRUE,
+      weights = NULL
+    ) {},
+    when = "3.0.0"
+  ),
+
+  cluster_infomap = list(
+    old = function(graph, e.weights, v.weights, nb.trials, modularity) {},
+    new = function(
+      graph,
+      ...,
+      e.weights = NULL,
+      v.weights = NULL,
+      nb.trials = 10,
+      modularity = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  cluster_louvain = list(
+    old = function(graph, weights, resolution) {},
+    new = function(
+      graph,
+      ...,
+      weights = NULL,
+      resolution = 1
+    ) {},
+    when = "3.0.0"
+  ),
+
+  cluster_optimal = list(
+    old = function(graph, weights) {},
+    new = function(
+      graph,
+      ...,
+      weights = NULL
+    ) {},
+    when = "3.0.0"
+  ),
+
+  cluster_spinglass = list(
+    old = function(
+      graph,
+      weights,
+      vertex,
+      spins,
+      parupdate,
+      start.temp,
+      stop.temp,
+      cool.fact,
+      update.rule,
+      gamma,
+      implementation,
+      gamma.minus
+    ) {},
+    new = function(
+      graph,
+      ...,
+      weights = NULL,
+      vertex = NULL,
+      spins = 25,
+      parupdate = FALSE,
+      start.temp = 1,
+      stop.temp = 0.01,
+      cool.fact = 0.99,
+      update.rule = c("config", "random", "simple"),
+      gamma = 1.0,
+      implementation = c("orig", "neg"),
+      gamma.minus = 1.0
+    ) {},
+    when = "3.0.0"
+  ),
+
+  cluster_walktrap = list(
+    old = function(graph, weights, steps, merges, modularity, membership) {},
+    new = function(
+      graph,
+      ...,
+      weights = NULL,
+      steps = 4,
+      merges = TRUE,
+      modularity = TRUE,
+      membership = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  make_clusters = list(
+    old = function(graph, membership, algorithm, merges, modularity) {},
+    new = function(
+      graph,
+      membership = NULL,
+      ...,
+      algorithm = NULL,
+      merges = NULL,
+      modularity = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  modularity_matrix = list(
+    old = function(graph, membership, weights, resolution, directed) {},
+    new = function(
+      graph,
+      membership = lifecycle::deprecated(),
+      ...,
+      weights = NULL,
+      resolution = 1,
+      directed = TRUE
+    ) {},
+    when = "3.0.0"
+  )
+)


### PR DESCRIPTION
Part of the repo-wide ellipsis migration coordinated in #2757 —
see that PR for the full rationale (CONTRIBUTING.md, *Argument Order and the Ellipsis*).
Based directly on `main` (the registry split landed via #2779); a single topic commit.

## What this does

Inserts `...` between the *defining* arguments (head) and the *optional
modifiers* (tail) of **9 exported community functions**.
Arguments after `...` become keyword-only.

- Legacy positional or abbreviated calls are **recovered** by the generated
  ARG_HANDLE block and emit a single `lifecycle::deprecate_soft("3.0.0", …)` —
  behavior is unchanged.
- No defaults change, no arguments are renamed, deprecated functions untouched.
- Registry: `tools/migrations/community.R`; blocks regenerated via
  `Rscript tools/generate-migrations.R` (idempotent, CI-checked).
- Rd usage/arguments updated mechanically (see note below).

## New signatures

| function | head (positional) | keyword-only tail |
|---|---|---|
| `cluster_edge_betweenness()` | `graph` | `weights, directed, edge.betweenness, merges, bridges, modularity, membership` |
| `cluster_fast_greedy()` | `graph` | `merges, modularity, membership, weights` |
| `cluster_infomap()` | `graph` | `e.weights, v.weights, nb.trials, modularity` |
| `cluster_louvain()` | `graph` | `weights, resolution` |
| `cluster_optimal()` | `graph` | `weights` |
| `cluster_spinglass()` | `graph` | `weights, vertex, spins, parupdate, start.temp, stop.temp, cool.fact, update.rule, gamma, implementation, gamma.minus` |
| `cluster_walktrap()` | `graph` | `weights, steps, merges, modularity, membership` |
| `make_clusters()` | `graph, membership` | `algorithm, merges, modularity` |
| `modularity_matrix()` | `graph, membership` | `weights, resolution, directed` |

## Notes for review

- The environment used to prepare this PR cannot install `igraph.r2cdocs`
  (GitHub API unreachable), so `man/*.Rd` files were updated **mechanically**
  (usage + `...` argument item) instead of via `devtools::document()`.
  R CMD check's usage↔formals validation passes; a follow-up
  `devtools::document()` run may reflow whitespace but should produce no
  semantic diff.
- Package tests that called these functions positionally were updated to
  named arguments (they are the same soft-deprecation user code will see).
