### PR TITLE
ci: Sync R-CMD-check workflow; drop matrix-env plumbing from custom action

### DIFF
--- a/.github/versions-matrix.R
+++ b/.github/versions-matrix.R
@@ -2,8 +2,8 @@ list(
   # Lifecycle-deprecations-as-errors run: tests/testthat/setup-lifecycle.R
   # reacts to IGRAPH_LIFECYCLE_ERRORS=true by failing any test in which an
   # unasserted lifecycle deprecation fires. The flag travels through the
-  # generic "env" matrix field and is exported by the custom before-install
-  # action.
+  # generic "env" matrix field, which the rcc-full job applies to the
+  # environment of all steps.
   data.frame(
     os = "ubuntu-26.04",
     r = r_versions[[2]],

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -317,12 +317,23 @@ jobs:
         with:
           ref: ${{ needs.rcc-smoke.outputs.sha }}
 
+      - name: Apply environment variables from the test matrix
+        # Generic: matrix entries defined in .github/versions-matrix.R can
+        # carry an "env" field (one KEY=VALUE per line).
+        # Write it to $GITHUB_ENV here, in the workflow,
+        # because composite actions cannot read the matrix context.
+        # The variables then reach every subsequent step,
+        # including the custom before-install and after-install actions,
+        # without requiring repos to implement any plumbing of their own.
+        if: matrix.env != ''
+        env:
+          MATRIX_ENV: ${{ matrix.env }}
+        run: |
+          printf '%s\n' "$MATRIX_ENV" | tee -a "$GITHUB_ENV"
+        shell: bash
+
       - uses: ./.github/workflows/custom/before-install
         if: hashFiles('.github/workflows/custom/before-install/action.yml') != ''
-        with:
-          # Generic: forward any per-entry environment variables defined in the
-          # test matrix (see .github/versions-matrix.R) to the custom action.
-          env: ${{ matrix.env }}
 
       - uses: ./.github/workflows/install
         with:

--- a/.github/workflows/custom/before-install/action.yml
+++ b/.github/workflows/custom/before-install/action.yml
@@ -1,26 +1,13 @@
 name: 'Custom steps to run before R packages are installed'
 
-inputs:
-  env:
-    description: >
-      Additional environment variables (one KEY=VALUE per line) contributed by
-      the test matrix. Generic hook used by .github/versions-matrix.R to flag
-      special matrix entries (e.g. the lifecycle-errors entry, which sets
-      IGRAPH_LIFECYCLE_ERRORS=true).
-    required: false
-    default: ""
+# Environment variables from the "env" field of test matrix entries
+# (see .github/versions-matrix.R, e.g. IGRAPH_LIFECYCLE_ERRORS=true)
+# are applied by the rcc-full job in R-CMD-check.yaml before this action runs,
+# so they are already visible here and in all later steps.
 
 runs:
   using: "composite"
   steps:
-    - name: Apply environment variables from the test matrix
-      if: inputs.env != ''
-      env:
-        MATRIX_ENV: ${{ inputs.env }}
-      run: |
-        printf '%s\n' "$MATRIX_ENV" | tee -a "$GITHUB_ENV"
-      shell: bash
-
     - name: Define R CMD check error condition
       run: |
         echo '_R_CHECK_PKG_SIZES_=FALSE' | tee -a $GITHUB_ENV

--- a/.github/workflows/versions-matrix/action.R
+++ b/.github/workflows/versions-matrix/action.R
@@ -67,9 +67,18 @@ if (!is.na(filter)) {
 
 to_json <- function(x) {
   if (nrow(x) == 0) return(character())
+  # Minimal JSON string escaping: backslash, double quote, newline.
+  # Newlines matter for the "env" field,
+  # which carries one KEY=VALUE per line.
+  escape <- function(v) {
+    v <- gsub("\\", "\\\\", v, fixed = TRUE)
+    v <- gsub('"', '\\"', v, fixed = TRUE)
+    v <- gsub("\n", "\\n", v, fixed = TRUE)
+    v
+  }
   parallel <- vector("list", length(x))
   for (i in seq_along(x)) {
-    parallel[[i]] <- paste0('"', names(x)[[i]], '":"', x[[i]], '"')
+    parallel[[i]] <- paste0('"', escape(names(x)[[i]]), '":"', escape(x[[i]]), '"')
   }
   paste0("{", do.call(paste, c(parallel, sep = ",")), "}")
 }

--- a/R/adjacency.R
+++ b/R/adjacency.R
@@ -293,6 +293,11 @@ graph_from_adjacency_matrix <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph_from_adjacency_matrix, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("a", "ad"),
+      "graph_from_adjacency_matrix"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(
@@ -456,6 +461,11 @@ from_adjacency <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: from_adjacency, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("a", "ad"),
+      "from_adjacency"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(

--- a/R/games.R
+++ b/R/games.R
@@ -1888,6 +1888,11 @@ sample_pa_age <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_pa_age, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("a", "ag", "agi", "agin", "aging", "aging."),
+      "sample_pa_age"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(
@@ -2107,6 +2112,11 @@ pa_age <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: pa_age, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("a", "ag", "agi", "agin", "aging", "aging."),
+      "pa_age"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(
@@ -2264,6 +2274,11 @@ sample_traits_callaway <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_traits_callaway, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("t", "ty", "typ", "type"),
+      "sample_traits_callaway"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(
@@ -2330,6 +2345,11 @@ traits_callaway <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: traits_callaway, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("t", "ty", "typ", "type"),
+      "traits_callaway"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(
@@ -2385,6 +2405,11 @@ sample_traits <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_traits, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("t", "ty", "typ", "type"),
+      "sample_traits"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(
@@ -2445,6 +2470,11 @@ traits <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: traits, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("t", "ty", "typ", "type"),
+      "traits"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(
@@ -2679,6 +2709,11 @@ sample_pref <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_pref, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("t", "ty", "typ", "type"),
+      "sample_pref"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(
@@ -2778,6 +2813,11 @@ pref <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: pref, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("t", "ty", "typ", "type"),
+      "pref"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(
@@ -2859,6 +2899,11 @@ sample_asym_pref <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_asym_pref, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("t", "ty", "typ", "type"),
+      "sample_asym_pref"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(
@@ -2934,6 +2979,11 @@ asym_pref <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: asym_pref, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("t", "ty", "typ", "type"),
+      "asym_pref"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(

--- a/R/layout.R
+++ b/R/layout.R
@@ -1733,6 +1733,11 @@ layout_with_fr <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_with_fr, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("g", "gr"),
+      "layout_with_fr"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(

--- a/R/motifs.R
+++ b/R/motifs.R
@@ -337,6 +337,11 @@ sample_motifs <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_motifs, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("s"),
+      "sample_motifs"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(

--- a/R/topology.R
+++ b/R/topology.R
@@ -197,6 +197,11 @@ graph.subisomorphic.lad <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph.subisomorphic.lad, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
+    migrate_check_call_tags(
+      sys.call(),
+      c("t"),
+      "graph.subisomorphic.lad"
+    )
     .arg_handle <- migrate_recover_args(
       list(...),
       current = list(


### PR DESCRIPTION
This PR was prepared with Claude Code (LLM disclosure).

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

---

Sync `.github/workflows/R-CMD-check.yaml` and
`.github/workflows/versions-matrix/action.R` from cynkratemplate
(cynkra/cynkratemplate#95).

The claim from #2782 —
that a custom before-install action is needed
to pick up the `env` field of a test matrix entry —
was accurate under the old template design,
and it applied to **all** template consumers, not just rigraph:
composite actions cannot read the `matrix` context,
so the workflow forwarded `matrix.env` as an action input,
and each repo had to apply it to `$GITHUB_ENV` itself.

The template's `rcc-full` job now applies the generic `env` field
to `$GITHUB_ENV` directly, before the custom before-install action runs,
so no repo needs plumbing of its own.
The apply boilerplate and the `env` input
are therefore removed from the custom before-install action;
`IGRAPH_LIFECYCLE_ERRORS=true` from the lifecycle-errors matrix entry
keeps reaching the tests through the workflow-level step.

Additionally, this PR regenerates the `ARG_HANDLE` blocks
(`Rscript tools/generate-migrations.R`, generated code only):
current `main` carries drift —
most likely from the merge order of today's migration refactors
(#2760, #2761, #2762 and the registry side of #2782) —
and the rcc-smoke drift check fails on every branch
until the regenerated blocks are committed.
The first CI run on this PR failed exactly there,
before the regeneration commit was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136C9bRMjBGkUrtLdkYNmAg