### PR TITLE
fix: heal `main` — unleak `warnPartialMatchArgs` on R 4.2 and name args at `norm_coords()`/`make_star()` call sites for the lifecycle-errors leg

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -176,7 +176,7 @@ plot.igraph <- function(
     if (is.null(ylim)) {
       ylim <- c(-1, 1)
     }
-    layout <- norm_coords(layout, -1, 1, -1, 1)
+    layout <- norm_coords(layout, xmin = -1, xmax = 1, ymin = -1, ymax = 1)
     fact <- (1 - vertex.size.scaling)
     maxv <- 1 / 200 * max(vertex.size)
 

--- a/tests/testthat/test-centralization.R
+++ b/tests/testthat/test-centralization.R
@@ -50,7 +50,7 @@ test_that("centr_degree() covers migrated tail args and positional recovery", {
 
 test_that("centr_betw() covers migrated tail args and positional recovery", {
   rlang::local_options(lifecycle_verbosity = "warning")
-  g <- make_star(5, "undirected")
+  g <- make_star(5, mode = "undirected")
 
   res <- centr_betw(g, directed = FALSE, normalized = FALSE)
   # The centre lies on the geodesics of all 6 leaf pairs.
@@ -66,7 +66,7 @@ test_that("centr_betw() covers migrated tail args and positional recovery", {
 
 test_that("centr_betw_tmax() covers migrated tail args and positional recovery", {
   rlang::local_options(lifecycle_verbosity = "warning")
-  g <- make_star(5, "undirected")
+  g <- make_star(5, mode = "undirected")
 
   # The graph form and the vertex-count form must agree.
   expect_equal(centr_betw_tmax(g, directed = FALSE), 24)
@@ -125,7 +125,7 @@ test_that("centr_clo_tmax() covers migrated tail args and positional recovery", 
 
 test_that("centralize() covers migrated tail args and positional recovery", {
   rlang::local_options(lifecycle_verbosity = "warning")
-  scores <- degree(make_star(5, "undirected"))
+  scores <- degree(make_star(5, mode = "undirected"))
 
   # The star's degree sequence gives sum(max - x) = 12.
   expect_equal(centralize(scores, theoretical.max = 12, normalized = TRUE), 1)

--- a/tests/testthat/test-migration-fixture.R
+++ b/tests/testthat/test-migration-fixture.R
@@ -139,6 +139,11 @@ test_that("abbreviations longer than the head arg are recovered", {
 })
 
 test_that("forbidden prefixes error only when legacy arguments engage recovery", {
+  ## The snapshot differs on R 4.2: `warnPartialMatchArgs` enabled earlier in
+  ## this file leaks through its scoped restore there (see above), adding a
+  ## partial-match warning to the recorded condition. Skip on older R.
+  skip_if(getRversion() < "4.3")
+
   # `di =` steals the head slot `dimvector`, `c(2, 2)` shifts into `p`,
   # and `0.5` lands in `...`:
   # recovery would rescue this never-valid call behind a deprecation

--- a/tests/testthat/test-migration-fixture.R
+++ b/tests/testthat/test-migration-fixture.R
@@ -72,6 +72,12 @@ test_that("head args go through base R partial matching, not our recovery", {
   # recovery. With `warnPartialMatchArgs` on, R emits its own partial-match
   # warning and our deprecation does not fire; when a tail arg is abbreviated
   # too, both warnings appear -- R's for the head, ours for the tail.
+  #
+  # Pin the option to FALSE before flipping it on: on R < 4.3, restoring
+  # `warnPartialMatchArgs` to NULL (unset) does not switch the warning off
+  # again, so it would leak into every later test and (on R 4.2) add a
+  # partial-match warning to the `migration_fixture_prefix()` snapshots below.
+  options(warnPartialMatchArgs = FALSE)
   rlang::local_options(
     lifecycle_verbosity = "warning",
     warnPartialMatchArgs = TRUE

--- a/tests/testthat/test-stochastic_matrix.R
+++ b/tests/testthat/test-stochastic_matrix.R
@@ -20,7 +20,7 @@ test_that("stochastic_matrix works", {
 # and the legacy positional recovery path.
 
 test_that("stochastic_matrix() returns a sparse matrix when `sparse = TRUE`", {
-  g <- make_star(5, "undirected")
+  g <- make_star(5, mode = "undirected")
   W <- stochastic_matrix(g, sparse = TRUE)
   expect_s4_class(W, "Matrix")
   # The sparse and dense forms describe the same stochastic matrix.
@@ -31,7 +31,7 @@ test_that("stochastic_matrix() returns a sparse matrix when `sparse = TRUE`", {
 })
 
 test_that("stochastic_matrix() recovers a legacy positional `column.wise`", {
-  g <- make_star(5, "undirected")
+  g <- make_star(5, mode = "undirected")
   lifecycle::expect_deprecated(
     W <- stochastic_matrix(g, TRUE)
   )


### PR DESCRIPTION
<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->
Prepared with Claude Code (Claude Fable 5).

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

---

`main` has been red since 17:36 UTC today,
after #2787 (guard-emitting migrations generator)
and the ellipsis-refactor train merged close together.
The diagnosis found four independent breakages;
the first was fixed by #2798 while this PR was in preparation
(it carries the identical regeneration this branch originally produced,
so that commit dropped out on rebase),
and this PR delivers the remaining three.

## 1. (landed via #2798) `rcc-smoke` migrations drift check

For the record, every `main` push from 17:36 to 19:04 UTC failed
"Smoke test: stock R" at `Run ./.github/workflows/custom/after-install`:

```
##[error]Generated ARG_HANDLE blocks are out of sync with the registry (tools/migrations/).
Run 'Rscript tools/generate-migrations.R' and commit the result.
```

because the refactor PRs had regenerated their ARG_HANDLE blocks
on branches cut before #2787's generator learned to emit
`migrate_check_call_tags()` guards.
#2798 committed the regenerated blocks;
on this branch `Rscript tools/generate-migrations.R`
is a verified no-op on `R/`.

## 2. `rcc: ubuntu-26.04 (4.2)` rewrites the migration-fixture snapshot

The runs whose smoke test still passed
(e.g. #2787's own merge run, 30289034966)
failed only in the R 4.2 leg,
at `Run ./.github/workflows/update-snapshots`,
which keeps force-pushing snapshot PR #2796 and then fails via `false`.
The recorded difference, in
`tests/testthat/test-migration-fixture.R` >
`test_that("forbidden prefixes error only when legacy arguments engage recovery")`:

```diff
     Code
       migration_fixture_prefix(c(2, 2), 0.5, di = 2)
     Condition
+      Warning in `migration_fixture_prefix()`:
+      partial argument match of 'di' to 'dimvector'
       Error in `migration_fixture_prefix()`:
       ! Argument `di` matches multiple formal arguments of `migration_fixture_prefix()`.
```

**Root cause:** an earlier test in the same file enables
`warnPartialMatchArgs` via `rlang::local_options()`.
On R < 4.3, restoring that option to `NULL` (unset)
does not switch the warning off again —
the internal flag keeps its last set value (fixed in R 4.3) —
so it leaks into every later test in the file, on R 4.2 only.
Verified on stock R 4.2.3 (via `rig`):
set `TRUE` → restore to `NULL` still warns, while R 4.5.3 does not.
Beyond the snapshot, the leak would also fail the
`expect_no_condition()` test two blocks later on R 4.2,
so a skip alone would not heal the leg.

**Fix (two layers):**

- pin `options(warnPartialMatchArgs = FALSE)` before flipping it on,
  so the scoped restore lands on `FALSE`,
  which resets the flag on every R version;
- per maintainer decision, additionally skip the affected snapshot test
  on R 4.2 (`skip_if(getRversion() < "4.3")`),
  mirroring the existing version-gated skips in
  `test-adjacency.R` and `test-community.R`.
  (A sweep of every failed rcc run across all branches since 2026-07-18
  confirmed this is the only snapshot that ever diverges on the 4.2 leg;
  the local suite runs R 4.5.3, so the skip is exercised only in CI.)

## 3. The never-yet-run "with lifecycle errors" leg would fail next

#2782 added a matrix leg (ubuntu-26.04, R release,
`IGRAPH_LIFECYCLE_ERRORS=true`) that fails any test
in which an unasserted lifecycle deprecation fires.
It has not executed yet — the smoke gate broke first —
but once smoke passes it will,
and the refactors that merged after #2782 was cut
left exactly two unasserted call sites
(all 36 deprecation warnings of the default suite reduce to them):

- `plot.igraph()` itself called
  `norm_coords(layout, -1, 1, -1, 1)` positionally (`R/plot.R`) —
  32 warnings across the plotting tests;
- `make_star(5, "undirected")` with positional `mode`
  in `test-stochastic_matrix.R` and `test-centralization.R` — 5 warnings.

**Fix:** name the arguments at both sites
(`norm_coords(layout, xmin = -1, xmax = 1, ymin = -1, ymax = 1)`,
`make_star(5, mode = "undirected")`).

The matrix plumbing itself is sound:
a faithful offline simulation of
`.github/workflows/versions-matrix/action.R` as of #2798
(stubbing only the svn fetch)
sources `.github/versions-matrix.R` cleanly
and appends the leg
`{"os":"ubuntu-26.04","r":"4.6","env":"IGRAPH_LIFECYCLE_ERRORS=true","desc":"with lifecycle errors"}`
to matrix JSON that `jsonlite` parses.

## Validation (all on this branch, R 4.5.3)

- `Rscript tools/generate-migrations.R` is a no-op on `R/`
  (three consecutive runs; `git status --porcelain R/` stays empty),
- `air format R/ tools/ tests/` is a no-op,
- `devtools::document()` leaves `man/` and `NAMESPACE` untouched,
- migration-focused tests
  (`filter = "migration|generate-migrations|constant-defaults"`):
  FAIL 0 | WARN 0 | SKIP 0 | PASS 83,
- full suite: FAIL 1 | WARN 36 | SKIP 8 | PASS 9181 before the
  call-site fixes,
- full suite with `IGRAPH_LIFECYCLE_ERRORS=true` after them:
  **FAIL 1 | WARN 0 | SKIP 8 | PASS 9181** —
  the single failure is the sandbox-only `test-foreign.R`
  `graph_from_graphdb()` download
  (no network in the sandbox; CI can reach it).

---
_Generated by [Claude Code](https://claude.ai/code/session_016M32izVHZPfxAqemAe4BrX)_