### PR TITLE
feat(migrations): allow head/recoverable prefix overlaps, guarded at run time

### DIFF
--- a/R/community.R
+++ b/R/community.R
@@ -779,6 +779,11 @@ make_clusters <- function(
   modularity = TRUE
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_clusters, do not edit, see tools/generate-migrations.R
+  migrate_check_call_tags(
+    sys.call(),
+    c("m", "me"),
+    "make_clusters"
+  )
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),
@@ -1549,6 +1554,11 @@ cluster_spinglass <- function(
   gamma.minus = 1.0
 ) {
   # BEGIN GENERATED ARG_HANDLE: cluster_spinglass, do not edit, see tools/generate-migrations.R
+  migrate_check_call_tags(
+    sys.call(),
+    c("g"),
+    "cluster_spinglass"
+  )
   if (...length() > 0L) {
     .arg_handle <- migrate_recover_args(
       list(...),

--- a/R/community.R
+++ b/R/community.R
@@ -779,12 +779,12 @@ make_clusters <- function(
   modularity = TRUE
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_clusters, do not edit, see tools/generate-migrations.R
-  migrate_check_call_tags(
-    sys.call(),
-    c("m", "me"),
-    "make_clusters"
-  )
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("m", "me"),
+      "make_clusters"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(
@@ -1554,12 +1554,12 @@ cluster_spinglass <- function(
   gamma.minus = 1.0
 ) {
   # BEGIN GENERATED ARG_HANDLE: cluster_spinglass, do not edit, see tools/generate-migrations.R
-  migrate_check_call_tags(
-    sys.call(),
-    c("g"),
-    "cluster_spinglass"
-  )
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("g"),
+      "cluster_spinglass"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(

--- a/R/migrate-args.R
+++ b/R/migrate-args.R
@@ -115,19 +115,26 @@ migrate_recover_args <- function(
 
 # Runtime guard for head/recoverable prefix overlaps. A supplied tag that is
 # a strict prefix of a head arg *and* of a recoverable name was ambiguous --
-# an error -- under the old signature, but base R partial matching would now
-# silently bind it to the head arg before the recovery layer can see it. The
-# generator enumerates those tags per function (`ambiguous_tags`) and the
-# ARG_HANDLE block calls this first, restoring the old error.
+# an error -- under the old signature; base R partial matching now binds it
+# to the head arg before the recovery layer can see it. On its own that is
+# accepted: previously broken code that now works in a well-defined, silent
+# way is not a problem. What must not happen is that same tag combined with
+# legacy arguments in `...`: the tag steals the head slot, positionals shift
+# into the wrong formals, and the recovery layer would rescue a never-valid
+# call behind a soft-deprecation warning. The generator enumerates those
+# tags per function (`forbidden_tags`) and the ARG_HANDLE block calls this
+# as the first statement inside its recovery gate -- i.e. only ever when
+# `...` is non-empty and recovery is about to engage -- so exactly that
+# combination is rejected.
 
 #' @noRd
 migrate_check_call_tags <- function(
   call,
-  tags,
+  forbidden,
   fn_name,
   env = rlang::caller_env()
 ) {
-  bad <- intersect(names(call), tags)
+  bad <- intersect(names(call), forbidden)
   if (length(bad) == 0L) {
     return(invisible(NULL))
   }

--- a/R/migrate-args.R
+++ b/R/migrate-args.R
@@ -112,3 +112,30 @@ migrate_recover_args <- function(
     )
   )
 }
+
+# Runtime guard for head/recoverable prefix overlaps. A supplied tag that is
+# a strict prefix of a head arg *and* of a recoverable name was ambiguous --
+# an error -- under the old signature, but base R partial matching would now
+# silently bind it to the head arg before the recovery layer can see it. The
+# generator enumerates those tags per function (`ambiguous_tags`) and the
+# ARG_HANDLE block calls this first, restoring the old error.
+
+#' @noRd
+migrate_check_call_tags <- function(
+  call,
+  tags,
+  fn_name,
+  env = rlang::caller_env()
+) {
+  bad <- intersect(names(call), tags)
+  if (length(bad) == 0L) {
+    return(invisible(NULL))
+  }
+  cli::cli_abort(
+    c(
+      "Argument {.arg {bad}} matches multiple formal arguments of {.fn {fn_name}}.",
+      i = "Spell out the full argument name."
+    ),
+    call = env
+  )
+}

--- a/R/migration-fixture.R
+++ b/R/migration-fixture.R
@@ -52,8 +52,9 @@ migration_fixture <- function(
 # strict prefix of the head arg `dimvector`, and the head arg `p` is a strict
 # prefix of the recoverable `permutation` -- the two shapes that
 # make_lattice()- and sample_correlated_gnp_pair()-style signatures hit. The
-# generated block gains a migrate_check_call_tags() guard for the tags that
-# were ambiguous under the old signature (`d`, `di`).
+# generated block gains a migrate_check_call_tags() guard that rejects the
+# forbidden prefixes (`d`, `di`) when legacy arguments in `...` engage
+# recovery; with empty dots they bind the head arg via plain partial matching.
 migration_fixture_prefix <- function(
   dimvector,
   p,
@@ -62,12 +63,12 @@ migration_fixture_prefix <- function(
   permutation = NULL
 ) {
   # BEGIN GENERATED ARG_HANDLE: migration_fixture_prefix, do not edit, see tools/generate-migrations.R
-  migrate_check_call_tags(
-    sys.call(),
-    c("d", "di"),
-    "migration_fixture_prefix"
-  )
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("d", "di"),
+      "migration_fixture_prefix"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(dim = dim, permutation = permutation),

--- a/R/migration-fixture.R
+++ b/R/migration-fixture.R
@@ -47,3 +47,51 @@ migration_fixture <- function(
     directed = directed
   )
 }
+
+# Second fixture: head/recoverable prefix overlaps. `dim` (recoverable) is a
+# strict prefix of the head arg `dimvector`, and the head arg `p` is a strict
+# prefix of the recoverable `permutation` -- the two shapes that
+# make_lattice()- and sample_correlated_gnp_pair()-style signatures hit. The
+# generated block gains a migrate_check_call_tags() guard for the tags that
+# were ambiguous under the old signature (`d`, `di`).
+migration_fixture_prefix <- function(
+  dimvector,
+  p,
+  ...,
+  dim = NULL,
+  permutation = NULL
+) {
+  # BEGIN GENERATED ARG_HANDLE: migration_fixture_prefix, do not edit, see tools/generate-migrations.R
+  migrate_check_call_tags(
+    sys.call(),
+    c("d", "di"),
+    "migration_fixture_prefix"
+  )
+  if (...length() > 0L) {
+    .arg_handle <- migrate_recover_args(
+      list(...),
+      current = list(dim = dim, permutation = permutation),
+      recover_new = c("dim", "permutation"),
+      recover_old = c("dim", "permutation"),
+      match_names = c("dim", "permutation"),
+      match_to = c("dim", "permutation"),
+      defaults = list(dim = NULL, permutation = NULL),
+      head_args = c("dimvector", "p"),
+      fn_name = "migration_fixture_prefix"
+    )
+    list2env(.arg_handle$values, environment())
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      what = I(.arg_handle$what),
+      details = .arg_handle$details
+    )
+  }
+  # END GENERATED ARG_HANDLE
+
+  list(
+    dimvector = dimvector,
+    p = p,
+    dim = dim,
+    permutation = permutation
+  )
+}

--- a/tests/testthat/_snaps/migration-fixture.md
+++ b/tests/testthat/_snaps/migration-fixture.md
@@ -50,6 +50,24 @@
       [1] FALSE
       
 
+# tags that were ambiguous under the old signature error again
+
+    Code
+      migration_fixture_prefix(c(2, 2), 0.5, di = 2)
+    Condition
+      Error in `migration_fixture_prefix()`:
+      ! Argument `di` matches multiple formal arguments of `migration_fixture_prefix()`.
+      i Spell out the full argument name.
+
+---
+
+    Code
+      migration_fixture_prefix(d = c(2, 2), p = 0.5)
+    Condition
+      Error in `migration_fixture_prefix()`:
+      ! Argument `d` matches multiple formal arguments of `migration_fixture_prefix()`.
+      i Spell out the full argument name.
+
 # recovery deprecation messages
 
     Code

--- a/tests/testthat/_snaps/migration-fixture.md
+++ b/tests/testthat/_snaps/migration-fixture.md
@@ -50,22 +50,13 @@
       [1] FALSE
       
 
-# tags that were ambiguous under the old signature error again
+# forbidden prefixes error only when legacy arguments engage recovery
 
     Code
       migration_fixture_prefix(c(2, 2), 0.5, di = 2)
     Condition
       Error in `migration_fixture_prefix()`:
       ! Argument `di` matches multiple formal arguments of `migration_fixture_prefix()`.
-      i Spell out the full argument name.
-
----
-
-    Code
-      migration_fixture_prefix(d = c(2, 2), p = 0.5)
-    Condition
-      Error in `migration_fixture_prefix()`:
-      ! Argument `d` matches multiple formal arguments of `migration_fixture_prefix()`.
       i Spell out the full argument name.
 
 # recovery deprecation messages

--- a/tests/testthat/test-migration-fixture.R
+++ b/tests/testthat/test-migration-fixture.R
@@ -93,6 +93,68 @@ test_that("recovery emits a single deprecation warning, not one per slot", {
   expect_length(warnings, 1L)
 })
 
+# ---- prefix-overlap fixture -------------------------------------------------
+
+# migration_fixture_prefix(dimvector, p, ..., dim = NULL, permutation = NULL):
+# `dim` is a strict prefix of the head arg `dimvector`, `p` is a strict prefix
+# of the recoverable `permutation`. Previously the generator rejected such
+# signatures outright; now it allows them and guards the tags that were
+# ambiguity errors under the old signature (`d`, `di`).
+
+test_that("full tail names bind exactly despite the head prefix overlap", {
+  expect_no_condition(
+    res <- migration_fixture_prefix(c(2, 2), 0.5, dim = 2)
+  )
+  expect_equal(
+    res,
+    list(dimvector = c(2, 2), p = 0.5, dim = 2, permutation = NULL)
+  )
+})
+
+test_that("legacy positional calls are recovered across the overlap", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  lifecycle::expect_deprecated(
+    res <- migration_fixture_prefix(c(2, 2), 0.5, 2, "perm")
+  )
+  expect_equal(
+    res,
+    migration_fixture_prefix(c(2, 2), 0.5, dim = 2, permutation = "perm")
+  )
+})
+
+test_that("abbreviations longer than the head arg are recovered", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  # `perm` is no prefix of the head `p`, so it reaches `...` and recovery.
+  lifecycle::expect_deprecated(
+    res <- migration_fixture_prefix(c(2, 2), 0.5, perm = "x")
+  )
+  expect_identical(res$permutation, "x")
+})
+
+test_that("tags that were ambiguous under the old signature error again", {
+  # Base R partial matching would silently bind `di =` to `dimvector`; the
+  # generated guard restores the old ambiguity error.
+  expect_snapshot(
+    migration_fixture_prefix(c(2, 2), 0.5, di = 2),
+    error = TRUE
+  )
+  expect_snapshot(
+    migration_fixture_prefix(d = c(2, 2), p = 0.5),
+    error = TRUE
+  )
+})
+
+test_that("the guard ignores calls without hazardous tags", {
+  # Unnamed / fully named calls never trip the guard, including do.call().
+  expect_no_condition(
+    res <- do.call(migration_fixture_prefix, list(c(2, 2), 0.5))
+  )
+  expect_null(res$dim)
+  expect_no_condition(
+    migration_fixture_prefix(dimvector = c(2, 2), p = 0.5, dim = 1)
+  )
+})
+
 # ---- deprecation message snapshots -----------------------------------------
 
 test_that("recovery deprecation messages", {
@@ -175,51 +237,90 @@ test_that("the generated block is in sync with the registry", {
   expect_identical(spliced$lines, lines)
 })
 
-test_that("normalise_migration() rejects head/recoverable prefix clashes", {
-  # Head args are matched by base R (with partial matching) before `...`, so a
-  # head arg in a prefix relationship with a recoverable name would silently
-  # capture it before the recovery layer runs. The generator must reject this.
+test_that("normalise_migration() handles head/recoverable prefix overlaps", {
+  # Head args are matched by base R (with partial matching) before `...`.
+  # Exact matching protects full names, so prefix overlaps are allowed; the
+  # generator enumerates the tags that were ambiguity errors under the old
+  # signature (strict prefixes of a head arg that also prefix a recoverable
+  # name) for the runtime guard.
   generator <- testthat::test_path("..", "..", "tools", "generate-migrations.R")
   skip_if_not(file.exists(generator))
   gen_env <- new.env()
   sys.source(generator, envir = gen_env)
 
-  # Head arg `type` is a prefix of the recoverable `typeof`.
-  expect_error(
-    gen_env$normalise_migration(
-      "bad_head_prefix",
-      list(
-        old = function(graph, typeof) {},
-        new = function(graph, type = "x", ..., typeof = NULL) {},
-        when = "3.0.0"
-      )
-    ),
-    "prefix relationship"
-  )
-
-  # Recoverable `type` is a prefix of the head arg `typeof`.
-  expect_error(
-    gen_env$normalise_migration(
-      "bad_recover_prefix",
-      list(
-        old = function(graph, type) {},
-        new = function(graph, typeof = "x", ..., type = NULL) {},
-        when = "3.0.0"
-      )
-    ),
-    "prefix relationship"
-  )
-
-  # Merely sharing a leading letter (`graph` vs `groups`) is allowed.
-  expect_no_error(
-    gen_env$normalise_migration(
-      "ok_shared_letter",
-      list(
-        old = function(graph, groups) {},
-        new = function(graph, ..., groups = NULL) {},
-        when = "3.0.0"
-      )
+  # Head arg `type` is a prefix of the recoverable `typeof`: allowed. The
+  # strict prefixes of `type` all prefix `typeof` too, so they are guarded.
+  norm <- gen_env$normalise_migration(
+    "head_prefix",
+    list(
+      old = function(graph, type, typeof) {},
+      new = function(graph, type = "x", ..., typeof = NULL) {},
+      when = "3.0.0"
     )
+  )
+  expect_identical(norm$ambiguous_tags, c("t", "ty", "typ"))
+
+  # Recoverable `type` is a prefix of the head arg `typeof`: allowed. A
+  # supplied `type =` binds the post-`...` formal exactly; only the shorter
+  # tags (which were ambiguous before) are guarded.
+  norm <- gen_env$normalise_migration(
+    "recover_prefix",
+    list(
+      old = function(graph, typeof, type) {},
+      new = function(graph, typeof = "x", ..., type = NULL) {},
+      when = "3.0.0"
+    )
+  )
+  expect_identical(norm$ambiguous_tags, c("t", "ty", "typ"))
+
+  # Sharing a leading letter (`graph` vs `groups`) now guards the shared
+  # prefixes too -- `f(g = )` was an ambiguity error before the migration.
+  norm <- gen_env$normalise_migration(
+    "ok_shared_letter",
+    list(
+      old = function(graph, groups) {},
+      new = function(graph, ..., groups = NULL) {},
+      when = "3.0.0"
+    )
+  )
+  expect_identical(norm$ambiguous_tags, c("g", "gr"))
+
+  # A tag that abbreviates two head args stays out of the guard list: base R
+  # errors on it by itself before the body ever runs.
+  norm <- gen_env$normalise_migration(
+    "two_heads",
+    list(
+      old = function(g1, g2, graph.attr.comb) {},
+      new = function(g1, g2, ..., graph.attr.comb = NULL) {},
+      when = "3.0.0"
+    )
+  )
+  expect_identical(norm$ambiguous_tags, character(0))
+
+  # No overlap at all: no tags, no guard.
+  norm <- gen_env$normalise_migration(
+    "no_overlap",
+    list(
+      old = function(graph, n, weights) {},
+      new = function(graph, n, ..., weights = NULL) {},
+      when = "3.0.0"
+    )
+  )
+  expect_identical(norm$ambiguous_tags, character(0))
+
+  # A renamed-away old name that is a prefix of a head arg stays fatal: the
+  # old name is no longer a formal, so a valid legacy `f(weight = )` would
+  # silently bind the head arg -- no runtime guard can restore it.
+  expect_error(
+    gen_env$normalise_migration(
+      "renamed_prefix",
+      list(
+        old = function(graph, weightx, weight = weights) {},
+        new = function(graph, weightx = 1, ..., weights = NULL) {},
+        when = "3.0.0"
+      )
+    ),
+    "renamed-away"
   )
 })
 

--- a/tests/testthat/test-migration-fixture.R
+++ b/tests/testthat/test-migration-fixture.R
@@ -98,8 +98,9 @@ test_that("recovery emits a single deprecation warning, not one per slot", {
 # migration_fixture_prefix(dimvector, p, ..., dim = NULL, permutation = NULL):
 # `dim` is a strict prefix of the head arg `dimvector`, `p` is a strict prefix
 # of the recoverable `permutation`. Previously the generator rejected such
-# signatures outright; now it allows them and guards the tags that were
-# ambiguity errors under the old signature (`d`, `di`).
+# signatures outright; now it allows them and enumerates the forbidden
+# prefixes (`d`, `di`), which error only when legacy arguments in `...`
+# engage the recovery layer.
 
 test_that("full tail names bind exactly despite the head prefix overlap", {
   expect_no_condition(
@@ -131,16 +132,33 @@ test_that("abbreviations longer than the head arg are recovered", {
   expect_identical(res$permutation, "x")
 })
 
-test_that("tags that were ambiguous under the old signature error again", {
-  # Base R partial matching would silently bind `di =` to `dimvector`; the
-  # generated guard restores the old ambiguity error.
+test_that("forbidden prefixes error only when legacy arguments engage recovery", {
+  # `di =` steals the head slot `dimvector`, `c(2, 2)` shifts into `p`,
+  # and `0.5` lands in `...`:
+  # recovery would rescue this never-valid call behind a deprecation
+  # warning, so the guard errors instead.
   expect_snapshot(
     migration_fixture_prefix(c(2, 2), 0.5, di = 2),
     error = TRUE
   )
-  expect_snapshot(
-    migration_fixture_prefix(d = c(2, 2), p = 0.5),
-    error = TRUE
+  # A named legacy argument in `...` engages recovery just the same.
+  expect_error(
+    migration_fixture_prefix(c(2, 2), 0.5, d = 2, perm = "x"),
+    "matches multiple formal arguments"
+  )
+})
+
+test_that("forbidden prefixes with empty dots bind the head arg silently", {
+  # Previously broken calls that now work in a well-defined, silent way
+  # are accepted:
+  # `d =` was an ambiguity error under the old signature and now binds
+  # `dimvector` via ordinary base R partial matching.
+  # Only the warning-rescued combination -- a forbidden prefix plus legacy
+  # arguments in `...` -- stays an error.
+  expect_no_condition(res <- migration_fixture_prefix(d = c(2, 2), p = 0.5))
+  expect_equal(
+    res,
+    list(dimvector = c(2, 2), p = 0.5, dim = NULL, permutation = NULL)
   )
 })
 
@@ -240,16 +258,17 @@ test_that("the generated block is in sync with the registry", {
 test_that("normalise_migration() handles head/recoverable prefix overlaps", {
   # Head args are matched by base R (with partial matching) before `...`.
   # Exact matching protects full names, so prefix overlaps are allowed; the
-  # generator enumerates the tags that were ambiguity errors under the old
-  # signature (strict prefixes of a head arg that also prefix a recoverable
-  # name) for the runtime guard.
+  # generator enumerates the forbidden prefixes (strict prefixes of a head
+  # arg that also prefix a recoverable name) for the runtime guard, which
+  # rejects them only when legacy arguments in `...` engage recovery.
   generator <- testthat::test_path("..", "..", "tools", "generate-migrations.R")
   skip_if_not(file.exists(generator))
   gen_env <- new.env()
   sys.source(generator, envir = gen_env)
 
   # Head arg `type` is a prefix of the recoverable `typeof`: allowed. The
-  # strict prefixes of `type` all prefix `typeof` too, so they are guarded.
+  # strict prefixes of `type` all prefix `typeof` too, so they are forbidden
+  # in combination with legacy arguments in `...`.
   norm <- gen_env$normalise_migration(
     "head_prefix",
     list(
@@ -258,11 +277,11 @@ test_that("normalise_migration() handles head/recoverable prefix overlaps", {
       when = "3.0.0"
     )
   )
-  expect_identical(norm$ambiguous_tags, c("t", "ty", "typ"))
+  expect_identical(norm$forbidden_tags, c("t", "ty", "typ"))
 
   # Recoverable `type` is a prefix of the head arg `typeof`: allowed. A
   # supplied `type =` binds the post-`...` formal exactly; only the shorter
-  # tags (which were ambiguous before) are guarded.
+  # tags (which were ambiguous before) are enumerated.
   norm <- gen_env$normalise_migration(
     "recover_prefix",
     list(
@@ -271,10 +290,11 @@ test_that("normalise_migration() handles head/recoverable prefix overlaps", {
       when = "3.0.0"
     )
   )
-  expect_identical(norm$ambiguous_tags, c("t", "ty", "typ"))
+  expect_identical(norm$forbidden_tags, c("t", "ty", "typ"))
 
-  # Sharing a leading letter (`graph` vs `groups`) now guards the shared
-  # prefixes too -- `f(g = )` was an ambiguity error before the migration.
+  # Sharing a leading letter (`graph` vs `groups`) enumerates the shared
+  # prefixes too -- `f(g = )` binding `graph` is fine on its own, but not
+  # when the recovery layer would rescue the rest of the call.
   norm <- gen_env$normalise_migration(
     "ok_shared_letter",
     list(
@@ -283,10 +303,10 @@ test_that("normalise_migration() handles head/recoverable prefix overlaps", {
       when = "3.0.0"
     )
   )
-  expect_identical(norm$ambiguous_tags, c("g", "gr"))
+  expect_identical(norm$forbidden_tags, c("g", "gr"))
 
-  # A tag that abbreviates two head args stays out of the guard list: base R
-  # errors on it by itself before the body ever runs.
+  # A tag that abbreviates two head args stays out of the forbidden list:
+  # base R errors on it by itself before the body ever runs.
   norm <- gen_env$normalise_migration(
     "two_heads",
     list(
@@ -295,7 +315,7 @@ test_that("normalise_migration() handles head/recoverable prefix overlaps", {
       when = "3.0.0"
     )
   )
-  expect_identical(norm$ambiguous_tags, character(0))
+  expect_identical(norm$forbidden_tags, character(0))
 
   # No overlap at all: no tags, no guard.
   norm <- gen_env$normalise_migration(
@@ -306,7 +326,7 @@ test_that("normalise_migration() handles head/recoverable prefix overlaps", {
       when = "3.0.0"
     )
   )
-  expect_identical(norm$ambiguous_tags, character(0))
+  expect_identical(norm$forbidden_tags, character(0))
 
   # A renamed-away old name that is a prefix of a head arg stays fatal: the
   # old name is no longer a formal, so a valid legacy `f(weight = )` would

--- a/tools/generate-migrations.R
+++ b/tools/generate-migrations.R
@@ -239,35 +239,75 @@ normalise_migration <- function(fn, entry) {
   entry$match_names <- c(entry$recover_old[renamed], entry$tail)
   entry$match_to <- c(entry$recover_new[renamed], entry$tail)
 
-  # Head args are matched by base R *before* `...`, with base R partial matching,
-  # so they are resolved before the recovery layer ever runs. If a head arg name
-  # and a recoverable name are in a prefix relationship, base R silently captures
-  # the abbreviation (or even the full name) for the head arg and it never
-  # reaches `...`: e.g. head `type` swallows `ty=` meant for a recoverable
-  # `typeof`, and a recoverable `type` is swallowed whole by a head `typeof`. The
-  # recovery layer cannot see or defend against this, so reject it here rather
-  # than ship a silent hole. (Merely sharing a leading letter -- `graph` vs a
-  # recoverable `groups` -- is a weaker base-R hazard the two-layer scheme can't
-  # fully eliminate and is left unguarded.)
-  clashes <- character(0)
+  # Head args are matched by base R *before* `...`, with base R partial
+  # matching, so they are resolved before the recovery layer ever runs.
+  # Prefix overlaps between head args and recoverable names therefore need
+  # care, but almost all of them are safe for previously-valid calls, because
+  # *exact* matching beats partial matching and runs across all formals:
+  #
+  # - A full tail name binds its post-`...` formal exactly (head `typeof`
+  #   never swallows a supplied `type =` when `type` is a formal).
+  # - An abbreviation longer than the head arg is no prefix of it, falls
+  #   through to `...`, and is recovered with the deprecation.
+  # - The head arg itself keeps its exact-match meaning from the old
+  #   signature.
+  #
+  # Two hazards remain:
+  #
+  # 1. A *renamed-away* old name that is a prefix of (or equal to) a head
+  #    arg is fatal: it is no longer a formal, so a valid legacy call like
+  #    `f(weight = )` would silently partial-match into the head arg instead
+  #    of reaching recovery. No runtime guard can help; reject at generation
+  #    time.
+  # 2. A *strict prefix* of a head arg that also prefixes a recoverable name
+  #    was ambiguous -- an error -- under the old signature, but would now
+  #    silently bind the head arg. Those tags are enumerable: emit a runtime
+  #    guard (migrate_check_call_tags()) that restores the old error. Tags
+  #    that prefix two head args stay out of the list -- base R still errors
+  #    on those by itself.
+  renamed_old <- entry$recover_old[renamed]
+  fatal <- character(0)
   for (h in entry$head) {
-    for (r in entry$match_names) {
-      if (startsWith(h, r) || startsWith(r, h)) {
-        clashes <- c(clashes, paste0(h, " <-> ", r))
+    for (r in renamed_old) {
+      if (startsWith(h, r)) {
+        fatal <- c(fatal, paste0("`", r, "` -> `", h, "`"))
       }
     }
   }
-  if (length(clashes)) {
+  if (length(fatal)) {
     stop(
       "Migration `",
       fn,
-      "`: head arg(s) and recoverable name(s) are in a prefix relationship, ",
-      "so base R partial matching would capture them before recovery runs: ",
-      paste(unique(clashes), collapse = ", "),
-      ". Rename to remove the prefix overlap.",
+      "`: renamed-away old name(s) are prefixes of head arg(s): ",
+      paste(unique(fatal), collapse = ", "),
+      ". A legacy call using the old name would silently bind the head ",
+      "arg. Pick a different head split.",
       call. = FALSE
     )
   }
+
+  tags <- character(0)
+  for (h in entry$head) {
+    if (nchar(h) < 2L) {
+      next
+    }
+    for (len in seq_len(nchar(h) - 1L)) {
+      s <- substr(h, 1L, len)
+      if (!any(startsWith(entry$match_names, s))) {
+        next
+      }
+      # exact matching wins: a tag spelling out any formal is never misrouted
+      if (s %in% entry$new) {
+        next
+      }
+      # a tag prefixing two head args is an R error already, not a silent bind
+      if (sum(startsWith(entry$head, s)) > 1L) {
+        next
+      }
+      tags <- c(tags, s)
+    }
+  }
+  entry$ambiguous_tags <- sort(unique(tags))
 
   entry
 }
@@ -340,7 +380,23 @@ render_arg_handle <- function(entry) {
     character(1),
     USE.NAMES = FALSE
   )
+  guard <- character(0)
+  if (length(entry$ambiguous_tags)) {
+    quoted <- quote_items(entry$ambiguous_tags)
+    joined <- paste0("  c(", paste(quoted, collapse = ", "), "),")
+    if (nchar(joined) + 2L > 80L) {
+      joined <- c("  c(", paste0("    ", quoted, c(rep(",", length(quoted) - 1L), "")), "  ),")
+    }
+    guard <- c(
+      "migrate_check_call_tags(",
+      "  sys.call(),",
+      joined,
+      paste0("  \"", entry$fn, "\""),
+      ")"
+    )
+  }
   c(
+    guard,
     "if (...length() > 0L) {",
     "  .arg_handle <- migrate_recover_args(",
     "    list(...),",

--- a/tools/generate-migrations.R
+++ b/tools/generate-migrations.R
@@ -260,11 +260,17 @@ normalise_migration <- function(fn, entry) {
   #    of reaching recovery. No runtime guard can help; reject at generation
   #    time.
   # 2. A *strict prefix* of a head arg that also prefixes a recoverable name
-  #    was ambiguous -- an error -- under the old signature, but would now
-  #    silently bind the head arg. Those tags are enumerable: emit a runtime
-  #    guard (migrate_check_call_tags()) that restores the old error. Tags
-  #    that prefix two head args stay out of the list -- base R still errors
-  #    on those by itself.
+  #    was ambiguous -- an error -- under the old signature, but now binds
+  #    the head arg via ordinary partial matching. On its own that is
+  #    accepted: previously broken code that now works in a well-defined,
+  #    silent way is not a problem. It is hazardous only in combination
+  #    with legacy arguments in `...`: the tag steals the head slot,
+  #    positionals shift into the wrong formals, and the recovery layer
+  #    would rescue a never-valid call behind a soft-deprecation warning.
+  #    Those *forbidden prefixes* are enumerable: emit a runtime guard
+  #    (migrate_check_call_tags()) inside the recovery gate, so the tag is
+  #    rejected only when `...` is non-empty. Tags that prefix two head
+  #    args stay out of the list -- base R still errors on those by itself.
   renamed_old <- entry$recover_old[renamed]
   fatal <- character(0)
   for (h in entry$head) {
@@ -307,7 +313,7 @@ normalise_migration <- function(fn, entry) {
       tags <- c(tags, s)
     }
   }
-  entry$ambiguous_tags <- sort(unique(tags))
+  entry$forbidden_tags <- sort(unique(tags))
 
   entry
 }
@@ -381,23 +387,27 @@ render_arg_handle <- function(entry) {
     USE.NAMES = FALSE
   )
   guard <- character(0)
-  if (length(entry$ambiguous_tags)) {
-    quoted <- quote_items(entry$ambiguous_tags)
-    joined <- paste0("  c(", paste(quoted, collapse = ", "), "),")
+  if (length(entry$forbidden_tags)) {
+    quoted <- quote_items(entry$forbidden_tags)
+    joined <- paste0("    c(", paste(quoted, collapse = ", "), "),")
     if (nchar(joined) + 2L > 80L) {
-      joined <- c("  c(", paste0("    ", quoted, c(rep(",", length(quoted) - 1L), "")), "  ),")
+      joined <- c(
+        "    c(",
+        paste0("      ", quoted, c(rep(",", length(quoted) - 1L), "")),
+        "    ),"
+      )
     }
     guard <- c(
-      "migrate_check_call_tags(",
-      "  sys.call(),",
+      "  migrate_check_call_tags(",
+      "    sys.call(),",
       joined,
-      paste0("  \"", entry$fn, "\""),
-      ")"
+      paste0("    \"", entry$fn, "\""),
+      "  )"
     )
   }
   c(
-    guard,
     "if (...length() > 0L) {",
+    guard,
     "  .arg_handle <- migrate_recover_args(",
     "    list(...),",
     render_call_arg("current", "list", paste0(keep, " = ", keep), "list()"),

--- a/tools/migrations/fixture.R
+++ b/tools/migrations/fixture.R
@@ -21,5 +21,17 @@ migrations <- list(
       directed = FALSE
     ) {},
     when = "3.0.0"
+  ),
+
+  # Exercises the head/recoverable prefix-overlap rules: the recoverable
+  # `dim` is a strict prefix of the head arg `dimvector` (the make_lattice()
+  # shape), and the head arg `p` is a strict prefix of the recoverable
+  # `permutation` (the sample_correlated_gnp_pair() shape). The generator
+  # computes ambiguous_tags = c("d", "di") -- the tags that were ambiguity
+  # errors under the old signature -- and emits the runtime guard for them.
+  migration_fixture_prefix = list(
+    old = function(dimvector, p, dim, permutation) {},
+    new = function(dimvector, p, ..., dim = NULL, permutation = NULL) {},
+    when = "3.0.0"
   )
 )

--- a/tools/migrations/fixture.R
+++ b/tools/migrations/fixture.R
@@ -27,8 +27,8 @@ migrations <- list(
   # `dim` is a strict prefix of the head arg `dimvector` (the make_lattice()
   # shape), and the head arg `p` is a strict prefix of the recoverable
   # `permutation` (the sample_correlated_gnp_pair() shape). The generator
-  # computes ambiguous_tags = c("d", "di") -- the tags that were ambiguity
-  # errors under the old signature -- and emits the runtime guard for them.
+  # computes forbidden_tags = c("d", "di") and emits the runtime guard that
+  # rejects those tags when legacy arguments in `...` engage recovery.
   migration_fixture_prefix = list(
     old = function(dimvector, p, dim, permutation) {},
     new = function(dimvector, p, ..., dim = NULL, permutation = NULL) {},


### PR DESCRIPTION
Unblocks the `sample_correlated_gnp_pair()` and `make_lattice()`-shape
migrations the generator's blanket prefix guard excluded from the sweep.

## Why the blanket rejection was over-cautious

The old rule rejected *any* prefix relationship between a head arg and a
recoverable name. But R's **exact matching beats partial matching and
runs across all formals**, so for previously-valid calls the overlap is
almost always harmless:

- a full tail name binds its post-`...` formal exactly
  (head `dimvector` never swallows a supplied `dim =`
  while `dim` is a formal);
- an abbreviation longer than the head arg is no prefix of it,
  falls through to `...`, and is recovered with the deprecation
  (`perm =` → `permutation`);
- the head arg itself keeps its exact-match meaning
  (`p =` meant `p` before, still does).

## The two real hazards, and their treatments

1. **A renamed-away old name that is a prefix of (or equal to) a head
   arg** stays a generation-time error: the old name is no longer a
   formal, so a valid legacy call like `f(weight = )` would silently
   partial-match into the head arg before recovery can see it.
   No runtime guard can restore that; pick a different head split.
2. **A strict prefix of a head arg that also prefixes a recoverable
   name** — an ambiguity *error* under the old signature — now binds the
   head arg via ordinary partial matching. On its own that is accepted:
   previously broken code that now works in a well-defined, *silent* way
   is not a problem. What must not happen is that same tag combined with
   legacy arguments in `...`: the tag steals the head slot, positionals
   shift into the wrong formals, and the recovery layer would rescue a
   never-valid call behind a soft-deprecation warning. The generator
   enumerates these *forbidden prefixes* per entry (`forbidden_tags`) and
   the block rejects exactly that combination — the guard is called from
   inside the recovery gate, so a call with empty `...` never trips it:

   ```r
   if (...length() > 0L) {
     migrate_check_call_tags(
       sys.call(),
       c("d", "di"),
       "migration_fixture_prefix"
     )
     ...
   }
   ```

## Demonstrated by a new fixture

`migration_fixture_prefix(dimvector, p, ..., dim = NULL, permutation = NULL)`
covers both real-world shapes in one signature:
the recoverable `dim` is a strict prefix of head `dimvector`
(the `make_lattice()` case), and head `p` is a strict prefix of the
recoverable `permutation` (the `sample_correlated_gnp_pair()` case).
Tests pin: exact tail names bind silently, legacy positional and
long-abbreviation calls recover with the deprecation,
`di =` with empty dots binds `dimvector` silently,
while `di =` combined with legacy arguments in `...` errors (snapshot),
and unnamed / `do.call()` calls never trip the guard.

## Effect on two existing migrations

Regeneration gives `make_clusters()` (tags `m`, `me`) and
`cluster_spinglass()` (tag `g`) the same conditional guard. Plain calls
like `cluster_spinglass(g = graph)` or `make_clusters(g, m = memb)` —
ambiguity errors before their migration — now bind the head argument
silently and deterministically, which is accepted. Only mixing those
tags with legacy arguments in `...` errors.

## Follow-up once approved

Add the actual `sample_correlated_gnp_pair()` and `make_lattice()`
migrations to their topic branches (games / make), which this PR
unblocks. Note `make_lattice()` also has the alternative-spec
`lattice()` signature to handle manually.

Validation: generator idempotent, blocks air-stable, full suite
FAIL 0 · WARN 0 · PASS 8190 (known sandbox network skip only).

---
_Generated by [Claude Code](https://claude.ai/code/session_016M32izVHZPfxAqemAe4BrX)_