### PR TITLE
chore: restore one-value-per-line layout of long enum defaults

### DIFF
--- a/R/structural-properties.R
+++ b/R/structural-properties.R
@@ -1365,7 +1365,14 @@ distances <- function(
   ...,
   mode = c("all", "out", "in"),
   weights = NULL,
-  algorithm = c( "automatic", "unweighted", "dijkstra", "bellman-ford", "johnson", "floyd-warshall" )
+  algorithm = c(
+    "automatic",
+    "unweighted",
+    "dijkstra",
+    "bellman-ford",
+    "johnson",
+    "floyd-warshall"
+  )
 ) {
   # BEGIN GENERATED ARG_HANDLE: distances, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
@@ -2133,7 +2140,18 @@ subgraph.edges <- function(graph, eids, delete.vertices = TRUE) {
 #'
 transitivity <- function(
   graph,
-  type = c( "undirected", "global", "globalundirected", "localundirected", "local", "average", "localaverage", "localaverageundirected", "barrat", "weighted" ),
+  type = c(
+    "undirected",
+    "global",
+    "globalundirected",
+    "localundirected",
+    "local",
+    "average",
+    "localaverage",
+    "localaverageundirected",
+    "barrat",
+    "weighted"
+  ),
   ...,
   vids = NULL,
   weights = NULL,

--- a/tools/migrations/structural-properties.R
+++ b/tools/migrations/structural-properties.R
@@ -157,7 +157,14 @@ migrations <- list(
       ...,
       mode = c("all", "out", "in"),
       weights = NULL,
-      algorithm = c( "automatic", "unweighted", "dijkstra", "bellman-ford", "johnson", "floyd-warshall" )
+      algorithm = c(
+        "automatic",
+        "unweighted",
+        "dijkstra",
+        "bellman-ford",
+        "johnson",
+        "floyd-warshall"
+      )
     ) {},
     when = "3.0.0"
   ),
@@ -410,7 +417,18 @@ migrations <- list(
     old = function(graph, type, vids, weights, isolates) {},
     new = function(
       graph,
-      type = c( "undirected", "global", "globalundirected", "localundirected", "local", "average", "localaverage", "localaverageundirected", "barrat", "weighted" ),
+      type = c(
+        "undirected",
+        "global",
+        "globalundirected",
+        "localundirected",
+        "local",
+        "average",
+        "localaverage",
+        "localaverageundirected",
+        "barrat",
+        "weighted"
+      ),
       ...,
       vids = NULL,
       weights = NULL,


### PR DESCRIPTION
Follow-up to the `transitivity()` formatting review on the merged #2759.

## The defect

The ellipsis-migration rewriter normalized each formal onto one line and
collapsed multi-line enum defaults, producing a 155-character line with stray
inner spaces:

```r
type = c( "undirected", "global", "globalundirected", "localundirected", "local", "average", "localaverage", "localaverageundirected", "barrat", "weighted" ),
```

`air` did not repair it because `c` is on `air.toml`'s `skip` list
(intentionally, so data vectors keep their authored layout) — which is also
why this must be fixed by hand rather than by the formatter.

## The fix

Restore the pre-migration one-value-per-line layout for the two affected
functions on `main` — `transitivity()` (`type`) and `distances()`
(`algorithm`) — in both the function signatures
(`R/structural-properties.R`) and the migration registry
(`tools/migrations/structural-properties.R`).

No behavior change:

- the generated ARG_HANDLE blocks are deparse-based and stay byte-identical
  (`Rscript tools/generate-migrations.R` is a no-op on this branch);
- `man/*.Rd` usage is deparse-based too — `devtools::document()` produces no
  diff;
- `transitivity()`/`distances()` behavior verified unchanged.

The same collapse exists on three not-yet-merged topic branches
(games ×2, conversion ×1, similarity-efficiency ×2 functions);
those branches are being amended directly with the identical layout fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_016M32izVHZPfxAqemAe4BrX)_