### PR TITLE
fix: name `norm_coords()` arguments at the `rglplot.igraph()` call site

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -1623,7 +1623,15 @@ rglplot.igraph <- function(x, ...) {
     layout <- cbind(layout, 0)
   }
   if (rescale) {
-    layout <- norm_coords(layout, -1, 1, -1, 1, -1, 1)
+    layout <- norm_coords(
+      layout,
+      xmin = -1,
+      xmax = 1,
+      ymin = -1,
+      ymax = 1,
+      zmin = -1,
+      zmax = 1
+    )
   }
 
   # add the edges, the loops are handled separately


### PR DESCRIPTION
Fixes the sole red leg of the scheduled full rcc matrix on `main`,
`rcc: ubuntu-26.04 (4.6) with lifecycle errors`:

```
── Error ('test-plot.R:85:3'): rglplot() works ──
Error: Calling `norm_coords()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
 11.   └─igraph::norm_coords(layout, -1, 1, -1, 1, -1, 1) at igraph/R/plot.R:1626:5
```

#2799 named the arguments at `plot.igraph()`'s 2-D call site but missed
the 3-D one in `rglplot.igraph()`.
The leg only runs on schedule or manual dispatch
(the versions-matrix step is skipped on same-repo PRs),
so PR runs never surfaced it.
The fix names `xmin`/`xmax`/`ymin`/`ymax`/`zmin`/`zmax` at the caller —
no verbosity pin, per the fix-the-caller policy.

Validation (with `libglu1-mesa` + rgl installed so `rglplot() works`
actually runs instead of skipping):
full suite FAIL 0 both plain and with `IGRAPH_LIFECYCLE_ERRORS=true`;
generator, `air`, and `devtools::document()` are no-ops.

Not addressed here (deliberately):
the nightly Sanitizer failure
(`R_getRegisteredNamespace` undeclared on the CSAN image)
was removed from this PR per maintainer request
and remains open;
the Bioconductor `graph` pak outage and the sandbox-only
graphsdb fetch are environmental.