### PR TITLE
fix: initialize `c_options` in the Stimulus type definition

### DIFF
--- a/src/rinterface.c
+++ b/src/rinterface.c
@@ -5323,7 +5323,7 @@ SEXP R_igraph_pagerank(SEXP graph, SEXP algo, SEXP vids, SEXP directed, SEXP dam
   igraph_real_t c_damping;
   igraph_vector_t c_weights;
   igraph_arpack_options_t c_options1;
-  void* c_options;
+  void* c_options = NULL;
   SEXP vector;
   SEXP value;
 
@@ -5396,7 +5396,7 @@ SEXP R_igraph_personalized_pagerank(SEXP graph, SEXP algo, SEXP vids, SEXP direc
   igraph_vector_t c_personalized;
   igraph_vector_t c_weights;
   igraph_arpack_options_t c_options1;
-  void* c_options;
+  void* c_options = NULL;
   SEXP vector;
   SEXP value;
 
@@ -5472,7 +5472,7 @@ SEXP R_igraph_personalized_pagerank_vs(SEXP graph, SEXP algo, SEXP vids, SEXP di
   igraph_vs_t c_reset_vids;
   igraph_vector_t c_weights;
   igraph_arpack_options_t c_options1;
-  void* c_options;
+  void* c_options = NULL;
   SEXP vector;
   SEXP value;
 

--- a/src/rinterface.c
+++ b/src/rinterface.c
@@ -5346,8 +5346,6 @@ SEXP R_igraph_pagerank(SEXP graph, SEXP algo, SEXP vids, SEXP directed, SEXP dam
     if (c_algo == IGRAPH_PAGERANK_ALGO_ARPACK) {
       Rz_SEXP_to_igraph_arpack_options(options, &c_options1);
       c_options = &c_options1;
-    } else {
-      c_options = NULL;
     }
   }
                                         /* Call igraph */
@@ -5422,8 +5420,6 @@ SEXP R_igraph_personalized_pagerank(SEXP graph, SEXP algo, SEXP vids, SEXP direc
     if (c_algo == IGRAPH_PAGERANK_ALGO_ARPACK) {
       Rz_SEXP_to_igraph_arpack_options(options, &c_options1);
       c_options = &c_options1;
-    } else {
-      c_options = NULL;
     }
   }
                                         /* Call igraph */
@@ -5497,8 +5493,6 @@ SEXP R_igraph_personalized_pagerank_vs(SEXP graph, SEXP algo, SEXP vids, SEXP di
     if (c_algo == IGRAPH_PAGERANK_ALGO_ARPACK) {
       Rz_SEXP_to_igraph_arpack_options(options, &c_options1);
       c_options = &c_options1;
-    } else {
-      c_options = NULL;
     }
   }
                                         /* Call igraph */

--- a/tools/stimulus/types-RC.yaml
+++ b/tools/stimulus/types-RC.yaml
@@ -995,16 +995,20 @@ SIR_LIST:
             IGRAPH_FINALLY_CLEAN(1);
 
 PAGERANKOPT:
-    CTYPE: |-
+    CTYPE: void*
+    # The argument is optional,
+    # so the code generator wraps the input conversion into `if (!Rf_isNull(...))`.
+    # The pointer is passed on to igraph unconditionally,
+    # therefore it must be initialized here
+    # to stay well-defined on the path where the conversion is skipped.
+    CDECL: |-
       igraph_arpack_options_t %C%1;
-      void*
+      void* %C% = NULL;
     INCONV:
         INOUT: |-
           if (%C1% == IGRAPH_PAGERANK_ALGO_ARPACK) {
             Rz_SEXP_to_igraph_arpack_options(%I%, &%C%1);
             %C% = &%C%1;
-          } else {
-            %C% = NULL;
           }
     OUTCONV:
         INOUT: |-


### PR DESCRIPTION
<!-- Prepared with Claude Code. -->

Stacked on #2751: the first commit is @MichaelChirico's fix to `src/rinterface.c`, the second moves it into the code generator so that it survives the next regeneration.
GitHub cannot use a fork branch as a PR base, so the commit is carried along here instead of being a true base branch; it can be dropped once #2751 is merged.

## The fix

`PAGERANKOPT` is an `OPTIONAL INOUT` argument, so Stimulus wraps its input conversion into `if (!Rf_isNull(options))`, while `chunk_call()` adds the `(Rf_isNull(...) ? 0 : ...)` guard only for arguments that are purely input.
The pointer is therefore read unconditionally at the call site, which is an uninitialized read when `options` is `NULL` at the R level, as flagged by `clang -Wsometimes-uninitialized`.

The type definition now declares the variable through `CDECL` with a `NULL` initializer:

```yaml
PAGERANKOPT:
    CTYPE: void*
    CDECL: |-
      igraph_arpack_options_t %C%1;
      void* %C% = NULL;
```

`CTYPE` no longer has to smuggle the extra `igraph_arpack_options_t` declaration past the type, so it can name the actual C type again.

The `else { %C% = NULL; }` branch of the input conversion is dropped: with the initializer in place it is a redundant re-assignment, and keeping it would suggest that the two `NULL` paths differ.
The default now lives in exactly one place.

Generated code for the three affected functions (`igraph_pagerank()`, `igraph_personalized_pagerank()`, `igraph_personalized_pagerank_vs()`):

```c
   igraph_arpack_options_t c_options1;
-  void* c_options;
+  void* c_options = NULL;
...
   if (!Rf_isNull(options)) {
     if (c_algo == IGRAPH_PAGERANK_ALGO_ARPACK) {
       Rz_SEXP_to_igraph_arpack_options(options, &c_options1);
       c_options = &c_options1;
-    } else {
-      c_options = NULL;
     }
   }
```

## Are other functions affected?

No, these three are the only real cases.
Compiling the regenerated `src/rinterface.c` with `clang -Wall -Wextra` reports no `-Wsometimes-uninitialized` warning any more.

Five further sites are reported by `gcc -O2 -Wmaybe-uninitialized` and `clang -Wconditional-uninitialized`: `c_outfile` in `igraph_maximal_cliques_subset()`, `c_creator` in `igraph_write_graph_gml()`, `c_start` in `igraph_fundamental_cycles()` and `igraph_vertex_path_from_edge_path()`, and `c_vid` in `igraph_random_spanning_tree()`.
These are false positives: the arguments are purely input, so the call site does carry the `(Rf_isNull(x) ? 0 : c_x)` guard and never reads the variable on the path where the conversion is skipped.
The compilers just do not correlate the two `Rf_isNull()` tests.
Silencing them would mean initializing every optional scalar declaration, which would churn the generated code and weaken the warning elsewhere, so this PR leaves them alone.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RF5eavxtBTfTSquRjc2San

---
_Generated by [Claude Code](https://claude.ai/code/session_01RF5eavxtBTfTSquRjc2San)_