### PR TITLE
refactor: move optional arguments of hrg-embedding functions behind the ellipsis

### DIFF
--- a/R/cycles.R
+++ b/R/cycles.R
@@ -31,6 +31,7 @@
 #' a specific cycle.
 #'
 #' @param graph The input graph.
+#' @inheritParams rlang::args_dots_empty
 #' @param mode Character constant specifying how to handle directed graphs.
 #'   `out` follows edge directions, `in` follows edges in the reverse direction,
 #'   and `all` ignores edge directions. Ignored in undirected graphs.

--- a/R/embedding.R
+++ b/R/embedding.R
@@ -48,6 +48,7 @@
 #'   spectral embedding. Should be smaller than the number of vertices. The
 #'   largest `no`-dimensional non-zero singular values are used for the
 #'   spectral embedding.
+#' @inheritParams rlang::args_dots_empty
 #' @param weights Optional positive weight vector for calculating a weighted
 #'   embedding. If the graph has a `weight` edge attribute, then this is
 #'   used by default. In a weighted embedding, the edge weights are used instead
@@ -104,12 +105,47 @@
 embed_adjacency_matrix <- function(
   graph,
   no,
+  ...,
   weights = NULL,
   which = c("lm", "la", "sa"),
   scaled = TRUE,
   cvec = strength(graph, weights = weights) / (vcount(graph) - 1),
   options = arpack_defaults()
 ) {
+  # BEGIN GENERATED ARG_HANDLE: embed_adjacency_matrix, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        weights = weights,
+        which = which,
+        scaled = scaled,
+        cvec = cvec,
+        options = options
+      ),
+      recover_new = c("weights", "which", "scaled", "cvec", "options"),
+      recover_old = c("weights", "which", "scaled", "cvec", "options"),
+      match_names = c("weights", "which", "scaled", "cvec", "options"),
+      match_to = c("weights", "which", "scaled", "cvec", "options"),
+      defaults = list(
+        weights = NULL,
+        which = c("lm", "la", "sa"),
+        scaled = TRUE,
+        cvec = strength(graph, weights = weights) / (vcount(graph) - 1),
+        options = arpack_defaults()
+      ),
+      head_args = c("graph", "no"),
+      fn_name = "embed_adjacency_matrix"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   adjacency_spectral_embedding_impl(
     graph = graph,
     no = no,
@@ -203,6 +239,7 @@ dim_select <- function(sv) {
 #'   spectral embedding. Should be smaller than the number of vertices. The
 #'   largest `no`-dimensional non-zero singular values are used for the
 #'   spectral embedding.
+#' @inheritParams rlang::args_dots_empty
 #' @param weights Optional positive weight vector for calculating a weighted
 #'   embedding. If the graph has a `weight` edge attribute, then this is
 #'   used by default. For weighted embedding, edge weights are used instead
@@ -278,12 +315,47 @@ dim_select <- function(sv) {
 embed_laplacian_matrix <- function(
   graph,
   no,
+  ...,
   weights = NULL,
   which = c("lm", "la", "sa"),
   type = c("default", "D-A", "DAD", "I-DAD", "OAP"),
   scaled = TRUE,
   options = arpack_defaults()
 ) {
+  # BEGIN GENERATED ARG_HANDLE: embed_laplacian_matrix, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        weights = weights,
+        which = which,
+        type = type,
+        scaled = scaled,
+        options = options
+      ),
+      recover_new = c("weights", "which", "type", "scaled", "options"),
+      recover_old = c("weights", "which", "type", "scaled", "options"),
+      match_names = c("weights", "which", "type", "scaled", "options"),
+      match_to = c("weights", "which", "type", "scaled", "options"),
+      defaults = list(
+        weights = NULL,
+        which = c("lm", "la", "sa"),
+        type = c("default", "D-A", "DAD", "I-DAD", "OAP"),
+        scaled = TRUE,
+        options = arpack_defaults()
+      ),
+      head_args = c("graph", "no"),
+      fn_name = "embed_laplacian_matrix"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   laplacian_spectral_embedding_impl(
     graph = graph,
     no = no,
@@ -307,6 +379,7 @@ embed_laplacian_matrix <- function(
 #'
 #' @param dim Integer scalar, the dimension of the random vectors.
 #' @param n Integer scalar, the sample size.
+#' @inheritParams rlang::args_dots_empty
 #' @param radius Numeric scalar, the radius of the sphere to sample.
 #' @param positive Logical, whether to sample from the positive orthant
 #'   of the sphere.
@@ -324,7 +397,35 @@ embed_laplacian_matrix <- function(
 #'   sum(x^2)
 #' })
 #' vec.norm
-sample_sphere_surface <- function(dim, n = 1, radius = 1, positive = TRUE) {
+sample_sphere_surface <- function(
+  dim,
+  n = 1,
+  ...,
+  radius = 1,
+  positive = TRUE
+) {
+  # BEGIN GENERATED ARG_HANDLE: sample_sphere_surface, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(radius = radius, positive = positive),
+      recover_new = c("radius", "positive"),
+      recover_old = c("radius", "positive"),
+      match_names = c("radius", "positive"),
+      match_to = c("radius", "positive"),
+      defaults = list(radius = 1, positive = TRUE),
+      head_args = c("dim", "n"),
+      fn_name = "sample_sphere_surface"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   # Use the _impl function
   sample_sphere_surface_impl(
     dim = dim,
@@ -345,6 +446,7 @@ sample_sphere_surface <- function(dim, n = 1, radius = 1, positive = TRUE) {
 #'
 #' @param dim Integer scalar, the dimension of the random vectors.
 #' @param n Integer scalar, the sample size.
+#' @inheritParams rlang::args_dots_empty
 #' @param radius Numeric scalar, the radius of the sphere to sample.
 #' @param positive Logical, whether to sample from the positive orthant
 #'   of the sphere.
@@ -362,7 +464,35 @@ sample_sphere_surface <- function(dim, n = 1, radius = 1, positive = TRUE) {
 #'   sum(x^2)
 #' })
 #' vec.norm
-sample_sphere_volume <- function(dim, n = 1, radius = 1, positive = TRUE) {
+sample_sphere_volume <- function(
+  dim,
+  n = 1,
+  ...,
+  radius = 1,
+  positive = TRUE
+) {
+  # BEGIN GENERATED ARG_HANDLE: sample_sphere_volume, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(radius = radius, positive = positive),
+      recover_new = c("radius", "positive"),
+      recover_old = c("radius", "positive"),
+      match_names = c("radius", "positive"),
+      match_to = c("radius", "positive"),
+      defaults = list(radius = 1, positive = TRUE),
+      head_args = c("dim", "n"),
+      fn_name = "sample_sphere_volume"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   # Use the _impl function
   sample_sphere_volume_impl(
     dim = dim,

--- a/R/hrg.R
+++ b/R/hrg.R
@@ -177,6 +177,7 @@ NULL
 #' @param hrg A hierarchical random graph model, in the form of an
 #'   `igraphHRG` object. `fit_hrg()` allows this to be `NULL`, in
 #'   which case a random starting point is used for the fitting.
+#' @inheritParams rlang::args_dots_empty
 #' @param start Logical, whether to start the fitting/sampling from the
 #'   supplied `igraphHRG` object, or from a random starting point.
 #' @param steps The number of MCMC steps to make. If this is zero, then the
@@ -232,7 +233,35 @@ NULL
 #' predict_edges(g2)
 #' @export
 #' @family hierarchical random graph functions
-fit_hrg <- function(graph, hrg = NULL, start = FALSE, steps = 0) {
+fit_hrg <- function(
+  graph,
+  hrg = NULL,
+  ...,
+  start = FALSE,
+  steps = 0
+) {
+  # BEGIN GENERATED ARG_HANDLE: fit_hrg, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(start = start, steps = steps),
+      recover_new = c("start", "steps"),
+      recover_old = c("start", "steps"),
+      match_names = c("start", "steps"),
+      match_to = c("start", "steps"),
+      defaults = list(start = FALSE, steps = 0),
+      head_args = c("graph", "hrg"),
+      fn_name = "fit_hrg"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   # Argument checks
   ensure_igraph(graph)
   if (is.null(hrg)) {
@@ -281,6 +310,7 @@ fit_hrg <- function(graph, hrg = NULL, start = FALSE, steps = 0) {
 #'   `igraphHRG` object. `consensus_tree()` allows this to be
 #'   `NULL` as well, then a HRG is fitted to the graph first, from a
 #'   random starting point.
+#' @inheritParams rlang::args_dots_empty
 #' @param start Logical, whether to start the fitting/sampling from the
 #'   supplied `igraphHRG` object, or from a random starting point.
 #' @param num.samples Number of samples to use for consensus generation or
@@ -307,9 +337,32 @@ fit_hrg <- function(graph, hrg = NULL, start = FALSE, steps = 0) {
 consensus_tree <- function(
   graph,
   hrg = NULL,
+  ...,
   start = FALSE,
   num.samples = 10000
 ) {
+  # BEGIN GENERATED ARG_HANDLE: consensus_tree, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(start = start, num.samples = num.samples),
+      recover_new = c("start", "num.samples"),
+      recover_old = c("start", "num.samples"),
+      match_names = c("start", "num.samples"),
+      match_to = c("start", "num.samples"),
+      defaults = list(start = FALSE, num.samples = 10000),
+      head_args = c("graph", "hrg"),
+      fn_name = "consensus_tree"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   hrg_consensus_impl(
     graph = graph,
     hrg = hrg,
@@ -403,6 +456,7 @@ sample_hrg <- function(hrg) {
 #'   `igraphHRG` object. `predict_edges()` allow this to be
 #'   `NULL` as well, then a HRG is fitted to the graph first, from a
 #'   random starting point.
+#' @inheritParams rlang::args_dots_empty
 #' @param start Logical, whether to start the fitting/sampling from the
 #'   supplied `igraphHRG` object, or from a random starting point.
 #' @param num.samples Number of samples to use for consensus generation or
@@ -448,10 +502,37 @@ sample_hrg <- function(hrg) {
 predict_edges <- function(
   graph,
   hrg = NULL,
+  ...,
   start = FALSE,
   num.samples = 10000,
   num.bins = 25
 ) {
+  # BEGIN GENERATED ARG_HANDLE: predict_edges, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(
+        start = start,
+        num.samples = num.samples,
+        num.bins = num.bins
+      ),
+      recover_new = c("start", "num.samples", "num.bins"),
+      recover_old = c("start", "num.samples", "num.bins"),
+      match_names = c("start", "num.samples", "num.bins"),
+      match_to = c("start", "num.samples", "num.bins"),
+      defaults = list(start = FALSE, num.samples = 10000, num.bins = 25),
+      head_args = c("graph", "hrg"),
+      fn_name = "predict_edges"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
   res <- hrg_predict_impl(
     graph = graph,
     hrg = hrg,

--- a/man/consensus_tree.Rd
+++ b/man/consensus_tree.Rd
@@ -4,7 +4,7 @@
 \alias{consensus_tree}
 \title{Create a consensus tree from several hierarchical random graph models}
 \usage{
-consensus_tree(graph, hrg = NULL, start = FALSE, num.samples = 10000)
+consensus_tree(graph, hrg = NULL, ..., start = FALSE, num.samples = 10000)
 }
 \arguments{
 \item{graph}{The graph the models were fitted to.}
@@ -13,6 +13,8 @@ consensus_tree(graph, hrg = NULL, start = FALSE, num.samples = 10000)
 \code{igraphHRG} object. \code{consensus_tree()} allows this to be
 \code{NULL} as well, then a HRG is fitted to the graph first, from a
 random starting point.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{start}{Logical, whether to start the fitting/sampling from the
 supplied \code{igraphHRG} object, or from a random starting point.}

--- a/man/embed_adjacency_matrix.Rd
+++ b/man/embed_adjacency_matrix.Rd
@@ -7,6 +7,7 @@
 embed_adjacency_matrix(
   graph,
   no,
+  ...,
   weights = NULL,
   which = c("lm", "la", "sa"),
   scaled = TRUE,
@@ -21,6 +22,8 @@ embed_adjacency_matrix(
 spectral embedding. Should be smaller than the number of vertices. The
 largest \code{no}-dimensional non-zero singular values are used for the
 spectral embedding.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{weights}{Optional positive weight vector for calculating a weighted
 embedding. If the graph has a \code{weight} edge attribute, then this is

--- a/man/embed_laplacian_matrix.Rd
+++ b/man/embed_laplacian_matrix.Rd
@@ -7,6 +7,7 @@
 embed_laplacian_matrix(
   graph,
   no,
+  ...,
   weights = NULL,
   which = c("lm", "la", "sa"),
   type = c("default", "D-A", "DAD", "I-DAD", "OAP"),
@@ -21,6 +22,8 @@ embed_laplacian_matrix(
 spectral embedding. Should be smaller than the number of vertices. The
 largest \code{no}-dimensional non-zero singular values are used for the
 spectral embedding.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{weights}{Optional positive weight vector for calculating a weighted
 embedding. If the graph has a \code{weight} edge attribute, then this is

--- a/man/fit_hrg.Rd
+++ b/man/fit_hrg.Rd
@@ -4,7 +4,7 @@
 \alias{fit_hrg}
 \title{Fit a hierarchical random graph model}
 \usage{
-fit_hrg(graph, hrg = NULL, start = FALSE, steps = 0)
+fit_hrg(graph, hrg = NULL, ..., start = FALSE, steps = 0)
 }
 \arguments{
 \item{graph}{The graph to fit the model to. Edge directions are ignored in
@@ -13,6 +13,8 @@ directed graphs.}
 \item{hrg}{A hierarchical random graph model, in the form of an
 \code{igraphHRG} object. \code{fit_hrg()} allows this to be \code{NULL}, in
 which case a random starting point is used for the fitting.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{start}{Logical, whether to start the fitting/sampling from the
 supplied \code{igraphHRG} object, or from a random starting point.}

--- a/man/predict_edges.Rd
+++ b/man/predict_edges.Rd
@@ -7,6 +7,7 @@
 predict_edges(
   graph,
   hrg = NULL,
+  ...,
   start = FALSE,
   num.samples = 10000,
   num.bins = 25
@@ -20,6 +21,8 @@ directed graphs.}
 \code{igraphHRG} object. \code{predict_edges()} allow this to be
 \code{NULL} as well, then a HRG is fitted to the graph first, from a
 random starting point.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{start}{Logical, whether to start the fitting/sampling from the
 supplied \code{igraphHRG} object, or from a random starting point.}

--- a/man/sample_sphere_surface.Rd
+++ b/man/sample_sphere_surface.Rd
@@ -4,12 +4,14 @@
 \alias{sample_sphere_surface}
 \title{Sample vectors uniformly from the surface of a sphere}
 \usage{
-sample_sphere_surface(dim, n = 1, radius = 1, positive = TRUE)
+sample_sphere_surface(dim, n = 1, ..., radius = 1, positive = TRUE)
 }
 \arguments{
 \item{dim}{Integer scalar, the dimension of the random vectors.}
 
 \item{n}{Integer scalar, the sample size.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{radius}{Numeric scalar, the radius of the sphere to sample.}
 

--- a/man/sample_sphere_volume.Rd
+++ b/man/sample_sphere_volume.Rd
@@ -4,12 +4,14 @@
 \alias{sample_sphere_volume}
 \title{Sample vectors uniformly from the volume of a sphere}
 \usage{
-sample_sphere_volume(dim, n = 1, radius = 1, positive = TRUE)
+sample_sphere_volume(dim, n = 1, ..., radius = 1, positive = TRUE)
 }
 \arguments{
 \item{dim}{Integer scalar, the dimension of the random vectors.}
 
 \item{n}{Integer scalar, the sample size.}
+
+\item{...}{These dots are for future extensions and must be empty.}
 
 \item{radius}{Numeric scalar, the radius of the sphere to sample.}
 

--- a/tests/testthat/test-embedding.R
+++ b/tests/testthat/test-embedding.R
@@ -1311,3 +1311,105 @@ test_that("dimensionality selection works", {
   x <- c(rnorm(99, mean = 0, sd = 1), 10)
   expect_equal(dim_select(x), 99)
 })
+
+# ---- ellipsis migration: argument coverage ----------------------------
+
+test_that("embed_adjacency_matrix() covers keyword-only tail arguments", {
+  igraph_local_seed(42)
+  g <- sample_gnm(10, 20, directed = FALSE)
+  w <- runif(ecount(g), 1, 2)
+  opts <- arpack_defaults()
+  opts$maxiter <- 5000L
+
+  emb <- embed_adjacency_matrix(
+    g,
+    no = 3,
+    weights = w,
+    which = "lm",
+    scaled = FALSE,
+    cvec = rep(0, vcount(g)),
+    options = opts
+  )
+  expect_equal(dim(emb$X), c(vcount(g), 3))
+  expect_length(emb$D, 3)
+  # `options` is threaded through to ARPACK and echoed back in the result.
+  expect_equal(as.numeric(emb$options$maxiter), 5000)
+})
+
+test_that("embed_adjacency_matrix() recovers a legacy positional argument", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  igraph_local_seed(42)
+  g <- sample_gnm(10, 20, directed = FALSE)
+  w <- runif(ecount(g), 1, 2)
+  # Pin `cvec` so its `weights`-dependent default cannot diverge between the
+  # positional and named forms; `weights` is the recovered positional argument.
+  cvec <- rep(0, vcount(g))
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(
+    res <- embed_adjacency_matrix(g, 3, w, cvec = cvec)
+  )
+  igraph_local_seed(1)
+  expect_identical(res, embed_adjacency_matrix(g, 3, weights = w, cvec = cvec))
+})
+
+test_that("embed_laplacian_matrix() covers keyword-only tail arguments", {
+  igraph_local_seed(42)
+  g <- sample_gnm(10, 20, directed = FALSE)
+  w <- runif(ecount(g), 1, 2)
+  opts <- arpack_defaults()
+  opts$maxiter <- 5000L
+
+  emb <- embed_laplacian_matrix(
+    g,
+    no = 3,
+    weights = w,
+    which = "lm",
+    type = "DAD",
+    scaled = FALSE,
+    options = opts
+  )
+  expect_equal(dim(emb$X), c(vcount(g), 3))
+  expect_length(emb$D, 3)
+  expect_equal(as.numeric(emb$options$maxiter), 5000)
+})
+
+test_that("embed_laplacian_matrix() recovers a legacy positional argument", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  igraph_local_seed(42)
+  g <- sample_gnm(10, 20, directed = FALSE)
+  w <- runif(ecount(g), 1, 2)
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(
+    res <- embed_laplacian_matrix(g, 3, w)
+  )
+  igraph_local_seed(1)
+  expect_identical(res, embed_laplacian_matrix(g, 3, weights = w))
+})
+
+test_that("sample_sphere_surface() recovers a legacy positional argument", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(
+    res <- sample_sphere_surface(3, 20, 2)
+  )
+  igraph_local_seed(1)
+  expect_identical(res, sample_sphere_surface(3, 20, radius = 2))
+  # The recovered `radius` takes visible effect: every column has norm 2.
+  expect_equal(sqrt(colSums(res^2)), rep(2, 20))
+})
+
+test_that("sample_sphere_volume() recovers a legacy positional argument", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+
+  igraph_local_seed(1)
+  lifecycle::expect_deprecated(
+    res <- sample_sphere_volume(3, 20, 2)
+  )
+  igraph_local_seed(1)
+  expect_identical(res, sample_sphere_volume(3, 20, radius = 2))
+  # The recovered `radius` bounds the sampled vectors inside the sphere.
+  expect_true(all(sqrt(colSums(res^2)) <= 2))
+})

--- a/tests/testthat/test-hrg.R
+++ b/tests/testthat/test-hrg.R
@@ -138,3 +138,83 @@ test_that("print.igrapHRG() works", {
 
   expect_output(print(big_hrg, type = "tree"), "- ")
 })
+
+# ---- ellipsis migration: argument coverage ----------------------------
+
+# A compact shared fixture: a tiny two-clique graph and one HRG fitted to it,
+# reused by the consensus_tree() and predict_edges() blocks below.
+# Fitting a real HRG is the awkward part of constructing valid inputs there.
+hrg_fixture <- function() {
+  g <- make_full_graph(4) + make_full_graph(4)
+  igraph_with_seed(1, list(graph = g, hrg = fit_hrg(g)))
+}
+
+test_that("fit_hrg() recovers a legacy positional argument", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  fx <- hrg_fixture()
+
+  igraph_local_seed(2)
+  lifecycle::expect_deprecated(
+    res <- fit_hrg(fx$graph, fx$hrg, TRUE)
+  )
+  igraph_local_seed(2)
+  expect_identical(res, fit_hrg(fx$graph, fx$hrg, start = TRUE))
+})
+
+test_that("consensus_tree() covers keyword-only tail arguments", {
+  fx <- hrg_fixture()
+  igraph_local_seed(3)
+
+  res <- consensus_tree(fx$graph, hrg = fx$hrg, start = TRUE, num.samples = 100)
+  expect_named(res, c("parents", "weights", "hrg"))
+  expect_true(is.numeric(res$weights))
+  expect_gt(length(res$parents), 0)
+})
+
+test_that("consensus_tree() recovers a legacy positional argument", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  fx <- hrg_fixture()
+
+  # `num.samples` is pinned small (by name) to keep the two runs fast; `start`
+  # is the recovered positional argument.
+  igraph_local_seed(4)
+  lifecycle::expect_deprecated(
+    res <- consensus_tree(fx$graph, fx$hrg, TRUE, num.samples = 100)
+  )
+  igraph_local_seed(4)
+  expect_identical(
+    res,
+    consensus_tree(fx$graph, fx$hrg, start = TRUE, num.samples = 100)
+  )
+})
+
+test_that("predict_edges() covers keyword-only tail arguments", {
+  fx <- hrg_fixture()
+  igraph_local_seed(5)
+
+  res <- predict_edges(
+    fx$graph,
+    hrg = fx$hrg,
+    start = TRUE,
+    num.samples = 100,
+    num.bins = 5
+  )
+  expect_equal(ncol(res$edges), 2)
+  expect_length(res$prob, nrow(res$edges))
+  expect_s3_class(res$hrg, "igraphHRG")
+})
+
+test_that("predict_edges() recovers a legacy positional argument", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  fx <- hrg_fixture()
+
+  igraph_local_seed(6)
+  lifecycle::expect_deprecated(
+    res <- predict_edges(fx$graph, fx$hrg, TRUE, num.samples = 100)
+  )
+  igraph_local_seed(6)
+  expect_identical(
+    res,
+    predict_edges(fx$graph, fx$hrg, start = TRUE, num.samples = 100)
+  )
+})

--- a/tools/migrations/hrg-embedding.R
+++ b/tools/migrations/hrg-embedding.R
@@ -1,0 +1,96 @@
+# Argument-signature migrations: hrg-embedding
+# Schema: see tools/migrations/README.md. Regenerate with:
+#   Rscript tools/generate-migrations.R
+
+migrations <- list(
+  embed_adjacency_matrix = list(
+    old = function(graph, no, weights, which, scaled, cvec, options) {},
+    new = function(
+      graph,
+      no,
+      ...,
+      weights = NULL,
+      which = c("lm", "la", "sa"),
+      scaled = TRUE,
+      cvec = strength(graph, weights = weights) / (vcount(graph) - 1),
+      options = arpack_defaults()
+    ) {},
+    when = "3.0.0"
+  ),
+
+  embed_laplacian_matrix = list(
+    old = function(graph, no, weights, which, type, scaled, options) {},
+    new = function(
+      graph,
+      no,
+      ...,
+      weights = NULL,
+      which = c("lm", "la", "sa"),
+      type = c("default", "D-A", "DAD", "I-DAD", "OAP"),
+      scaled = TRUE,
+      options = arpack_defaults()
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_sphere_surface = list(
+    old = function(dim, n, radius, positive) {},
+    new = function(
+      dim,
+      n = 1,
+      ...,
+      radius = 1,
+      positive = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  sample_sphere_volume = list(
+    old = function(dim, n, radius, positive) {},
+    new = function(
+      dim,
+      n = 1,
+      ...,
+      radius = 1,
+      positive = TRUE
+    ) {},
+    when = "3.0.0"
+  ),
+
+  consensus_tree = list(
+    old = function(graph, hrg, start, num.samples) {},
+    new = function(
+      graph,
+      hrg = NULL,
+      ...,
+      start = FALSE,
+      num.samples = 10000
+    ) {},
+    when = "3.0.0"
+  ),
+
+  fit_hrg = list(
+    old = function(graph, hrg, start, steps) {},
+    new = function(
+      graph,
+      hrg = NULL,
+      ...,
+      start = FALSE,
+      steps = 0
+    ) {},
+    when = "3.0.0"
+  ),
+
+  predict_edges = list(
+    old = function(graph, hrg, start, num.samples, num.bins) {},
+    new = function(
+      graph,
+      hrg = NULL,
+      ...,
+      start = FALSE,
+      num.samples = 10000,
+      num.bins = 25
+    ) {},
+    when = "3.0.0"
+  )
+)


### PR DESCRIPTION
Part of the repo-wide ellipsis migration coordinated in #2757 —
see that PR for the full rationale (CONTRIBUTING.md, *Argument Order and the Ellipsis*).
Based directly on `main` (the registry split landed via #2779); a single topic commit.

## What this does

Inserts `...` between the *defining* arguments (head) and the *optional
modifiers* (tail) of **7 exported hrg-embedding functions**.
Arguments after `...` become keyword-only.

- Legacy positional or abbreviated calls are **recovered** by the generated
  ARG_HANDLE block and emit a single `lifecycle::deprecate_soft("3.0.0", …)` —
  behavior is unchanged.
- No defaults change, no arguments are renamed, deprecated functions untouched.
- Registry: `tools/migrations/hrg-embedding.R`; blocks regenerated via
  `Rscript tools/generate-migrations.R` (idempotent, CI-checked).
- Rd usage/arguments updated mechanically (see note below).

## New signatures

| function | head (positional) | keyword-only tail |
|---|---|---|
| `embed_adjacency_matrix()` | `graph, no` | `weights, which, scaled, cvec, options` |
| `embed_laplacian_matrix()` | `graph, no` | `weights, which, type, scaled, options` |
| `sample_sphere_surface()` | `dim, n` | `radius, positive` |
| `sample_sphere_volume()` | `dim, n` | `radius, positive` |
| `consensus_tree()` | `graph, hrg` | `start, num.samples` |
| `fit_hrg()` | `graph, hrg` | `start, steps` |
| `predict_edges()` | `graph, hrg` | `start, num.samples, num.bins` |

## Notes for review

- The environment used to prepare this PR cannot install `igraph.r2cdocs`
  (GitHub API unreachable), so `man/*.Rd` files were updated **mechanically**
  (usage + `...` argument item) instead of via `devtools::document()`.
  R CMD check's usage↔formals validation passes; a follow-up
  `devtools::document()` run may reflow whitespace but should produce no
  semantic diff.
- Package tests that called these functions positionally were updated to
  named arguments (they are the same soft-deprecation user code will see).
