### PR TITLE
fix(migrations): detect supplied tail args with `missing()`

### DIFF
--- a/R/centrality.R
+++ b/R/centrality.R
@@ -441,22 +441,16 @@ betweenness <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        directed = directed,
-        weights = weights,
-        normalized = normalized,
-        cutoff = cutoff
+      supplied = c(
+        directed = !missing(directed),
+        weights = !missing(weights),
+        normalized = !missing(normalized),
+        cutoff = !missing(cutoff)
       ),
       recover_new = c("directed", "weights", "normalized", "cutoff"),
       recover_old = c("directed", "weights", "normalized", "cutoff"),
       match_names = c("directed", "weights", "normalized", "cutoff"),
       match_to = c("directed", "weights", "normalized", "cutoff"),
-      defaults = list(
-        directed = TRUE,
-        weights = NULL,
-        normalized = FALSE,
-        cutoff = -1
-      ),
       head_args = c("graph", "v"),
       fn_name = "betweenness"
     )
@@ -503,12 +497,15 @@ edge_betweenness <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(directed = directed, weights = weights, cutoff = cutoff),
+      supplied = c(
+        directed = !missing(directed),
+        weights = !missing(weights),
+        cutoff = !missing(cutoff)
+      ),
       recover_new = c("directed", "weights", "cutoff"),
       recover_old = c("directed", "weights", "cutoff"),
       match_names = c("directed", "weights", "cutoff"),
       match_to = c("directed", "weights", "cutoff"),
-      defaults = list(directed = TRUE, weights = NULL, cutoff = -1),
       head_args = c("graph", "e"),
       fn_name = "edge_betweenness"
     )
@@ -639,22 +636,16 @@ closeness <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        mode = mode,
-        weights = weights,
-        normalized = normalized,
-        cutoff = cutoff
+      supplied = c(
+        mode = !missing(mode),
+        weights = !missing(weights),
+        normalized = !missing(normalized),
+        cutoff = !missing(cutoff)
       ),
       recover_new = c("mode", "weights", "normalized", "cutoff"),
       recover_old = c("mode", "weights", "normalized", "cutoff"),
       match_names = c("mode", "weights", "normalized", "cutoff"),
       match_to = c("mode", "weights", "normalized", "cutoff"),
-      defaults = list(
-        mode = c("out", "in", "all", "total"),
-        weights = NULL,
-        normalized = FALSE,
-        cutoff = -1
-      ),
       head_args = c("graph", "vids"),
       fn_name = "closeness"
     )
@@ -1161,12 +1152,11 @@ subgraph_centrality <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(diag = diag),
+      supplied = c(diag = !missing(diag)),
       recover_new = c("diag"),
       recover_old = c("diag"),
       match_names = c("diag"),
       match_to = c("diag"),
-      defaults = list(diag = FALSE),
       head_args = c("graph"),
       fn_name = "subgraph_centrality"
     )
@@ -1493,16 +1483,15 @@ strength <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode, loops = loops, weights = weights),
+      supplied = c(
+        mode = !missing(mode),
+        loops = !missing(loops),
+        weights = !missing(weights)
+      ),
       recover_new = c("mode", "loops", "weights"),
       recover_old = c("mode", "loops", "weights"),
       match_names = c("mode", "loops", "weights"),
       match_to = c("mode", "loops", "weights"),
-      defaults = list(
-        mode = c("all", "out", "in", "total"),
-        loops = TRUE,
-        weights = NULL
-      ),
       head_args = c("graph", "vids"),
       fn_name = "strength"
     )
@@ -1576,12 +1565,11 @@ diversity <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(weights = weights, vids = vids),
+      supplied = c(weights = !missing(weights), vids = !missing(vids)),
       recover_new = c("weights", "vids"),
       recover_old = c("weights", "vids"),
       match_names = c("weights", "vids"),
       match_to = c("weights", "vids"),
-      defaults = list(weights = NULL, vids = V(graph)),
       head_args = c("graph"),
       fn_name = "diversity"
     )
@@ -1859,14 +1847,14 @@ page_rank <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        algo = algo,
-        vids = vids,
-        directed = directed,
-        damping = damping,
-        personalized = personalized,
-        weights = weights,
-        options = options
+      supplied = c(
+        algo = !missing(algo),
+        vids = !missing(vids),
+        directed = !missing(directed),
+        damping = !missing(damping),
+        personalized = !missing(personalized),
+        weights = !missing(weights),
+        options = !missing(options)
       ),
       recover_new = c(
         "algo",
@@ -1903,15 +1891,6 @@ page_rank <- function(
         "personalized",
         "weights",
         "options"
-      ),
-      defaults = list(
-        algo = c("prpack", "arpack"),
-        vids = V(graph),
-        directed = TRUE,
-        damping = 0.85,
-        personalized = NULL,
-        weights = NULL,
-        options = NULL
       ),
       head_args = c("graph"),
       fn_name = "page_rank"
@@ -1996,22 +1975,16 @@ harmonic_centrality <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        mode = mode,
-        weights = weights,
-        normalized = normalized,
-        cutoff = cutoff
+      supplied = c(
+        mode = !missing(mode),
+        weights = !missing(weights),
+        normalized = !missing(normalized),
+        cutoff = !missing(cutoff)
       ),
       recover_new = c("mode", "weights", "normalized", "cutoff"),
       recover_old = c("mode", "weights", "normalized", "cutoff"),
       match_names = c("mode", "weights", "normalized", "cutoff"),
       match_to = c("mode", "weights", "normalized", "cutoff"),
-      defaults = list(
-        mode = c("out", "in", "all", "total"),
-        weights = NULL,
-        normalized = FALSE,
-        cutoff = -1
-      ),
       head_args = c("graph", "vids"),
       fn_name = "harmonic_centrality"
     )
@@ -2229,13 +2202,13 @@ power_centrality <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        loops = loops,
-        exponent = exponent,
-        rescale = rescale,
-        tol = tol,
-        sparse = sparse,
-        weights = weights
+      supplied = c(
+        loops = !missing(loops),
+        exponent = !missing(exponent),
+        rescale = !missing(rescale),
+        tol = !missing(tol),
+        sparse = !missing(sparse),
+        weights = !missing(weights)
       ),
       recover_new = c(
         "loops",
@@ -2262,14 +2235,6 @@ power_centrality <- function(
         "weights"
       ),
       match_to = c("loops", "exponent", "rescale", "tol", "sparse", "weights"),
-      defaults = list(
-        loops = FALSE,
-        exponent = 1,
-        rescale = FALSE,
-        tol = 1e-07,
-        sparse = TRUE,
-        weights = NULL
-      ),
       head_args = c("graph", "nodes"),
       fn_name = "power_centrality"
     )
@@ -2450,26 +2415,18 @@ alpha_centrality <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        alpha = alpha,
-        loops = loops,
-        exo = exo,
-        weights = weights,
-        tol = tol,
-        sparse = sparse
+      supplied = c(
+        alpha = !missing(alpha),
+        loops = !missing(loops),
+        exo = !missing(exo),
+        weights = !missing(weights),
+        tol = !missing(tol),
+        sparse = !missing(sparse)
       ),
       recover_new = c("alpha", "loops", "exo", "weights", "tol", "sparse"),
       recover_old = c("alpha", "loops", "exo", "weights", "tol", "sparse"),
       match_names = c("alpha", "loops", "exo", "weights", "tol", "sparse"),
       match_to = c("alpha", "loops", "exo", "weights", "tol", "sparse"),
-      defaults = list(
-        alpha = 1,
-        loops = FALSE,
-        exo = 1,
-        weights = NULL,
-        tol = 1e-07,
-        sparse = TRUE
-      ),
       head_args = c("graph", "nodes"),
       fn_name = "alpha_centrality"
     )

--- a/R/centralization.R
+++ b/R/centralization.R
@@ -325,15 +325,14 @@ centralize <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        theoretical.max = theoretical.max,
-        normalized = normalized
+      supplied = c(
+        theoretical.max = !missing(theoretical.max),
+        normalized = !missing(normalized)
       ),
       recover_new = c("theoretical.max", "normalized"),
       recover_old = c("theoretical.max", "normalized"),
       match_names = c("theoretical.max", "normalized"),
       match_to = c("theoretical.max", "normalized"),
-      defaults = list(theoretical.max = 0, normalized = TRUE),
       head_args = c("scores"),
       fn_name = "centralize"
     )
@@ -404,16 +403,15 @@ centr_degree <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode, loops = loops, normalized = normalized),
+      supplied = c(
+        mode = !missing(mode),
+        loops = !missing(loops),
+        normalized = !missing(normalized)
+      ),
       recover_new = c("mode", "loops", "normalized"),
       recover_old = c("mode", "loops", "normalized"),
       match_names = c("mode", "loops", "normalized"),
       match_to = c("mode", "loops", "normalized"),
-      defaults = list(
-        mode = c("all", "out", "in", "total"),
-        loops = TRUE,
-        normalized = TRUE
-      ),
       head_args = c("graph"),
       fn_name = "centr_degree"
     )
@@ -536,12 +534,14 @@ centr_betw <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(directed = directed, normalized = normalized),
+      supplied = c(
+        directed = !missing(directed),
+        normalized = !missing(normalized)
+      ),
       recover_new = c("directed", "normalized"),
       recover_old = c("directed", "normalized"),
       match_names = c("directed", "normalized"),
       match_to = c("directed", "normalized"),
-      defaults = list(directed = TRUE, normalized = TRUE),
       head_args = c("graph"),
       fn_name = "centr_betw"
     )
@@ -606,12 +606,11 @@ centr_betw_tmax <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(directed = directed),
+      supplied = c(directed = !missing(directed)),
       recover_new = c("directed"),
       recover_old = c("directed"),
       match_names = c("directed"),
       match_to = c("directed"),
-      defaults = list(directed = TRUE),
       head_args = c("graph", "nodes"),
       fn_name = "centr_betw_tmax"
     )
@@ -678,12 +677,11 @@ centr_clo <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode, normalized = normalized),
+      supplied = c(mode = !missing(mode), normalized = !missing(normalized)),
       recover_new = c("mode", "normalized"),
       recover_old = c("mode", "normalized"),
       match_names = c("mode", "normalized"),
       match_to = c("mode", "normalized"),
-      defaults = list(mode = c("out", "in", "all", "total"), normalized = TRUE),
       head_args = c("graph"),
       fn_name = "centr_clo"
     )
@@ -738,12 +736,11 @@ centr_clo_tmax <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode),
+      supplied = c(mode = !missing(mode)),
       recover_new = c("mode"),
       recover_old = c("mode"),
       match_names = c("mode"),
       match_to = c("mode"),
-      defaults = list(mode = c("out", "in", "all", "total")),
       head_args = c("graph", "nodes"),
       fn_name = "centr_clo_tmax"
     )

--- a/R/community.R
+++ b/R/community.R
@@ -782,16 +782,15 @@ make_clusters <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        algorithm = algorithm,
-        merges = merges,
-        modularity = modularity
+      supplied = c(
+        algorithm = !missing(algorithm),
+        merges = !missing(merges),
+        modularity = !missing(modularity)
       ),
       recover_new = c("algorithm", "merges", "modularity"),
       recover_old = c("algorithm", "merges", "modularity"),
       match_names = c("algorithm", "merges", "modularity"),
       match_to = c("algorithm", "merges", "modularity"),
-      defaults = list(algorithm = NULL, merges = NULL, modularity = TRUE),
       head_args = c("graph", "membership"),
       fn_name = "make_clusters"
     )
@@ -980,16 +979,15 @@ modularity_matrix <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        weights = weights,
-        resolution = resolution,
-        directed = directed
+      supplied = c(
+        weights = !missing(weights),
+        resolution = !missing(resolution),
+        directed = !missing(directed)
       ),
       recover_new = c("weights", "resolution", "directed"),
       recover_old = c("weights", "resolution", "directed"),
       match_names = c("weights", "resolution", "directed"),
       match_to = c("weights", "resolution", "directed"),
-      defaults = list(weights = NULL, resolution = 1, directed = TRUE),
       head_args = c("graph", "membership"),
       fn_name = "modularity_matrix"
     )
@@ -1552,18 +1550,18 @@ cluster_spinglass <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        weights = weights,
-        vertex = vertex,
-        spins = spins,
-        parupdate = parupdate,
-        start.temp = start.temp,
-        stop.temp = stop.temp,
-        cool.fact = cool.fact,
-        update.rule = update.rule,
-        gamma = gamma,
-        implementation = implementation,
-        gamma.minus = gamma.minus
+      supplied = c(
+        weights = !missing(weights),
+        vertex = !missing(vertex),
+        spins = !missing(spins),
+        parupdate = !missing(parupdate),
+        start.temp = !missing(start.temp),
+        stop.temp = !missing(stop.temp),
+        cool.fact = !missing(cool.fact),
+        update.rule = !missing(update.rule),
+        gamma = !missing(gamma),
+        implementation = !missing(implementation),
+        gamma.minus = !missing(gamma.minus)
       ),
       recover_new = c(
         "weights",
@@ -1616,19 +1614,6 @@ cluster_spinglass <- function(
         "gamma",
         "implementation",
         "gamma.minus"
-      ),
-      defaults = list(
-        weights = NULL,
-        vertex = NULL,
-        spins = 25,
-        parupdate = FALSE,
-        start.temp = 1,
-        stop.temp = 0.01,
-        cool.fact = 0.99,
-        update.rule = c("config", "random", "simple"),
-        gamma = 1,
-        implementation = c("orig", "neg"),
-        gamma.minus = 1
       ),
       head_args = c("graph"),
       fn_name = "cluster_spinglass"
@@ -2031,24 +2016,17 @@ cluster_walktrap <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        weights = weights,
-        steps = steps,
-        merges = merges,
-        modularity = modularity,
-        membership = membership
+      supplied = c(
+        weights = !missing(weights),
+        steps = !missing(steps),
+        merges = !missing(merges),
+        modularity = !missing(modularity),
+        membership = !missing(membership)
       ),
       recover_new = c("weights", "steps", "merges", "modularity", "membership"),
       recover_old = c("weights", "steps", "merges", "modularity", "membership"),
       match_names = c("weights", "steps", "merges", "modularity", "membership"),
       match_to = c("weights", "steps", "merges", "modularity", "membership"),
-      defaults = list(
-        weights = NULL,
-        steps = 4,
-        merges = TRUE,
-        modularity = TRUE,
-        membership = TRUE
-      ),
       head_args = c("graph"),
       fn_name = "cluster_walktrap"
     )
@@ -2199,14 +2177,14 @@ cluster_edge_betweenness <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        weights = weights,
-        directed = directed,
-        edge.betweenness = edge.betweenness,
-        merges = merges,
-        bridges = bridges,
-        modularity = modularity,
-        membership = membership
+      supplied = c(
+        weights = !missing(weights),
+        directed = !missing(directed),
+        edge.betweenness = !missing(edge.betweenness),
+        merges = !missing(merges),
+        bridges = !missing(bridges),
+        modularity = !missing(modularity),
+        membership = !missing(membership)
       ),
       recover_new = c(
         "weights",
@@ -2243,15 +2221,6 @@ cluster_edge_betweenness <- function(
         "bridges",
         "modularity",
         "membership"
-      ),
-      defaults = list(
-        weights = NULL,
-        directed = TRUE,
-        edge.betweenness = TRUE,
-        merges = TRUE,
-        bridges = TRUE,
-        modularity = TRUE,
-        membership = TRUE
       ),
       head_args = c("graph"),
       fn_name = "cluster_edge_betweenness"
@@ -2363,22 +2332,16 @@ cluster_fast_greedy <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        merges = merges,
-        modularity = modularity,
-        membership = membership,
-        weights = weights
+      supplied = c(
+        merges = !missing(merges),
+        modularity = !missing(modularity),
+        membership = !missing(membership),
+        weights = !missing(weights)
       ),
       recover_new = c("merges", "modularity", "membership", "weights"),
       recover_old = c("merges", "modularity", "membership", "weights"),
       match_names = c("merges", "modularity", "membership", "weights"),
       match_to = c("merges", "modularity", "membership", "weights"),
-      defaults = list(
-        merges = TRUE,
-        modularity = TRUE,
-        membership = TRUE,
-        weights = NULL
-      ),
       head_args = c("graph"),
       fn_name = "cluster_fast_greedy"
     )
@@ -2820,12 +2783,14 @@ cluster_louvain <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(weights = weights, resolution = resolution),
+      supplied = c(
+        weights = !missing(weights),
+        resolution = !missing(resolution)
+      ),
       recover_new = c("weights", "resolution"),
       recover_old = c("weights", "resolution"),
       match_names = c("weights", "resolution"),
       match_to = c("weights", "resolution"),
-      defaults = list(weights = NULL, resolution = 1),
       head_args = c("graph"),
       fn_name = "cluster_louvain"
     )
@@ -2939,12 +2904,11 @@ cluster_optimal <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(weights = weights),
+      supplied = c(weights = !missing(weights)),
       recover_new = c("weights"),
       recover_old = c("weights"),
       match_names = c("weights"),
       match_to = c("weights"),
-      defaults = list(weights = NULL),
       head_args = c("graph"),
       fn_name = "cluster_optimal"
     )
@@ -3048,22 +3012,16 @@ cluster_infomap <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        e.weights = e.weights,
-        v.weights = v.weights,
-        nb.trials = nb.trials,
-        modularity = modularity
+      supplied = c(
+        e.weights = !missing(e.weights),
+        v.weights = !missing(v.weights),
+        nb.trials = !missing(nb.trials),
+        modularity = !missing(modularity)
       ),
       recover_new = c("e.weights", "v.weights", "nb.trials", "modularity"),
       recover_old = c("e.weights", "v.weights", "nb.trials", "modularity"),
       match_names = c("e.weights", "v.weights", "nb.trials", "modularity"),
       match_to = c("e.weights", "v.weights", "nb.trials", "modularity"),
-      defaults = list(
-        e.weights = NULL,
-        v.weights = NULL,
-        nb.trials = 10,
-        modularity = TRUE
-      ),
       head_args = c("graph"),
       fn_name = "cluster_infomap"
     )

--- a/R/components.R
+++ b/R/components.R
@@ -208,20 +208,15 @@ decompose <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        mode = mode,
-        max.comps = max.comps,
-        min.vertices = min.vertices
+      supplied = c(
+        mode = !missing(mode),
+        max.comps = !missing(max.comps),
+        min.vertices = !missing(min.vertices)
       ),
       recover_new = c("mode", "max.comps", "min.vertices"),
       recover_old = c("mode", "max.comps", "min.vertices"),
       match_names = c("mode", "max.comps", "min.vertices"),
       match_to = c("mode", "max.comps", "min.vertices"),
-      defaults = list(
-        mode = c("weak", "strong"),
-        max.comps = NA,
-        min.vertices = 0
-      ),
       head_args = c("graph"),
       fn_name = "decompose"
     )
@@ -437,12 +432,11 @@ largest_component <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode),
+      supplied = c(mode = !missing(mode)),
       recover_new = c("mode"),
       recover_old = c("mode"),
       match_names = c("mode"),
       match_to = c("mode"),
-      defaults = list(mode = c("weak", "strong")),
       head_args = c("graph"),
       fn_name = "largest_component"
     )

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -454,24 +454,17 @@ as_adjacency_matrix <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        weights = weights,
-        names = names,
-        sparse = sparse,
-        edges = edges,
-        attr = attr
+      supplied = c(
+        weights = !missing(weights),
+        names = !missing(names),
+        sparse = !missing(sparse),
+        edges = !missing(edges),
+        attr = !missing(attr)
       ),
       recover_new = c("weights", "edges", "names", "sparse"),
       recover_old = c("attr", "edges", "names", "sparse"),
       match_names = c("attr", "weights", "names", "sparse", "edges", "attr"),
       match_to = c("weights", "weights", "names", "sparse", "edges", "attr"),
-      defaults = list(
-        weights = NULL,
-        names = TRUE,
-        sparse = igraph_opt("sparsematrices"),
-        edges = deprecated(),
-        attr = deprecated()
-      ),
       head_args = c("graph", "type"),
       fn_name = "as_adjacency_matrix"
     )
@@ -1187,22 +1180,16 @@ as_biadjacency_matrix <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        weights = weights,
-        names = names,
-        sparse = sparse,
-        attr = attr
+      supplied = c(
+        weights = !missing(weights),
+        names = !missing(names),
+        sparse = !missing(sparse),
+        attr = !missing(attr)
       ),
       recover_new = c("weights", "names", "sparse"),
       recover_old = c("attr", "names", "sparse"),
       match_names = c("attr", "weights", "names", "sparse", "attr"),
       match_to = c("weights", "weights", "names", "sparse", "attr"),
-      defaults = list(
-        weights = NULL,
-        names = TRUE,
-        sparse = FALSE,
-        attr = deprecated()
-      ),
       head_args = c("graph", "types"),
       fn_name = "as_biadjacency_matrix"
     )

--- a/R/games.R
+++ b/R/games.R
@@ -2148,12 +2148,11 @@ connect <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode),
+      supplied = c(mode = !missing(mode)),
       recover_new = c("mode"),
       recover_old = c("mode"),
       match_names = c("mode"),
       match_to = c("mode"),
-      defaults = list(mode = c("all", "out", "in", "total")),
       head_args = c("graph", "order"),
       fn_name = "connect"
     )

--- a/R/migrate-args.R
+++ b/R/migrate-args.R
@@ -10,16 +10,22 @@
 # itself -- the caller assigns the values into its own frame and calls
 # `lifecycle::deprecate_soft()` inline, so the warning is attributed correctly
 # without any caller-env plumbing.
+#
+# `supplied` is a named logical built from `missing()` in the host frame: it
+# marks the tail formals the caller passed explicitly, so a value recovered
+# from `...` for the same formal is a hard conflict. missing() never forces a
+# promise, so tail defaults are not evaluated here -- defaults that reference
+# other (possibly recovered) arguments, allocate environments, or draw random
+# numbers stay untouched until the function body first uses them.
 
 #' @noRd
 migrate_recover_args <- function(
   dots,
-  current,
+  supplied,
   recover_new,
   recover_old,
   match_names,
   match_to,
-  defaults,
   head_args,
   fn_name,
   call = rlang::caller_env()
@@ -69,10 +75,7 @@ migrate_recover_args <- function(
     }
 
     duplicated <- new_name %in% rebound_new
-    has_default <- new_name %in% names(defaults)
-    reassigned <- has_default &&
-      !identical(current[[new_name]], defaults[[new_name]])
-    if (duplicated || reassigned) {
+    if (duplicated || isTRUE(supplied[[new_name]])) {
       cli::cli_abort(
         c(
           "Argument {.arg {new_name}} of {.fn {fn_name}} was supplied more than once.",

--- a/R/migration-fixture.R
+++ b/R/migration-fixture.R
@@ -21,12 +21,15 @@ migration_fixture <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(weights = weights, type = type, directed = directed),
+      supplied = c(
+        weights = !missing(weights),
+        type = !missing(type),
+        directed = !missing(directed)
+      ),
       recover_new = c("weights", "type", "directed"),
       recover_old = c("weight", "kind", "directed"),
       match_names = c("weight", "kind", "weights", "type", "directed"),
       match_to = c("weights", "type", "weights", "type", "directed"),
-      defaults = list(weights = NULL, type = "out", directed = FALSE),
       head_args = c("graph", "n"),
       fn_name = "migration_fixture"
     )
@@ -46,4 +49,52 @@ migration_fixture <- function(
     type = type,
     directed = directed
   )
+}
+
+# Second fixture: locks in that recovery never forces tail promises. Its tail
+# defaults are exactly the hazardous kinds -- `breaks` references another tail
+# arg, `anchor` allocates a fresh environment on every evaluation (never
+# identical() across evaluations), and `noise` draws from the RNG. The old
+# value-comparison supplied-check forced all three, which froze cross-
+# referencing defaults at their pre-recovery values, misread irreproducible
+# defaults as user-supplied conflicts, and consumed RNG draws. `noise` is
+# deliberately never used in the body, so tests can assert the RNG state
+# stays untouched. See tests/testthat/test-migration-fixture.R.
+
+#' @noRd
+migration_fixture2 <- function(
+  graph,
+  ...,
+  bins = 7,
+  breaks = bins * 2,
+  anchor = new.env(),
+  noise = stats::runif(1)
+) {
+  # BEGIN GENERATED ARG_HANDLE: migration_fixture2, do not edit, see tools/generate-migrations.R
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      supplied = c(
+        bins = !missing(bins),
+        breaks = !missing(breaks),
+        anchor = !missing(anchor),
+        noise = !missing(noise)
+      ),
+      recover_new = c("bins", "breaks", "anchor", "noise"),
+      recover_old = c("bins", "breaks", "anchor", "noise"),
+      match_names = c("bins", "breaks", "anchor", "noise"),
+      match_to = c("bins", "breaks", "anchor", "noise"),
+      head_args = c("graph"),
+      fn_name = "migration_fixture2"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
+  list(graph = graph, bins = bins, breaks = breaks, anchor = anchor)
 }

--- a/R/paths.R
+++ b/R/paths.R
@@ -119,12 +119,11 @@ all_simple_paths <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode, cutoff = cutoff),
+      supplied = c(mode = !missing(mode), cutoff = !missing(cutoff)),
       recover_new = c("mode", "cutoff"),
       recover_old = c("mode", "cutoff"),
       match_names = c("mode", "cutoff"),
       match_to = c("mode", "cutoff"),
-      defaults = list(mode = c("out", "in", "all", "total"), cutoff = -1),
       head_args = c("graph", "from", "to"),
       fn_name = "all_simple_paths"
     )
@@ -444,12 +443,11 @@ distance_table <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(directed = directed),
+      supplied = c(directed = !missing(directed)),
       recover_new = c("directed"),
       recover_old = c("directed"),
       match_names = c("directed"),
       match_to = c("directed"),
-      defaults = list(directed = TRUE),
       head_args = c("graph"),
       fn_name = "distance_table"
     )

--- a/R/structural-properties.R
+++ b/R/structural-properties.R
@@ -762,16 +762,15 @@ diameter <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        directed = directed,
-        unconnected = unconnected,
-        weights = weights
+      supplied = c(
+        directed = !missing(directed),
+        unconnected = !missing(unconnected),
+        weights = !missing(weights)
       ),
       recover_new = c("directed", "unconnected", "weights"),
       recover_old = c("directed", "unconnected", "weights"),
       match_names = c("directed", "unconnected", "weights"),
       match_to = c("directed", "unconnected", "weights"),
-      defaults = list(directed = TRUE, unconnected = TRUE, weights = NULL),
       head_args = c("graph"),
       fn_name = "diameter"
     )
@@ -819,16 +818,15 @@ get_diameter <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        directed = directed,
-        unconnected = unconnected,
-        weights = weights
+      supplied = c(
+        directed = !missing(directed),
+        unconnected = !missing(unconnected),
+        weights = !missing(weights)
       ),
       recover_new = c("directed", "unconnected", "weights"),
       recover_old = c("directed", "unconnected", "weights"),
       match_names = c("directed", "unconnected", "weights"),
       match_to = c("directed", "unconnected", "weights"),
-      defaults = list(directed = TRUE, unconnected = TRUE, weights = NULL),
       head_args = c("graph"),
       fn_name = "get_diameter"
     )
@@ -883,16 +881,15 @@ farthest_vertices <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        directed = directed,
-        unconnected = unconnected,
-        weights = weights
+      supplied = c(
+        directed = !missing(directed),
+        unconnected = !missing(unconnected),
+        weights = !missing(weights)
       ),
       recover_new = c("directed", "unconnected", "weights"),
       recover_old = c("directed", "unconnected", "weights"),
       match_names = c("directed", "unconnected", "weights"),
       match_to = c("directed", "unconnected", "weights"),
-      defaults = list(directed = TRUE, unconnected = TRUE, weights = NULL),
       head_args = c("graph"),
       fn_name = "farthest_vertices"
     )
@@ -948,22 +945,16 @@ mean_distance <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        weights = weights,
-        directed = directed,
-        unconnected = unconnected,
-        details = details
+      supplied = c(
+        weights = !missing(weights),
+        directed = !missing(directed),
+        unconnected = !missing(unconnected),
+        details = !missing(details)
       ),
       recover_new = c("weights", "directed", "unconnected", "details"),
       recover_old = c("weights", "directed", "unconnected", "details"),
       match_names = c("weights", "directed", "unconnected", "details"),
       match_to = c("weights", "directed", "unconnected", "details"),
-      defaults = list(
-        weights = NULL,
-        directed = TRUE,
-        unconnected = TRUE,
-        details = FALSE
-      ),
       head_args = c("graph"),
       fn_name = "mean_distance"
     )
@@ -1040,16 +1031,15 @@ degree <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode, loops = loops, normalized = normalized),
+      supplied = c(
+        mode = !missing(mode),
+        loops = !missing(loops),
+        normalized = !missing(normalized)
+      ),
       recover_new = c("mode", "loops", "normalized"),
       recover_old = c("mode", "loops", "normalized"),
       match_names = c("mode", "loops", "normalized"),
       match_to = c("mode", "loops", "normalized"),
-      defaults = list(
-        mode = c("all", "out", "in", "total"),
-        loops = TRUE,
-        normalized = FALSE
-      ),
       head_args = c("graph", "v"),
       fn_name = "degree"
     )
@@ -1111,12 +1101,11 @@ mean_degree <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(loops = loops),
+      supplied = c(loops = !missing(loops)),
       recover_new = c("loops"),
       recover_old = c("loops"),
       match_names = c("loops"),
       match_to = c("loops"),
-      defaults = list(loops = TRUE),
       head_args = c("graph"),
       fn_name = "mean_degree"
     )
@@ -1378,16 +1367,15 @@ distances <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode, weights = weights, algorithm = algorithm),
+      supplied = c(
+        mode = !missing(mode),
+        weights = !missing(weights),
+        algorithm = !missing(algorithm)
+      ),
       recover_new = c("mode", "weights", "algorithm"),
       recover_old = c("mode", "weights", "algorithm"),
       match_names = c("mode", "weights", "algorithm"),
       match_to = c("mode", "weights", "algorithm"),
-      defaults = list(
-        mode = c("all", "out", "in"),
-        weights = NULL,
-        algorithm = c("automatic", "unweighted", "dijkstra", "bellman-ford", "johnson", "floyd-warshall")
-      ),
       head_args = c("graph", "v", "to"),
       fn_name = "distances"
     )
@@ -1499,13 +1487,13 @@ shortest_paths <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        mode = mode,
-        weights = weights,
-        output = output,
-        predecessors = predecessors,
-        inbound.edges = inbound.edges,
-        algorithm = algorithm
+      supplied = c(
+        mode = !missing(mode),
+        weights = !missing(weights),
+        output = !missing(output),
+        predecessors = !missing(predecessors),
+        inbound.edges = !missing(inbound.edges),
+        algorithm = !missing(algorithm)
       ),
       recover_new = c(
         "mode",
@@ -1538,14 +1526,6 @@ shortest_paths <- function(
         "predecessors",
         "inbound.edges",
         "algorithm"
-      ),
-      defaults = list(
-        mode = c("out", "all", "in"),
-        weights = NULL,
-        output = c("vpath", "epath", "both"),
-        predecessors = FALSE,
-        inbound.edges = FALSE,
-        algorithm = c("automatic", "unweighted", "dijkstra", "bellman-ford")
       ),
       head_args = c("graph", "from", "to"),
       fn_name = "shortest_paths"
@@ -1670,12 +1650,11 @@ all_shortest_paths <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode, weights = weights),
+      supplied = c(mode = !missing(mode), weights = !missing(weights)),
       recover_new = c("mode", "weights"),
       recover_old = c("mode", "weights"),
       match_names = c("mode", "weights"),
       match_to = c("mode", "weights"),
-      defaults = list(mode = c("out", "all", "in"), weights = NULL),
       head_args = c("graph", "from", "to"),
       fn_name = "all_shortest_paths"
     )
@@ -1818,12 +1797,11 @@ subcomponent <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode),
+      supplied = c(mode = !missing(mode)),
       recover_new = c("mode"),
       recover_old = c("mode"),
       match_names = c("mode"),
       match_to = c("mode"),
-      defaults = list(mode = c("all", "out", "in")),
       head_args = c("graph", "v"),
       fn_name = "subcomponent"
     )
@@ -1914,14 +1892,11 @@ induced_subgraph <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(impl = impl),
+      supplied = c(impl = !missing(impl)),
       recover_new = c("impl"),
       recover_old = c("impl"),
       match_names = c("impl"),
       match_to = c("impl"),
-      defaults = list(
-        impl = c("auto", "copy_and_delete", "create_from_scratch")
-      ),
       head_args = c("graph", "vids"),
       fn_name = "induced_subgraph"
     )
@@ -1965,12 +1940,11 @@ subgraph_from_edges <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(delete.vertices = delete.vertices),
+      supplied = c(delete.vertices = !missing(delete.vertices)),
       recover_new = c("delete.vertices"),
       recover_old = c("delete.vertices"),
       match_names = c("delete.vertices"),
       match_to = c("delete.vertices"),
-      defaults = list(delete.vertices = TRUE),
       head_args = c("graph", "eids"),
       fn_name = "subgraph_from_edges"
     )
@@ -2161,12 +2135,15 @@ transitivity <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(vids = vids, weights = weights, isolates = isolates),
+      supplied = c(
+        vids = !missing(vids),
+        weights = !missing(weights),
+        isolates = !missing(isolates)
+      ),
       recover_new = c("vids", "weights", "isolates"),
       recover_old = c("vids", "weights", "isolates"),
       match_names = c("vids", "weights", "isolates"),
       match_to = c("vids", "weights", "isolates"),
-      defaults = list(vids = NULL, weights = NULL, isolates = c("NaN", "zero")),
       head_args = c("graph", "type"),
       fn_name = "transitivity"
     )
@@ -2336,12 +2313,11 @@ constraint <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(weights = weights),
+      supplied = c(weights = !missing(weights)),
       recover_new = c("weights"),
       recover_old = c("weights"),
       match_names = c("weights"),
       match_to = c("weights"),
-      defaults = list(weights = NULL),
       head_args = c("graph", "nodes"),
       fn_name = "constraint"
     )
@@ -2419,12 +2395,14 @@ reciprocity <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(ignore.loops = ignore.loops, mode = mode),
+      supplied = c(
+        ignore.loops = !missing(ignore.loops),
+        mode = !missing(mode)
+      ),
       recover_new = c("ignore.loops", "mode"),
       recover_old = c("ignore.loops", "mode"),
       match_names = c("ignore.loops", "mode"),
       match_to = c("ignore.loops", "mode"),
-      defaults = list(ignore.loops = TRUE, mode = c("default", "ratio")),
       head_args = c("graph"),
       fn_name = "reciprocity"
     )
@@ -2492,12 +2470,11 @@ edge_density <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(loops = loops),
+      supplied = c(loops = !missing(loops)),
       recover_new = c("loops"),
       recover_old = c("loops"),
       match_names = c("loops"),
       match_to = c("loops"),
-      defaults = list(loops = FALSE),
       head_args = c("graph"),
       fn_name = "edge_density"
     )
@@ -2531,12 +2508,11 @@ ego_size <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode, mindist = mindist),
+      supplied = c(mode = !missing(mode), mindist = !missing(mindist)),
       recover_new = c("mode", "mindist"),
       recover_old = c("mode", "mindist"),
       match_names = c("mode", "mindist"),
       match_to = c("mode", "mindist"),
-      defaults = list(mode = c("all", "out", "in"), mindist = 0),
       head_args = c("graph", "order", "nodes"),
       fn_name = "ego_size"
     )
@@ -2669,12 +2645,11 @@ ego <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode, mindist = mindist),
+      supplied = c(mode = !missing(mode), mindist = !missing(mindist)),
       recover_new = c("mode", "mindist"),
       recover_old = c("mode", "mindist"),
       match_names = c("mode", "mindist"),
       match_to = c("mode", "mindist"),
-      defaults = list(mode = c("all", "out", "in"), mindist = 0),
       head_args = c("graph", "order", "nodes"),
       fn_name = "ego"
     )
@@ -2728,12 +2703,11 @@ make_ego_graph <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode, mindist = mindist),
+      supplied = c(mode = !missing(mode), mindist = !missing(mindist)),
       recover_new = c("mode", "mindist"),
       recover_old = c("mode", "mindist"),
       match_names = c("mode", "mindist"),
       match_to = c("mode", "mindist"),
-      defaults = list(mode = c("all", "out", "in"), mindist = 0),
       head_args = c("graph", "order", "nodes"),
       fn_name = "make_ego_graph"
     )
@@ -2812,12 +2786,11 @@ coreness <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode),
+      supplied = c(mode = !missing(mode)),
       recover_new = c("mode"),
       recover_old = c("mode"),
       match_names = c("mode"),
       match_to = c("mode"),
-      defaults = list(mode = c("all", "out", "in")),
       head_args = c("graph"),
       fn_name = "coreness"
     )
@@ -2882,12 +2855,11 @@ topo_sort <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode),
+      supplied = c(mode = !missing(mode)),
       recover_new = c("mode"),
       recover_old = c("mode"),
       match_names = c("mode"),
       match_to = c("mode"),
-      defaults = list(mode = c("out", "all", "in")),
       head_args = c("graph"),
       fn_name = "topo_sort"
     )
@@ -2957,12 +2929,11 @@ feedback_arc_set <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(weights = weights, algo = algo),
+      supplied = c(weights = !missing(weights), algo = !missing(algo)),
       recover_new = c("weights", "algo"),
       recover_old = c("weights", "algo"),
       match_names = c("weights", "algo"),
       match_to = c("weights", "algo"),
-      defaults = list(weights = NULL, algo = c("approx_eades", "exact_ip")),
       head_args = c("graph"),
       fn_name = "feedback_arc_set"
     )
@@ -3021,12 +2992,11 @@ feedback_vertex_set <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(weights = weights, algo = algo),
+      supplied = c(weights = !missing(weights), algo = !missing(algo)),
       recover_new = c("weights", "algo"),
       recover_old = c("weights", "algo"),
       match_names = c("weights", "algo"),
       match_to = c("weights", "algo"),
-      defaults = list(weights = NULL, algo = c("exact_ip")),
       head_args = c("graph"),
       fn_name = "feedback_vertex_set"
     )
@@ -3103,12 +3073,11 @@ girth <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(circle = circle),
+      supplied = c(circle = !missing(circle)),
       recover_new = c("circle"),
       recover_old = c("circle"),
       match_names = c("circle"),
       match_to = c("circle"),
-      defaults = list(circle = TRUE),
       head_args = c("graph"),
       fn_name = "girth"
     )
@@ -3841,12 +3810,11 @@ components <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode),
+      supplied = c(mode = !missing(mode)),
       recover_new = c("mode"),
       recover_old = c("mode"),
       match_names = c("mode"),
       match_to = c("mode"),
-      defaults = list(mode = c("weak", "strong")),
       head_args = c("graph"),
       fn_name = "components"
     )
@@ -3889,12 +3857,11 @@ is_connected <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode),
+      supplied = c(mode = !missing(mode)),
       recover_new = c("mode"),
       recover_old = c("mode"),
       match_names = c("mode"),
       match_to = c("mode"),
-      defaults = list(mode = c("weak", "strong")),
       head_args = c("graph"),
       fn_name = "is_connected"
     )
@@ -3925,12 +3892,11 @@ count_components <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode),
+      supplied = c(mode = !missing(mode)),
       recover_new = c("mode"),
       recover_old = c("mode"),
       match_names = c("mode"),
       match_to = c("mode"),
-      defaults = list(mode = c("weak", "strong")),
       head_args = c("graph"),
       fn_name = "count_components"
     )
@@ -4004,12 +3970,11 @@ count_reachable <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode),
+      supplied = c(mode = !missing(mode)),
       recover_new = c("mode"),
       recover_old = c("mode"),
       match_names = c("mode"),
       match_to = c("mode"),
-      defaults = list(mode = c("out", "in", "all", "total")),
       head_args = c("graph"),
       fn_name = "count_reachable"
     )
@@ -4078,12 +4043,11 @@ unfold_tree <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(mode = mode),
+      supplied = c(mode = !missing(mode), roots = !missing(roots)),
       recover_new = c("mode", "roots"),
       recover_old = c("mode", "roots"),
       match_names = c("mode", "roots"),
       match_to = c("mode", "roots"),
-      defaults = list(mode = c("all", "out", "in", "total")),
       head_args = c("graph"),
       fn_name = "unfold_tree"
     )
@@ -4370,12 +4334,11 @@ max_bipartite_match <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(weights = weights, eps = eps),
+      supplied = c(weights = !missing(weights), eps = !missing(eps)),
       recover_new = c("weights", "eps"),
       recover_old = c("weights", "eps"),
       match_names = c("weights", "eps"),
       match_to = c("weights", "eps"),
-      defaults = list(weights = NULL, eps = .Machine$double.eps),
       head_args = c("graph", "types"),
       fn_name = "max_bipartite_match"
     )
@@ -4446,12 +4409,11 @@ which_mutual <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(loops = loops),
+      supplied = c(loops = !missing(loops)),
       recover_new = c("loops"),
       recover_old = c("loops"),
       match_names = c("loops"),
       match_to = c("loops"),
-      defaults = list(loops = TRUE),
       head_args = c("graph", "eids"),
       fn_name = "which_mutual"
     )
@@ -4559,20 +4521,15 @@ knn <- function(
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
-      current = list(
-        mode = mode,
-        neighbor.degree.mode = neighbor.degree.mode,
-        weights = weights
+      supplied = c(
+        mode = !missing(mode),
+        neighbor.degree.mode = !missing(neighbor.degree.mode),
+        weights = !missing(weights)
       ),
       recover_new = c("mode", "neighbor.degree.mode", "weights"),
       recover_old = c("mode", "neighbor.degree.mode", "weights"),
       match_names = c("mode", "neighbor.degree.mode", "weights"),
       match_to = c("mode", "neighbor.degree.mode", "weights"),
-      defaults = list(
-        mode = c("all", "out", "in", "total"),
-        neighbor.degree.mode = c("all", "out", "in", "total"),
-        weights = NULL
-      ),
       head_args = c("graph", "vids"),
       fn_name = "knn"
     )

--- a/tests/testthat/helper-test-functions.R
+++ b/tests/testthat/helper-test-functions.R
@@ -160,16 +160,15 @@ graphlets.project.old <- function(graph, cliques, iter, Mu = NULL) {
 # Config equivalent to the fixture, for exercising the helper directly.
 fixture_args <- function(
   dots,
-  current = list(weights = NULL, type = "out", directed = FALSE)
+  supplied = c(weights = FALSE, type = FALSE, directed = FALSE)
 ) {
   migrate_recover_args(
     dots,
-    current = current,
+    supplied = supplied,
     recover_new = c("weights", "type", "directed"),
     recover_old = c("weight", "kind", "directed"),
     match_names = c("weight", "kind", "weights", "type", "directed"),
     match_to = c("weights", "type", "weights", "type", "directed"),
-    defaults = list(weights = NULL, type = "out", directed = FALSE),
     head_args = c("graph", "n"),
     fn_name = "migration_fixture"
   )

--- a/tests/testthat/test-migration-fixture.R
+++ b/tests/testthat/test-migration-fixture.R
@@ -142,7 +142,7 @@ test_that("migrate_recover_args() errors on unknown, ambiguous, conflict, overfl
   expect_error(
     fixture_args(
       list(1:3),
-      current = list(weights = 9, type = "out", directed = FALSE)
+      supplied = c(weights = TRUE, type = FALSE, directed = FALSE)
     ),
     "supplied more than once"
   )
@@ -281,4 +281,41 @@ test_that("render_call_arg() wraps long arguments the way air formats them", {
     paste0("      ", items, c(",", ",", ",", ",", ""))
   )
   expect_true(all(nchar(wrapped) + 2L <= 80L))
+})
+
+# ---- fixture2: recovery must never force tail promises ----------------------
+
+test_that("a tail default referencing another tail arg sees the recovered value", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  lifecycle::expect_deprecated(res <- migration_fixture2("g", 3))
+  expect_identical(res$bins, 3)
+  # breaks = bins * 2 must evaluate against the *recovered* bins, not the
+  # default it had before recovery
+  expect_identical(res$breaks, 6)
+})
+
+test_that("recovering an arg with an irreproducible default is not a conflict", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  e <- new.env()
+  # anchor = new.env() evaluates to a fresh environment on every call; the
+  # old value-comparison check misread that as "supplied more than once"
+  lifecycle::expect_deprecated(res <- migration_fixture2("g", 3, 8, e))
+  expect_identical(res$anchor, e)
+  expect_identical(res$breaks, 8)
+})
+
+test_that("recovery does not consume RNG draws from unused tail defaults", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  set.seed(20260726)
+  before <- .Random.seed
+  lifecycle::expect_deprecated(migration_fixture2("g", 3))
+  expect_identical(.Random.seed, before)
+})
+
+test_that("an explicitly supplied tail arg still conflicts with recovery", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  expect_error(
+    migration_fixture2("g", 3, bins = 5),
+    "supplied more than once"
+  )
 })

--- a/tools/generate-migrations.R
+++ b/tools/generate-migrations.R
@@ -325,7 +325,10 @@ render_call_arg <- function(name, ctor, items, empty, trailing = ",") {
 #
 # Shape: the per-function configuration is passed to `migrate_recover_args()`
 # (a hand-written, debuggable helper) which returns the recovered values plus the
-# deprecation message parts. The host frame then assigns the recovered values
+# deprecation message parts. Supplied-ness of the tail formals is captured with
+# `missing()` in the host frame -- promises are never forced, so tail defaults
+# that reference other arguments or draw random numbers stay untouched. The
+# host frame then assigns the recovered values
 # over its own locals and emits a single `lifecycle::deprecate_soft()`. Because
 # that call sits directly in the host function, its default `user_env`
 # (caller_env(2)) resolves to the user's frame -- no `.user_env` threading needed.
@@ -333,23 +336,16 @@ render_call_arg <- function(name, ctor, items, empty, trailing = ",") {
 # The whole thing is guarded by `...length() > 0L` so the common path (a correct
 # new-API call with nothing in `...`) skips the helper call entirely.
 render_arg_handle <- function(entry) {
-  keep <- intersect(entry$tail, names(entry$defaults))
-  default_items <- vapply(
-    keep,
-    function(nm) paste0(nm, " = ", entry$defaults[[nm]]),
-    character(1),
-    USE.NAMES = FALSE
-  )
+  supplied_items <- paste0(entry$tail, " = !missing(", entry$tail, ")")
   c(
     "if (...length() > 0L) {",
     "  .arg_handle <- migrate_recover_args(",
     "    list(...),",
-    render_call_arg("current", "list", paste0(keep, " = ", keep), "list()"),
+    render_call_arg("supplied", "c", supplied_items, "logical(0)"),
     render_call_arg("recover_new", "c", quote_items(entry$recover_new), "character(0)"),
     render_call_arg("recover_old", "c", quote_items(entry$recover_old), "character(0)"),
     render_call_arg("match_names", "c", quote_items(entry$match_names), "character(0)"),
     render_call_arg("match_to", "c", quote_items(entry$match_to), "character(0)"),
-    render_call_arg("defaults", "list", default_items, "list()"),
     render_call_arg("head_args", "c", quote_items(entry$head), "character(0)"),
     paste0("    fn_name = \"", entry$fn, "\""),
     "  )",

--- a/tools/migrations/fixture.R
+++ b/tools/migrations/fixture.R
@@ -21,5 +21,20 @@ migrations <- list(
       directed = FALSE
     ) {},
     when = "3.0.0"
+  ),
+
+  # Second fixture: hazardous tail defaults (cross-reference, fresh
+  # environment, RNG draw) -- recovery must not force any of them.
+  migration_fixture2 = list(
+    old = function(graph, bins, breaks, anchor, noise) {},
+    new = function(
+      graph,
+      ...,
+      bins = 7,
+      breaks = bins * 2,
+      anchor = new.env(),
+      noise = stats::runif(1)
+    ) {},
+    when = "3.0.0"
   )
 )


### PR DESCRIPTION
The argument-coverage test sweep surfaced a real defect class in the
recovery machinery — found independently twice (games and layout agents),
and one instance is live on `main`.

## The bug

The generated ARG_HANDLE blocks passed `current = list(<tail args>)` plus a
re-evaluated `defaults` list into `migrate_recover_args()`, which detected
"argument supplied twice" by comparing values. That **forces every tail
promise before recovery** and **re-evaluates defaults**, which breaks three
ways:

1. **Cross-referencing defaults freeze.** `sample_last_cit()`'s
   `pref = (1:(agebins + 1))^-3` memoizes against the pre-recovery `agebins`,
   so the legacy positional call `sample_last_cit(20, 2, 5)` errors
   (on the open games PR).
2. **Irreproducible defaults are misread as conflicts.** Defaults like
   `V(graph)[1]`, `matrix(runif(...))` are never `identical()` across
   evaluations, so recovering such a slot errors "supplied more than once" —
   `diversity(g, w, vids)` is affected **on `main` today**, and
   `layout_as_star(g, 3)` on the layout PR.
3. **RNG state is consumed** during recovery when a default draws random
   numbers (`layout_with_drl`'s `seed`), making seeded reproduction
   impossible.

## The fix

Capture supplied-ness in the host frame with `missing()` —
`supplied = c(weights = !missing(weights), …)` — and pass that to the
helper. `missing()` never forces a promise, so tail defaults are not touched
until the function body first uses them; the value comparison (and the
`defaults` re-evaluation) disappears entirely. The generated blocks shrink
accordingly (−99 lines across the 66 blocks on `main`, all regenerated
here).

A second migration fixture with exactly the hazardous default kinds —
cross-reference (`breaks = bins * 2`), fresh environment (`new.env()`), and
RNG draw (`runif(1)`) — locks in all three behaviors, including that the
RNG state stays untouched by recovery.

## Validation

- `filter = "migration|generate-migrations"`: FAIL 0 | PASS 73
  (all existing recovery/error/snapshot semantics unchanged).
- Legacy `diversity(g, weights, vids)` now recovers with the single soft
  deprecation instead of erroring.
- Generator remains idempotent (re-run produces no diff).

## Follow-up once merged

The open topic PRs carry blocks generated by the previous generator; their
own CI stays green (the drift check runs each branch's committed generator),
but after this merges I will regenerate and push each open topic branch so
the whole tree converges on the `missing()`-based blocks.

---
_Generated by [Claude Code](https://claude.ai/code/session_016M32izVHZPfxAqemAe4BrX)_