### PR TITLE
ci: Use the daily-rebuilt `r-debug` sanitizer image, and fix the leak it uncovered

### DIFF
--- a/.github/workflows/build-and-check.yml
+++ b/.github/workflows/build-and-check.yml
@@ -21,7 +21,7 @@ jobs:
     name: Sanitizer
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -34,7 +34,11 @@ jobs:
       - name: run sanitizer
         uses: addnab/docker-run-action@v3
         with:
-          image: ghcr.io/cynkra/docker-images/r-debug-csan-igraph:latest
+          # Built daily from https://github.com/cynkra/r-debug, so R-devel is
+          # at most a day old.
+          # The images under ghcr.io/cynkra/docker-images are no longer
+          # rebuilt; their R-devel is stale.
+          image: ghcr.io/cynkra/r-debug/r-debug-csan-igraph:latest
           options: --rm --platform linux/amd64 -v ${{ github.workspace }}:/rigraph
           run: |
             set -e

--- a/src/rinterface_extra.c
+++ b/src/rinterface_extra.c
@@ -6157,8 +6157,14 @@ SEXP Rx_igraph_is_chordal(SEXP graph, SEXP alpha, SEXP alpham1,
   SEXP result, names;
                                         /* Convert input */
   Rz_SEXP_to_igraph(graph, &c_graph);
-  if (!Rf_isNull(alpha)) { Rz_SEXP_to_vector_int_copy(alpha, &c_alpha); }
-  if (!Rf_isNull(alpham1)) { Rz_SEXP_to_vector_int_copy(alpham1, &c_alpham1); }
+  if (!Rf_isNull(alpha)) {
+    IGRAPH_R_CHECK(Rz_SEXP_to_vector_int_copy(alpha, &c_alpha));
+    IGRAPH_FINALLY_PV(igraph_vector_int_destroy, &c_alpha);
+  }
+  if (!Rf_isNull(alpham1)) {
+    IGRAPH_R_CHECK(Rz_SEXP_to_vector_int_copy(alpham1, &c_alpham1));
+    IGRAPH_FINALLY_PV(igraph_vector_int_destroy, &c_alpham1);
+  }
   if (LOGICAL(pfillin)[0]) {
     if (0 != igraph_vector_int_init(&c_fillin, 0)) {
       igraph_error("", __FILE__, __LINE__, IGRAPH_ENOMEM);
@@ -6186,6 +6192,16 @@ SEXP Rx_igraph_is_chordal(SEXP graph, SEXP alpha, SEXP alpham1,
     IGRAPH_FINALLY_CLEAN(1);
   } else {
     PROTECT(newgraph=R_NilValue);
+  }
+  /* Unwound in reverse order of registration, so that IGRAPH_FINALLY_CLEAN()
+   * pops the entry that belongs to the vector being destroyed. */
+  if (!Rf_isNull(alpham1)) {
+    igraph_vector_int_destroy(&c_alpham1);
+    IGRAPH_FINALLY_CLEAN(1);
+  }
+  if (!Rf_isNull(alpha)) {
+    igraph_vector_int_destroy(&c_alpha);
+    IGRAPH_FINALLY_CLEAN(1);
   }
   SET_VECTOR_ELT(result, 0, chordal);
   SET_VECTOR_ELT(result, 1, fillin);

--- a/tests/testthat/test-foreign.R
+++ b/tests/testthat/test-foreign.R
@@ -63,7 +63,7 @@ test_that("graph_from_graphdb works", {
   skip_on_cran()
 
   # Bug in base R? Checked with 2024-11-01 r87285:
-  # docker run --rm -ti -v $PWD:/rigraph -e MAKEFLAGS=-j4 ghcr.io/cynkra/docker-images/rigraph-san:latest RDcsan -q -e 'filename <- "/rigraph/DESCRIPTION"; gz_file_con <- file(filename, open = "rb"); file_con <- gzcon(gz_file_con); close(file_con); gc()'
+  # docker run --rm -ti -v $PWD:/rigraph -e MAKEFLAGS=-j4 ghcr.io/cynkra/r-debug/r-debug-csan-igraph:latest RDcsan -q -e 'filename <- "/rigraph/DESCRIPTION"; gz_file_con <- file(filename, open = "rb"); file_con <- gzcon(gz_file_con); close(file_con); gc()'
   skip_if(Sys.getenv("R_SANITIZER") == "true")
 
   expect_silent(graph_from_graphdb(nodes = 1000))


### PR DESCRIPTION
<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->

Prepared with Claude Code.

## Why the sanitizer job was red

The `Sanitizer` job pulled `r-debug-csan-igraph` from `ghcr.io/cynkra/docker-images`,
which stopped being rebuilt on 2026-03-30.
That R-devel snapshot already reports 4.6.0,
but predates the commit that made `R_getRegisteredNamespace()` part of the API,
so the `#if R_VERSION >= R_Version(4, 6, 0)` branch in `src/rinterface_extra.c` failed to compile:

    rinterface_extra.c:2520:9: error: use of undeclared identifier 'R_getRegisteredNamespace'

That guard landed on 2026-07-09,
which is when the nightly runs started failing;
every one since has died at this point, roughly three minutes in.

The same image is now published from https://github.com/cynkra/r-debug and rebuilt daily,
so its R-devel is at most a day old
(verified: image built 2026-07-28 01:57Z, carrying R-devel 2026-07-27 r90310, clang 17.0.6).

## The leak this uncovered

With the build working again, the suite ran green end to end,
and then LeakSanitizer failed the job at R exit:

    SUMMARY: AddressSanitizer: 288 byte(s) leaked in 4 allocation(s).

    #1 igraph_vector_int_init src/vendor/cigraph/src/core/vector.pmt:144
    #2 Rz_SEXP_to_vector_int_copy src/rinterface_extra.c:3725
    #3 Rx_igraph_is_chordal src/rinterface_extra.c:6160

`c_alpha` and `c_alpham1` are allocated by `Rz_SEXP_to_vector_int_copy()` and never destroyed,
so **every** `is_chordal()` call passing them leaks — this is not an error-path-only concern.
`c_fillin`, right beside them in the same function, was already registered and destroyed correctly.
The leak is pre-existing; it was simply unreachable while the build was broken.

Both vectors are now registered with `IGRAPH_FINALLY_PV()` and destroyed in reverse order,
so each `IGRAPH_FINALLY_CLEAN()` pops the entry belonging to the vector being destroyed.
The conversion result is also checked with `IGRAPH_R_CHECK()`,
matching every other call site of `Rz_SEXP_to_vector_int_copy()`;
the return value was previously discarded,
leaving the vector uninitialised on failure.
This is the same shape the generated code already uses in `R_igraph_canonical_permutation()`.

## Verification

- The sanitizer job on this branch is **green**: https://github.com/igraph/rigraph/actions/runs/30370406292
- Reproduced and fixed locally in the image, both directions:
  without the fix, a script calling `is_chordal()` four times leaks 392 bytes in 7 allocations
  (3 loop iterations × 2 vectors, plus one `alpha`-only call — exactly the expected count);
  with the fix, R exits cleanly with status 0 and no LeakSanitizer output.
- `test-decomposition.R` passes in full (14 tests, covering the `alpha`/`alpham1`/`fillin`/`newgraph` paths).

## Also in this PR

- `actions/checkout` v2 → v6, matching the other workflows and clearing the Node 20 deprecation warning this job logged.
- The reproduction command in `test-foreign.R` now points at an image that still exists.

## Not addressed here

The suite prints three UBSan `runtime error` diagnostics that do not affect exit status:
one function-pointer-type mismatch in vendored cigraph (`core/error.c:346`),
and two `nan is outside the range of representable values of type 'long'` in `rinterface_extra.c`.

<!-- The following text must be left intact and the box checked before the PR can be merged. -->

- [ ] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

https://claude.ai/code/session_01FcwDG9RDPdiXBjqw8zvUNu