### PR TITLE
fix(migrations): ignore empty argument slots in `...`

### DIFF
--- a/R/adjacency.R
+++ b/R/adjacency.R
@@ -293,58 +293,61 @@ graph_from_adjacency_matrix <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph_from_adjacency_matrix, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("a", "ad"),
-      "graph_from_adjacency_matrix"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        mode = mode,
-        weighted = weighted,
-        diag = diag,
-        add.colnames = add.colnames,
-        add.rownames = add.rownames
-      ),
-      recover_new = c(
-        "mode",
-        "weighted",
-        "diag",
-        "add.colnames",
-        "add.rownames"
-      ),
-      recover_old = c(
-        "mode",
-        "weighted",
-        "diag",
-        "add.colnames",
-        "add.rownames"
-      ),
-      match_names = c(
-        "mode",
-        "weighted",
-        "diag",
-        "add.colnames",
-        "add.rownames"
-      ),
-      match_to = c("mode", "weighted", "diag", "add.colnames", "add.rownames"),
-      defaults = list(
-        mode = c("directed", "undirected", "max", "min", "upper", "lower", "plus"),
-        weighted = NULL,
-        diag = TRUE,
-        add.colnames = NULL,
-        add.rownames = NA
-      ),
-      head_args = c("adjmatrix"),
-      fn_name = "graph_from_adjacency_matrix"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("a", "ad"),
+        "graph_from_adjacency_matrix"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          mode = mode,
+          weighted = weighted,
+          diag = diag,
+          add.colnames = add.colnames,
+          add.rownames = add.rownames
+        ),
+        recover_new = c(
+          "mode",
+          "weighted",
+          "diag",
+          "add.colnames",
+          "add.rownames"
+        ),
+        recover_old = c(
+          "mode",
+          "weighted",
+          "diag",
+          "add.colnames",
+          "add.rownames"
+        ),
+        match_names = c(
+          "mode",
+          "weighted",
+          "diag",
+          "add.colnames",
+          "add.rownames"
+        ),
+        match_to = c("mode", "weighted", "diag", "add.colnames", "add.rownames"),
+        defaults = list(
+          mode = c("directed", "undirected", "max", "min", "upper", "lower", "plus"),
+          weighted = NULL,
+          diag = TRUE,
+          add.colnames = NULL,
+          add.rownames = NA
+        ),
+        head_args = c("adjmatrix"),
+        fn_name = "graph_from_adjacency_matrix"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -461,58 +464,61 @@ from_adjacency <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: from_adjacency, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("a", "ad"),
-      "from_adjacency"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        mode = mode,
-        weighted = weighted,
-        diag = diag,
-        add.colnames = add.colnames,
-        add.rownames = add.rownames
-      ),
-      recover_new = c(
-        "mode",
-        "weighted",
-        "diag",
-        "add.colnames",
-        "add.rownames"
-      ),
-      recover_old = c(
-        "mode",
-        "weighted",
-        "diag",
-        "add.colnames",
-        "add.rownames"
-      ),
-      match_names = c(
-        "mode",
-        "weighted",
-        "diag",
-        "add.colnames",
-        "add.rownames"
-      ),
-      match_to = c("mode", "weighted", "diag", "add.colnames", "add.rownames"),
-      defaults = list(
-        mode = c("directed", "undirected", "max", "min", "upper", "lower", "plus"),
-        weighted = NULL,
-        diag = TRUE,
-        add.colnames = NULL,
-        add.rownames = NA
-      ),
-      head_args = c("adjmatrix"),
-      fn_name = "from_adjacency"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("a", "ad"),
+        "from_adjacency"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          mode = mode,
+          weighted = weighted,
+          diag = diag,
+          add.colnames = add.colnames,
+          add.rownames = add.rownames
+        ),
+        recover_new = c(
+          "mode",
+          "weighted",
+          "diag",
+          "add.colnames",
+          "add.rownames"
+        ),
+        recover_old = c(
+          "mode",
+          "weighted",
+          "diag",
+          "add.colnames",
+          "add.rownames"
+        ),
+        match_names = c(
+          "mode",
+          "weighted",
+          "diag",
+          "add.colnames",
+          "add.rownames"
+        ),
+        match_to = c("mode", "weighted", "diag", "add.colnames", "add.rownames"),
+        defaults = list(
+          mode = c("directed", "undirected", "max", "min", "upper", "lower", "plus"),
+          weighted = NULL,
+          diag = TRUE,
+          add.colnames = NULL,
+          add.rownames = NA
+        ),
+        head_args = c("adjmatrix"),
+        fn_name = "from_adjacency"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/assortativity.R
+++ b/R/assortativity.R
@@ -250,23 +250,26 @@ assortativity_nominal <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: assortativity_nominal, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, normalized = normalized),
-      recover_new = c("directed", "normalized"),
-      recover_old = c("directed", "normalized"),
-      match_names = c("directed", "normalized"),
-      match_to = c("directed", "normalized"),
-      defaults = list(directed = TRUE, normalized = TRUE),
-      head_args = c("graph", "types"),
-      fn_name = "assortativity_nominal"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, normalized = normalized),
+        recover_new = c("directed", "normalized"),
+        recover_old = c("directed", "normalized"),
+        match_names = c("directed", "normalized"),
+        match_to = c("directed", "normalized"),
+        defaults = list(directed = TRUE, normalized = TRUE),
+        head_args = c("graph", "types"),
+        fn_name = "assortativity_nominal"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -293,23 +296,26 @@ assortativity_degree <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: assortativity_degree, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = TRUE),
-      head_args = c("graph"),
-      fn_name = "assortativity_degree"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = TRUE),
+        head_args = c("graph"),
+        fn_name = "assortativity_degree"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/bipartite.R
+++ b/R/bipartite.R
@@ -171,33 +171,36 @@ bipartite_projection <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: bipartite_projection, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        multiplicity = multiplicity,
-        probe1 = probe1,
-        which = which,
-        remove.type = remove.type
-      ),
-      recover_new = c("multiplicity", "probe1", "which", "remove.type"),
-      recover_old = c("multiplicity", "probe1", "which", "remove.type"),
-      match_names = c("multiplicity", "probe1", "which", "remove.type"),
-      match_to = c("multiplicity", "probe1", "which", "remove.type"),
-      defaults = list(
-        multiplicity = TRUE,
-        probe1 = NULL,
-        which = c("both", "true", "false"),
-        remove.type = TRUE
-      ),
-      head_args = c("graph", "types"),
-      fn_name = "bipartite_projection"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          multiplicity = multiplicity,
+          probe1 = probe1,
+          which = which,
+          remove.type = remove.type
+        ),
+        recover_new = c("multiplicity", "probe1", "which", "remove.type"),
+        recover_old = c("multiplicity", "probe1", "which", "remove.type"),
+        match_names = c("multiplicity", "probe1", "which", "remove.type"),
+        match_to = c("multiplicity", "probe1", "which", "remove.type"),
+        defaults = list(
+          multiplicity = TRUE,
+          probe1 = NULL,
+          which = c("both", "true", "false"),
+          remove.type = TRUE
+        ),
+        head_args = c("graph", "types"),
+        fn_name = "bipartite_projection"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/centrality.R
+++ b/R/centrality.R
@@ -440,33 +440,36 @@ betweenness <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: betweenness, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        directed = directed,
-        weights = weights,
-        normalized = normalized,
-        cutoff = cutoff
-      ),
-      recover_new = c("directed", "weights", "normalized", "cutoff"),
-      recover_old = c("directed", "weights", "normalized", "cutoff"),
-      match_names = c("directed", "weights", "normalized", "cutoff"),
-      match_to = c("directed", "weights", "normalized", "cutoff"),
-      defaults = list(
-        directed = TRUE,
-        weights = NULL,
-        normalized = FALSE,
-        cutoff = -1
-      ),
-      head_args = c("graph", "v"),
-      fn_name = "betweenness"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          directed = directed,
+          weights = weights,
+          normalized = normalized,
+          cutoff = cutoff
+        ),
+        recover_new = c("directed", "weights", "normalized", "cutoff"),
+        recover_old = c("directed", "weights", "normalized", "cutoff"),
+        match_names = c("directed", "weights", "normalized", "cutoff"),
+        match_to = c("directed", "weights", "normalized", "cutoff"),
+        defaults = list(
+          directed = TRUE,
+          weights = NULL,
+          normalized = FALSE,
+          cutoff = -1
+        ),
+        head_args = c("graph", "v"),
+        fn_name = "betweenness"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -507,23 +510,26 @@ edge_betweenness <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: edge_betweenness, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, weights = weights, cutoff = cutoff),
-      recover_new = c("directed", "weights", "cutoff"),
-      recover_old = c("directed", "weights", "cutoff"),
-      match_names = c("directed", "weights", "cutoff"),
-      match_to = c("directed", "weights", "cutoff"),
-      defaults = list(directed = TRUE, weights = NULL, cutoff = -1),
-      head_args = c("graph", "e"),
-      fn_name = "edge_betweenness"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, weights = weights, cutoff = cutoff),
+        recover_new = c("directed", "weights", "cutoff"),
+        recover_old = c("directed", "weights", "cutoff"),
+        match_names = c("directed", "weights", "cutoff"),
+        match_to = c("directed", "weights", "cutoff"),
+        defaults = list(directed = TRUE, weights = NULL, cutoff = -1),
+        head_args = c("graph", "e"),
+        fn_name = "edge_betweenness"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -648,33 +654,36 @@ closeness <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: closeness, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        mode = mode,
-        weights = weights,
-        normalized = normalized,
-        cutoff = cutoff
-      ),
-      recover_new = c("mode", "weights", "normalized", "cutoff"),
-      recover_old = c("mode", "weights", "normalized", "cutoff"),
-      match_names = c("mode", "weights", "normalized", "cutoff"),
-      match_to = c("mode", "weights", "normalized", "cutoff"),
-      defaults = list(
-        mode = c("out", "in", "all", "total"),
-        weights = NULL,
-        normalized = FALSE,
-        cutoff = -1
-      ),
-      head_args = c("graph", "vids"),
-      fn_name = "closeness"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          mode = mode,
+          weights = weights,
+          normalized = normalized,
+          cutoff = cutoff
+        ),
+        recover_new = c("mode", "weights", "normalized", "cutoff"),
+        recover_old = c("mode", "weights", "normalized", "cutoff"),
+        match_names = c("mode", "weights", "normalized", "cutoff"),
+        match_to = c("mode", "weights", "normalized", "cutoff"),
+        defaults = list(
+          mode = c("out", "in", "all", "total"),
+          weights = NULL,
+          normalized = FALSE,
+          cutoff = -1
+        ),
+        head_args = c("graph", "vids"),
+        fn_name = "closeness"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1174,23 +1183,26 @@ subgraph_centrality <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: subgraph_centrality, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(diag = diag),
-      recover_new = c("diag"),
-      recover_old = c("diag"),
-      match_names = c("diag"),
-      match_to = c("diag"),
-      defaults = list(diag = FALSE),
-      head_args = c("graph"),
-      fn_name = "subgraph_centrality"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(diag = diag),
+        recover_new = c("diag"),
+        recover_old = c("diag"),
+        match_names = c("diag"),
+        match_to = c("diag"),
+        defaults = list(diag = FALSE),
+        head_args = c("graph"),
+        fn_name = "subgraph_centrality"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1507,27 +1519,30 @@ strength <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: strength, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, loops = loops, weights = weights),
-      recover_new = c("mode", "loops", "weights"),
-      recover_old = c("mode", "loops", "weights"),
-      match_names = c("mode", "loops", "weights"),
-      match_to = c("mode", "loops", "weights"),
-      defaults = list(
-        mode = c("all", "out", "in", "total"),
-        loops = TRUE,
-        weights = NULL
-      ),
-      head_args = c("graph", "vids"),
-      fn_name = "strength"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, loops = loops, weights = weights),
+        recover_new = c("mode", "loops", "weights"),
+        recover_old = c("mode", "loops", "weights"),
+        match_names = c("mode", "loops", "weights"),
+        match_to = c("mode", "loops", "weights"),
+        defaults = list(
+          mode = c("all", "out", "in", "total"),
+          loops = TRUE,
+          weights = NULL
+        ),
+        head_args = c("graph", "vids"),
+        fn_name = "strength"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1595,23 +1610,26 @@ diversity <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: diversity, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights, vids = vids),
-      recover_new = c("weights", "vids"),
-      recover_old = c("weights", "vids"),
-      match_names = c("weights", "vids"),
-      match_to = c("weights", "vids"),
-      defaults = list(weights = NULL, vids = NULL),
-      head_args = c("graph"),
-      fn_name = "diversity"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights, vids = vids),
+        recover_new = c("weights", "vids"),
+        recover_old = c("weights", "vids"),
+        match_names = c("weights", "vids"),
+        match_to = c("weights", "vids"),
+        defaults = list(weights = NULL, vids = NULL),
+        head_args = c("graph"),
+        fn_name = "diversity"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1887,71 +1905,74 @@ page_rank <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: page_rank, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        algo = algo,
-        vids = vids,
-        directed = directed,
-        damping = damping,
-        personalized = personalized,
-        weights = weights,
-        options = options
-      ),
-      recover_new = c(
-        "algo",
-        "vids",
-        "directed",
-        "damping",
-        "personalized",
-        "weights",
-        "options"
-      ),
-      recover_old = c(
-        "algo",
-        "vids",
-        "directed",
-        "damping",
-        "personalized",
-        "weights",
-        "options"
-      ),
-      match_names = c(
-        "algo",
-        "vids",
-        "directed",
-        "damping",
-        "personalized",
-        "weights",
-        "options"
-      ),
-      match_to = c(
-        "algo",
-        "vids",
-        "directed",
-        "damping",
-        "personalized",
-        "weights",
-        "options"
-      ),
-      defaults = list(
-        algo = c("prpack", "arpack"),
-        vids = NULL,
-        directed = TRUE,
-        damping = 0.85,
-        personalized = NULL,
-        weights = NULL,
-        options = NULL
-      ),
-      head_args = c("graph"),
-      fn_name = "page_rank"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          algo = algo,
+          vids = vids,
+          directed = directed,
+          damping = damping,
+          personalized = personalized,
+          weights = weights,
+          options = options
+        ),
+        recover_new = c(
+          "algo",
+          "vids",
+          "directed",
+          "damping",
+          "personalized",
+          "weights",
+          "options"
+        ),
+        recover_old = c(
+          "algo",
+          "vids",
+          "directed",
+          "damping",
+          "personalized",
+          "weights",
+          "options"
+        ),
+        match_names = c(
+          "algo",
+          "vids",
+          "directed",
+          "damping",
+          "personalized",
+          "weights",
+          "options"
+        ),
+        match_to = c(
+          "algo",
+          "vids",
+          "directed",
+          "damping",
+          "personalized",
+          "weights",
+          "options"
+        ),
+        defaults = list(
+          algo = c("prpack", "arpack"),
+          vids = NULL,
+          directed = TRUE,
+          damping = 0.85,
+          personalized = NULL,
+          weights = NULL,
+          options = NULL
+        ),
+        head_args = c("graph"),
+        fn_name = "page_rank"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2029,33 +2050,36 @@ harmonic_centrality <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: harmonic_centrality, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        mode = mode,
-        weights = weights,
-        normalized = normalized,
-        cutoff = cutoff
-      ),
-      recover_new = c("mode", "weights", "normalized", "cutoff"),
-      recover_old = c("mode", "weights", "normalized", "cutoff"),
-      match_names = c("mode", "weights", "normalized", "cutoff"),
-      match_to = c("mode", "weights", "normalized", "cutoff"),
-      defaults = list(
-        mode = c("out", "in", "all", "total"),
-        weights = NULL,
-        normalized = FALSE,
-        cutoff = -1
-      ),
-      head_args = c("graph", "vids"),
-      fn_name = "harmonic_centrality"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          mode = mode,
+          weights = weights,
+          normalized = normalized,
+          cutoff = cutoff
+        ),
+        recover_new = c("mode", "weights", "normalized", "cutoff"),
+        recover_old = c("mode", "weights", "normalized", "cutoff"),
+        match_names = c("mode", "weights", "normalized", "cutoff"),
+        match_to = c("mode", "weights", "normalized", "cutoff"),
+        defaults = list(
+          mode = c("out", "in", "all", "total"),
+          weights = NULL,
+          normalized = FALSE,
+          cutoff = -1
+        ),
+        head_args = c("graph", "vids"),
+        fn_name = "harmonic_centrality"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2266,58 +2290,61 @@ power_centrality <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: power_centrality, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        loops = loops,
-        exponent = exponent,
-        rescale = rescale,
-        tol = tol,
-        sparse = sparse,
-        weights = weights
-      ),
-      recover_new = c(
-        "loops",
-        "exponent",
-        "rescale",
-        "tol",
-        "sparse",
-        "weights"
-      ),
-      recover_old = c(
-        "loops",
-        "exponent",
-        "rescale",
-        "tol",
-        "sparse",
-        "weights"
-      ),
-      match_names = c(
-        "loops",
-        "exponent",
-        "rescale",
-        "tol",
-        "sparse",
-        "weights"
-      ),
-      match_to = c("loops", "exponent", "rescale", "tol", "sparse", "weights"),
-      defaults = list(
-        loops = FALSE,
-        exponent = 1,
-        rescale = FALSE,
-        tol = 1e-07,
-        sparse = TRUE,
-        weights = NULL
-      ),
-      head_args = c("graph", "nodes"),
-      fn_name = "power_centrality"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          loops = loops,
+          exponent = exponent,
+          rescale = rescale,
+          tol = tol,
+          sparse = sparse,
+          weights = weights
+        ),
+        recover_new = c(
+          "loops",
+          "exponent",
+          "rescale",
+          "tol",
+          "sparse",
+          "weights"
+        ),
+        recover_old = c(
+          "loops",
+          "exponent",
+          "rescale",
+          "tol",
+          "sparse",
+          "weights"
+        ),
+        match_names = c(
+          "loops",
+          "exponent",
+          "rescale",
+          "tol",
+          "sparse",
+          "weights"
+        ),
+        match_to = c("loops", "exponent", "rescale", "tol", "sparse", "weights"),
+        defaults = list(
+          loops = FALSE,
+          exponent = 1,
+          rescale = FALSE,
+          tol = 1e-07,
+          sparse = TRUE,
+          weights = NULL
+        ),
+        head_args = c("graph", "nodes"),
+        fn_name = "power_centrality"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2491,37 +2518,40 @@ alpha_centrality <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: alpha_centrality, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        alpha = alpha,
-        loops = loops,
-        exo = exo,
-        weights = weights,
-        tol = tol,
-        sparse = sparse
-      ),
-      recover_new = c("alpha", "loops", "exo", "weights", "tol", "sparse"),
-      recover_old = c("alpha", "loops", "exo", "weights", "tol", "sparse"),
-      match_names = c("alpha", "loops", "exo", "weights", "tol", "sparse"),
-      match_to = c("alpha", "loops", "exo", "weights", "tol", "sparse"),
-      defaults = list(
-        alpha = 1,
-        loops = FALSE,
-        exo = 1,
-        weights = NULL,
-        tol = 1e-07,
-        sparse = TRUE
-      ),
-      head_args = c("graph", "nodes"),
-      fn_name = "alpha_centrality"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          alpha = alpha,
+          loops = loops,
+          exo = exo,
+          weights = weights,
+          tol = tol,
+          sparse = sparse
+        ),
+        recover_new = c("alpha", "loops", "exo", "weights", "tol", "sparse"),
+        recover_old = c("alpha", "loops", "exo", "weights", "tol", "sparse"),
+        match_names = c("alpha", "loops", "exo", "weights", "tol", "sparse"),
+        match_to = c("alpha", "loops", "exo", "weights", "tol", "sparse"),
+        defaults = list(
+          alpha = 1,
+          loops = FALSE,
+          exo = 1,
+          weights = NULL,
+          tol = 1e-07,
+          sparse = TRUE
+        ),
+        head_args = c("graph", "nodes"),
+        fn_name = "alpha_centrality"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/centralization.R
+++ b/R/centralization.R
@@ -323,26 +323,29 @@ centralize <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: centralize, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        theoretical.max = theoretical.max,
-        normalized = normalized
-      ),
-      recover_new = c("theoretical.max", "normalized"),
-      recover_old = c("theoretical.max", "normalized"),
-      match_names = c("theoretical.max", "normalized"),
-      match_to = c("theoretical.max", "normalized"),
-      defaults = list(theoretical.max = 0, normalized = TRUE),
-      head_args = c("scores"),
-      fn_name = "centralize"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          theoretical.max = theoretical.max,
+          normalized = normalized
+        ),
+        recover_new = c("theoretical.max", "normalized"),
+        recover_old = c("theoretical.max", "normalized"),
+        match_names = c("theoretical.max", "normalized"),
+        match_to = c("theoretical.max", "normalized"),
+        defaults = list(theoretical.max = 0, normalized = TRUE),
+        head_args = c("scores"),
+        fn_name = "centralize"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -402,27 +405,30 @@ centr_degree <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: centr_degree, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, loops = loops, normalized = normalized),
-      recover_new = c("mode", "loops", "normalized"),
-      recover_old = c("mode", "loops", "normalized"),
-      match_names = c("mode", "loops", "normalized"),
-      match_to = c("mode", "loops", "normalized"),
-      defaults = list(
-        mode = c("all", "out", "in", "total"),
-        loops = TRUE,
-        normalized = TRUE
-      ),
-      head_args = c("graph"),
-      fn_name = "centr_degree"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, loops = loops, normalized = normalized),
+        recover_new = c("mode", "loops", "normalized"),
+        recover_old = c("mode", "loops", "normalized"),
+        match_names = c("mode", "loops", "normalized"),
+        match_to = c("mode", "loops", "normalized"),
+        defaults = list(
+          mode = c("all", "out", "in", "total"),
+          loops = TRUE,
+          normalized = TRUE
+        ),
+        head_args = c("graph"),
+        fn_name = "centr_degree"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -534,23 +540,26 @@ centr_betw <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: centr_betw, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, normalized = normalized),
-      recover_new = c("directed", "normalized"),
-      recover_old = c("directed", "normalized"),
-      match_names = c("directed", "normalized"),
-      match_to = c("directed", "normalized"),
-      defaults = list(directed = TRUE, normalized = TRUE),
-      head_args = c("graph"),
-      fn_name = "centr_betw"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, normalized = normalized),
+        recover_new = c("directed", "normalized"),
+        recover_old = c("directed", "normalized"),
+        match_names = c("directed", "normalized"),
+        match_to = c("directed", "normalized"),
+        defaults = list(directed = TRUE, normalized = TRUE),
+        head_args = c("graph"),
+        fn_name = "centr_betw"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -604,23 +613,26 @@ centr_betw_tmax <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: centr_betw_tmax, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = TRUE),
-      head_args = c("graph", "nodes"),
-      fn_name = "centr_betw_tmax"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = TRUE),
+        head_args = c("graph", "nodes"),
+        fn_name = "centr_betw_tmax"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -676,23 +688,26 @@ centr_clo <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: centr_clo, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, normalized = normalized),
-      recover_new = c("mode", "normalized"),
-      recover_old = c("mode", "normalized"),
-      match_names = c("mode", "normalized"),
-      match_to = c("mode", "normalized"),
-      defaults = list(mode = c("out", "in", "all", "total"), normalized = TRUE),
-      head_args = c("graph"),
-      fn_name = "centr_clo"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, normalized = normalized),
+        recover_new = c("mode", "normalized"),
+        recover_old = c("mode", "normalized"),
+        match_names = c("mode", "normalized"),
+        match_to = c("mode", "normalized"),
+        defaults = list(mode = c("out", "in", "all", "total"), normalized = TRUE),
+        head_args = c("graph"),
+        fn_name = "centr_clo"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -736,23 +751,26 @@ centr_clo_tmax <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: centr_clo_tmax, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("out", "in", "all", "total")),
-      head_args = c("graph", "nodes"),
-      fn_name = "centr_clo_tmax"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("out", "in", "all", "total")),
+        head_args = c("graph", "nodes"),
+        fn_name = "centr_clo_tmax"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/cliques.R
+++ b/R/cliques.R
@@ -392,23 +392,26 @@ count_max_cliques <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: count_max_cliques, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(subset = subset),
-      recover_new = c("subset"),
-      recover_old = c("subset"),
-      match_names = c("subset"),
-      match_to = c("subset"),
-      defaults = list(subset = NULL),
-      head_args = c("graph", "min", "max"),
-      fn_name = "count_max_cliques"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(subset = subset),
+        recover_new = c("subset"),
+        recover_old = c("subset"),
+        match_names = c("subset"),
+        match_to = c("subset"),
+        defaults = list(subset = NULL),
+        head_args = c("graph", "min", "max"),
+        fn_name = "count_max_cliques"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -504,33 +507,36 @@ weighted_cliques <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: weighted_cliques, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        vertex.weights = vertex.weights,
-        min.weight = min.weight,
-        max.weight = max.weight,
-        maximal = maximal
-      ),
-      recover_new = c("vertex.weights", "min.weight", "max.weight", "maximal"),
-      recover_old = c("vertex.weights", "min.weight", "max.weight", "maximal"),
-      match_names = c("vertex.weights", "min.weight", "max.weight", "maximal"),
-      match_to = c("vertex.weights", "min.weight", "max.weight", "maximal"),
-      defaults = list(
-        vertex.weights = NULL,
-        min.weight = 0,
-        max.weight = 0,
-        maximal = FALSE
-      ),
-      head_args = c("graph"),
-      fn_name = "weighted_cliques"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          vertex.weights = vertex.weights,
+          min.weight = min.weight,
+          max.weight = max.weight,
+          maximal = maximal
+        ),
+        recover_new = c("vertex.weights", "min.weight", "max.weight", "maximal"),
+        recover_old = c("vertex.weights", "min.weight", "max.weight", "maximal"),
+        match_names = c("vertex.weights", "min.weight", "max.weight", "maximal"),
+        match_to = c("vertex.weights", "min.weight", "max.weight", "maximal"),
+        defaults = list(
+          vertex.weights = NULL,
+          min.weight = 0,
+          max.weight = 0,
+          maximal = FALSE
+        ),
+        head_args = c("graph"),
+        fn_name = "weighted_cliques"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -552,23 +558,26 @@ largest_weighted_cliques <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: largest_weighted_cliques, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(vertex.weights = vertex.weights),
-      recover_new = c("vertex.weights"),
-      recover_old = c("vertex.weights"),
-      match_names = c("vertex.weights"),
-      match_to = c("vertex.weights"),
-      defaults = list(vertex.weights = NULL),
-      head_args = c("graph"),
-      fn_name = "largest_weighted_cliques"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(vertex.weights = vertex.weights),
+        recover_new = c("vertex.weights"),
+        recover_old = c("vertex.weights"),
+        match_names = c("vertex.weights"),
+        match_to = c("vertex.weights"),
+        defaults = list(vertex.weights = NULL),
+        head_args = c("graph"),
+        fn_name = "largest_weighted_cliques"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -587,23 +596,26 @@ weighted_clique_num <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: weighted_clique_num, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(vertex.weights = vertex.weights),
-      recover_new = c("vertex.weights"),
-      recover_old = c("vertex.weights"),
-      match_names = c("vertex.weights"),
-      match_to = c("vertex.weights"),
-      defaults = list(vertex.weights = NULL),
-      head_args = c("graph"),
-      fn_name = "weighted_clique_num"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(vertex.weights = vertex.weights),
+        recover_new = c("vertex.weights"),
+        recover_old = c("vertex.weights"),
+        match_names = c("vertex.weights"),
+        match_to = c("vertex.weights"),
+        defaults = list(vertex.weights = NULL),
+        head_args = c("graph"),
+        fn_name = "weighted_clique_num"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -760,23 +772,26 @@ clique_size_counts <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: clique_size_counts, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(min = min, max = max, maximal = maximal),
-      recover_new = c("min", "max", "maximal"),
-      recover_old = c("min", "max", "maximal"),
-      match_names = c("min", "max", "maximal"),
-      match_to = c("min", "max", "maximal"),
-      defaults = list(min = 0, max = 0, maximal = FALSE),
-      head_args = c("graph"),
-      fn_name = "clique_size_counts"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(min = min, max = max, maximal = maximal),
+        recover_new = c("min", "max", "maximal"),
+        recover_old = c("min", "max", "maximal"),
+        match_names = c("min", "max", "maximal"),
+        match_to = c("min", "max", "maximal"),
+        defaults = list(min = 0, max = 0, maximal = FALSE),
+        head_args = c("graph"),
+        fn_name = "clique_size_counts"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -843,23 +858,26 @@ is_clique <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: is_clique, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = FALSE),
-      head_args = c("graph", "candidate"),
-      fn_name = "is_clique"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = FALSE),
+        head_args = c("graph", "candidate"),
+        fn_name = "is_clique"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/cohesive.blocks.R
+++ b/R/cohesive.blocks.R
@@ -358,23 +358,26 @@ cohesive_blocks <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: cohesive_blocks, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(labels = labels),
-      recover_new = c("labels"),
-      recover_old = c("labels"),
-      match_names = c("labels"),
-      match_to = c("labels"),
-      defaults = list(labels = TRUE),
-      head_args = c("graph"),
-      fn_name = "cohesive_blocks"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(labels = labels),
+        recover_new = c("labels"),
+        recover_old = c("labels"),
+        match_names = c("labels"),
+        match_to = c("labels"),
+        defaults = list(labels = TRUE),
+        head_args = c("graph"),
+        fn_name = "cohesive_blocks"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -630,23 +633,26 @@ export_pajek <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: export_pajek, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(project.file = project.file),
-      recover_new = c("project.file"),
-      recover_old = c("project.file"),
-      match_names = c("project.file"),
-      match_to = c("project.file"),
-      defaults = list(project.file = TRUE),
-      head_args = c("blocks", "graph", "file"),
-      fn_name = "export_pajek"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(project.file = project.file),
+        recover_new = c("project.file"),
+        recover_old = c("project.file"),
+        match_names = c("project.file"),
+        match_to = c("project.file"),
+        defaults = list(project.file = TRUE),
+        head_args = c("blocks", "graph", "file"),
+        fn_name = "export_pajek"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/coloring.R
+++ b/R/coloring.R
@@ -38,23 +38,26 @@ greedy_vertex_coloring <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: greedy_vertex_coloring, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(heuristic = heuristic),
-      recover_new = c("heuristic"),
-      recover_old = c("heuristic"),
-      match_names = c("heuristic"),
-      match_to = c("heuristic"),
-      defaults = list(heuristic = c("colored_neighbors", "dsatur")),
-      head_args = c("graph"),
-      fn_name = "greedy_vertex_coloring"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(heuristic = heuristic),
+        recover_new = c("heuristic"),
+        recover_old = c("heuristic"),
+        match_names = c("heuristic"),
+        match_to = c("heuristic"),
+        defaults = list(heuristic = c("colored_neighbors", "dsatur")),
+        head_args = c("graph"),
+        fn_name = "greedy_vertex_coloring"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/community.R
+++ b/R/community.R
@@ -780,32 +780,35 @@ make_clusters <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_clusters, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("m", "me"),
-      "make_clusters"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        algorithm = algorithm,
-        merges = merges,
-        modularity = modularity
-      ),
-      recover_new = c("algorithm", "merges", "modularity"),
-      recover_old = c("algorithm", "merges", "modularity"),
-      match_names = c("algorithm", "merges", "modularity"),
-      match_to = c("algorithm", "merges", "modularity"),
-      defaults = list(algorithm = NULL, merges = NULL, modularity = TRUE),
-      head_args = c("graph", "membership"),
-      fn_name = "make_clusters"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("m", "me"),
+        "make_clusters"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          algorithm = algorithm,
+          merges = merges,
+          modularity = modularity
+        ),
+        recover_new = c("algorithm", "merges", "modularity"),
+        recover_old = c("algorithm", "merges", "modularity"),
+        match_names = c("algorithm", "merges", "modularity"),
+        match_to = c("algorithm", "merges", "modularity"),
+        defaults = list(algorithm = NULL, merges = NULL, modularity = TRUE),
+        head_args = c("graph", "membership"),
+        fn_name = "make_clusters"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -983,27 +986,30 @@ modularity_matrix <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: modularity_matrix, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        weights = weights,
-        resolution = resolution,
-        directed = directed
-      ),
-      recover_new = c("weights", "resolution", "directed"),
-      recover_old = c("weights", "resolution", "directed"),
-      match_names = c("weights", "resolution", "directed"),
-      match_to = c("weights", "resolution", "directed"),
-      defaults = list(weights = NULL, resolution = 1, directed = TRUE),
-      head_args = c("graph", "membership"),
-      fn_name = "modularity_matrix"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          weights = weights,
+          resolution = resolution,
+          directed = directed
+        ),
+        recover_new = c("weights", "resolution", "directed"),
+        recover_old = c("weights", "resolution", "directed"),
+        match_names = c("weights", "resolution", "directed"),
+        match_to = c("weights", "resolution", "directed"),
+        defaults = list(weights = NULL, resolution = 1, directed = TRUE),
+        head_args = c("graph", "membership"),
+        fn_name = "modularity_matrix"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1555,100 +1561,103 @@ cluster_spinglass <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: cluster_spinglass, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("g"),
-      "cluster_spinglass"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        weights = weights,
-        vertex = vertex,
-        spins = spins,
-        parupdate = parupdate,
-        start.temp = start.temp,
-        stop.temp = stop.temp,
-        cool.fact = cool.fact,
-        update.rule = update.rule,
-        gamma = gamma,
-        implementation = implementation,
-        gamma.minus = gamma.minus
-      ),
-      recover_new = c(
-        "weights",
-        "vertex",
-        "spins",
-        "parupdate",
-        "start.temp",
-        "stop.temp",
-        "cool.fact",
-        "update.rule",
-        "gamma",
-        "implementation",
-        "gamma.minus"
-      ),
-      recover_old = c(
-        "weights",
-        "vertex",
-        "spins",
-        "parupdate",
-        "start.temp",
-        "stop.temp",
-        "cool.fact",
-        "update.rule",
-        "gamma",
-        "implementation",
-        "gamma.minus"
-      ),
-      match_names = c(
-        "weights",
-        "vertex",
-        "spins",
-        "parupdate",
-        "start.temp",
-        "stop.temp",
-        "cool.fact",
-        "update.rule",
-        "gamma",
-        "implementation",
-        "gamma.minus"
-      ),
-      match_to = c(
-        "weights",
-        "vertex",
-        "spins",
-        "parupdate",
-        "start.temp",
-        "stop.temp",
-        "cool.fact",
-        "update.rule",
-        "gamma",
-        "implementation",
-        "gamma.minus"
-      ),
-      defaults = list(
-        weights = NULL,
-        vertex = NULL,
-        spins = 25,
-        parupdate = FALSE,
-        start.temp = 1,
-        stop.temp = 0.01,
-        cool.fact = 0.99,
-        update.rule = c("config", "random", "simple"),
-        gamma = 1,
-        implementation = c("orig", "neg"),
-        gamma.minus = 1
-      ),
-      head_args = c("graph"),
-      fn_name = "cluster_spinglass"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("g"),
+        "cluster_spinglass"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          weights = weights,
+          vertex = vertex,
+          spins = spins,
+          parupdate = parupdate,
+          start.temp = start.temp,
+          stop.temp = stop.temp,
+          cool.fact = cool.fact,
+          update.rule = update.rule,
+          gamma = gamma,
+          implementation = implementation,
+          gamma.minus = gamma.minus
+        ),
+        recover_new = c(
+          "weights",
+          "vertex",
+          "spins",
+          "parupdate",
+          "start.temp",
+          "stop.temp",
+          "cool.fact",
+          "update.rule",
+          "gamma",
+          "implementation",
+          "gamma.minus"
+        ),
+        recover_old = c(
+          "weights",
+          "vertex",
+          "spins",
+          "parupdate",
+          "start.temp",
+          "stop.temp",
+          "cool.fact",
+          "update.rule",
+          "gamma",
+          "implementation",
+          "gamma.minus"
+        ),
+        match_names = c(
+          "weights",
+          "vertex",
+          "spins",
+          "parupdate",
+          "start.temp",
+          "stop.temp",
+          "cool.fact",
+          "update.rule",
+          "gamma",
+          "implementation",
+          "gamma.minus"
+        ),
+        match_to = c(
+          "weights",
+          "vertex",
+          "spins",
+          "parupdate",
+          "start.temp",
+          "stop.temp",
+          "cool.fact",
+          "update.rule",
+          "gamma",
+          "implementation",
+          "gamma.minus"
+        ),
+        defaults = list(
+          weights = NULL,
+          vertex = NULL,
+          spins = 25,
+          parupdate = FALSE,
+          start.temp = 1,
+          stop.temp = 0.01,
+          cool.fact = 0.99,
+          update.rule = c("config", "random", "simple"),
+          gamma = 1,
+          implementation = c("orig", "neg"),
+          gamma.minus = 1
+        ),
+        head_args = c("graph"),
+        fn_name = "cluster_spinglass"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2039,35 +2048,38 @@ cluster_walktrap <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: cluster_walktrap, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        weights = weights,
-        steps = steps,
-        merges = merges,
-        modularity = modularity,
-        membership = membership
-      ),
-      recover_new = c("weights", "steps", "merges", "modularity", "membership"),
-      recover_old = c("weights", "steps", "merges", "modularity", "membership"),
-      match_names = c("weights", "steps", "merges", "modularity", "membership"),
-      match_to = c("weights", "steps", "merges", "modularity", "membership"),
-      defaults = list(
-        weights = NULL,
-        steps = 4,
-        merges = TRUE,
-        modularity = TRUE,
-        membership = TRUE
-      ),
-      head_args = c("graph"),
-      fn_name = "cluster_walktrap"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          weights = weights,
+          steps = steps,
+          merges = merges,
+          modularity = modularity,
+          membership = membership
+        ),
+        recover_new = c("weights", "steps", "merges", "modularity", "membership"),
+        recover_old = c("weights", "steps", "merges", "modularity", "membership"),
+        match_names = c("weights", "steps", "merges", "modularity", "membership"),
+        match_to = c("weights", "steps", "merges", "modularity", "membership"),
+        defaults = list(
+          weights = NULL,
+          steps = 4,
+          merges = TRUE,
+          modularity = TRUE,
+          membership = TRUE
+        ),
+        head_args = c("graph"),
+        fn_name = "cluster_walktrap"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2207,71 +2219,74 @@ cluster_edge_betweenness <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: cluster_edge_betweenness, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        weights = weights,
-        directed = directed,
-        edge.betweenness = edge.betweenness,
-        merges = merges,
-        bridges = bridges,
-        modularity = modularity,
-        membership = membership
-      ),
-      recover_new = c(
-        "weights",
-        "directed",
-        "edge.betweenness",
-        "merges",
-        "bridges",
-        "modularity",
-        "membership"
-      ),
-      recover_old = c(
-        "weights",
-        "directed",
-        "edge.betweenness",
-        "merges",
-        "bridges",
-        "modularity",
-        "membership"
-      ),
-      match_names = c(
-        "weights",
-        "directed",
-        "edge.betweenness",
-        "merges",
-        "bridges",
-        "modularity",
-        "membership"
-      ),
-      match_to = c(
-        "weights",
-        "directed",
-        "edge.betweenness",
-        "merges",
-        "bridges",
-        "modularity",
-        "membership"
-      ),
-      defaults = list(
-        weights = NULL,
-        directed = TRUE,
-        edge.betweenness = TRUE,
-        merges = TRUE,
-        bridges = TRUE,
-        modularity = TRUE,
-        membership = TRUE
-      ),
-      head_args = c("graph"),
-      fn_name = "cluster_edge_betweenness"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          weights = weights,
+          directed = directed,
+          edge.betweenness = edge.betweenness,
+          merges = merges,
+          bridges = bridges,
+          modularity = modularity,
+          membership = membership
+        ),
+        recover_new = c(
+          "weights",
+          "directed",
+          "edge.betweenness",
+          "merges",
+          "bridges",
+          "modularity",
+          "membership"
+        ),
+        recover_old = c(
+          "weights",
+          "directed",
+          "edge.betweenness",
+          "merges",
+          "bridges",
+          "modularity",
+          "membership"
+        ),
+        match_names = c(
+          "weights",
+          "directed",
+          "edge.betweenness",
+          "merges",
+          "bridges",
+          "modularity",
+          "membership"
+        ),
+        match_to = c(
+          "weights",
+          "directed",
+          "edge.betweenness",
+          "merges",
+          "bridges",
+          "modularity",
+          "membership"
+        ),
+        defaults = list(
+          weights = NULL,
+          directed = TRUE,
+          edge.betweenness = TRUE,
+          merges = TRUE,
+          bridges = TRUE,
+          modularity = TRUE,
+          membership = TRUE
+        ),
+        head_args = c("graph"),
+        fn_name = "cluster_edge_betweenness"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2371,33 +2386,36 @@ cluster_fast_greedy <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: cluster_fast_greedy, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        merges = merges,
-        modularity = modularity,
-        membership = membership,
-        weights = weights
-      ),
-      recover_new = c("merges", "modularity", "membership", "weights"),
-      recover_old = c("merges", "modularity", "membership", "weights"),
-      match_names = c("merges", "modularity", "membership", "weights"),
-      match_to = c("merges", "modularity", "membership", "weights"),
-      defaults = list(
-        merges = TRUE,
-        modularity = TRUE,
-        membership = TRUE,
-        weights = NULL
-      ),
-      head_args = c("graph"),
-      fn_name = "cluster_fast_greedy"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          merges = merges,
+          modularity = modularity,
+          membership = membership,
+          weights = weights
+        ),
+        recover_new = c("merges", "modularity", "membership", "weights"),
+        recover_old = c("merges", "modularity", "membership", "weights"),
+        match_names = c("merges", "modularity", "membership", "weights"),
+        match_to = c("merges", "modularity", "membership", "weights"),
+        defaults = list(
+          merges = TRUE,
+          modularity = TRUE,
+          membership = TRUE,
+          weights = NULL
+        ),
+        head_args = c("graph"),
+        fn_name = "cluster_fast_greedy"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2828,23 +2846,26 @@ cluster_louvain <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: cluster_louvain, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights, resolution = resolution),
-      recover_new = c("weights", "resolution"),
-      recover_old = c("weights", "resolution"),
-      match_names = c("weights", "resolution"),
-      match_to = c("weights", "resolution"),
-      defaults = list(weights = NULL, resolution = 1),
-      head_args = c("graph"),
-      fn_name = "cluster_louvain"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights, resolution = resolution),
+        recover_new = c("weights", "resolution"),
+        recover_old = c("weights", "resolution"),
+        match_names = c("weights", "resolution"),
+        match_to = c("weights", "resolution"),
+        defaults = list(weights = NULL, resolution = 1),
+        head_args = c("graph"),
+        fn_name = "cluster_louvain"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2947,23 +2968,26 @@ cluster_optimal <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: cluster_optimal, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights),
-      recover_new = c("weights"),
-      recover_old = c("weights"),
-      match_names = c("weights"),
-      match_to = c("weights"),
-      defaults = list(weights = NULL),
-      head_args = c("graph"),
-      fn_name = "cluster_optimal"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights),
+        recover_new = c("weights"),
+        recover_old = c("weights"),
+        match_names = c("weights"),
+        match_to = c("weights"),
+        defaults = list(weights = NULL),
+        head_args = c("graph"),
+        fn_name = "cluster_optimal"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3056,33 +3080,36 @@ cluster_infomap <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: cluster_infomap, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        e.weights = e.weights,
-        v.weights = v.weights,
-        nb.trials = nb.trials,
-        modularity = modularity
-      ),
-      recover_new = c("e.weights", "v.weights", "nb.trials", "modularity"),
-      recover_old = c("e.weights", "v.weights", "nb.trials", "modularity"),
-      match_names = c("e.weights", "v.weights", "nb.trials", "modularity"),
-      match_to = c("e.weights", "v.weights", "nb.trials", "modularity"),
-      defaults = list(
-        e.weights = NULL,
-        v.weights = NULL,
-        nb.trials = 10,
-        modularity = TRUE
-      ),
-      head_args = c("graph"),
-      fn_name = "cluster_infomap"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          e.weights = e.weights,
+          v.weights = v.weights,
+          nb.trials = nb.trials,
+          modularity = modularity
+        ),
+        recover_new = c("e.weights", "v.weights", "nb.trials", "modularity"),
+        recover_old = c("e.weights", "v.weights", "nb.trials", "modularity"),
+        match_names = c("e.weights", "v.weights", "nb.trials", "modularity"),
+        match_to = c("e.weights", "v.weights", "nb.trials", "modularity"),
+        defaults = list(
+          e.weights = NULL,
+          v.weights = NULL,
+          nb.trials = 10,
+          modularity = TRUE
+        ),
+        head_args = c("graph"),
+        fn_name = "cluster_infomap"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/components.R
+++ b/R/components.R
@@ -206,31 +206,34 @@ decompose <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: decompose, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        mode = mode,
-        max.comps = max.comps,
-        min.vertices = min.vertices
-      ),
-      recover_new = c("mode", "max.comps", "min.vertices"),
-      recover_old = c("mode", "max.comps", "min.vertices"),
-      match_names = c("mode", "max.comps", "min.vertices"),
-      match_to = c("mode", "max.comps", "min.vertices"),
-      defaults = list(
-        mode = c("weak", "strong"),
-        max.comps = NA,
-        min.vertices = 0
-      ),
-      head_args = c("graph"),
-      fn_name = "decompose"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          mode = mode,
+          max.comps = max.comps,
+          min.vertices = min.vertices
+        ),
+        recover_new = c("mode", "max.comps", "min.vertices"),
+        recover_old = c("mode", "max.comps", "min.vertices"),
+        match_names = c("mode", "max.comps", "min.vertices"),
+        match_to = c("mode", "max.comps", "min.vertices"),
+        defaults = list(
+          mode = c("weak", "strong"),
+          max.comps = NA,
+          min.vertices = 0
+        ),
+        head_args = c("graph"),
+        fn_name = "decompose"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -435,23 +438,26 @@ largest_component <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: largest_component, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("weak", "strong")),
-      head_args = c("graph"),
-      fn_name = "largest_component"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("weak", "strong")),
+        head_args = c("graph"),
+        fn_name = "largest_component"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -452,35 +452,38 @@ as_adjacency_matrix <- function(
 
   # BEGIN GENERATED ARG_HANDLE: as_adjacency_matrix, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        weights = weights,
-        names = names,
-        sparse = sparse,
-        edges = edges,
-        attr = attr
-      ),
-      recover_new = c("weights", "edges", "names", "sparse"),
-      recover_old = c("attr", "edges", "names", "sparse"),
-      match_names = c("attr", "weights", "names", "sparse", "edges", "attr"),
-      match_to = c("weights", "weights", "names", "sparse", "edges", "attr"),
-      defaults = list(
-        weights = NULL,
-        names = TRUE,
-        sparse = NULL,
-        edges = deprecated(),
-        attr = deprecated()
-      ),
-      head_args = c("graph", "type"),
-      fn_name = "as_adjacency_matrix"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          weights = weights,
+          names = names,
+          sparse = sparse,
+          edges = edges,
+          attr = attr
+        ),
+        recover_new = c("weights", "edges", "names", "sparse"),
+        recover_old = c("attr", "edges", "names", "sparse"),
+        match_names = c("attr", "weights", "names", "sparse", "edges", "attr"),
+        match_to = c("weights", "weights", "names", "sparse", "edges", "attr"),
+        defaults = list(
+          weights = NULL,
+          names = TRUE,
+          sparse = NULL,
+          edges = deprecated(),
+          attr = deprecated()
+        ),
+        head_args = c("graph", "type"),
+        fn_name = "as_adjacency_matrix"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -574,23 +577,26 @@ as_edgelist <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: as_edgelist, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(names = names),
-      recover_new = c("names"),
-      recover_old = c("names"),
-      match_names = c("names"),
-      match_to = c("names"),
-      defaults = list(names = TRUE),
-      head_args = c("graph"),
-      fn_name = "as_edgelist"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(names = names),
+        recover_new = c("names"),
+        recover_old = c("names"),
+        match_names = c("names"),
+        match_to = c("names"),
+        defaults = list(names = TRUE),
+        head_args = c("graph"),
+        fn_name = "as_edgelist"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -713,23 +719,26 @@ as_directed <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: as_directed, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("mutual", "arbitrary", "random", "acyclic")),
-      head_args = c("graph"),
-      fn_name = "as_directed"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("mutual", "arbitrary", "random", "acyclic")),
+        head_args = c("graph"),
+        fn_name = "as_directed"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -820,27 +829,30 @@ as_adj_list <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: as_adj_list, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, loops = loops, multiple = multiple),
-      recover_new = c("mode", "loops", "multiple"),
-      recover_old = c("mode", "loops", "multiple"),
-      match_names = c("mode", "loops", "multiple"),
-      match_to = c("mode", "loops", "multiple"),
-      defaults = list(
-        mode = c("all", "out", "in", "total"),
-        loops = c("twice", "once", "ignore"),
-        multiple = TRUE
-      ),
-      head_args = c("graph"),
-      fn_name = "as_adj_list"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, loops = loops, multiple = multiple),
+        recover_new = c("mode", "loops", "multiple"),
+        recover_old = c("mode", "loops", "multiple"),
+        match_names = c("mode", "loops", "multiple"),
+        match_to = c("mode", "loops", "multiple"),
+        defaults = list(
+          mode = c("all", "out", "in", "total"),
+          loops = c("twice", "once", "ignore"),
+          multiple = TRUE
+        ),
+        head_args = c("graph"),
+        fn_name = "as_adj_list"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -879,26 +891,29 @@ as_adj_edge_list <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: as_adj_edge_list, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, loops = loops),
-      recover_new = c("mode", "loops"),
-      recover_old = c("mode", "loops"),
-      match_names = c("mode", "loops"),
-      match_to = c("mode", "loops"),
-      defaults = list(
-        mode = c("all", "out", "in", "total"),
-        loops = c("twice", "once", "ignore")
-      ),
-      head_args = c("graph"),
-      fn_name = "as_adj_edge_list"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, loops = loops),
+        recover_new = c("mode", "loops"),
+        recover_old = c("mode", "loops"),
+        match_names = c("mode", "loops"),
+        match_to = c("mode", "loops"),
+        defaults = list(
+          mode = c("all", "out", "in", "total"),
+          loops = c("twice", "once", "ignore")
+        ),
+        head_args = c("graph"),
+        fn_name = "as_adj_edge_list"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -977,23 +992,26 @@ graph_from_graphnel <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph_from_graphnel, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(name = name, weight = weight, unlist.attrs = unlist.attrs),
-      recover_new = c("name", "weight", "unlist.attrs"),
-      recover_old = c("name", "weight", "unlist.attrs"),
-      match_names = c("name", "weight", "unlist.attrs"),
-      match_to = c("name", "weight", "unlist.attrs"),
-      defaults = list(name = TRUE, weight = TRUE, unlist.attrs = TRUE),
-      head_args = c("graphNEL"),
-      fn_name = "graph_from_graphnel"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(name = name, weight = weight, unlist.attrs = unlist.attrs),
+        recover_new = c("name", "weight", "unlist.attrs"),
+        recover_old = c("name", "weight", "unlist.attrs"),
+        match_names = c("name", "weight", "unlist.attrs"),
+        match_to = c("name", "weight", "unlist.attrs"),
+        defaults = list(name = TRUE, weight = TRUE, unlist.attrs = TRUE),
+        head_args = c("graphNEL"),
+        fn_name = "graph_from_graphnel"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1326,33 +1344,36 @@ as_biadjacency_matrix <- function(
 
   # BEGIN GENERATED ARG_HANDLE: as_biadjacency_matrix, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        weights = weights,
-        names = names,
-        sparse = sparse,
-        attr = attr
-      ),
-      recover_new = c("weights", "names", "sparse"),
-      recover_old = c("attr", "names", "sparse"),
-      match_names = c("attr", "weights", "names", "sparse", "attr"),
-      match_to = c("weights", "weights", "names", "sparse", "attr"),
-      defaults = list(
-        weights = NULL,
-        names = TRUE,
-        sparse = FALSE,
-        attr = deprecated()
-      ),
-      head_args = c("graph", "types"),
-      fn_name = "as_biadjacency_matrix"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          weights = weights,
+          names = names,
+          sparse = sparse,
+          attr = attr
+        ),
+        recover_new = c("weights", "names", "sparse"),
+        recover_old = c("attr", "names", "sparse"),
+        match_names = c("attr", "weights", "names", "sparse", "attr"),
+        match_to = c("weights", "weights", "names", "sparse", "attr"),
+        defaults = list(
+          weights = NULL,
+          names = TRUE,
+          sparse = FALSE,
+          attr = deprecated()
+        ),
+        head_args = c("graph", "types"),
+        fn_name = "as_biadjacency_matrix"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1507,23 +1528,26 @@ graph_from_adj_list <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph_from_adj_list, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, duplicate = duplicate),
-      recover_new = c("mode", "duplicate"),
-      recover_old = c("mode", "duplicate"),
-      match_names = c("mode", "duplicate"),
-      match_to = c("mode", "duplicate"),
-      defaults = list(mode = c("out", "in", "all", "total"), duplicate = TRUE),
-      head_args = c("adjlist"),
-      fn_name = "graph_from_adj_list"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, duplicate = duplicate),
+        recover_new = c("mode", "duplicate"),
+        recover_old = c("mode", "duplicate"),
+        match_names = c("mode", "duplicate"),
+        match_to = c("mode", "duplicate"),
+        defaults = list(mode = c("out", "in", "all", "total"), duplicate = TRUE),
+        head_args = c("adjlist"),
+        fn_name = "graph_from_adj_list"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1852,23 +1876,26 @@ graph_from_data_frame <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph_from_data_frame, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(vertices = vertices),
-      recover_new = c("vertices"),
-      recover_old = c("vertices"),
-      match_names = c("vertices"),
-      match_to = c("vertices"),
-      defaults = list(vertices = NULL),
-      head_args = c("d", "directed"),
-      fn_name = "graph_from_data_frame"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(vertices = vertices),
+        recover_new = c("vertices"),
+        recover_old = c("vertices"),
+        match_names = c("vertices"),
+        match_to = c("vertices"),
+        defaults = list(vertices = NULL),
+        head_args = c("d", "directed"),
+        fn_name = "graph_from_data_frame"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1982,23 +2009,26 @@ graph_from_edgelist <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph_from_edgelist, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = TRUE),
-      head_args = c("el"),
-      fn_name = "graph_from_edgelist"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = TRUE),
+        head_args = c("el"),
+        fn_name = "graph_from_edgelist"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/cycles.R
+++ b/R/cycles.R
@@ -57,23 +57,26 @@ find_cycle <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: find_cycle, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("out", "in", "all", "total")),
-      head_args = c("graph"),
-      fn_name = "find_cycle"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("out", "in", "all", "total")),
+        head_args = c("graph"),
+        fn_name = "find_cycle"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/decomposition.R
+++ b/R/decomposition.R
@@ -127,33 +127,36 @@ is_chordal <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: is_chordal, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        alpha = alpha,
-        alpham1 = alpham1,
-        fillin = fillin,
-        newgraph = newgraph
-      ),
-      recover_new = c("alpha", "alpham1", "fillin", "newgraph"),
-      recover_old = c("alpha", "alpham1", "fillin", "newgraph"),
-      match_names = c("alpha", "alpham1", "fillin", "newgraph"),
-      match_to = c("alpha", "alpham1", "fillin", "newgraph"),
-      defaults = list(
-        alpha = NULL,
-        alpham1 = NULL,
-        fillin = FALSE,
-        newgraph = FALSE
-      ),
-      head_args = c("graph"),
-      fn_name = "is_chordal"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          alpha = alpha,
+          alpham1 = alpham1,
+          fillin = fillin,
+          newgraph = newgraph
+        ),
+        recover_new = c("alpha", "alpham1", "fillin", "newgraph"),
+        recover_old = c("alpha", "alpham1", "fillin", "newgraph"),
+        match_names = c("alpha", "alpham1", "fillin", "newgraph"),
+        match_to = c("alpha", "alpham1", "fillin", "newgraph"),
+        defaults = list(
+          alpha = NULL,
+          alpham1 = NULL,
+          fillin = FALSE,
+          newgraph = FALSE
+        ),
+        head_args = c("graph"),
+        fn_name = "is_chordal"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/degseq.R
+++ b/R/degseq.R
@@ -148,25 +148,28 @@ is_graphical <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: is_graphical, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(allowed.edge.types = allowed.edge.types),
-      recover_new = c("allowed.edge.types"),
-      recover_old = c("allowed.edge.types"),
-      match_names = c("allowed.edge.types"),
-      match_to = c("allowed.edge.types"),
-      defaults = list(
-        allowed.edge.types = c("simple", "loops", "multi", "all")
-      ),
-      head_args = c("out.deg", "in.deg"),
-      fn_name = "is_graphical"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(allowed.edge.types = allowed.edge.types),
+        recover_new = c("allowed.edge.types"),
+        recover_old = c("allowed.edge.types"),
+        match_names = c("allowed.edge.types"),
+        match_to = c("allowed.edge.types"),
+        defaults = list(
+          allowed.edge.types = c("simple", "loops", "multi", "all")
+        ),
+        head_args = c("out.deg", "in.deg"),
+        fn_name = "is_graphical"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/efficiency.R
+++ b/R/efficiency.R
@@ -76,23 +76,26 @@ global_efficiency <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: global_efficiency, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights, directed = directed),
-      recover_new = c("weights", "directed"),
-      recover_old = c("weights", "directed"),
-      match_names = c("weights", "directed"),
-      match_to = c("weights", "directed"),
-      defaults = list(weights = NULL, directed = TRUE),
-      head_args = c("graph"),
-      fn_name = "global_efficiency"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights, directed = directed),
+        recover_new = c("weights", "directed"),
+        recover_old = c("weights", "directed"),
+        match_names = c("weights", "directed"),
+        match_to = c("weights", "directed"),
+        defaults = list(weights = NULL, directed = TRUE),
+        head_args = c("graph"),
+        fn_name = "global_efficiency"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -116,27 +119,30 @@ local_efficiency <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: local_efficiency, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights, directed = directed, mode = mode),
-      recover_new = c("weights", "directed", "mode"),
-      recover_old = c("weights", "directed", "mode"),
-      match_names = c("weights", "directed", "mode"),
-      match_to = c("weights", "directed", "mode"),
-      defaults = list(
-        weights = NULL,
-        directed = TRUE,
-        mode = c("all", "out", "in", "total")
-      ),
-      head_args = c("graph", "vids"),
-      fn_name = "local_efficiency"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights, directed = directed, mode = mode),
+        recover_new = c("weights", "directed", "mode"),
+        recover_old = c("weights", "directed", "mode"),
+        match_names = c("weights", "directed", "mode"),
+        match_to = c("weights", "directed", "mode"),
+        defaults = list(
+          weights = NULL,
+          directed = TRUE,
+          mode = c("all", "out", "in", "total")
+        ),
+        head_args = c("graph", "vids"),
+        fn_name = "local_efficiency"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -165,27 +171,30 @@ average_local_efficiency <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: average_local_efficiency, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights, directed = directed, mode = mode),
-      recover_new = c("weights", "directed", "mode"),
-      recover_old = c("weights", "directed", "mode"),
-      match_names = c("weights", "directed", "mode"),
-      match_to = c("weights", "directed", "mode"),
-      defaults = list(
-        weights = NULL,
-        directed = TRUE,
-        mode = c("all", "out", "in", "total")
-      ),
-      head_args = c("graph"),
-      fn_name = "average_local_efficiency"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights, directed = directed, mode = mode),
+        recover_new = c("weights", "directed", "mode"),
+        recover_old = c("weights", "directed", "mode"),
+        match_names = c("weights", "directed", "mode"),
+        match_to = c("weights", "directed", "mode"),
+        defaults = list(
+          weights = NULL,
+          directed = TRUE,
+          mode = c("all", "out", "in", "total")
+        ),
+        head_args = c("graph"),
+        fn_name = "average_local_efficiency"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/embedding.R
+++ b/R/embedding.R
@@ -116,35 +116,38 @@ embed_adjacency_matrix <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: embed_adjacency_matrix, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        weights = weights,
-        which = which,
-        scaled = scaled,
-        cvec = cvec,
-        options = options
-      ),
-      recover_new = c("weights", "which", "scaled", "cvec", "options"),
-      recover_old = c("weights", "which", "scaled", "cvec", "options"),
-      match_names = c("weights", "which", "scaled", "cvec", "options"),
-      match_to = c("weights", "which", "scaled", "cvec", "options"),
-      defaults = list(
-        weights = NULL,
-        which = c("lm", "la", "sa"),
-        scaled = TRUE,
-        cvec = NULL,
-        options = NULL
-      ),
-      head_args = c("graph", "no"),
-      fn_name = "embed_adjacency_matrix"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          weights = weights,
+          which = which,
+          scaled = scaled,
+          cvec = cvec,
+          options = options
+        ),
+        recover_new = c("weights", "which", "scaled", "cvec", "options"),
+        recover_old = c("weights", "which", "scaled", "cvec", "options"),
+        match_names = c("weights", "which", "scaled", "cvec", "options"),
+        match_to = c("weights", "which", "scaled", "cvec", "options"),
+        defaults = list(
+          weights = NULL,
+          which = c("lm", "la", "sa"),
+          scaled = TRUE,
+          cvec = NULL,
+          options = NULL
+        ),
+        head_args = c("graph", "no"),
+        fn_name = "embed_adjacency_matrix"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -333,35 +336,38 @@ embed_laplacian_matrix <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: embed_laplacian_matrix, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        weights = weights,
-        which = which,
-        type = type,
-        scaled = scaled,
-        options = options
-      ),
-      recover_new = c("weights", "which", "type", "scaled", "options"),
-      recover_old = c("weights", "which", "type", "scaled", "options"),
-      match_names = c("weights", "which", "type", "scaled", "options"),
-      match_to = c("weights", "which", "type", "scaled", "options"),
-      defaults = list(
-        weights = NULL,
-        which = c("lm", "la", "sa"),
-        type = c("default", "D-A", "DAD", "I-DAD", "OAP"),
-        scaled = TRUE,
-        options = NULL
-      ),
-      head_args = c("graph", "no"),
-      fn_name = "embed_laplacian_matrix"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          weights = weights,
+          which = which,
+          type = type,
+          scaled = scaled,
+          options = options
+        ),
+        recover_new = c("weights", "which", "type", "scaled", "options"),
+        recover_old = c("weights", "which", "type", "scaled", "options"),
+        match_names = c("weights", "which", "type", "scaled", "options"),
+        match_to = c("weights", "which", "type", "scaled", "options"),
+        defaults = list(
+          weights = NULL,
+          which = c("lm", "la", "sa"),
+          type = c("default", "D-A", "DAD", "I-DAD", "OAP"),
+          scaled = TRUE,
+          options = NULL
+        ),
+        head_args = c("graph", "no"),
+        fn_name = "embed_laplacian_matrix"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -419,23 +425,26 @@ sample_sphere_surface <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_sphere_surface, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(radius = radius, positive = positive),
-      recover_new = c("radius", "positive"),
-      recover_old = c("radius", "positive"),
-      match_names = c("radius", "positive"),
-      match_to = c("radius", "positive"),
-      defaults = list(radius = 1, positive = TRUE),
-      head_args = c("dim", "n"),
-      fn_name = "sample_sphere_surface"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(radius = radius, positive = positive),
+        recover_new = c("radius", "positive"),
+        recover_old = c("radius", "positive"),
+        match_names = c("radius", "positive"),
+        match_to = c("radius", "positive"),
+        defaults = list(radius = 1, positive = TRUE),
+        head_args = c("dim", "n"),
+        fn_name = "sample_sphere_surface"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -486,23 +495,26 @@ sample_sphere_volume <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_sphere_volume, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(radius = radius, positive = positive),
-      recover_new = c("radius", "positive"),
-      recover_old = c("radius", "positive"),
-      match_names = c("radius", "positive"),
-      match_to = c("radius", "positive"),
-      defaults = list(radius = 1, positive = TRUE),
-      head_args = c("dim", "n"),
-      fn_name = "sample_sphere_volume"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(radius = radius, positive = positive),
+        recover_new = c("radius", "positive"),
+        recover_old = c("radius", "positive"),
+        match_names = c("radius", "positive"),
+        match_to = c("radius", "positive"),
+        defaults = list(radius = 1, positive = TRUE),
+        head_args = c("dim", "n"),
+        fn_name = "sample_sphere_volume"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/epi.R
+++ b/R/epi.R
@@ -37,23 +37,26 @@ time_bins <- function(
 time_bins.sir <- function(x, ..., middle = TRUE) {
   # BEGIN GENERATED ARG_HANDLE: time_bins, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(middle = middle),
-      recover_new = c("middle"),
-      recover_old = c("middle"),
-      match_names = c("middle"),
-      match_to = c("middle"),
-      defaults = list(middle = TRUE),
-      head_args = c("x"),
-      fn_name = "time_bins"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(middle = middle),
+        recover_new = c("middle"),
+        recover_old = c("middle"),
+        match_names = c("middle"),
+        match_to = c("middle"),
+        defaults = list(middle = TRUE),
+        head_args = c("x"),
+        fn_name = "time_bins"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/flow.R
+++ b/R/flow.R
@@ -394,23 +394,26 @@ min_cut <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: min_cut, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(capacity = capacity, value.only = value.only),
-      recover_new = c("capacity", "value.only"),
-      recover_old = c("capacity", "value.only"),
-      match_names = c("capacity", "value.only"),
-      match_to = c("capacity", "value.only"),
-      defaults = list(capacity = NULL, value.only = TRUE),
-      head_args = c("graph", "source", "target"),
-      fn_name = "min_cut"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(capacity = capacity, value.only = value.only),
+        recover_new = c("capacity", "value.only"),
+        recover_old = c("capacity", "value.only"),
+        match_names = c("capacity", "value.only"),
+        match_to = c("capacity", "value.only"),
+        defaults = list(capacity = NULL, value.only = TRUE),
+        head_args = c("graph", "source", "target"),
+        fn_name = "min_cut"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -548,23 +551,26 @@ vertex_connectivity <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: vertex_connectivity, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(checks = checks),
-      recover_new = c("checks"),
-      recover_old = c("checks"),
-      match_names = c("checks"),
-      match_to = c("checks"),
-      defaults = list(checks = TRUE),
-      head_args = c("graph", "source", "target"),
-      fn_name = "vertex_connectivity"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(checks = checks),
+        recover_new = c("checks"),
+        recover_old = c("checks"),
+        match_names = c("checks"),
+        match_to = c("checks"),
+        defaults = list(checks = TRUE),
+        head_args = c("graph", "source", "target"),
+        fn_name = "vertex_connectivity"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -675,23 +681,26 @@ edge_connectivity <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: edge_connectivity, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(checks = checks),
-      recover_new = c("checks"),
-      recover_old = c("checks"),
-      match_names = c("checks"),
-      match_to = c("checks"),
-      defaults = list(checks = TRUE),
-      head_args = c("graph", "source", "target"),
-      fn_name = "edge_connectivity"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(checks = checks),
+        recover_new = c("checks"),
+        recover_old = c("checks"),
+        match_names = c("checks"),
+        match_to = c("checks"),
+        defaults = list(checks = TRUE),
+        head_args = c("graph", "source", "target"),
+        fn_name = "edge_connectivity"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -752,23 +761,26 @@ adhesion <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: adhesion, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(checks = checks),
-      recover_new = c("checks"),
-      recover_old = c("checks"),
-      match_names = c("checks"),
-      match_to = c("checks"),
-      defaults = list(checks = TRUE),
-      head_args = c("graph"),
-      fn_name = "adhesion"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(checks = checks),
+        recover_new = c("checks"),
+        recover_old = c("checks"),
+        match_names = c("checks"),
+        match_to = c("checks"),
+        defaults = list(checks = TRUE),
+        head_args = c("graph"),
+        fn_name = "adhesion"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -904,23 +916,26 @@ st_min_cuts <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: st_min_cuts, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(capacity = capacity),
-      recover_new = c("capacity"),
-      recover_old = c("capacity"),
-      match_names = c("capacity"),
-      match_to = c("capacity"),
-      defaults = list(capacity = NULL),
-      head_args = c("graph", "source", "target"),
-      fn_name = "st_min_cuts"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(capacity = capacity),
+        recover_new = c("capacity"),
+        recover_old = c("capacity"),
+        match_names = c("capacity"),
+        match_to = c("capacity"),
+        defaults = list(capacity = NULL),
+        head_args = c("graph", "source", "target"),
+        fn_name = "st_min_cuts"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1004,23 +1019,26 @@ dominator_tree <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: dominator_tree, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("out", "in", "all", "total")),
-      head_args = c("graph", "root"),
-      fn_name = "dominator_tree"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("out", "in", "all", "total")),
+        head_args = c("graph", "root"),
+        fn_name = "dominator_tree"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1180,23 +1198,26 @@ max_flow <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: max_flow, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(capacity = capacity),
-      recover_new = c("capacity"),
-      recover_old = c("capacity"),
-      match_names = c("capacity"),
-      match_to = c("capacity"),
-      defaults = list(capacity = NULL),
-      head_args = c("graph", "source", "target"),
-      fn_name = "max_flow"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(capacity = capacity),
+        recover_new = c("capacity"),
+        recover_old = c("capacity"),
+        match_names = c("capacity"),
+        match_to = c("capacity"),
+        defaults = list(capacity = NULL),
+        head_args = c("graph", "source", "target"),
+        fn_name = "max_flow"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/foreign.R
+++ b/R/foreign.R
@@ -838,77 +838,80 @@ graph_from_graphdb <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph_from_graphdb, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        prefix = prefix,
-        type = type,
-        nodes = nodes,
-        pair = pair,
-        which = which,
-        base = base,
-        compressed = compressed,
-        directed = directed
-      ),
-      recover_new = c(
-        "prefix",
-        "type",
-        "nodes",
-        "pair",
-        "which",
-        "base",
-        "compressed",
-        "directed"
-      ),
-      recover_old = c(
-        "prefix",
-        "type",
-        "nodes",
-        "pair",
-        "which",
-        "base",
-        "compressed",
-        "directed"
-      ),
-      match_names = c(
-        "prefix",
-        "type",
-        "nodes",
-        "pair",
-        "which",
-        "base",
-        "compressed",
-        "directed"
-      ),
-      match_to = c(
-        "prefix",
-        "type",
-        "nodes",
-        "pair",
-        "which",
-        "base",
-        "compressed",
-        "directed"
-      ),
-      defaults = list(
-        prefix = "iso",
-        type = "r001",
-        nodes = NULL,
-        pair = "A",
-        which = 0,
-        base = "https://github.com/igraph/graphsdb/raw/refs/heads/main",
-        compressed = TRUE,
-        directed = TRUE
-      ),
-      head_args = c("url"),
-      fn_name = "graph_from_graphdb"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          prefix = prefix,
+          type = type,
+          nodes = nodes,
+          pair = pair,
+          which = which,
+          base = base,
+          compressed = compressed,
+          directed = directed
+        ),
+        recover_new = c(
+          "prefix",
+          "type",
+          "nodes",
+          "pair",
+          "which",
+          "base",
+          "compressed",
+          "directed"
+        ),
+        recover_old = c(
+          "prefix",
+          "type",
+          "nodes",
+          "pair",
+          "which",
+          "base",
+          "compressed",
+          "directed"
+        ),
+        match_names = c(
+          "prefix",
+          "type",
+          "nodes",
+          "pair",
+          "which",
+          "base",
+          "compressed",
+          "directed"
+        ),
+        match_to = c(
+          "prefix",
+          "type",
+          "nodes",
+          "pair",
+          "which",
+          "base",
+          "compressed",
+          "directed"
+        ),
+        defaults = list(
+          prefix = "iso",
+          type = "r001",
+          nodes = NULL,
+          pair = "A",
+          which = 0,
+          base = "https://github.com/igraph/graphsdb/raw/refs/heads/main",
+          compressed = TRUE,
+          directed = TRUE
+        ),
+        head_args = c("url"),
+        fn_name = "graph_from_graphdb"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/games.R
+++ b/R/games.R
@@ -885,71 +885,74 @@ sample_pa <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_pa, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        out.dist = out.dist,
-        out.seq = out.seq,
-        out.pref = out.pref,
-        zero.appeal = zero.appeal,
-        directed = directed,
-        algorithm = algorithm,
-        start.graph = start.graph
-      ),
-      recover_new = c(
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "zero.appeal",
-        "directed",
-        "algorithm",
-        "start.graph"
-      ),
-      recover_old = c(
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "zero.appeal",
-        "directed",
-        "algorithm",
-        "start.graph"
-      ),
-      match_names = c(
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "zero.appeal",
-        "directed",
-        "algorithm",
-        "start.graph"
-      ),
-      match_to = c(
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "zero.appeal",
-        "directed",
-        "algorithm",
-        "start.graph"
-      ),
-      defaults = list(
-        out.dist = NULL,
-        out.seq = NULL,
-        out.pref = FALSE,
-        zero.appeal = 1,
-        directed = TRUE,
-        algorithm = c("psumtree", "psumtree-multiple", "bag"),
-        start.graph = NULL
-      ),
-      head_args = c("n", "power", "m"),
-      fn_name = "sample_pa"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          out.dist = out.dist,
+          out.seq = out.seq,
+          out.pref = out.pref,
+          zero.appeal = zero.appeal,
+          directed = directed,
+          algorithm = algorithm,
+          start.graph = start.graph
+        ),
+        recover_new = c(
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "zero.appeal",
+          "directed",
+          "algorithm",
+          "start.graph"
+        ),
+        recover_old = c(
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "zero.appeal",
+          "directed",
+          "algorithm",
+          "start.graph"
+        ),
+        match_names = c(
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "zero.appeal",
+          "directed",
+          "algorithm",
+          "start.graph"
+        ),
+        match_to = c(
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "zero.appeal",
+          "directed",
+          "algorithm",
+          "start.graph"
+        ),
+        defaults = list(
+          out.dist = NULL,
+          out.seq = NULL,
+          out.pref = FALSE,
+          zero.appeal = 1,
+          directed = TRUE,
+          algorithm = c("psumtree", "psumtree-multiple", "bag"),
+          start.graph = NULL
+        ),
+        head_args = c("n", "power", "m"),
+        fn_name = "sample_pa"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1052,71 +1055,74 @@ pa <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: pa, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        out.dist = out.dist,
-        out.seq = out.seq,
-        out.pref = out.pref,
-        zero.appeal = zero.appeal,
-        directed = directed,
-        algorithm = algorithm,
-        start.graph = start.graph
-      ),
-      recover_new = c(
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "zero.appeal",
-        "directed",
-        "algorithm",
-        "start.graph"
-      ),
-      recover_old = c(
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "zero.appeal",
-        "directed",
-        "algorithm",
-        "start.graph"
-      ),
-      match_names = c(
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "zero.appeal",
-        "directed",
-        "algorithm",
-        "start.graph"
-      ),
-      match_to = c(
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "zero.appeal",
-        "directed",
-        "algorithm",
-        "start.graph"
-      ),
-      defaults = list(
-        out.dist = NULL,
-        out.seq = NULL,
-        out.pref = FALSE,
-        zero.appeal = 1,
-        directed = TRUE,
-        algorithm = c("psumtree", "psumtree-multiple", "bag"),
-        start.graph = NULL
-      ),
-      head_args = c("n", "power", "m"),
-      fn_name = "pa"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          out.dist = out.dist,
+          out.seq = out.seq,
+          out.pref = out.pref,
+          zero.appeal = zero.appeal,
+          directed = directed,
+          algorithm = algorithm,
+          start.graph = start.graph
+        ),
+        recover_new = c(
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "zero.appeal",
+          "directed",
+          "algorithm",
+          "start.graph"
+        ),
+        recover_old = c(
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "zero.appeal",
+          "directed",
+          "algorithm",
+          "start.graph"
+        ),
+        match_names = c(
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "zero.appeal",
+          "directed",
+          "algorithm",
+          "start.graph"
+        ),
+        match_to = c(
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "zero.appeal",
+          "directed",
+          "algorithm",
+          "start.graph"
+        ),
+        defaults = list(
+          out.dist = NULL,
+          out.seq = NULL,
+          out.pref = FALSE,
+          zero.appeal = 1,
+          directed = TRUE,
+          algorithm = c("psumtree", "psumtree-multiple", "bag"),
+          start.graph = NULL
+        ),
+        head_args = c("n", "power", "m"),
+        fn_name = "pa"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1183,23 +1189,26 @@ sample_gnp <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_gnp, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, loops = loops),
-      recover_new = c("directed", "loops"),
-      recover_old = c("directed", "loops"),
-      match_names = c("directed", "loops"),
-      match_to = c("directed", "loops"),
-      defaults = list(directed = FALSE, loops = FALSE),
-      head_args = c("n", "p"),
-      fn_name = "sample_gnp"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, loops = loops),
+        recover_new = c("directed", "loops"),
+        recover_old = c("directed", "loops"),
+        match_names = c("directed", "loops"),
+        match_to = c("directed", "loops"),
+        defaults = list(directed = FALSE, loops = FALSE),
+        head_args = c("n", "p"),
+        fn_name = "sample_gnp"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1233,23 +1242,26 @@ gnp <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: gnp, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, loops = loops),
-      recover_new = c("directed", "loops"),
-      recover_old = c("directed", "loops"),
-      match_names = c("directed", "loops"),
-      match_to = c("directed", "loops"),
-      defaults = list(directed = FALSE, loops = FALSE),
-      head_args = c("n", "p"),
-      fn_name = "gnp"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, loops = loops),
+        recover_new = c("directed", "loops"),
+        recover_old = c("directed", "loops"),
+        match_names = c("directed", "loops"),
+        match_to = c("directed", "loops"),
+        defaults = list(directed = FALSE, loops = FALSE),
+        head_args = c("n", "p"),
+        fn_name = "gnp"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1290,23 +1302,26 @@ sample_gnm <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_gnm, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, loops = loops),
-      recover_new = c("directed", "loops"),
-      recover_old = c("directed", "loops"),
-      match_names = c("directed", "loops"),
-      match_to = c("directed", "loops"),
-      defaults = list(directed = FALSE, loops = FALSE),
-      head_args = c("n", "m"),
-      fn_name = "sample_gnm"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, loops = loops),
+        recover_new = c("directed", "loops"),
+        recover_old = c("directed", "loops"),
+        match_names = c("directed", "loops"),
+        match_to = c("directed", "loops"),
+        defaults = list(directed = FALSE, loops = FALSE),
+        head_args = c("n", "m"),
+        fn_name = "sample_gnm"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1340,23 +1355,26 @@ gnm <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: gnm, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, loops = loops),
-      recover_new = c("directed", "loops"),
-      recover_old = c("directed", "loops"),
-      match_names = c("directed", "loops"),
-      match_to = c("directed", "loops"),
-      defaults = list(directed = FALSE, loops = FALSE),
-      head_args = c("n", "m"),
-      fn_name = "gnm"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, loops = loops),
+        recover_new = c("directed", "loops"),
+        recover_old = c("directed", "loops"),
+        match_names = c("directed", "loops"),
+        match_to = c("directed", "loops"),
+        defaults = list(directed = FALSE, loops = FALSE),
+        head_args = c("n", "m"),
+        fn_name = "gnm"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1624,25 +1642,28 @@ sample_degseq <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_degseq, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(method = method),
-      recover_new = c("method"),
-      recover_old = c("method"),
-      match_names = c("method"),
-      match_to = c("method"),
-      defaults = list(
-        method = c("configuration", "vl", "fast.heur.simple", "configuration.simple", "edge.switching.simple")
-      ),
-      head_args = c("out.deg", "in.deg"),
-      fn_name = "sample_degseq"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(method = method),
+        recover_new = c("method"),
+        recover_old = c("method"),
+        match_names = c("method"),
+        match_to = c("method"),
+        defaults = list(
+          method = c("configuration", "vl", "fast.heur.simple", "configuration.simple", "edge.switching.simple")
+        ),
+        head_args = c("out.deg", "in.deg"),
+        fn_name = "sample_degseq"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1888,94 +1909,97 @@ sample_pa_age <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_pa_age, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("a", "ag", "agi", "agin", "aging", "aging."),
-      "sample_pa_age"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        aging.bin = aging.bin,
-        out.dist = out.dist,
-        out.seq = out.seq,
-        out.pref = out.pref,
-        directed = directed,
-        zero.deg.appeal = zero.deg.appeal,
-        zero.age.appeal = zero.age.appeal,
-        deg.coef = deg.coef,
-        age.coef = age.coef,
-        time.window = time.window
-      ),
-      recover_new = c(
-        "aging.bin",
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "directed",
-        "zero.deg.appeal",
-        "zero.age.appeal",
-        "deg.coef",
-        "age.coef",
-        "time.window"
-      ),
-      recover_old = c(
-        "aging.bin",
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "directed",
-        "zero.deg.appeal",
-        "zero.age.appeal",
-        "deg.coef",
-        "age.coef",
-        "time.window"
-      ),
-      match_names = c(
-        "aging.bin",
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "directed",
-        "zero.deg.appeal",
-        "zero.age.appeal",
-        "deg.coef",
-        "age.coef",
-        "time.window"
-      ),
-      match_to = c(
-        "aging.bin",
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "directed",
-        "zero.deg.appeal",
-        "zero.age.appeal",
-        "deg.coef",
-        "age.coef",
-        "time.window"
-      ),
-      defaults = list(
-        aging.bin = 300,
-        out.dist = NULL,
-        out.seq = NULL,
-        out.pref = FALSE,
-        directed = TRUE,
-        zero.deg.appeal = 1,
-        zero.age.appeal = 0,
-        deg.coef = 1,
-        age.coef = 1,
-        time.window = NULL
-      ),
-      head_args = c("n", "pa.exp", "aging.exp", "m"),
-      fn_name = "sample_pa_age"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("a", "ag", "agi", "agin", "aging", "aging."),
+        "sample_pa_age"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          aging.bin = aging.bin,
+          out.dist = out.dist,
+          out.seq = out.seq,
+          out.pref = out.pref,
+          directed = directed,
+          zero.deg.appeal = zero.deg.appeal,
+          zero.age.appeal = zero.age.appeal,
+          deg.coef = deg.coef,
+          age.coef = age.coef,
+          time.window = time.window
+        ),
+        recover_new = c(
+          "aging.bin",
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "directed",
+          "zero.deg.appeal",
+          "zero.age.appeal",
+          "deg.coef",
+          "age.coef",
+          "time.window"
+        ),
+        recover_old = c(
+          "aging.bin",
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "directed",
+          "zero.deg.appeal",
+          "zero.age.appeal",
+          "deg.coef",
+          "age.coef",
+          "time.window"
+        ),
+        match_names = c(
+          "aging.bin",
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "directed",
+          "zero.deg.appeal",
+          "zero.age.appeal",
+          "deg.coef",
+          "age.coef",
+          "time.window"
+        ),
+        match_to = c(
+          "aging.bin",
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "directed",
+          "zero.deg.appeal",
+          "zero.age.appeal",
+          "deg.coef",
+          "age.coef",
+          "time.window"
+        ),
+        defaults = list(
+          aging.bin = 300,
+          out.dist = NULL,
+          out.seq = NULL,
+          out.pref = FALSE,
+          directed = TRUE,
+          zero.deg.appeal = 1,
+          zero.age.appeal = 0,
+          deg.coef = 1,
+          age.coef = 1,
+          time.window = NULL
+        ),
+        head_args = c("n", "pa.exp", "aging.exp", "m"),
+        fn_name = "sample_pa_age"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2112,94 +2136,97 @@ pa_age <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: pa_age, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("a", "ag", "agi", "agin", "aging", "aging."),
-      "pa_age"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        aging.bin = aging.bin,
-        out.dist = out.dist,
-        out.seq = out.seq,
-        out.pref = out.pref,
-        directed = directed,
-        zero.deg.appeal = zero.deg.appeal,
-        zero.age.appeal = zero.age.appeal,
-        deg.coef = deg.coef,
-        age.coef = age.coef,
-        time.window = time.window
-      ),
-      recover_new = c(
-        "aging.bin",
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "directed",
-        "zero.deg.appeal",
-        "zero.age.appeal",
-        "deg.coef",
-        "age.coef",
-        "time.window"
-      ),
-      recover_old = c(
-        "aging.bin",
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "directed",
-        "zero.deg.appeal",
-        "zero.age.appeal",
-        "deg.coef",
-        "age.coef",
-        "time.window"
-      ),
-      match_names = c(
-        "aging.bin",
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "directed",
-        "zero.deg.appeal",
-        "zero.age.appeal",
-        "deg.coef",
-        "age.coef",
-        "time.window"
-      ),
-      match_to = c(
-        "aging.bin",
-        "out.dist",
-        "out.seq",
-        "out.pref",
-        "directed",
-        "zero.deg.appeal",
-        "zero.age.appeal",
-        "deg.coef",
-        "age.coef",
-        "time.window"
-      ),
-      defaults = list(
-        aging.bin = 300,
-        out.dist = NULL,
-        out.seq = NULL,
-        out.pref = FALSE,
-        directed = TRUE,
-        zero.deg.appeal = 1,
-        zero.age.appeal = 0,
-        deg.coef = 1,
-        age.coef = 1,
-        time.window = NULL
-      ),
-      head_args = c("n", "pa.exp", "aging.exp", "m"),
-      fn_name = "pa_age"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("a", "ag", "agi", "agin", "aging", "aging."),
+        "pa_age"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          aging.bin = aging.bin,
+          out.dist = out.dist,
+          out.seq = out.seq,
+          out.pref = out.pref,
+          directed = directed,
+          zero.deg.appeal = zero.deg.appeal,
+          zero.age.appeal = zero.age.appeal,
+          deg.coef = deg.coef,
+          age.coef = age.coef,
+          time.window = time.window
+        ),
+        recover_new = c(
+          "aging.bin",
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "directed",
+          "zero.deg.appeal",
+          "zero.age.appeal",
+          "deg.coef",
+          "age.coef",
+          "time.window"
+        ),
+        recover_old = c(
+          "aging.bin",
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "directed",
+          "zero.deg.appeal",
+          "zero.age.appeal",
+          "deg.coef",
+          "age.coef",
+          "time.window"
+        ),
+        match_names = c(
+          "aging.bin",
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "directed",
+          "zero.deg.appeal",
+          "zero.age.appeal",
+          "deg.coef",
+          "age.coef",
+          "time.window"
+        ),
+        match_to = c(
+          "aging.bin",
+          "out.dist",
+          "out.seq",
+          "out.pref",
+          "directed",
+          "zero.deg.appeal",
+          "zero.age.appeal",
+          "deg.coef",
+          "age.coef",
+          "time.window"
+        ),
+        defaults = list(
+          aging.bin = 300,
+          out.dist = NULL,
+          out.seq = NULL,
+          out.pref = FALSE,
+          directed = TRUE,
+          zero.deg.appeal = 1,
+          zero.age.appeal = 0,
+          deg.coef = 1,
+          age.coef = 1,
+          time.window = NULL
+        ),
+        head_args = c("n", "pa.exp", "aging.exp", "m"),
+        fn_name = "pa_age"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2275,38 +2302,41 @@ sample_traits_callaway <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_traits_callaway, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("t", "ty", "typ", "type"),
-      "sample_traits_callaway"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        edge.per.step = edge.per.step,
-        type.dist = type.dist,
-        pref.matrix = pref.matrix,
-        directed = directed
-      ),
-      recover_new = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
-      recover_old = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
-      match_names = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
-      match_to = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
-      defaults = list(
-        edge.per.step = 1,
-        type.dist = NULL,
-        pref.matrix = NULL,
-        directed = FALSE
-      ),
-      head_args = c("nodes", "types"),
-      fn_name = "sample_traits_callaway"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("t", "ty", "typ", "type"),
+        "sample_traits_callaway"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          edge.per.step = edge.per.step,
+          type.dist = type.dist,
+          pref.matrix = pref.matrix,
+          directed = directed
+        ),
+        recover_new = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+        recover_old = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+        match_names = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+        match_to = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+        defaults = list(
+          edge.per.step = 1,
+          type.dist = NULL,
+          pref.matrix = NULL,
+          directed = FALSE
+        ),
+        head_args = c("nodes", "types"),
+        fn_name = "sample_traits_callaway"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2353,38 +2383,41 @@ traits_callaway <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: traits_callaway, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("t", "ty", "typ", "type"),
-      "traits_callaway"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        edge.per.step = edge.per.step,
-        type.dist = type.dist,
-        pref.matrix = pref.matrix,
-        directed = directed
-      ),
-      recover_new = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
-      recover_old = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
-      match_names = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
-      match_to = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
-      defaults = list(
-        edge.per.step = 1,
-        type.dist = NULL,
-        pref.matrix = NULL,
-        directed = FALSE
-      ),
-      head_args = c("nodes", "types"),
-      fn_name = "traits_callaway"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("t", "ty", "typ", "type"),
+        "traits_callaway"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          edge.per.step = edge.per.step,
+          type.dist = type.dist,
+          pref.matrix = pref.matrix,
+          directed = directed
+        ),
+        recover_new = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+        recover_old = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+        match_names = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+        match_to = c("edge.per.step", "type.dist", "pref.matrix", "directed"),
+        defaults = list(
+          edge.per.step = 1,
+          type.dist = NULL,
+          pref.matrix = NULL,
+          directed = FALSE
+        ),
+        head_args = c("nodes", "types"),
+        fn_name = "traits_callaway"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2420,32 +2453,35 @@ sample_traits <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_traits, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("t", "ty", "typ", "type"),
-      "sample_traits"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        type.dist = type.dist,
-        pref.matrix = pref.matrix,
-        directed = directed
-      ),
-      recover_new = c("type.dist", "pref.matrix", "directed"),
-      recover_old = c("type.dist", "pref.matrix", "directed"),
-      match_names = c("type.dist", "pref.matrix", "directed"),
-      match_to = c("type.dist", "pref.matrix", "directed"),
-      defaults = list(type.dist = NULL, pref.matrix = NULL, directed = FALSE),
-      head_args = c("nodes", "types", "k"),
-      fn_name = "sample_traits"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("t", "ty", "typ", "type"),
+        "sample_traits"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          type.dist = type.dist,
+          pref.matrix = pref.matrix,
+          directed = directed
+        ),
+        recover_new = c("type.dist", "pref.matrix", "directed"),
+        recover_old = c("type.dist", "pref.matrix", "directed"),
+        match_names = c("type.dist", "pref.matrix", "directed"),
+        match_to = c("type.dist", "pref.matrix", "directed"),
+        defaults = list(type.dist = NULL, pref.matrix = NULL, directed = FALSE),
+        head_args = c("nodes", "types", "k"),
+        fn_name = "sample_traits"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2488,32 +2524,35 @@ traits <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: traits, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("t", "ty", "typ", "type"),
-      "traits"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        type.dist = type.dist,
-        pref.matrix = pref.matrix,
-        directed = directed
-      ),
-      recover_new = c("type.dist", "pref.matrix", "directed"),
-      recover_old = c("type.dist", "pref.matrix", "directed"),
-      match_names = c("type.dist", "pref.matrix", "directed"),
-      match_to = c("type.dist", "pref.matrix", "directed"),
-      defaults = list(type.dist = NULL, pref.matrix = NULL, directed = FALSE),
-      head_args = c("nodes", "types", "k"),
-      fn_name = "traits"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("t", "ty", "typ", "type"),
+        "traits"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          type.dist = type.dist,
+          pref.matrix = pref.matrix,
+          directed = directed
+        ),
+        recover_new = c("type.dist", "pref.matrix", "directed"),
+        recover_old = c("type.dist", "pref.matrix", "directed"),
+        match_names = c("type.dist", "pref.matrix", "directed"),
+        match_to = c("type.dist", "pref.matrix", "directed"),
+        defaults = list(type.dist = NULL, pref.matrix = NULL, directed = FALSE),
+        head_args = c("nodes", "types", "k"),
+        fn_name = "traits"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2576,23 +2615,26 @@ sample_grg <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_grg, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(torus = torus, coords = coords),
-      recover_new = c("torus", "coords"),
-      recover_old = c("torus", "coords"),
-      match_names = c("torus", "coords"),
-      match_to = c("torus", "coords"),
-      defaults = list(torus = FALSE, coords = FALSE),
-      head_args = c("nodes", "radius"),
-      fn_name = "sample_grg"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(torus = torus, coords = coords),
+        recover_new = c("torus", "coords"),
+        recover_old = c("torus", "coords"),
+        match_names = c("torus", "coords"),
+        match_to = c("torus", "coords"),
+        defaults = list(torus = FALSE, coords = FALSE),
+        head_args = c("nodes", "radius"),
+        fn_name = "sample_grg"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2628,23 +2670,26 @@ grg <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: grg, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(torus = torus, coords = coords),
-      recover_new = c("torus", "coords"),
-      recover_old = c("torus", "coords"),
-      match_names = c("torus", "coords"),
-      match_to = c("torus", "coords"),
-      defaults = list(torus = FALSE, coords = FALSE),
-      head_args = c("nodes", "radius"),
-      fn_name = "grg"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(torus = torus, coords = coords),
+        recover_new = c("torus", "coords"),
+        recover_old = c("torus", "coords"),
+        match_names = c("torus", "coords"),
+        match_to = c("torus", "coords"),
+        defaults = list(torus = FALSE, coords = FALSE),
+        head_args = c("nodes", "radius"),
+        fn_name = "grg"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2732,64 +2777,67 @@ sample_pref <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_pref, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("t", "ty", "typ", "type"),
-      "sample_pref"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        type.dist = type.dist,
-        fixed.sizes = fixed.sizes,
-        pref.matrix = pref.matrix,
-        directed = directed,
-        loops = loops
-      ),
-      recover_new = c(
-        "type.dist",
-        "fixed.sizes",
-        "pref.matrix",
-        "directed",
-        "loops"
-      ),
-      recover_old = c(
-        "type.dist",
-        "fixed.sizes",
-        "pref.matrix",
-        "directed",
-        "loops"
-      ),
-      match_names = c(
-        "type.dist",
-        "fixed.sizes",
-        "pref.matrix",
-        "directed",
-        "loops"
-      ),
-      match_to = c(
-        "type.dist",
-        "fixed.sizes",
-        "pref.matrix",
-        "directed",
-        "loops"
-      ),
-      defaults = list(
-        type.dist = NULL,
-        fixed.sizes = FALSE,
-        pref.matrix = NULL,
-        directed = FALSE,
-        loops = FALSE
-      ),
-      head_args = c("nodes", "types"),
-      fn_name = "sample_pref"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("t", "ty", "typ", "type"),
+        "sample_pref"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          type.dist = type.dist,
+          fixed.sizes = fixed.sizes,
+          pref.matrix = pref.matrix,
+          directed = directed,
+          loops = loops
+        ),
+        recover_new = c(
+          "type.dist",
+          "fixed.sizes",
+          "pref.matrix",
+          "directed",
+          "loops"
+        ),
+        recover_old = c(
+          "type.dist",
+          "fixed.sizes",
+          "pref.matrix",
+          "directed",
+          "loops"
+        ),
+        match_names = c(
+          "type.dist",
+          "fixed.sizes",
+          "pref.matrix",
+          "directed",
+          "loops"
+        ),
+        match_to = c(
+          "type.dist",
+          "fixed.sizes",
+          "pref.matrix",
+          "directed",
+          "loops"
+        ),
+        defaults = list(
+          type.dist = NULL,
+          fixed.sizes = FALSE,
+          pref.matrix = NULL,
+          directed = FALSE,
+          loops = FALSE
+        ),
+        head_args = c("nodes", "types"),
+        fn_name = "sample_pref"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2843,64 +2891,67 @@ pref <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: pref, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("t", "ty", "typ", "type"),
-      "pref"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        type.dist = type.dist,
-        fixed.sizes = fixed.sizes,
-        pref.matrix = pref.matrix,
-        directed = directed,
-        loops = loops
-      ),
-      recover_new = c(
-        "type.dist",
-        "fixed.sizes",
-        "pref.matrix",
-        "directed",
-        "loops"
-      ),
-      recover_old = c(
-        "type.dist",
-        "fixed.sizes",
-        "pref.matrix",
-        "directed",
-        "loops"
-      ),
-      match_names = c(
-        "type.dist",
-        "fixed.sizes",
-        "pref.matrix",
-        "directed",
-        "loops"
-      ),
-      match_to = c(
-        "type.dist",
-        "fixed.sizes",
-        "pref.matrix",
-        "directed",
-        "loops"
-      ),
-      defaults = list(
-        type.dist = NULL,
-        fixed.sizes = FALSE,
-        pref.matrix = NULL,
-        directed = FALSE,
-        loops = FALSE
-      ),
-      head_args = c("nodes", "types"),
-      fn_name = "pref"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("t", "ty", "typ", "type"),
+        "pref"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          type.dist = type.dist,
+          fixed.sizes = fixed.sizes,
+          pref.matrix = pref.matrix,
+          directed = directed,
+          loops = loops
+        ),
+        recover_new = c(
+          "type.dist",
+          "fixed.sizes",
+          "pref.matrix",
+          "directed",
+          "loops"
+        ),
+        recover_old = c(
+          "type.dist",
+          "fixed.sizes",
+          "pref.matrix",
+          "directed",
+          "loops"
+        ),
+        match_names = c(
+          "type.dist",
+          "fixed.sizes",
+          "pref.matrix",
+          "directed",
+          "loops"
+        ),
+        match_to = c(
+          "type.dist",
+          "fixed.sizes",
+          "pref.matrix",
+          "directed",
+          "loops"
+        ),
+        defaults = list(
+          type.dist = NULL,
+          fixed.sizes = FALSE,
+          pref.matrix = NULL,
+          directed = FALSE,
+          loops = FALSE
+        ),
+        head_args = c("nodes", "types"),
+        fn_name = "pref"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2936,36 +2987,39 @@ sample_asym_pref <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_asym_pref, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("t", "ty", "typ", "type"),
-      "sample_asym_pref"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        type.dist.matrix = type.dist.matrix,
-        pref.matrix = pref.matrix,
-        loops = loops
-      ),
-      recover_new = c("type.dist.matrix", "pref.matrix", "loops"),
-      recover_old = c("type.dist.matrix", "pref.matrix", "loops"),
-      match_names = c("type.dist.matrix", "pref.matrix", "loops"),
-      match_to = c("type.dist.matrix", "pref.matrix", "loops"),
-      defaults = list(
-        type.dist.matrix = NULL,
-        pref.matrix = NULL,
-        loops = FALSE
-      ),
-      head_args = c("nodes", "types"),
-      fn_name = "sample_asym_pref"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("t", "ty", "typ", "type"),
+        "sample_asym_pref"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          type.dist.matrix = type.dist.matrix,
+          pref.matrix = pref.matrix,
+          loops = loops
+        ),
+        recover_new = c("type.dist.matrix", "pref.matrix", "loops"),
+        recover_old = c("type.dist.matrix", "pref.matrix", "loops"),
+        match_names = c("type.dist.matrix", "pref.matrix", "loops"),
+        match_to = c("type.dist.matrix", "pref.matrix", "loops"),
+        defaults = list(
+          type.dist.matrix = NULL,
+          pref.matrix = NULL,
+          loops = FALSE
+        ),
+        head_args = c("nodes", "types"),
+        fn_name = "sample_asym_pref"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3023,36 +3077,39 @@ asym_pref <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: asym_pref, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("t", "ty", "typ", "type"),
-      "asym_pref"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        type.dist.matrix = type.dist.matrix,
-        pref.matrix = pref.matrix,
-        loops = loops
-      ),
-      recover_new = c("type.dist.matrix", "pref.matrix", "loops"),
-      recover_old = c("type.dist.matrix", "pref.matrix", "loops"),
-      match_names = c("type.dist.matrix", "pref.matrix", "loops"),
-      match_to = c("type.dist.matrix", "pref.matrix", "loops"),
-      defaults = list(
-        type.dist.matrix = NULL,
-        pref.matrix = NULL,
-        loops = FALSE
-      ),
-      head_args = c("nodes", "types"),
-      fn_name = "asym_pref"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("t", "ty", "typ", "type"),
+        "asym_pref"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          type.dist.matrix = type.dist.matrix,
+          pref.matrix = pref.matrix,
+          loops = loops
+        ),
+        recover_new = c("type.dist.matrix", "pref.matrix", "loops"),
+        recover_old = c("type.dist.matrix", "pref.matrix", "loops"),
+        match_names = c("type.dist.matrix", "pref.matrix", "loops"),
+        match_to = c("type.dist.matrix", "pref.matrix", "loops"),
+        defaults = list(
+          type.dist.matrix = NULL,
+          pref.matrix = NULL,
+          loops = FALSE
+        ),
+        head_args = c("nodes", "types"),
+        fn_name = "asym_pref"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3087,23 +3144,26 @@ connect <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: connect, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("all", "out", "in", "total")),
-      head_args = c("graph", "order"),
-      fn_name = "connect"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("all", "out", "in", "total")),
+        head_args = c("graph", "order"),
+        fn_name = "connect"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3175,23 +3235,26 @@ sample_smallworld <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_smallworld, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(loops = loops, multiple = multiple),
-      recover_new = c("loops", "multiple"),
-      recover_old = c("loops", "multiple"),
-      match_names = c("loops", "multiple"),
-      match_to = c("loops", "multiple"),
-      defaults = list(loops = FALSE, multiple = FALSE),
-      head_args = c("dim", "size", "nei", "p"),
-      fn_name = "sample_smallworld"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(loops = loops, multiple = multiple),
+        recover_new = c("loops", "multiple"),
+        recover_old = c("loops", "multiple"),
+        match_names = c("loops", "multiple"),
+        match_to = c("loops", "multiple"),
+        defaults = list(loops = FALSE, multiple = FALSE),
+        head_args = c("dim", "size", "nei", "p"),
+        fn_name = "sample_smallworld"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3229,23 +3292,26 @@ smallworld <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: smallworld, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(loops = loops, multiple = multiple),
-      recover_new = c("loops", "multiple"),
-      recover_old = c("loops", "multiple"),
-      match_names = c("loops", "multiple"),
-      match_to = c("loops", "multiple"),
-      defaults = list(loops = FALSE, multiple = FALSE),
-      head_args = c("dim", "size", "nei", "p"),
-      fn_name = "smallworld"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(loops = loops, multiple = multiple),
+        recover_new = c("loops", "multiple"),
+        recover_old = c("loops", "multiple"),
+        match_names = c("loops", "multiple"),
+        match_to = c("loops", "multiple"),
+        defaults = list(loops = FALSE, multiple = FALSE),
+        head_args = c("dim", "size", "nei", "p"),
+        fn_name = "smallworld"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3305,23 +3371,26 @@ sample_last_cit <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_last_cit, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(agebins = agebins, pref = pref, directed = directed),
-      recover_new = c("agebins", "pref", "directed"),
-      recover_old = c("agebins", "pref", "directed"),
-      match_names = c("agebins", "pref", "directed"),
-      match_to = c("agebins", "pref", "directed"),
-      defaults = list(agebins = NULL, pref = NULL, directed = TRUE),
-      head_args = c("n", "edges"),
-      fn_name = "sample_last_cit"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(agebins = agebins, pref = pref, directed = directed),
+        recover_new = c("agebins", "pref", "directed"),
+        recover_old = c("agebins", "pref", "directed"),
+        match_names = c("agebins", "pref", "directed"),
+        match_to = c("agebins", "pref", "directed"),
+        defaults = list(agebins = NULL, pref = NULL, directed = TRUE),
+        head_args = c("n", "edges"),
+        fn_name = "sample_last_cit"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3360,23 +3429,26 @@ last_cit <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: last_cit, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(agebins = agebins, pref = pref, directed = directed),
-      recover_new = c("agebins", "pref", "directed"),
-      recover_old = c("agebins", "pref", "directed"),
-      match_names = c("agebins", "pref", "directed"),
-      match_to = c("agebins", "pref", "directed"),
-      defaults = list(agebins = NULL, pref = NULL, directed = TRUE),
-      head_args = c("n", "edges"),
-      fn_name = "last_cit"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(agebins = agebins, pref = pref, directed = directed),
+        recover_new = c("agebins", "pref", "directed"),
+        recover_old = c("agebins", "pref", "directed"),
+        match_names = c("agebins", "pref", "directed"),
+        match_to = c("agebins", "pref", "directed"),
+        defaults = list(agebins = NULL, pref = NULL, directed = TRUE),
+        head_args = c("n", "edges"),
+        fn_name = "last_cit"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3411,23 +3483,26 @@ sample_cit_types <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_cit_types, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(pref = pref, directed = directed, attr = attr),
-      recover_new = c("pref", "directed", "attr"),
-      recover_old = c("pref", "directed", "attr"),
-      match_names = c("pref", "directed", "attr"),
-      match_to = c("pref", "directed", "attr"),
-      defaults = list(pref = NULL, directed = TRUE, attr = TRUE),
-      head_args = c("n", "edges", "types"),
-      fn_name = "sample_cit_types"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(pref = pref, directed = directed, attr = attr),
+        recover_new = c("pref", "directed", "attr"),
+        recover_old = c("pref", "directed", "attr"),
+        match_names = c("pref", "directed", "attr"),
+        match_to = c("pref", "directed", "attr"),
+        defaults = list(pref = NULL, directed = TRUE, attr = TRUE),
+        head_args = c("n", "edges", "types"),
+        fn_name = "sample_cit_types"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3469,23 +3544,26 @@ cit_types <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: cit_types, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(pref = pref, directed = directed, attr = attr),
-      recover_new = c("pref", "directed", "attr"),
-      recover_old = c("pref", "directed", "attr"),
-      match_names = c("pref", "directed", "attr"),
-      match_to = c("pref", "directed", "attr"),
-      defaults = list(pref = NULL, directed = TRUE, attr = TRUE),
-      head_args = c("n", "edges", "types"),
-      fn_name = "cit_types"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(pref = pref, directed = directed, attr = attr),
+        recover_new = c("pref", "directed", "attr"),
+        recover_old = c("pref", "directed", "attr"),
+        match_names = c("pref", "directed", "attr"),
+        match_to = c("pref", "directed", "attr"),
+        defaults = list(pref = NULL, directed = TRUE, attr = TRUE),
+        head_args = c("n", "edges", "types"),
+        fn_name = "cit_types"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3521,23 +3599,26 @@ sample_cit_cit_types <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_cit_cit_types, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(pref = pref, directed = directed, attr = attr),
-      recover_new = c("pref", "directed", "attr"),
-      recover_old = c("pref", "directed", "attr"),
-      match_names = c("pref", "directed", "attr"),
-      match_to = c("pref", "directed", "attr"),
-      defaults = list(pref = NULL, directed = TRUE, attr = TRUE),
-      head_args = c("n", "edges", "types"),
-      fn_name = "sample_cit_cit_types"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(pref = pref, directed = directed, attr = attr),
+        recover_new = c("pref", "directed", "attr"),
+        recover_old = c("pref", "directed", "attr"),
+        match_names = c("pref", "directed", "attr"),
+        match_to = c("pref", "directed", "attr"),
+        defaults = list(pref = NULL, directed = TRUE, attr = TRUE),
+        head_args = c("n", "edges", "types"),
+        fn_name = "sample_cit_cit_types"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3580,23 +3661,26 @@ cit_cit_types <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: cit_cit_types, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(pref = pref, directed = directed, attr = attr),
-      recover_new = c("pref", "directed", "attr"),
-      recover_old = c("pref", "directed", "attr"),
-      match_names = c("pref", "directed", "attr"),
-      match_to = c("pref", "directed", "attr"),
-      defaults = list(pref = NULL, directed = TRUE, attr = TRUE),
-      head_args = c("n", "edges", "types"),
-      fn_name = "cit_cit_types"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(pref = pref, directed = directed, attr = attr),
+        recover_new = c("pref", "directed", "attr"),
+        recover_old = c("pref", "directed", "attr"),
+        match_names = c("pref", "directed", "attr"),
+        match_to = c("pref", "directed", "attr"),
+        defaults = list(pref = NULL, directed = TRUE, attr = TRUE),
+        head_args = c("n", "edges", "types"),
+        fn_name = "cit_cit_types"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3902,23 +3986,26 @@ sample_sbm <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_sbm, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, loops = loops),
-      recover_new = c("directed", "loops"),
-      recover_old = c("directed", "loops"),
-      match_names = c("directed", "loops"),
-      match_to = c("directed", "loops"),
-      defaults = list(directed = FALSE, loops = FALSE),
-      head_args = c("n", "pref.matrix", "block.sizes"),
-      fn_name = "sample_sbm"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, loops = loops),
+        recover_new = c("directed", "loops"),
+        recover_old = c("directed", "loops"),
+        match_names = c("directed", "loops"),
+        match_to = c("directed", "loops"),
+        defaults = list(directed = FALSE, loops = FALSE),
+        head_args = c("n", "pref.matrix", "block.sizes"),
+        fn_name = "sample_sbm"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3944,23 +4031,26 @@ sbm <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sbm, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, loops = loops),
-      recover_new = c("directed", "loops"),
-      recover_old = c("directed", "loops"),
-      match_names = c("directed", "loops"),
-      match_to = c("directed", "loops"),
-      defaults = list(directed = FALSE, loops = FALSE),
-      head_args = c("n", "pref.matrix", "block.sizes"),
-      fn_name = "sbm"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, loops = loops),
+        recover_new = c("directed", "loops"),
+        recover_old = c("directed", "loops"),
+        match_names = c("directed", "loops"),
+        match_to = c("directed", "loops"),
+        defaults = list(directed = FALSE, loops = FALSE),
+        head_args = c("n", "pref.matrix", "block.sizes"),
+        fn_name = "sbm"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -4119,23 +4209,26 @@ sample_dot_product <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_dot_product, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = FALSE),
-      head_args = c("vecs"),
-      fn_name = "sample_dot_product"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = FALSE),
+        head_args = c("vecs"),
+        fn_name = "sample_dot_product"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -4155,23 +4248,26 @@ dot_product <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: dot_product, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = FALSE),
-      head_args = c("vecs"),
-      fn_name = "dot_product"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = FALSE),
+        head_args = c("vecs"),
+        fn_name = "dot_product"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -4267,23 +4363,26 @@ sample_k_regular <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_k_regular, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, multiple = multiple),
-      recover_new = c("directed", "multiple"),
-      recover_old = c("directed", "multiple"),
-      match_names = c("directed", "multiple"),
-      match_to = c("directed", "multiple"),
-      defaults = list(directed = FALSE, multiple = FALSE),
-      head_args = c("no.of.nodes", "k"),
-      fn_name = "sample_k_regular"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, multiple = multiple),
+        recover_new = c("directed", "multiple"),
+        recover_old = c("directed", "multiple"),
+        match_names = c("directed", "multiple"),
+        match_to = c("directed", "multiple"),
+        defaults = list(directed = FALSE, multiple = FALSE),
+        head_args = c("no.of.nodes", "k"),
+        fn_name = "sample_k_regular"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -4543,23 +4642,26 @@ sample_fitness <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_fitness, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(loops = loops, multiple = multiple),
-      recover_new = c("loops", "multiple"),
-      recover_old = c("loops", "multiple"),
-      match_names = c("loops", "multiple"),
-      match_to = c("loops", "multiple"),
-      defaults = list(loops = FALSE, multiple = FALSE),
-      head_args = c("no.of.edges", "fitness.out", "fitness.in"),
-      fn_name = "sample_fitness"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(loops = loops, multiple = multiple),
+        recover_new = c("loops", "multiple"),
+        recover_old = c("loops", "multiple"),
+        match_names = c("loops", "multiple"),
+        match_to = c("loops", "multiple"),
+        defaults = list(loops = FALSE, multiple = FALSE),
+        head_args = c("no.of.edges", "fitness.out", "fitness.in"),
+        fn_name = "sample_fitness"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -4646,36 +4748,39 @@ sample_fitness_pl <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_fitness_pl, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        loops = loops,
-        multiple = multiple,
-        finite.size.correction = finite.size.correction
-      ),
-      recover_new = c("loops", "multiple", "finite.size.correction"),
-      recover_old = c("loops", "multiple", "finite.size.correction"),
-      match_names = c("loops", "multiple", "finite.size.correction"),
-      match_to = c("loops", "multiple", "finite.size.correction"),
-      defaults = list(
-        loops = FALSE,
-        multiple = FALSE,
-        finite.size.correction = TRUE
-      ),
-      head_args = c(
-        "no.of.nodes",
-        "no.of.edges",
-        "exponent.out",
-        "exponent.in"
-      ),
-      fn_name = "sample_fitness_pl"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          loops = loops,
+          multiple = multiple,
+          finite.size.correction = finite.size.correction
+        ),
+        recover_new = c("loops", "multiple", "finite.size.correction"),
+        recover_old = c("loops", "multiple", "finite.size.correction"),
+        match_names = c("loops", "multiple", "finite.size.correction"),
+        match_to = c("loops", "multiple", "finite.size.correction"),
+        defaults = list(
+          loops = FALSE,
+          multiple = FALSE,
+          finite.size.correction = TRUE
+        ),
+        head_args = c(
+          "no.of.nodes",
+          "no.of.edges",
+          "exponent.out",
+          "exponent.in"
+        ),
+        fn_name = "sample_fitness_pl"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -4770,23 +4875,26 @@ sample_forestfire <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_forestfire, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(bw.factor = bw.factor, ambs = ambs, directed = directed),
-      recover_new = c("bw.factor", "ambs", "directed"),
-      recover_old = c("bw.factor", "ambs", "directed"),
-      match_names = c("bw.factor", "ambs", "directed"),
-      match_to = c("bw.factor", "ambs", "directed"),
-      defaults = list(bw.factor = 1, ambs = 1, directed = TRUE),
-      head_args = c("nodes", "fw.prob"),
-      fn_name = "sample_forestfire"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(bw.factor = bw.factor, ambs = ambs, directed = directed),
+        recover_new = c("bw.factor", "ambs", "directed"),
+        recover_old = c("bw.factor", "ambs", "directed"),
+        match_names = c("bw.factor", "ambs", "directed"),
+        match_to = c("bw.factor", "ambs", "directed"),
+        defaults = list(bw.factor = 1, ambs = 1, directed = TRUE),
+        head_args = c("nodes", "fw.prob"),
+        fn_name = "sample_forestfire"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -4854,23 +4962,26 @@ sample_correlated_gnp <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_correlated_gnp, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(p = p, permutation = permutation),
-      recover_new = c("p", "permutation"),
-      recover_old = c("p", "permutation"),
-      match_names = c("p", "permutation"),
-      match_to = c("p", "permutation"),
-      defaults = list(p = NULL, permutation = NULL),
-      head_args = c("old.graph", "corr"),
-      fn_name = "sample_correlated_gnp"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(p = p, permutation = permutation),
+        recover_new = c("p", "permutation"),
+        recover_old = c("p", "permutation"),
+        match_names = c("p", "permutation"),
+        match_to = c("p", "permutation"),
+        defaults = list(p = NULL, permutation = NULL),
+        head_args = c("old.graph", "corr"),
+        fn_name = "sample_correlated_gnp"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/glet.R
+++ b/R/glet.R
@@ -144,23 +144,26 @@ graphlet_basis <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graphlet_basis, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights),
-      recover_new = c("weights"),
-      recover_old = c("weights"),
-      match_names = c("weights"),
-      match_to = c("weights"),
-      defaults = list(weights = NULL),
-      head_args = c("graph"),
-      fn_name = "graphlet_basis"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights),
+        recover_new = c("weights"),
+        recover_old = c("weights"),
+        match_names = c("weights"),
+        match_to = c("weights"),
+        defaults = list(weights = NULL),
+        head_args = c("graph"),
+        fn_name = "graphlet_basis"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -183,23 +186,26 @@ graphlet_proj <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graphlet_proj, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights, niter = niter, Mu = Mu),
-      recover_new = c("weights", "cliques", "niter", "Mu"),
-      recover_old = c("weights", "cliques", "niter", "Mu"),
-      match_names = c("weights", "cliques", "niter", "Mu"),
-      match_to = c("weights", "cliques", "niter", "Mu"),
-      defaults = list(weights = NULL, niter = 1000, Mu = NULL),
-      head_args = c("graph"),
-      fn_name = "graphlet_proj"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights, niter = niter, Mu = Mu),
+        recover_new = c("weights", "cliques", "niter", "Mu"),
+        recover_old = c("weights", "cliques", "niter", "Mu"),
+        match_names = c("weights", "cliques", "niter", "Mu"),
+        match_to = c("weights", "cliques", "niter", "Mu"),
+        defaults = list(weights = NULL, niter = 1000, Mu = NULL),
+        head_args = c("graph"),
+        fn_name = "graphlet_proj"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -294,23 +300,26 @@ graphlets <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graphlets, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights, niter = niter),
-      recover_new = c("weights", "niter"),
-      recover_old = c("weights", "niter"),
-      match_names = c("weights", "niter"),
-      match_to = c("weights", "niter"),
-      defaults = list(weights = NULL, niter = 1000),
-      head_args = c("graph"),
-      fn_name = "graphlets"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights, niter = niter),
+        recover_new = c("weights", "niter"),
+        recover_old = c("weights", "niter"),
+        match_names = c("weights", "niter"),
+        match_to = c("weights", "niter"),
+        defaults = list(weights = NULL, niter = 1000),
+        head_args = c("graph"),
+        fn_name = "graphlets"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/hrg.R
+++ b/R/hrg.R
@@ -242,23 +242,26 @@ fit_hrg <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: fit_hrg, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(start = start, steps = steps),
-      recover_new = c("start", "steps"),
-      recover_old = c("start", "steps"),
-      match_names = c("start", "steps"),
-      match_to = c("start", "steps"),
-      defaults = list(start = FALSE, steps = 0),
-      head_args = c("graph", "hrg"),
-      fn_name = "fit_hrg"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(start = start, steps = steps),
+        recover_new = c("start", "steps"),
+        recover_old = c("start", "steps"),
+        match_names = c("start", "steps"),
+        match_to = c("start", "steps"),
+        defaults = list(start = FALSE, steps = 0),
+        head_args = c("graph", "hrg"),
+        fn_name = "fit_hrg"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -343,23 +346,26 @@ consensus_tree <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: consensus_tree, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(start = start, num.samples = num.samples),
-      recover_new = c("start", "num.samples"),
-      recover_old = c("start", "num.samples"),
-      match_names = c("start", "num.samples"),
-      match_to = c("start", "num.samples"),
-      defaults = list(start = FALSE, num.samples = 10000),
-      head_args = c("graph", "hrg"),
-      fn_name = "consensus_tree"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(start = start, num.samples = num.samples),
+        recover_new = c("start", "num.samples"),
+        recover_old = c("start", "num.samples"),
+        match_names = c("start", "num.samples"),
+        match_to = c("start", "num.samples"),
+        defaults = list(start = FALSE, num.samples = 10000),
+        head_args = c("graph", "hrg"),
+        fn_name = "consensus_tree"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -509,27 +515,30 @@ predict_edges <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: predict_edges, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        start = start,
-        num.samples = num.samples,
-        num.bins = num.bins
-      ),
-      recover_new = c("start", "num.samples", "num.bins"),
-      recover_old = c("start", "num.samples", "num.bins"),
-      match_names = c("start", "num.samples", "num.bins"),
-      match_to = c("start", "num.samples", "num.bins"),
-      defaults = list(start = FALSE, num.samples = 10000, num.bins = 25),
-      head_args = c("graph", "hrg"),
-      fn_name = "predict_edges"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          start = start,
+          num.samples = num.samples,
+          num.bins = num.bins
+        ),
+        recover_new = c("start", "num.samples", "num.bins"),
+        recover_old = c("start", "num.samples", "num.bins"),
+        match_names = c("start", "num.samples", "num.bins"),
+        match_to = c("start", "num.samples", "num.bins"),
+        defaults = list(start = FALSE, num.samples = 10000, num.bins = 25),
+        head_args = c("graph", "hrg"),
+        fn_name = "predict_edges"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/incidence.R
+++ b/R/incidence.R
@@ -196,35 +196,38 @@ graph_from_biadjacency_matrix <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph_from_biadjacency_matrix, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        directed = directed,
-        mode = mode,
-        multiple = multiple,
-        weighted = weighted,
-        add.names = add.names
-      ),
-      recover_new = c("directed", "mode", "multiple", "weighted", "add.names"),
-      recover_old = c("directed", "mode", "multiple", "weighted", "add.names"),
-      match_names = c("directed", "mode", "multiple", "weighted", "add.names"),
-      match_to = c("directed", "mode", "multiple", "weighted", "add.names"),
-      defaults = list(
-        directed = FALSE,
-        mode = c("all", "out", "in", "total"),
-        multiple = FALSE,
-        weighted = NULL,
-        add.names = NULL
-      ),
-      head_args = c("incidence"),
-      fn_name = "graph_from_biadjacency_matrix"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          directed = directed,
+          mode = mode,
+          multiple = multiple,
+          weighted = weighted,
+          add.names = add.names
+        ),
+        recover_new = c("directed", "mode", "multiple", "weighted", "add.names"),
+        recover_old = c("directed", "mode", "multiple", "weighted", "add.names"),
+        match_names = c("directed", "mode", "multiple", "weighted", "add.names"),
+        match_to = c("directed", "mode", "multiple", "weighted", "add.names"),
+        defaults = list(
+          directed = FALSE,
+          mode = c("all", "out", "in", "total"),
+          multiple = FALSE,
+          weighted = NULL,
+          add.names = NULL
+        ),
+        head_args = c("incidence"),
+        fn_name = "graph_from_biadjacency_matrix"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/interface.R
+++ b/R/interface.R
@@ -357,23 +357,26 @@ neighbors <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: neighbors, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("out", "in", "all", "total")),
-      head_args = c("graph", "v"),
-      fn_name = "neighbors"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("out", "in", "all", "total")),
+        head_args = c("graph", "v"),
+        fn_name = "neighbors"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -416,23 +419,26 @@ incident <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: incident, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("all", "out", "in", "total")),
-      head_args = c("graph", "v"),
-      fn_name = "incident"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("all", "out", "in", "total")),
+        head_args = c("graph", "v"),
+        fn_name = "incident"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -495,23 +501,26 @@ ends <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: ends, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(names = names),
-      recover_new = c("names"),
-      recover_old = c("names"),
-      match_names = c("names"),
-      match_to = c("names"),
-      defaults = list(names = TRUE),
-      head_args = c("graph", "es"),
-      fn_name = "ends"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(names = names),
+        recover_new = c("names"),
+        recover_old = c("names"),
+        match_names = c("names"),
+        match_to = c("names"),
+        defaults = list(names = TRUE),
+        head_args = c("graph", "es"),
+        fn_name = "ends"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -637,23 +646,26 @@ get_edge_ids <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: get_edge_ids, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, error = error),
-      recover_new = c("directed", "error"),
-      recover_old = c("directed", "error"),
-      match_names = c("directed", "error"),
-      match_to = c("directed", "error"),
-      defaults = list(directed = TRUE, error = FALSE),
-      head_args = c("graph", "vp"),
-      fn_name = "get_edge_ids"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, error = error),
+        recover_new = c("directed", "error"),
+        recover_old = c("directed", "error"),
+        match_names = c("directed", "error"),
+        match_to = c("directed", "error"),
+        defaults = list(directed = TRUE, error = FALSE),
+        head_args = c("graph", "vp"),
+        fn_name = "get_edge_ids"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -751,23 +763,26 @@ adjacent_vertices <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: adjacent_vertices, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("out", "in", "all", "total")),
-      head_args = c("graph", "v"),
-      fn_name = "adjacent_vertices"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("out", "in", "all", "total")),
+        head_args = c("graph", "v"),
+        fn_name = "adjacent_vertices"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -816,23 +831,26 @@ incident_edges <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: incident_edges, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("out", "in", "all", "total")),
-      head_args = c("graph", "v"),
-      fn_name = "incident_edges"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("out", "in", "all", "total")),
+        head_args = c("graph", "v"),
+        fn_name = "incident_edges"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/iterators.R
+++ b/R/iterators.R
@@ -87,23 +87,26 @@ identical_graphs <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: identical_graphs, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(attrs = attrs),
-      recover_new = c("attrs"),
-      recover_old = c("attrs"),
-      match_names = c("attrs"),
-      match_to = c("attrs"),
-      defaults = list(attrs = TRUE),
-      head_args = c("g1", "g2"),
-      fn_name = "identical_graphs"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(attrs = attrs),
+        recover_new = c("attrs"),
+        recover_old = c("attrs"),
+        match_names = c("attrs"),
+        match_to = c("attrs"),
+        defaults = list(attrs = TRUE),
+        head_args = c("g1", "g2"),
+        fn_name = "identical_graphs"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -381,23 +384,26 @@ E <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: E, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(P = P, path = path, directed = directed),
-      recover_new = c("P", "path", "directed"),
-      recover_old = c("P", "path", "directed"),
-      match_names = c("P", "path", "directed"),
-      match_to = c("P", "path", "directed"),
-      defaults = list(P = NULL, path = NULL, directed = TRUE),
-      head_args = c("graph"),
-      fn_name = "E"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(P = P, path = path, directed = directed),
+        recover_new = c("P", "path", "directed"),
+        recover_old = c("P", "path", "directed"),
+        match_names = c("P", "path", "directed"),
+        match_to = c("P", "path", "directed"),
+        defaults = list(P = NULL, path = NULL, directed = TRUE),
+        head_args = c("graph"),
+        fn_name = "E"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/layout.R
+++ b/R/layout.R
@@ -729,23 +729,26 @@ layout_as_bipartite <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_as_bipartite, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(hgap = hgap, vgap = vgap, maxiter = maxiter),
-      recover_new = c("hgap", "vgap", "maxiter"),
-      recover_old = c("hgap", "vgap", "maxiter"),
-      match_names = c("hgap", "vgap", "maxiter"),
-      match_to = c("hgap", "vgap", "maxiter"),
-      defaults = list(hgap = 1, vgap = 1, maxiter = 100),
-      head_args = c("graph", "types"),
-      fn_name = "layout_as_bipartite"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(hgap = hgap, vgap = vgap, maxiter = maxiter),
+        recover_new = c("hgap", "vgap", "maxiter"),
+        recover_old = c("hgap", "vgap", "maxiter"),
+        match_names = c("hgap", "vgap", "maxiter"),
+        match_to = c("hgap", "vgap", "maxiter"),
+        defaults = list(hgap = 1, vgap = 1, maxiter = 100),
+        head_args = c("graph", "types"),
+        fn_name = "layout_as_bipartite"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -808,23 +811,26 @@ layout_as_star <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_as_star, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(center = center, order = order),
-      recover_new = c("center", "order"),
-      recover_old = c("center", "order"),
-      match_names = c("center", "order"),
-      match_to = c("center", "order"),
-      defaults = list(center = NULL, order = NULL),
-      head_args = c("graph"),
-      fn_name = "layout_as_star"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(center = center, order = order),
+        recover_new = c("center", "order"),
+        recover_old = c("center", "order"),
+        match_names = c("center", "order"),
+        match_to = c("center", "order"),
+        defaults = list(center = NULL, order = NULL),
+        head_args = c("graph"),
+        fn_name = "layout_as_star"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -923,35 +929,38 @@ layout_as_tree <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_as_tree, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        root = root,
-        circular = circular,
-        rootlevel = rootlevel,
-        mode = mode,
-        flip.y = flip.y
-      ),
-      recover_new = c("root", "circular", "rootlevel", "mode", "flip.y"),
-      recover_old = c("root", "circular", "rootlevel", "mode", "flip.y"),
-      match_names = c("root", "circular", "rootlevel", "mode", "flip.y"),
-      match_to = c("root", "circular", "rootlevel", "mode", "flip.y"),
-      defaults = list(
-        root = numeric(),
-        circular = FALSE,
-        rootlevel = numeric(),
-        mode = c("out", "in", "all"),
-        flip.y = TRUE
-      ),
-      head_args = c("graph"),
-      fn_name = "layout_as_tree"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          root = root,
+          circular = circular,
+          rootlevel = rootlevel,
+          mode = mode,
+          flip.y = flip.y
+        ),
+        recover_new = c("root", "circular", "rootlevel", "mode", "flip.y"),
+        recover_old = c("root", "circular", "rootlevel", "mode", "flip.y"),
+        match_names = c("root", "circular", "rootlevel", "mode", "flip.y"),
+        match_to = c("root", "circular", "rootlevel", "mode", "flip.y"),
+        defaults = list(
+          root = numeric(),
+          circular = FALSE,
+          rootlevel = numeric(),
+          mode = c("out", "in", "all"),
+          flip.y = TRUE
+        ),
+        head_args = c("graph"),
+        fn_name = "layout_as_tree"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1240,23 +1249,26 @@ layout_on_grid <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_on_grid, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(width = width, height = height, dim = dim),
-      recover_new = c("width", "height", "dim"),
-      recover_old = c("width", "height", "dim"),
-      match_names = c("width", "height", "dim"),
-      match_to = c("width", "height", "dim"),
-      defaults = list(width = 0, height = 0, dim = 2),
-      head_args = c("graph"),
-      fn_name = "layout_on_grid"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(width = width, height = height, dim = dim),
+        recover_new = c("width", "height", "dim"),
+        recover_old = c("width", "height", "dim"),
+        match_names = c("width", "height", "dim"),
+        match_to = c("width", "height", "dim"),
+        defaults = list(width = 0, height = 0, dim = 2),
+        head_args = c("graph"),
+        fn_name = "layout_on_grid"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1364,23 +1376,26 @@ layout_randomly <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_randomly, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(dim = dim),
-      recover_new = c("dim"),
-      recover_old = c("dim"),
-      match_names = c("dim"),
-      match_to = c("dim"),
-      defaults = list(dim = c(2, 3)),
-      head_args = c("graph"),
-      fn_name = "layout_randomly"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(dim = dim),
+        recover_new = c("dim"),
+        recover_old = c("dim"),
+        match_names = c("dim"),
+        match_to = c("dim"),
+        defaults = list(dim = c(2, 3)),
+        head_args = c("graph"),
+        fn_name = "layout_randomly"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1551,83 +1566,86 @@ layout_with_dh <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_with_dh, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        coords = coords,
-        maxiter = maxiter,
-        fineiter = fineiter,
-        cool.fact = cool.fact,
-        weight.node.dist = weight.node.dist,
-        weight.border = weight.border,
-        weight.edge.lengths = weight.edge.lengths,
-        weight.edge.crossings = weight.edge.crossings,
-        weight.node.edge.dist = weight.node.edge.dist
-      ),
-      recover_new = c(
-        "coords",
-        "maxiter",
-        "fineiter",
-        "cool.fact",
-        "weight.node.dist",
-        "weight.border",
-        "weight.edge.lengths",
-        "weight.edge.crossings",
-        "weight.node.edge.dist"
-      ),
-      recover_old = c(
-        "coords",
-        "maxiter",
-        "fineiter",
-        "cool.fact",
-        "weight.node.dist",
-        "weight.border",
-        "weight.edge.lengths",
-        "weight.edge.crossings",
-        "weight.node.edge.dist"
-      ),
-      match_names = c(
-        "coords",
-        "maxiter",
-        "fineiter",
-        "cool.fact",
-        "weight.node.dist",
-        "weight.border",
-        "weight.edge.lengths",
-        "weight.edge.crossings",
-        "weight.node.edge.dist"
-      ),
-      match_to = c(
-        "coords",
-        "maxiter",
-        "fineiter",
-        "cool.fact",
-        "weight.node.dist",
-        "weight.border",
-        "weight.edge.lengths",
-        "weight.edge.crossings",
-        "weight.node.edge.dist"
-      ),
-      defaults = list(
-        coords = NULL,
-        maxiter = 10,
-        fineiter = NULL,
-        cool.fact = 0.75,
-        weight.node.dist = 1,
-        weight.border = 0,
-        weight.edge.lengths = NULL,
-        weight.edge.crossings = NULL,
-        weight.node.edge.dist = NULL
-      ),
-      head_args = c("graph"),
-      fn_name = "layout_with_dh"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          coords = coords,
+          maxiter = maxiter,
+          fineiter = fineiter,
+          cool.fact = cool.fact,
+          weight.node.dist = weight.node.dist,
+          weight.border = weight.border,
+          weight.edge.lengths = weight.edge.lengths,
+          weight.edge.crossings = weight.edge.crossings,
+          weight.node.edge.dist = weight.node.edge.dist
+        ),
+        recover_new = c(
+          "coords",
+          "maxiter",
+          "fineiter",
+          "cool.fact",
+          "weight.node.dist",
+          "weight.border",
+          "weight.edge.lengths",
+          "weight.edge.crossings",
+          "weight.node.edge.dist"
+        ),
+        recover_old = c(
+          "coords",
+          "maxiter",
+          "fineiter",
+          "cool.fact",
+          "weight.node.dist",
+          "weight.border",
+          "weight.edge.lengths",
+          "weight.edge.crossings",
+          "weight.node.edge.dist"
+        ),
+        match_names = c(
+          "coords",
+          "maxiter",
+          "fineiter",
+          "cool.fact",
+          "weight.node.dist",
+          "weight.border",
+          "weight.edge.lengths",
+          "weight.edge.crossings",
+          "weight.node.edge.dist"
+        ),
+        match_to = c(
+          "coords",
+          "maxiter",
+          "fineiter",
+          "cool.fact",
+          "weight.node.dist",
+          "weight.border",
+          "weight.edge.lengths",
+          "weight.edge.crossings",
+          "weight.node.edge.dist"
+        ),
+        defaults = list(
+          coords = NULL,
+          maxiter = 10,
+          fineiter = NULL,
+          cool.fact = 0.75,
+          weight.node.dist = 1,
+          weight.border = 0,
+          weight.edge.lengths = NULL,
+          weight.edge.crossings = NULL,
+          weight.node.edge.dist = NULL
+        ),
+        head_args = c("graph"),
+        fn_name = "layout_with_dh"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1778,136 +1796,139 @@ layout_with_fr <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_with_fr, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("g", "gr"),
-      "layout_with_fr"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        coords = coords,
-        dim = dim,
-        niter = niter,
-        start.temp = start.temp,
-        grid = grid,
-        weights = weights,
-        minx = minx,
-        maxx = maxx,
-        miny = miny,
-        maxy = maxy,
-        minz = minz,
-        maxz = maxz,
-        coolexp = coolexp,
-        maxdelta = maxdelta,
-        area = area,
-        repulserad = repulserad,
-        maxiter = maxiter
-      ),
-      recover_new = c(
-        "coords",
-        "dim",
-        "niter",
-        "start.temp",
-        "grid",
-        "weights",
-        "minx",
-        "maxx",
-        "miny",
-        "maxy",
-        "minz",
-        "maxz",
-        "coolexp",
-        "maxdelta",
-        "area",
-        "repulserad",
-        "maxiter"
-      ),
-      recover_old = c(
-        "coords",
-        "dim",
-        "niter",
-        "start.temp",
-        "grid",
-        "weights",
-        "minx",
-        "maxx",
-        "miny",
-        "maxy",
-        "minz",
-        "maxz",
-        "coolexp",
-        "maxdelta",
-        "area",
-        "repulserad",
-        "maxiter"
-      ),
-      match_names = c(
-        "coords",
-        "dim",
-        "niter",
-        "start.temp",
-        "grid",
-        "weights",
-        "minx",
-        "maxx",
-        "miny",
-        "maxy",
-        "minz",
-        "maxz",
-        "coolexp",
-        "maxdelta",
-        "area",
-        "repulserad",
-        "maxiter"
-      ),
-      match_to = c(
-        "coords",
-        "dim",
-        "niter",
-        "start.temp",
-        "grid",
-        "weights",
-        "minx",
-        "maxx",
-        "miny",
-        "maxy",
-        "minz",
-        "maxz",
-        "coolexp",
-        "maxdelta",
-        "area",
-        "repulserad",
-        "maxiter"
-      ),
-      defaults = list(
-        coords = NULL,
-        dim = c(2, 3),
-        niter = 500,
-        start.temp = NULL,
-        grid = c("auto", "grid", "nogrid"),
-        weights = NULL,
-        minx = NULL,
-        maxx = NULL,
-        miny = NULL,
-        maxy = NULL,
-        minz = NULL,
-        maxz = NULL,
-        coolexp = deprecated(),
-        maxdelta = deprecated(),
-        area = deprecated(),
-        repulserad = deprecated(),
-        maxiter = deprecated()
-      ),
-      head_args = c("graph"),
-      fn_name = "layout_with_fr"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("g", "gr"),
+        "layout_with_fr"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          coords = coords,
+          dim = dim,
+          niter = niter,
+          start.temp = start.temp,
+          grid = grid,
+          weights = weights,
+          minx = minx,
+          maxx = maxx,
+          miny = miny,
+          maxy = maxy,
+          minz = minz,
+          maxz = maxz,
+          coolexp = coolexp,
+          maxdelta = maxdelta,
+          area = area,
+          repulserad = repulserad,
+          maxiter = maxiter
+        ),
+        recover_new = c(
+          "coords",
+          "dim",
+          "niter",
+          "start.temp",
+          "grid",
+          "weights",
+          "minx",
+          "maxx",
+          "miny",
+          "maxy",
+          "minz",
+          "maxz",
+          "coolexp",
+          "maxdelta",
+          "area",
+          "repulserad",
+          "maxiter"
+        ),
+        recover_old = c(
+          "coords",
+          "dim",
+          "niter",
+          "start.temp",
+          "grid",
+          "weights",
+          "minx",
+          "maxx",
+          "miny",
+          "maxy",
+          "minz",
+          "maxz",
+          "coolexp",
+          "maxdelta",
+          "area",
+          "repulserad",
+          "maxiter"
+        ),
+        match_names = c(
+          "coords",
+          "dim",
+          "niter",
+          "start.temp",
+          "grid",
+          "weights",
+          "minx",
+          "maxx",
+          "miny",
+          "maxy",
+          "minz",
+          "maxz",
+          "coolexp",
+          "maxdelta",
+          "area",
+          "repulserad",
+          "maxiter"
+        ),
+        match_to = c(
+          "coords",
+          "dim",
+          "niter",
+          "start.temp",
+          "grid",
+          "weights",
+          "minx",
+          "maxx",
+          "miny",
+          "maxy",
+          "minz",
+          "maxz",
+          "coolexp",
+          "maxdelta",
+          "area",
+          "repulserad",
+          "maxiter"
+        ),
+        defaults = list(
+          coords = NULL,
+          dim = c(2, 3),
+          niter = 500,
+          start.temp = NULL,
+          grid = c("auto", "grid", "nogrid"),
+          weights = NULL,
+          minx = NULL,
+          maxx = NULL,
+          miny = NULL,
+          maxy = NULL,
+          minz = NULL,
+          maxz = NULL,
+          coolexp = deprecated(),
+          maxdelta = deprecated(),
+          area = deprecated(),
+          repulserad = deprecated(),
+          maxiter = deprecated()
+        ),
+        head_args = c("graph"),
+        fn_name = "layout_with_fr"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2084,35 +2105,38 @@ layout_with_gem <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_with_gem, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        coords = coords,
-        maxiter = maxiter,
-        temp.max = temp.max,
-        temp.min = temp.min,
-        temp.init = temp.init
-      ),
-      recover_new = c("coords", "maxiter", "temp.max", "temp.min", "temp.init"),
-      recover_old = c("coords", "maxiter", "temp.max", "temp.min", "temp.init"),
-      match_names = c("coords", "maxiter", "temp.max", "temp.min", "temp.init"),
-      match_to = c("coords", "maxiter", "temp.max", "temp.min", "temp.init"),
-      defaults = list(
-        coords = NULL,
-        maxiter = NULL,
-        temp.max = NULL,
-        temp.min = 0.1,
-        temp.init = NULL
-      ),
-      head_args = c("graph"),
-      fn_name = "layout_with_gem"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          coords = coords,
+          maxiter = maxiter,
+          temp.max = temp.max,
+          temp.min = temp.min,
+          temp.init = temp.init
+        ),
+        recover_new = c("coords", "maxiter", "temp.max", "temp.min", "temp.init"),
+        recover_old = c("coords", "maxiter", "temp.max", "temp.min", "temp.init"),
+        match_names = c("coords", "maxiter", "temp.max", "temp.min", "temp.init"),
+        match_to = c("coords", "maxiter", "temp.max", "temp.min", "temp.init"),
+        defaults = list(
+          coords = NULL,
+          maxiter = NULL,
+          temp.max = NULL,
+          temp.min = 0.1,
+          temp.init = NULL
+        ),
+        head_args = c("graph"),
+        fn_name = "layout_with_gem"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2207,71 +2231,74 @@ layout_with_graphopt <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_with_graphopt, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        start = start,
-        niter = niter,
-        charge = charge,
-        mass = mass,
-        spring.length = spring.length,
-        spring.constant = spring.constant,
-        max.sa.movement = max.sa.movement
-      ),
-      recover_new = c(
-        "start",
-        "niter",
-        "charge",
-        "mass",
-        "spring.length",
-        "spring.constant",
-        "max.sa.movement"
-      ),
-      recover_old = c(
-        "start",
-        "niter",
-        "charge",
-        "mass",
-        "spring.length",
-        "spring.constant",
-        "max.sa.movement"
-      ),
-      match_names = c(
-        "start",
-        "niter",
-        "charge",
-        "mass",
-        "spring.length",
-        "spring.constant",
-        "max.sa.movement"
-      ),
-      match_to = c(
-        "start",
-        "niter",
-        "charge",
-        "mass",
-        "spring.length",
-        "spring.constant",
-        "max.sa.movement"
-      ),
-      defaults = list(
-        start = NULL,
-        niter = 500,
-        charge = 0.001,
-        mass = 30,
-        spring.length = 0,
-        spring.constant = 1,
-        max.sa.movement = 5
-      ),
-      head_args = c("graph"),
-      fn_name = "layout_with_graphopt"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          start = start,
+          niter = niter,
+          charge = charge,
+          mass = mass,
+          spring.length = spring.length,
+          spring.constant = spring.constant,
+          max.sa.movement = max.sa.movement
+        ),
+        recover_new = c(
+          "start",
+          "niter",
+          "charge",
+          "mass",
+          "spring.length",
+          "spring.constant",
+          "max.sa.movement"
+        ),
+        recover_old = c(
+          "start",
+          "niter",
+          "charge",
+          "mass",
+          "spring.length",
+          "spring.constant",
+          "max.sa.movement"
+        ),
+        match_names = c(
+          "start",
+          "niter",
+          "charge",
+          "mass",
+          "spring.length",
+          "spring.constant",
+          "max.sa.movement"
+        ),
+        match_to = c(
+          "start",
+          "niter",
+          "charge",
+          "mass",
+          "spring.length",
+          "spring.constant",
+          "max.sa.movement"
+        ),
+        defaults = list(
+          start = NULL,
+          niter = 500,
+          charge = 0.001,
+          mass = 30,
+          spring.length = 0,
+          spring.constant = 1,
+          max.sa.movement = 5
+        ),
+        head_args = c("graph"),
+        fn_name = "layout_with_graphopt"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2393,131 +2420,134 @@ layout_with_kk <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_with_kk, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        coords = coords,
-        dim = dim,
-        maxiter = maxiter,
-        epsilon = epsilon,
-        kkconst = kkconst,
-        weights = weights,
-        minx = minx,
-        maxx = maxx,
-        miny = miny,
-        maxy = maxy,
-        minz = minz,
-        maxz = maxz,
-        niter = niter,
-        sigma = sigma,
-        initemp = initemp,
-        coolexp = coolexp,
-        start = start
-      ),
-      recover_new = c(
-        "coords",
-        "dim",
-        "maxiter",
-        "epsilon",
-        "kkconst",
-        "weights",
-        "minx",
-        "maxx",
-        "miny",
-        "maxy",
-        "minz",
-        "maxz",
-        "niter",
-        "sigma",
-        "initemp",
-        "coolexp",
-        "start"
-      ),
-      recover_old = c(
-        "coords",
-        "dim",
-        "maxiter",
-        "epsilon",
-        "kkconst",
-        "weights",
-        "minx",
-        "maxx",
-        "miny",
-        "maxy",
-        "minz",
-        "maxz",
-        "niter",
-        "sigma",
-        "initemp",
-        "coolexp",
-        "start"
-      ),
-      match_names = c(
-        "coords",
-        "dim",
-        "maxiter",
-        "epsilon",
-        "kkconst",
-        "weights",
-        "minx",
-        "maxx",
-        "miny",
-        "maxy",
-        "minz",
-        "maxz",
-        "niter",
-        "sigma",
-        "initemp",
-        "coolexp",
-        "start"
-      ),
-      match_to = c(
-        "coords",
-        "dim",
-        "maxiter",
-        "epsilon",
-        "kkconst",
-        "weights",
-        "minx",
-        "maxx",
-        "miny",
-        "maxy",
-        "minz",
-        "maxz",
-        "niter",
-        "sigma",
-        "initemp",
-        "coolexp",
-        "start"
-      ),
-      defaults = list(
-        coords = NULL,
-        dim = c(2, 3),
-        maxiter = NULL,
-        epsilon = 0,
-        kkconst = NULL,
-        weights = NULL,
-        minx = NULL,
-        maxx = NULL,
-        miny = NULL,
-        maxy = NULL,
-        minz = NULL,
-        maxz = NULL,
-        niter = deprecated(),
-        sigma = deprecated(),
-        initemp = deprecated(),
-        coolexp = deprecated(),
-        start = deprecated()
-      ),
-      head_args = c("graph"),
-      fn_name = "layout_with_kk"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          coords = coords,
+          dim = dim,
+          maxiter = maxiter,
+          epsilon = epsilon,
+          kkconst = kkconst,
+          weights = weights,
+          minx = minx,
+          maxx = maxx,
+          miny = miny,
+          maxy = maxy,
+          minz = minz,
+          maxz = maxz,
+          niter = niter,
+          sigma = sigma,
+          initemp = initemp,
+          coolexp = coolexp,
+          start = start
+        ),
+        recover_new = c(
+          "coords",
+          "dim",
+          "maxiter",
+          "epsilon",
+          "kkconst",
+          "weights",
+          "minx",
+          "maxx",
+          "miny",
+          "maxy",
+          "minz",
+          "maxz",
+          "niter",
+          "sigma",
+          "initemp",
+          "coolexp",
+          "start"
+        ),
+        recover_old = c(
+          "coords",
+          "dim",
+          "maxiter",
+          "epsilon",
+          "kkconst",
+          "weights",
+          "minx",
+          "maxx",
+          "miny",
+          "maxy",
+          "minz",
+          "maxz",
+          "niter",
+          "sigma",
+          "initemp",
+          "coolexp",
+          "start"
+        ),
+        match_names = c(
+          "coords",
+          "dim",
+          "maxiter",
+          "epsilon",
+          "kkconst",
+          "weights",
+          "minx",
+          "maxx",
+          "miny",
+          "maxy",
+          "minz",
+          "maxz",
+          "niter",
+          "sigma",
+          "initemp",
+          "coolexp",
+          "start"
+        ),
+        match_to = c(
+          "coords",
+          "dim",
+          "maxiter",
+          "epsilon",
+          "kkconst",
+          "weights",
+          "minx",
+          "maxx",
+          "miny",
+          "maxy",
+          "minz",
+          "maxz",
+          "niter",
+          "sigma",
+          "initemp",
+          "coolexp",
+          "start"
+        ),
+        defaults = list(
+          coords = NULL,
+          dim = c(2, 3),
+          maxiter = NULL,
+          epsilon = 0,
+          kkconst = NULL,
+          weights = NULL,
+          minx = NULL,
+          maxx = NULL,
+          miny = NULL,
+          maxy = NULL,
+          minz = NULL,
+          maxz = NULL,
+          niter = deprecated(),
+          sigma = deprecated(),
+          initemp = deprecated(),
+          coolexp = deprecated(),
+          start = deprecated()
+        ),
+        head_args = c("graph"),
+        fn_name = "layout_with_kk"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2693,71 +2723,74 @@ layout_with_lgl <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_with_lgl, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        maxiter = maxiter,
-        maxdelta = maxdelta,
-        area = area,
-        coolexp = coolexp,
-        repulserad = repulserad,
-        cellsize = cellsize,
-        root = root
-      ),
-      recover_new = c(
-        "maxiter",
-        "maxdelta",
-        "area",
-        "coolexp",
-        "repulserad",
-        "cellsize",
-        "root"
-      ),
-      recover_old = c(
-        "maxiter",
-        "maxdelta",
-        "area",
-        "coolexp",
-        "repulserad",
-        "cellsize",
-        "root"
-      ),
-      match_names = c(
-        "maxiter",
-        "maxdelta",
-        "area",
-        "coolexp",
-        "repulserad",
-        "cellsize",
-        "root"
-      ),
-      match_to = c(
-        "maxiter",
-        "maxdelta",
-        "area",
-        "coolexp",
-        "repulserad",
-        "cellsize",
-        "root"
-      ),
-      defaults = list(
-        maxiter = 150,
-        maxdelta = NULL,
-        area = NULL,
-        coolexp = 1.5,
-        repulserad = NULL,
-        cellsize = NULL,
-        root = NULL
-      ),
-      head_args = c("graph"),
-      fn_name = "layout_with_lgl"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          maxiter = maxiter,
+          maxdelta = maxdelta,
+          area = area,
+          coolexp = coolexp,
+          repulserad = repulserad,
+          cellsize = cellsize,
+          root = root
+        ),
+        recover_new = c(
+          "maxiter",
+          "maxdelta",
+          "area",
+          "coolexp",
+          "repulserad",
+          "cellsize",
+          "root"
+        ),
+        recover_old = c(
+          "maxiter",
+          "maxdelta",
+          "area",
+          "coolexp",
+          "repulserad",
+          "cellsize",
+          "root"
+        ),
+        match_names = c(
+          "maxiter",
+          "maxdelta",
+          "area",
+          "coolexp",
+          "repulserad",
+          "cellsize",
+          "root"
+        ),
+        match_to = c(
+          "maxiter",
+          "maxdelta",
+          "area",
+          "coolexp",
+          "repulserad",
+          "cellsize",
+          "root"
+        ),
+        defaults = list(
+          maxiter = 150,
+          maxdelta = NULL,
+          area = NULL,
+          coolexp = 1.5,
+          repulserad = NULL,
+          cellsize = NULL,
+          root = NULL
+        ),
+        head_args = c("graph"),
+        fn_name = "layout_with_lgl"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3123,65 +3156,68 @@ layout_with_sugiyama <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_with_sugiyama, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        layers = layers,
-        hgap = hgap,
-        vgap = vgap,
-        maxiter = maxiter,
-        weights = weights,
-        attributes = attributes
-      ),
-      recover_new = c(
-        "layers",
-        "hgap",
-        "vgap",
-        "maxiter",
-        "weights",
-        "attributes"
-      ),
-      recover_old = c(
-        "layers",
-        "hgap",
-        "vgap",
-        "maxiter",
-        "weights",
-        "attributes"
-      ),
-      match_names = c(
-        "layers",
-        "hgap",
-        "vgap",
-        "maxiter",
-        "weights",
-        "attributes"
-      ),
-      match_to = c(
-        "layers",
-        "hgap",
-        "vgap",
-        "maxiter",
-        "weights",
-        "attributes"
-      ),
-      defaults = list(
-        layers = NULL,
-        hgap = 1,
-        vgap = 1,
-        maxiter = 100,
-        weights = NULL,
-        attributes = c("default", "all", "none")
-      ),
-      head_args = c("graph"),
-      fn_name = "layout_with_sugiyama"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          layers = layers,
+          hgap = hgap,
+          vgap = vgap,
+          maxiter = maxiter,
+          weights = weights,
+          attributes = attributes
+        ),
+        recover_new = c(
+          "layers",
+          "hgap",
+          "vgap",
+          "maxiter",
+          "weights",
+          "attributes"
+        ),
+        recover_old = c(
+          "layers",
+          "hgap",
+          "vgap",
+          "maxiter",
+          "weights",
+          "attributes"
+        ),
+        match_names = c(
+          "layers",
+          "hgap",
+          "vgap",
+          "maxiter",
+          "weights",
+          "attributes"
+        ),
+        match_to = c(
+          "layers",
+          "hgap",
+          "vgap",
+          "maxiter",
+          "weights",
+          "attributes"
+        ),
+        defaults = list(
+          layers = NULL,
+          hgap = 1,
+          vgap = 1,
+          maxiter = 100,
+          weights = NULL,
+          attributes = c("default", "all", "none")
+        ),
+        head_args = c("graph"),
+        fn_name = "layout_with_sugiyama"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3363,23 +3399,26 @@ merge_coords <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: merge_coords, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(method = method),
-      recover_new = c("method"),
-      recover_old = c("method"),
-      match_names = c("method"),
-      match_to = c("method"),
-      defaults = list(method = "dla"),
-      head_args = c("graphs", "layouts"),
-      fn_name = "merge_coords"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(method = method),
+        recover_new = c("method"),
+        recover_old = c("method"),
+        match_names = c("method"),
+        match_to = c("method"),
+        defaults = list(method = "dla"),
+        head_args = c("graphs", "layouts"),
+        fn_name = "merge_coords"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3430,37 +3469,40 @@ norm_coords <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: norm_coords, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        xmin = xmin,
-        xmax = xmax,
-        ymin = ymin,
-        ymax = ymax,
-        zmin = zmin,
-        zmax = zmax
-      ),
-      recover_new = c("xmin", "xmax", "ymin", "ymax", "zmin", "zmax"),
-      recover_old = c("xmin", "xmax", "ymin", "ymax", "zmin", "zmax"),
-      match_names = c("xmin", "xmax", "ymin", "ymax", "zmin", "zmax"),
-      match_to = c("xmin", "xmax", "ymin", "ymax", "zmin", "zmax"),
-      defaults = list(
-        xmin = -1,
-        xmax = 1,
-        ymin = -1,
-        ymax = 1,
-        zmin = -1,
-        zmax = 1
-      ),
-      head_args = c("layout"),
-      fn_name = "norm_coords"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          xmin = xmin,
+          xmax = xmax,
+          ymin = ymin,
+          ymax = ymax,
+          zmin = zmin,
+          zmax = zmax
+        ),
+        recover_new = c("xmin", "xmax", "ymin", "ymax", "zmin", "zmax"),
+        recover_old = c("xmin", "xmax", "ymin", "ymax", "zmin", "zmax"),
+        match_names = c("xmin", "xmax", "ymin", "ymax", "zmin", "zmax"),
+        match_to = c("xmin", "xmax", "ymin", "ymax", "zmin", "zmax"),
+        defaults = list(
+          xmin = -1,
+          xmax = 1,
+          ymin = -1,
+          ymax = 1,
+          zmin = -1,
+          zmax = 1
+        ),
+        head_args = c("layout"),
+        fn_name = "norm_coords"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3755,35 +3797,38 @@ layout_with_drl <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_with_drl, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        use.seed = use.seed,
-        seed = seed,
-        options = options,
-        weights = weights,
-        dim = dim
-      ),
-      recover_new = c("use.seed", "seed", "options", "weights", "dim"),
-      recover_old = c("use.seed", "seed", "options", "weights", "dim"),
-      match_names = c("use.seed", "seed", "options", "weights", "dim"),
-      match_to = c("use.seed", "seed", "options", "weights", "dim"),
-      defaults = list(
-        use.seed = FALSE,
-        seed = NULL,
-        options = NULL,
-        weights = NULL,
-        dim = c(2, 3)
-      ),
-      head_args = c("graph"),
-      fn_name = "layout_with_drl"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          use.seed = use.seed,
+          seed = seed,
+          options = options,
+          weights = weights,
+          dim = dim
+        ),
+        recover_new = c("use.seed", "seed", "options", "weights", "dim"),
+        recover_old = c("use.seed", "seed", "options", "weights", "dim"),
+        match_names = c("use.seed", "seed", "options", "weights", "dim"),
+        match_to = c("use.seed", "seed", "options", "weights", "dim"),
+        defaults = list(
+          use.seed = FALSE,
+          seed = NULL,
+          options = NULL,
+          weights = NULL,
+          dim = c(2, 3)
+        ),
+        head_args = c("graph"),
+        fn_name = "layout_with_drl"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/make.R
+++ b/R/make.R
@@ -1601,23 +1601,26 @@ make_empty_graph <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_empty_graph, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = TRUE),
-      head_args = c("n"),
-      fn_name = "make_empty_graph"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = TRUE),
+        head_args = c("n"),
+        fn_name = "make_empty_graph"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1645,23 +1648,26 @@ empty_graph <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: empty_graph, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = TRUE),
-      head_args = c("n"),
-      fn_name = "empty_graph"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = TRUE),
+        head_args = c("n"),
+        fn_name = "empty_graph"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1932,26 +1938,29 @@ make_star <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_star, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, center = center),
-      recover_new = c("mode", "center"),
-      recover_old = c("mode", "center"),
-      match_names = c("mode", "center"),
-      match_to = c("mode", "center"),
-      defaults = list(
-        mode = c("in", "out", "mutual", "undirected"),
-        center = 1
-      ),
-      head_args = c("n"),
-      fn_name = "make_star"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, center = center),
+        recover_new = c("mode", "center"),
+        recover_old = c("mode", "center"),
+        match_names = c("mode", "center"),
+        match_to = c("mode", "center"),
+        defaults = list(
+          mode = c("in", "out", "mutual", "undirected"),
+          center = 1
+        ),
+        head_args = c("n"),
+        fn_name = "make_star"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1981,26 +1990,29 @@ star <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: star, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, center = center),
-      recover_new = c("mode", "center"),
-      recover_old = c("mode", "center"),
-      match_names = c("mode", "center"),
-      match_to = c("mode", "center"),
-      defaults = list(
-        mode = c("in", "out", "mutual", "undirected"),
-        center = 1
-      ),
-      head_args = c("n"),
-      fn_name = "star"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, center = center),
+        recover_new = c("mode", "center"),
+        recover_old = c("mode", "center"),
+        match_names = c("mode", "center"),
+        match_to = c("mode", "center"),
+        defaults = list(
+          mode = c("in", "out", "mutual", "undirected"),
+          center = 1
+        ),
+        head_args = c("n"),
+        fn_name = "star"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2031,23 +2043,26 @@ make_full_graph <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_full_graph, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, loops = loops),
-      recover_new = c("directed", "loops"),
-      recover_old = c("directed", "loops"),
-      match_names = c("directed", "loops"),
-      match_to = c("directed", "loops"),
-      defaults = list(directed = FALSE, loops = FALSE),
-      head_args = c("n"),
-      fn_name = "make_full_graph"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, loops = loops),
+        recover_new = c("directed", "loops"),
+        recover_old = c("directed", "loops"),
+        match_names = c("directed", "loops"),
+        match_to = c("directed", "loops"),
+        defaults = list(directed = FALSE, loops = FALSE),
+        head_args = c("n"),
+        fn_name = "make_full_graph"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2074,23 +2089,26 @@ full_graph <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: full_graph, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, loops = loops),
-      recover_new = c("directed", "loops"),
-      recover_old = c("directed", "loops"),
-      match_names = c("directed", "loops"),
-      match_to = c("directed", "loops"),
-      defaults = list(directed = FALSE, loops = FALSE),
-      head_args = c("n"),
-      fn_name = "full_graph"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, loops = loops),
+        recover_new = c("directed", "loops"),
+        recover_old = c("directed", "loops"),
+        match_names = c("directed", "loops"),
+        match_to = c("directed", "loops"),
+        defaults = list(directed = FALSE, loops = FALSE),
+        head_args = c("n"),
+        fn_name = "full_graph"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2235,23 +2253,26 @@ make_ring <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_ring, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, mutual = mutual, circular = circular),
-      recover_new = c("directed", "mutual", "circular"),
-      recover_old = c("directed", "mutual", "circular"),
-      match_names = c("directed", "mutual", "circular"),
-      match_to = c("directed", "mutual", "circular"),
-      defaults = list(directed = FALSE, mutual = FALSE, circular = TRUE),
-      head_args = c("n"),
-      fn_name = "make_ring"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, mutual = mutual, circular = circular),
+        recover_new = c("directed", "mutual", "circular"),
+        recover_old = c("directed", "mutual", "circular"),
+        match_names = c("directed", "mutual", "circular"),
+        match_to = c("directed", "mutual", "circular"),
+        defaults = list(directed = FALSE, mutual = FALSE, circular = TRUE),
+        head_args = c("n"),
+        fn_name = "make_ring"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2281,23 +2302,26 @@ ring <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: ring, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, mutual = mutual, circular = circular),
-      recover_new = c("directed", "mutual", "circular"),
-      recover_old = c("directed", "mutual", "circular"),
-      match_names = c("directed", "mutual", "circular"),
-      match_to = c("directed", "mutual", "circular"),
-      defaults = list(directed = FALSE, mutual = FALSE, circular = TRUE),
-      head_args = c("n"),
-      fn_name = "ring"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, mutual = mutual, circular = circular),
+        recover_new = c("directed", "mutual", "circular"),
+        recover_old = c("directed", "mutual", "circular"),
+        match_names = c("directed", "mutual", "circular"),
+        match_to = c("directed", "mutual", "circular"),
+        defaults = list(directed = FALSE, mutual = FALSE, circular = TRUE),
+        head_args = c("n"),
+        fn_name = "ring"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2412,23 +2436,26 @@ make_tree <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_tree, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("out", "in", "undirected")),
-      head_args = c("n", "children"),
-      fn_name = "make_tree"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("out", "in", "undirected")),
+        head_args = c("n", "children"),
+        fn_name = "make_tree"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2482,23 +2509,26 @@ sample_tree <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_tree, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, method = method),
-      recover_new = c("directed", "method"),
-      recover_old = c("directed", "method"),
-      match_names = c("directed", "method"),
-      match_to = c("directed", "method"),
-      defaults = list(directed = FALSE, method = c("lerw", "prufer")),
-      head_args = c("n"),
-      fn_name = "sample_tree"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, method = method),
+        recover_new = c("directed", "method"),
+        recover_old = c("directed", "method"),
+        match_names = c("directed", "method"),
+        match_to = c("directed", "method"),
+        defaults = list(directed = FALSE, method = c("lerw", "prufer")),
+        head_args = c("n"),
+        fn_name = "sample_tree"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2637,23 +2667,26 @@ make_chordal_ring <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_chordal_ring, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = FALSE),
-      head_args = c("n", "w"),
-      fn_name = "make_chordal_ring"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = FALSE),
+        head_args = c("n", "w"),
+        fn_name = "make_chordal_ring"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2680,23 +2713,26 @@ chordal_ring <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: chordal_ring, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = FALSE),
-      head_args = c("n", "w"),
-      fn_name = "chordal_ring"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = FALSE),
+        head_args = c("n", "w"),
+        fn_name = "chordal_ring"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2738,23 +2774,26 @@ make_circulant <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_circulant, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = FALSE),
-      head_args = c("n", "shifts"),
-      fn_name = "make_circulant"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = FALSE),
+        head_args = c("n", "shifts"),
+        fn_name = "make_circulant"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2776,23 +2815,26 @@ circulant <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: circulant, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = FALSE),
-      head_args = c("n", "shifts"),
-      fn_name = "circulant"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = FALSE),
+        head_args = c("n", "shifts"),
+        fn_name = "circulant"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2989,23 +3031,26 @@ make_full_bipartite_graph <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_full_bipartite_graph, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, mode = mode),
-      recover_new = c("directed", "mode"),
-      recover_old = c("directed", "mode"),
-      match_names = c("directed", "mode"),
-      match_to = c("directed", "mode"),
-      defaults = list(directed = FALSE, mode = c("all", "out", "in")),
-      head_args = c("n1", "n2"),
-      fn_name = "make_full_bipartite_graph"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, mode = mode),
+        recover_new = c("directed", "mode"),
+        recover_old = c("directed", "mode"),
+        match_names = c("directed", "mode"),
+        match_to = c("directed", "mode"),
+        defaults = list(directed = FALSE, mode = c("all", "out", "in")),
+        head_args = c("n1", "n2"),
+        fn_name = "make_full_bipartite_graph"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3040,23 +3085,26 @@ full_bipartite_graph <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: full_bipartite_graph, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, mode = mode),
-      recover_new = c("directed", "mode"),
-      recover_old = c("directed", "mode"),
-      match_names = c("directed", "mode"),
-      match_to = c("directed", "mode"),
-      defaults = list(directed = FALSE, mode = c("all", "out", "in")),
-      head_args = c("n1", "n2"),
-      fn_name = "full_bipartite_graph"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, mode = mode),
+        recover_new = c("directed", "mode"),
+        recover_old = c("directed", "mode"),
+        match_names = c("directed", "mode"),
+        match_to = c("directed", "mode"),
+        defaults = list(directed = FALSE, mode = c("all", "out", "in")),
+        head_args = c("n1", "n2"),
+        fn_name = "full_bipartite_graph"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3121,23 +3169,26 @@ make_bipartite_graph <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_bipartite_graph, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = FALSE),
-      head_args = c("types", "edges"),
-      fn_name = "make_bipartite_graph"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = FALSE),
+        head_args = c("types", "edges"),
+        fn_name = "make_bipartite_graph"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3186,23 +3237,26 @@ bipartite_graph <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: bipartite_graph, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = FALSE),
-      head_args = c("types", "edges"),
-      fn_name = "bipartite_graph"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = FALSE),
+        head_args = c("types", "edges"),
+        fn_name = "bipartite_graph"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3252,23 +3306,26 @@ make_full_multipartite <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_full_multipartite, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, mode = mode),
-      recover_new = c("directed", "mode"),
-      recover_old = c("directed", "mode"),
-      match_names = c("directed", "mode"),
-      match_to = c("directed", "mode"),
-      defaults = list(directed = FALSE, mode = c("all", "out", "in")),
-      head_args = c("n"),
-      fn_name = "make_full_multipartite"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, mode = mode),
+        recover_new = c("directed", "mode"),
+        recover_old = c("directed", "mode"),
+        match_names = c("directed", "mode"),
+        match_to = c("directed", "mode"),
+        defaults = list(directed = FALSE, mode = c("all", "out", "in")),
+        head_args = c("n"),
+        fn_name = "make_full_multipartite"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3303,23 +3360,26 @@ full_multipartite <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: full_multipartite, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed, mode = mode),
-      recover_new = c("directed", "mode"),
-      recover_old = c("directed", "mode"),
-      match_names = c("directed", "mode"),
-      match_to = c("directed", "mode"),
-      defaults = list(directed = FALSE, mode = c("all", "out", "in")),
-      head_args = c("n"),
-      fn_name = "full_multipartite"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed, mode = mode),
+        recover_new = c("directed", "mode"),
+        recover_old = c("directed", "mode"),
+        match_names = c("directed", "mode"),
+        match_to = c("directed", "mode"),
+        defaults = list(directed = FALSE, mode = c("all", "out", "in")),
+        head_args = c("n"),
+        fn_name = "full_multipartite"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3409,23 +3469,26 @@ make_full_citation_graph <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_full_citation_graph, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = TRUE),
-      head_args = c("n"),
-      fn_name = "make_full_citation_graph"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = TRUE),
+        head_args = c("n"),
+        fn_name = "make_full_citation_graph"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3449,23 +3512,26 @@ full_citation_graph <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: full_citation_graph, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = TRUE),
-      head_args = c("n"),
-      fn_name = "full_citation_graph"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = TRUE),
+        head_args = c("n"),
+        fn_name = "full_citation_graph"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3636,26 +3702,29 @@ realize_degseq <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: realize_degseq, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(allowed.edge.types = allowed.edge.types, method = method),
-      recover_new = c("allowed.edge.types", "method"),
-      recover_old = c("allowed.edge.types", "method"),
-      match_names = c("allowed.edge.types", "method"),
-      match_to = c("allowed.edge.types", "method"),
-      defaults = list(
-        allowed.edge.types = c("simple", "loops", "multi", "all"),
-        method = c("smallest", "largest", "index")
-      ),
-      head_args = c("out.deg", "in.deg"),
-      fn_name = "realize_degseq"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(allowed.edge.types = allowed.edge.types, method = method),
+        recover_new = c("allowed.edge.types", "method"),
+        recover_old = c("allowed.edge.types", "method"),
+        match_names = c("allowed.edge.types", "method"),
+        match_to = c("allowed.edge.types", "method"),
+        defaults = list(
+          allowed.edge.types = c("simple", "loops", "multi", "all"),
+          method = c("smallest", "largest", "index")
+        ),
+        head_args = c("out.deg", "in.deg"),
+        fn_name = "realize_degseq"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/migrate-args.R
+++ b/R/migrate-args.R
@@ -1,8 +1,63 @@
+# Capture `...` for the recovery layer without tripping over empty arguments.
+#
+# A call may leave an argument slot empty -- a trailing comma
+# (`f(x, mode = "out", )`) or a skipped positional slot, which is what
+# magrittr produces for `x %>% f(., , directed = FALSE)`. Under the old
+# signatures those empty slots matched a formal by position and simply left it
+# missing, so the formal's default applied. Now that the optional arguments sit
+# behind `...`, the empty slot lands in `...` instead, where `list(...)` forces
+# it and errors with "argument is missing, with no default" (#2646).
+#
+# So collect the supplied dots only, and remember where each one sat among the
+# unnamed slots: an empty slot still consumed a formal under the old signature,
+# so `f(g, , 5)` must recover `5` into the *second* recoverable argument, not
+# the first. `pos` carries that ordinal (NA for named dots, which recover by
+# name); `values` holds just the supplied ones.
+#
+# `substitute(...())` yields the unevaluated dot expressions -- an empty slot
+# shows up as the empty symbol -- so missing-ness is decided without forcing
+# anything. Only the supplied slots are then forced, via `...elt()`.
+
+#' @noRd
+migrate_capture_dots <- function(env = parent.frame()) {
+  exprs <- as.list(eval(quote(substitute(...())), env))
+  if (length(exprs) == 0L) {
+    return(list(values = list(), pos = integer(0)))
+  }
+
+  # `quote(expr = )` is inlined rather than bound to a local: evaluating a
+  # variable that holds the empty symbol is itself a "argument is missing"
+  # error, so it must never be looked up by name.
+  supplied <- !vapply(exprs, identical, logical(1), quote(expr = ))
+  if (!any(supplied)) {
+    # Nothing but empty slots: the formals keep their defaults, exactly as
+    # under the old signature. No recovery, and no deprecation warning.
+    return(list(values = list(), pos = integer(0)))
+  }
+
+  nms <- rlang::names2(exprs)
+  unnamed <- !nzchar(nms)
+  # Ordinal among the unnamed slots, counting the empty ones.
+  ordinal <- cumsum(unnamed)
+  ordinal[!unnamed] <- NA_integer_
+
+  idx <- which(supplied)
+  values <- lapply(idx, function(k) eval(call("...elt", k), env))
+  if (any(nzchar(nms[idx]))) {
+    # Left unnamed when no dot was tagged, matching what `list(...)` produced.
+    names(values) <- nms[idx]
+  }
+  list(values = values, pos = as.integer(ordinal[idx]))
+}
+
 # Runtime helper behind the generated `# ... ARG_HANDLE` blocks (see
 # tools/migrations.R, tools/generate-migrations.R). Hand-written and tested
 # directly -- the generated blocks only carry the per-function configuration and
 # call this. Kept a plain function (not an inline closure) so it is easy to step
 # through in a debugger.
+#
+# `dots` is the `migrate_capture_dots()` result -- `$values` (supplied dots
+# only) and `$pos` (their ordinal among the unnamed slots).
 #
 # Pure: it inspects `dots` against the supplied maps and returns the recovered
 # values plus the deprecation message parts, or NULL when there is nothing to
@@ -24,6 +79,8 @@ migrate_recover_args <- function(
   fn_name,
   call = rlang::caller_env()
 ) {
+  dot_pos <- dots$pos
+  dots <- dots$values
   if (length(dots) == 0L) {
     return(NULL)
   }
@@ -32,7 +89,6 @@ migrate_recover_args <- function(
   values <- list()
   rebound_old <- character()
   rebound_new <- character()
-  pos <- 0L
   for (k in seq_along(dots)) {
     nm <- dot_names[[k]]
     if (nzchar(nm)) {
@@ -56,8 +112,10 @@ migrate_recover_args <- function(
       new_name <- match_to[[j]]
       old_label <- match_names[[j]]
     } else {
-      # Unnamed: recover by position into the next old slot past the head.
-      pos <- pos + 1L
+      # Unnamed: recover by position into the old slot this one sat in, past
+      # the head. Empty slots were dropped but still count towards the
+      # ordinal, so a skipped slot shifts the later positionals along.
+      pos <- dot_pos[[k]]
       if (pos > length(recover_new)) {
         cli::cli_abort(
           "Too many arguments passed to {.fn {fn_name}}.",

--- a/R/migration-fixture.R
+++ b/R/migration-fixture.R
@@ -19,23 +19,26 @@ migration_fixture <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: migration_fixture, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights, type = type, directed = directed),
-      recover_new = c("weights", "type", "directed"),
-      recover_old = c("weight", "kind", "directed"),
-      match_names = c("weight", "kind", "weights", "type", "directed"),
-      match_to = c("weights", "type", "weights", "type", "directed"),
-      defaults = list(weights = NULL, type = "out", directed = FALSE),
-      head_args = c("graph", "n"),
-      fn_name = "migration_fixture"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights, type = type, directed = directed),
+        recover_new = c("weights", "type", "directed"),
+        recover_old = c("weight", "kind", "directed"),
+        match_names = c("weight", "kind", "weights", "type", "directed"),
+        match_to = c("weights", "type", "weights", "type", "directed"),
+        defaults = list(weights = NULL, type = "out", directed = FALSE),
+        head_args = c("graph", "n"),
+        fn_name = "migration_fixture"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -64,28 +67,31 @@ migration_fixture_prefix <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: migration_fixture_prefix, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("d", "di"),
-      "migration_fixture_prefix"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(dim = dim, permutation = permutation),
-      recover_new = c("dim", "permutation"),
-      recover_old = c("dim", "permutation"),
-      match_names = c("dim", "permutation"),
-      match_to = c("dim", "permutation"),
-      defaults = list(dim = NULL, permutation = NULL),
-      head_args = c("dimvector", "p"),
-      fn_name = "migration_fixture_prefix"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("d", "di"),
+        "migration_fixture_prefix"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(dim = dim, permutation = permutation),
+        recover_new = c("dim", "permutation"),
+        recover_old = c("dim", "permutation"),
+        match_names = c("dim", "permutation"),
+        match_to = c("dim", "permutation"),
+        defaults = list(dim = NULL, permutation = NULL),
+        head_args = c("dimvector", "p"),
+        fn_name = "migration_fixture_prefix"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/motifs.R
+++ b/R/motifs.R
@@ -181,23 +181,26 @@ motifs <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: motifs, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(cut.prob = cut.prob, callback = callback),
-      recover_new = c("cut.prob", "callback"),
-      recover_old = c("cut.prob", "callback"),
-      match_names = c("cut.prob", "callback"),
-      match_to = c("cut.prob", "callback"),
-      defaults = list(cut.prob = NULL, callback = NULL),
-      head_args = c("graph", "size"),
-      fn_name = "motifs"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(cut.prob = cut.prob, callback = callback),
+        recover_new = c("cut.prob", "callback"),
+        recover_old = c("cut.prob", "callback"),
+        match_names = c("cut.prob", "callback"),
+        match_to = c("cut.prob", "callback"),
+        defaults = list(cut.prob = NULL, callback = NULL),
+        head_args = c("graph", "size"),
+        fn_name = "motifs"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -261,23 +264,26 @@ count_motifs <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: count_motifs, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(cut.prob = cut.prob),
-      recover_new = c("cut.prob"),
-      recover_old = c("cut.prob"),
-      match_names = c("cut.prob"),
-      match_to = c("cut.prob"),
-      defaults = list(cut.prob = NULL),
-      head_args = c("graph", "size"),
-      fn_name = "count_motifs"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(cut.prob = cut.prob),
+        recover_new = c("cut.prob"),
+        recover_old = c("cut.prob"),
+        match_names = c("cut.prob"),
+        match_to = c("cut.prob"),
+        defaults = list(cut.prob = NULL),
+        head_args = c("graph", "size"),
+        fn_name = "count_motifs"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -337,32 +343,35 @@ sample_motifs <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_motifs, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("s"),
-      "sample_motifs"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        cut.prob = cut.prob,
-        sample.size = sample.size,
-        sample = sample
-      ),
-      recover_new = c("cut.prob", "sample.size", "sample"),
-      recover_old = c("cut.prob", "sample.size", "sample"),
-      match_names = c("cut.prob", "sample.size", "sample"),
-      match_to = c("cut.prob", "sample.size", "sample"),
-      defaults = list(cut.prob = NULL, sample.size = NULL, sample = NULL),
-      head_args = c("graph", "size"),
-      fn_name = "sample_motifs"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("s"),
+        "sample_motifs"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          cut.prob = cut.prob,
+          sample.size = sample.size,
+          sample = sample
+        ),
+        recover_new = c("cut.prob", "sample.size", "sample"),
+        recover_old = c("cut.prob", "sample.size", "sample"),
+        match_names = c("cut.prob", "sample.size", "sample"),
+        match_to = c("cut.prob", "sample.size", "sample"),
+        defaults = list(cut.prob = NULL, sample.size = NULL, sample = NULL),
+        head_args = c("graph", "size"),
+        fn_name = "sample_motifs"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/operators.R
+++ b/R/operators.R
@@ -908,23 +908,26 @@ complementer <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: complementer, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(loops = loops),
-      recover_new = c("loops"),
-      recover_old = c("loops"),
-      match_names = c("loops"),
-      match_to = c("loops"),
-      defaults = list(loops = FALSE),
-      head_args = c("graph"),
-      fn_name = "complementer"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(loops = loops),
+        recover_new = c("loops"),
+        recover_old = c("loops"),
+        match_names = c("loops"),
+        match_to = c("loops"),
+        defaults = list(loops = FALSE),
+        head_args = c("graph"),
+        fn_name = "complementer"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1015,53 +1018,56 @@ compose <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: compose, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        byname = byname,
-        graph.attr.comb = graph.attr.comb,
-        vertex.attr.comb = vertex.attr.comb,
-        edge.attr.comb = edge.attr.comb
-      ),
-      recover_new = c(
-        "byname",
-        "graph.attr.comb",
-        "vertex.attr.comb",
-        "edge.attr.comb"
-      ),
-      recover_old = c(
-        "byname",
-        "graph.attr.comb",
-        "vertex.attr.comb",
-        "edge.attr.comb"
-      ),
-      match_names = c(
-        "byname",
-        "graph.attr.comb",
-        "vertex.attr.comb",
-        "edge.attr.comb"
-      ),
-      match_to = c(
-        "byname",
-        "graph.attr.comb",
-        "vertex.attr.comb",
-        "edge.attr.comb"
-      ),
-      defaults = list(
-        byname = "auto",
-        graph.attr.comb = NULL,
-        vertex.attr.comb = "rename",
-        edge.attr.comb = "rename"
-      ),
-      head_args = c("g1", "g2"),
-      fn_name = "compose"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          byname = byname,
+          graph.attr.comb = graph.attr.comb,
+          vertex.attr.comb = vertex.attr.comb,
+          edge.attr.comb = edge.attr.comb
+        ),
+        recover_new = c(
+          "byname",
+          "graph.attr.comb",
+          "vertex.attr.comb",
+          "edge.attr.comb"
+        ),
+        recover_old = c(
+          "byname",
+          "graph.attr.comb",
+          "vertex.attr.comb",
+          "edge.attr.comb"
+        ),
+        match_names = c(
+          "byname",
+          "graph.attr.comb",
+          "vertex.attr.comb",
+          "edge.attr.comb"
+        ),
+        match_to = c(
+          "byname",
+          "graph.attr.comb",
+          "vertex.attr.comb",
+          "edge.attr.comb"
+        ),
+        defaults = list(
+          byname = "auto",
+          graph.attr.comb = NULL,
+          vertex.attr.comb = "rename",
+          edge.attr.comb = "rename"
+        ),
+        head_args = c("g1", "g2"),
+        fn_name = "compose"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/par.R
+++ b/R/par.R
@@ -304,23 +304,26 @@ igraph_opt <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: igraph_opt, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(default = default),
-      recover_new = c("default"),
-      recover_old = c("default"),
-      match_names = c("default"),
-      match_to = c("default"),
-      defaults = list(default = NULL),
-      head_args = c("x"),
-      fn_name = "igraph_opt"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(default = default),
+        recover_new = c("default"),
+        recover_old = c("default"),
+        match_names = c("default"),
+        match_to = c("default"),
+        defaults = list(default = NULL),
+        head_args = c("x"),
+        fn_name = "igraph_opt"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/paths.R
+++ b/R/paths.R
@@ -118,23 +118,26 @@ all_simple_paths <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: all_simple_paths, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, cutoff = cutoff),
-      recover_new = c("mode", "cutoff"),
-      recover_old = c("mode", "cutoff"),
-      match_names = c("mode", "cutoff"),
-      match_to = c("mode", "cutoff"),
-      defaults = list(mode = c("out", "in", "all", "total"), cutoff = -1),
-      head_args = c("graph", "from", "to"),
-      fn_name = "all_simple_paths"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, cutoff = cutoff),
+        recover_new = c("mode", "cutoff"),
+        recover_old = c("mode", "cutoff"),
+        match_names = c("mode", "cutoff"),
+        match_to = c("mode", "cutoff"),
+        defaults = list(mode = c("out", "in", "all", "total"), cutoff = -1),
+        head_args = c("graph", "from", "to"),
+        fn_name = "all_simple_paths"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -446,23 +449,26 @@ distance_table <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: distance_table, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = TRUE),
-      head_args = c("graph"),
-      fn_name = "distance_table"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = TRUE),
+        head_args = c("graph"),
+        fn_name = "distance_table"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/plot.common.R
+++ b/R/plot.common.R
@@ -738,23 +738,26 @@ curve_multiple <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: curve_multiple, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(start = start),
-      recover_new = c("start"),
-      recover_old = c("start"),
-      match_names = c("start"),
-      match_to = c("start"),
-      defaults = list(start = 0.5),
-      head_args = c("graph"),
-      fn_name = "curve_multiple"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(start = start),
+        recover_new = c("start"),
+        recover_old = c("start"),
+        match_names = c("start"),
+        match_to = c("start"),
+        defaults = list(start = 0.5),
+        head_args = c("graph"),
+        fn_name = "curve_multiple"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/plot.shapes.R
+++ b/R/plot.shapes.R
@@ -382,23 +382,26 @@ add_shape <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: add_shape, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(clip = clip, plot = plot, parameters = parameters),
-      recover_new = c("clip", "plot", "parameters"),
-      recover_old = c("clip", "plot", "parameters"),
-      match_names = c("clip", "plot", "parameters"),
-      match_to = c("clip", "plot", "parameters"),
-      defaults = list(clip = NULL, plot = NULL, parameters = list()),
-      head_args = c("shape"),
-      fn_name = "add_shape"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(clip = clip, plot = plot, parameters = parameters),
+        recover_new = c("clip", "plot", "parameters"),
+        recover_old = c("clip", "plot", "parameters"),
+        match_names = c("clip", "plot", "parameters"),
+        match_to = c("clip", "plot", "parameters"),
+        defaults = list(clip = NULL, plot = NULL, parameters = list()),
+        head_args = c("shape"),
+        fn_name = "add_shape"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/random_walk.R
+++ b/R/random_walk.R
@@ -59,27 +59,30 @@ random_walk <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: random_walk, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights, mode = mode, stuck = stuck),
-      recover_new = c("weights", "mode", "stuck"),
-      recover_old = c("weights", "mode", "stuck"),
-      match_names = c("weights", "mode", "stuck"),
-      match_to = c("weights", "mode", "stuck"),
-      defaults = list(
-        weights = NULL,
-        mode = c("out", "in", "all", "total"),
-        stuck = c("return", "error")
-      ),
-      head_args = c("graph", "start", "steps"),
-      fn_name = "random_walk"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights, mode = mode, stuck = stuck),
+        recover_new = c("weights", "mode", "stuck"),
+        recover_old = c("weights", "mode", "stuck"),
+        match_names = c("weights", "mode", "stuck"),
+        match_to = c("weights", "mode", "stuck"),
+        defaults = list(
+          weights = NULL,
+          mode = c("out", "in", "all", "total"),
+          stuck = c("return", "error")
+        ),
+        head_args = c("graph", "start", "steps"),
+        fn_name = "random_walk"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -112,27 +115,30 @@ random_edge_walk <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: random_edge_walk, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights, mode = mode, stuck = stuck),
-      recover_new = c("weights", "mode", "stuck"),
-      recover_old = c("weights", "mode", "stuck"),
-      match_names = c("weights", "mode", "stuck"),
-      match_to = c("weights", "mode", "stuck"),
-      defaults = list(
-        weights = NULL,
-        mode = c("out", "in", "all", "total"),
-        stuck = c("return", "error")
-      ),
-      head_args = c("graph", "start", "steps"),
-      fn_name = "random_edge_walk"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights, mode = mode, stuck = stuck),
+        recover_new = c("weights", "mode", "stuck"),
+        recover_old = c("weights", "mode", "stuck"),
+        match_names = c("weights", "mode", "stuck"),
+        match_to = c("weights", "mode", "stuck"),
+        defaults = list(
+          weights = NULL,
+          mode = c("out", "in", "all", "total"),
+          stuck = c("return", "error")
+        ),
+        head_args = c("graph", "start", "steps"),
+        fn_name = "random_edge_walk"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/rewire.R
+++ b/R/rewire.R
@@ -138,27 +138,30 @@ each_edge <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: each_edge, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(loops = loops, multiple = multiple, mode = mode),
-      recover_new = c("loops", "multiple", "mode"),
-      recover_old = c("loops", "multiple", "mode"),
-      match_names = c("loops", "multiple", "mode"),
-      match_to = c("loops", "multiple", "mode"),
-      defaults = list(
-        loops = FALSE,
-        multiple = FALSE,
-        mode = c("all", "out", "in", "total")
-      ),
-      head_args = c("prob"),
-      fn_name = "each_edge"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(loops = loops, multiple = multiple, mode = mode),
+        recover_new = c("loops", "multiple", "mode"),
+        recover_old = c("loops", "multiple", "mode"),
+        match_names = c("loops", "multiple", "mode"),
+        match_to = c("loops", "multiple", "mode"),
+        defaults = list(
+          loops = FALSE,
+          multiple = FALSE,
+          mode = c("all", "out", "in", "total")
+        ),
+        head_args = c("prob"),
+        fn_name = "each_edge"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/similarity.R
+++ b/R/similarity.R
@@ -70,27 +70,30 @@ similarity <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: similarity, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, loops = loops, method = method),
-      recover_new = c("mode", "loops", "method"),
-      recover_old = c("mode", "loops", "method"),
-      match_names = c("mode", "loops", "method"),
-      match_to = c("mode", "loops", "method"),
-      defaults = list(
-        mode = c("all", "out", "in", "total"),
-        loops = FALSE,
-        method = c("jaccard", "dice", "invlogweighted")
-      ),
-      head_args = c("graph", "vids"),
-      fn_name = "similarity"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, loops = loops, method = method),
+        recover_new = c("mode", "loops", "method"),
+        recover_old = c("mode", "loops", "method"),
+        match_names = c("mode", "loops", "method"),
+        match_to = c("mode", "loops", "method"),
+        defaults = list(
+          mode = c("all", "out", "in", "total"),
+          loops = FALSE,
+          method = c("jaccard", "dice", "invlogweighted")
+        ),
+        head_args = c("graph", "vids"),
+        fn_name = "similarity"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/sir.R
+++ b/R/sir.R
@@ -118,23 +118,26 @@ sir <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sir, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(no.sim = no.sim),
-      recover_new = c("no.sim"),
-      recover_old = c("no.sim"),
-      match_names = c("no.sim"),
-      match_to = c("no.sim"),
-      defaults = list(no.sim = 100),
-      head_args = c("graph", "beta", "gamma"),
-      fn_name = "sir"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(no.sim = no.sim),
+        recover_new = c("no.sim"),
+        recover_old = c("no.sim"),
+        match_names = c("no.sim"),
+        match_to = c("no.sim"),
+        defaults = list(no.sim = 100),
+        head_args = c("graph", "beta", "gamma"),
+        fn_name = "sir"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/stochastic_matrix.R
+++ b/R/stochastic_matrix.R
@@ -84,23 +84,26 @@ stochastic_matrix <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: stochastic_matrix, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(column.wise = column.wise, sparse = sparse),
-      recover_new = c("column.wise", "sparse"),
-      recover_old = c("column.wise", "sparse"),
-      match_names = c("column.wise", "sparse"),
-      match_to = c("column.wise", "sparse"),
-      defaults = list(column.wise = FALSE, sparse = NULL),
-      head_args = c("graph"),
-      fn_name = "stochastic_matrix"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(column.wise = column.wise, sparse = sparse),
+        recover_new = c("column.wise", "sparse"),
+        recover_old = c("column.wise", "sparse"),
+        match_names = c("column.wise", "sparse"),
+        match_to = c("column.wise", "sparse"),
+        defaults = list(column.wise = FALSE, sparse = NULL),
+        head_args = c("graph"),
+        fn_name = "stochastic_matrix"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/structural-properties.R
+++ b/R/structural-properties.R
@@ -760,27 +760,30 @@ diameter <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: diameter, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        directed = directed,
-        unconnected = unconnected,
-        weights = weights
-      ),
-      recover_new = c("directed", "unconnected", "weights"),
-      recover_old = c("directed", "unconnected", "weights"),
-      match_names = c("directed", "unconnected", "weights"),
-      match_to = c("directed", "unconnected", "weights"),
-      defaults = list(directed = TRUE, unconnected = TRUE, weights = NULL),
-      head_args = c("graph"),
-      fn_name = "diameter"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          directed = directed,
+          unconnected = unconnected,
+          weights = weights
+        ),
+        recover_new = c("directed", "unconnected", "weights"),
+        recover_old = c("directed", "unconnected", "weights"),
+        match_names = c("directed", "unconnected", "weights"),
+        match_to = c("directed", "unconnected", "weights"),
+        defaults = list(directed = TRUE, unconnected = TRUE, weights = NULL),
+        head_args = c("graph"),
+        fn_name = "diameter"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -817,27 +820,30 @@ get_diameter <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: get_diameter, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        directed = directed,
-        unconnected = unconnected,
-        weights = weights
-      ),
-      recover_new = c("directed", "unconnected", "weights"),
-      recover_old = c("directed", "unconnected", "weights"),
-      match_names = c("directed", "unconnected", "weights"),
-      match_to = c("directed", "unconnected", "weights"),
-      defaults = list(directed = TRUE, unconnected = TRUE, weights = NULL),
-      head_args = c("graph"),
-      fn_name = "get_diameter"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          directed = directed,
+          unconnected = unconnected,
+          weights = weights
+        ),
+        recover_new = c("directed", "unconnected", "weights"),
+        recover_old = c("directed", "unconnected", "weights"),
+        match_names = c("directed", "unconnected", "weights"),
+        match_to = c("directed", "unconnected", "weights"),
+        defaults = list(directed = TRUE, unconnected = TRUE, weights = NULL),
+        head_args = c("graph"),
+        fn_name = "get_diameter"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -881,27 +887,30 @@ farthest_vertices <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: farthest_vertices, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        directed = directed,
-        unconnected = unconnected,
-        weights = weights
-      ),
-      recover_new = c("directed", "unconnected", "weights"),
-      recover_old = c("directed", "unconnected", "weights"),
-      match_names = c("directed", "unconnected", "weights"),
-      match_to = c("directed", "unconnected", "weights"),
-      defaults = list(directed = TRUE, unconnected = TRUE, weights = NULL),
-      head_args = c("graph"),
-      fn_name = "farthest_vertices"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          directed = directed,
+          unconnected = unconnected,
+          weights = weights
+        ),
+        recover_new = c("directed", "unconnected", "weights"),
+        recover_old = c("directed", "unconnected", "weights"),
+        match_names = c("directed", "unconnected", "weights"),
+        match_to = c("directed", "unconnected", "weights"),
+        defaults = list(directed = TRUE, unconnected = TRUE, weights = NULL),
+        head_args = c("graph"),
+        fn_name = "farthest_vertices"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -946,33 +955,36 @@ mean_distance <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: mean_distance, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        weights = weights,
-        directed = directed,
-        unconnected = unconnected,
-        details = details
-      ),
-      recover_new = c("weights", "directed", "unconnected", "details"),
-      recover_old = c("weights", "directed", "unconnected", "details"),
-      match_names = c("weights", "directed", "unconnected", "details"),
-      match_to = c("weights", "directed", "unconnected", "details"),
-      defaults = list(
-        weights = NULL,
-        directed = TRUE,
-        unconnected = TRUE,
-        details = FALSE
-      ),
-      head_args = c("graph"),
-      fn_name = "mean_distance"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          weights = weights,
+          directed = directed,
+          unconnected = unconnected,
+          details = details
+        ),
+        recover_new = c("weights", "directed", "unconnected", "details"),
+        recover_old = c("weights", "directed", "unconnected", "details"),
+        match_names = c("weights", "directed", "unconnected", "details"),
+        match_to = c("weights", "directed", "unconnected", "details"),
+        defaults = list(
+          weights = NULL,
+          directed = TRUE,
+          unconnected = TRUE,
+          details = FALSE
+        ),
+        head_args = c("graph"),
+        fn_name = "mean_distance"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1039,27 +1051,30 @@ degree <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: degree, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, loops = loops, normalized = normalized),
-      recover_new = c("mode", "loops", "normalized"),
-      recover_old = c("mode", "loops", "normalized"),
-      match_names = c("mode", "loops", "normalized"),
-      match_to = c("mode", "loops", "normalized"),
-      defaults = list(
-        mode = c("all", "out", "in", "total"),
-        loops = TRUE,
-        normalized = FALSE
-      ),
-      head_args = c("graph", "v"),
-      fn_name = "degree"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, loops = loops, normalized = normalized),
+        recover_new = c("mode", "loops", "normalized"),
+        recover_old = c("mode", "loops", "normalized"),
+        match_names = c("mode", "loops", "normalized"),
+        match_to = c("mode", "loops", "normalized"),
+        defaults = list(
+          mode = c("all", "out", "in", "total"),
+          loops = TRUE,
+          normalized = FALSE
+        ),
+        head_args = c("graph", "v"),
+        fn_name = "degree"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1117,23 +1132,26 @@ mean_degree <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: mean_degree, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(loops = loops),
-      recover_new = c("loops"),
-      recover_old = c("loops"),
-      match_names = c("loops"),
-      match_to = c("loops"),
-      defaults = list(loops = TRUE),
-      head_args = c("graph"),
-      fn_name = "mean_degree"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(loops = loops),
+        recover_new = c("loops"),
+        recover_old = c("loops"),
+        match_names = c("loops"),
+        match_to = c("loops"),
+        defaults = list(loops = TRUE),
+        head_args = c("graph"),
+        fn_name = "mean_degree"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1384,27 +1402,30 @@ distances <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: distances, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, weights = weights, algorithm = algorithm),
-      recover_new = c("mode", "weights", "algorithm"),
-      recover_old = c("mode", "weights", "algorithm"),
-      match_names = c("mode", "weights", "algorithm"),
-      match_to = c("mode", "weights", "algorithm"),
-      defaults = list(
-        mode = c("all", "out", "in"),
-        weights = NULL,
-        algorithm = c("automatic", "unweighted", "dijkstra", "bellman-ford", "johnson", "floyd-warshall")
-      ),
-      head_args = c("graph", "v", "to"),
-      fn_name = "distances"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, weights = weights, algorithm = algorithm),
+        recover_new = c("mode", "weights", "algorithm"),
+        recover_old = c("mode", "weights", "algorithm"),
+        match_names = c("mode", "weights", "algorithm"),
+        match_to = c("mode", "weights", "algorithm"),
+        defaults = list(
+          mode = c("all", "out", "in"),
+          weights = NULL,
+          algorithm = c("automatic", "unweighted", "dijkstra", "bellman-ford", "johnson", "floyd-warshall")
+        ),
+        head_args = c("graph", "v", "to"),
+        fn_name = "distances"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1511,65 +1532,68 @@ shortest_paths <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: shortest_paths, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        mode = mode,
-        weights = weights,
-        output = output,
-        predecessors = predecessors,
-        inbound.edges = inbound.edges,
-        algorithm = algorithm
-      ),
-      recover_new = c(
-        "mode",
-        "weights",
-        "output",
-        "predecessors",
-        "inbound.edges",
-        "algorithm"
-      ),
-      recover_old = c(
-        "mode",
-        "weights",
-        "output",
-        "predecessors",
-        "inbound.edges",
-        "algorithm"
-      ),
-      match_names = c(
-        "mode",
-        "weights",
-        "output",
-        "predecessors",
-        "inbound.edges",
-        "algorithm"
-      ),
-      match_to = c(
-        "mode",
-        "weights",
-        "output",
-        "predecessors",
-        "inbound.edges",
-        "algorithm"
-      ),
-      defaults = list(
-        mode = c("out", "all", "in"),
-        weights = NULL,
-        output = c("vpath", "epath", "both"),
-        predecessors = FALSE,
-        inbound.edges = FALSE,
-        algorithm = c("automatic", "unweighted", "dijkstra", "bellman-ford")
-      ),
-      head_args = c("graph", "from", "to"),
-      fn_name = "shortest_paths"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          mode = mode,
+          weights = weights,
+          output = output,
+          predecessors = predecessors,
+          inbound.edges = inbound.edges,
+          algorithm = algorithm
+        ),
+        recover_new = c(
+          "mode",
+          "weights",
+          "output",
+          "predecessors",
+          "inbound.edges",
+          "algorithm"
+        ),
+        recover_old = c(
+          "mode",
+          "weights",
+          "output",
+          "predecessors",
+          "inbound.edges",
+          "algorithm"
+        ),
+        match_names = c(
+          "mode",
+          "weights",
+          "output",
+          "predecessors",
+          "inbound.edges",
+          "algorithm"
+        ),
+        match_to = c(
+          "mode",
+          "weights",
+          "output",
+          "predecessors",
+          "inbound.edges",
+          "algorithm"
+        ),
+        defaults = list(
+          mode = c("out", "all", "in"),
+          weights = NULL,
+          output = c("vpath", "epath", "both"),
+          predecessors = FALSE,
+          inbound.edges = FALSE,
+          algorithm = c("automatic", "unweighted", "dijkstra", "bellman-ford")
+        ),
+        head_args = c("graph", "from", "to"),
+        fn_name = "shortest_paths"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1685,23 +1709,26 @@ all_shortest_paths <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: all_shortest_paths, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, weights = weights),
-      recover_new = c("mode", "weights"),
-      recover_old = c("mode", "weights"),
-      match_names = c("mode", "weights"),
-      match_to = c("mode", "weights"),
-      defaults = list(mode = c("out", "all", "in"), weights = NULL),
-      head_args = c("graph", "from", "to"),
-      fn_name = "all_shortest_paths"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, weights = weights),
+        recover_new = c("mode", "weights"),
+        recover_old = c("mode", "weights"),
+        match_names = c("mode", "weights"),
+        match_to = c("mode", "weights"),
+        defaults = list(mode = c("out", "all", "in"), weights = NULL),
+        head_args = c("graph", "from", "to"),
+        fn_name = "all_shortest_paths"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1836,23 +1863,26 @@ subcomponent <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: subcomponent, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("all", "out", "in")),
-      head_args = c("graph", "v"),
-      fn_name = "subcomponent"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("all", "out", "in")),
+        head_args = c("graph", "v"),
+        fn_name = "subcomponent"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1932,25 +1962,28 @@ induced_subgraph <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: induced_subgraph, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(impl = impl),
-      recover_new = c("impl"),
-      recover_old = c("impl"),
-      match_names = c("impl"),
-      match_to = c("impl"),
-      defaults = list(
-        impl = c("auto", "copy_and_delete", "create_from_scratch")
-      ),
-      head_args = c("graph", "vids"),
-      fn_name = "induced_subgraph"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(impl = impl),
+        recover_new = c("impl"),
+        recover_old = c("impl"),
+        match_names = c("impl"),
+        match_to = c("impl"),
+        defaults = list(
+          impl = c("auto", "copy_and_delete", "create_from_scratch")
+        ),
+        head_args = c("graph", "vids"),
+        fn_name = "induced_subgraph"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1983,23 +2016,26 @@ subgraph_from_edges <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: subgraph_from_edges, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(delete.vertices = delete.vertices),
-      recover_new = c("delete.vertices"),
-      recover_old = c("delete.vertices"),
-      match_names = c("delete.vertices"),
-      match_to = c("delete.vertices"),
-      defaults = list(delete.vertices = TRUE),
-      head_args = c("graph", "eids"),
-      fn_name = "subgraph_from_edges"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(delete.vertices = delete.vertices),
+        recover_new = c("delete.vertices"),
+        recover_old = c("delete.vertices"),
+        match_names = c("delete.vertices"),
+        match_to = c("delete.vertices"),
+        defaults = list(delete.vertices = TRUE),
+        head_args = c("graph", "eids"),
+        fn_name = "subgraph_from_edges"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2179,23 +2215,26 @@ transitivity <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: transitivity, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(vids = vids, weights = weights, isolates = isolates),
-      recover_new = c("vids", "weights", "isolates"),
-      recover_old = c("vids", "weights", "isolates"),
-      match_names = c("vids", "weights", "isolates"),
-      match_to = c("vids", "weights", "isolates"),
-      defaults = list(vids = NULL, weights = NULL, isolates = c("NaN", "zero")),
-      head_args = c("graph", "type"),
-      fn_name = "transitivity"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(vids = vids, weights = weights, isolates = isolates),
+        recover_new = c("vids", "weights", "isolates"),
+        recover_old = c("vids", "weights", "isolates"),
+        match_names = c("vids", "weights", "isolates"),
+        match_to = c("vids", "weights", "isolates"),
+        defaults = list(vids = NULL, weights = NULL, isolates = c("NaN", "zero")),
+        head_args = c("graph", "type"),
+        fn_name = "transitivity"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2354,23 +2393,26 @@ constraint <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: constraint, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights),
-      recover_new = c("weights"),
-      recover_old = c("weights"),
-      match_names = c("weights"),
-      match_to = c("weights"),
-      defaults = list(weights = NULL),
-      head_args = c("graph", "nodes"),
-      fn_name = "constraint"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights),
+        recover_new = c("weights"),
+        recover_old = c("weights"),
+        match_names = c("weights"),
+        match_to = c("weights"),
+        defaults = list(weights = NULL),
+        head_args = c("graph", "nodes"),
+        fn_name = "constraint"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2440,23 +2482,26 @@ reciprocity <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: reciprocity, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(ignore.loops = ignore.loops, mode = mode),
-      recover_new = c("ignore.loops", "mode"),
-      recover_old = c("ignore.loops", "mode"),
-      match_names = c("ignore.loops", "mode"),
-      match_to = c("ignore.loops", "mode"),
-      defaults = list(ignore.loops = TRUE, mode = c("default", "ratio")),
-      head_args = c("graph"),
-      fn_name = "reciprocity"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(ignore.loops = ignore.loops, mode = mode),
+        recover_new = c("ignore.loops", "mode"),
+        recover_old = c("ignore.loops", "mode"),
+        match_names = c("ignore.loops", "mode"),
+        match_to = c("ignore.loops", "mode"),
+        defaults = list(ignore.loops = TRUE, mode = c("default", "ratio")),
+        head_args = c("graph"),
+        fn_name = "reciprocity"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2513,23 +2558,26 @@ edge_density <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: edge_density, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(loops = loops),
-      recover_new = c("loops"),
-      recover_old = c("loops"),
-      match_names = c("loops"),
-      match_to = c("loops"),
-      defaults = list(loops = FALSE),
-      head_args = c("graph"),
-      fn_name = "edge_density"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(loops = loops),
+        recover_new = c("loops"),
+        recover_old = c("loops"),
+        match_names = c("loops"),
+        match_to = c("loops"),
+        defaults = list(loops = FALSE),
+        head_args = c("graph"),
+        fn_name = "edge_density"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2552,23 +2600,26 @@ ego_size <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: ego_size, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, mindist = mindist),
-      recover_new = c("mode", "mindist"),
-      recover_old = c("mode", "mindist"),
-      match_names = c("mode", "mindist"),
-      match_to = c("mode", "mindist"),
-      defaults = list(mode = c("all", "out", "in"), mindist = 0),
-      head_args = c("graph", "order", "nodes"),
-      fn_name = "ego_size"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, mindist = mindist),
+        recover_new = c("mode", "mindist"),
+        recover_old = c("mode", "mindist"),
+        match_names = c("mode", "mindist"),
+        match_to = c("mode", "mindist"),
+        defaults = list(mode = c("all", "out", "in"), mindist = 0),
+        head_args = c("graph", "order", "nodes"),
+        fn_name = "ego_size"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2694,23 +2745,26 @@ ego <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: ego, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, mindist = mindist),
-      recover_new = c("mode", "mindist"),
-      recover_old = c("mode", "mindist"),
-      match_names = c("mode", "mindist"),
-      match_to = c("mode", "mindist"),
-      defaults = list(mode = c("all", "out", "in"), mindist = 0),
-      head_args = c("graph", "order", "nodes"),
-      fn_name = "ego"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, mindist = mindist),
+        recover_new = c("mode", "mindist"),
+        recover_old = c("mode", "mindist"),
+        match_names = c("mode", "mindist"),
+        match_to = c("mode", "mindist"),
+        defaults = list(mode = c("all", "out", "in"), mindist = 0),
+        head_args = c("graph", "order", "nodes"),
+        fn_name = "ego"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2756,23 +2810,26 @@ make_ego_graph <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: make_ego_graph, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, mindist = mindist),
-      recover_new = c("mode", "mindist"),
-      recover_old = c("mode", "mindist"),
-      match_names = c("mode", "mindist"),
-      match_to = c("mode", "mindist"),
-      defaults = list(mode = c("all", "out", "in"), mindist = 0),
-      head_args = c("graph", "order", "nodes"),
-      fn_name = "make_ego_graph"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, mindist = mindist),
+        recover_new = c("mode", "mindist"),
+        recover_old = c("mode", "mindist"),
+        match_names = c("mode", "mindist"),
+        match_to = c("mode", "mindist"),
+        defaults = list(mode = c("all", "out", "in"), mindist = 0),
+        head_args = c("graph", "order", "nodes"),
+        fn_name = "make_ego_graph"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2843,23 +2900,26 @@ coreness <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: coreness, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("all", "out", "in")),
-      head_args = c("graph"),
-      fn_name = "coreness"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("all", "out", "in")),
+        head_args = c("graph"),
+        fn_name = "coreness"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2913,23 +2973,26 @@ topo_sort <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: topo_sort, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("out", "all", "in")),
-      head_args = c("graph"),
-      fn_name = "topo_sort"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("out", "all", "in")),
+        head_args = c("graph"),
+        fn_name = "topo_sort"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -2988,23 +3051,26 @@ feedback_arc_set <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: feedback_arc_set, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights, algo = algo),
-      recover_new = c("weights", "algo"),
-      recover_old = c("weights", "algo"),
-      match_names = c("weights", "algo"),
-      match_to = c("weights", "algo"),
-      defaults = list(weights = NULL, algo = c("approx_eades", "exact_ip")),
-      head_args = c("graph"),
-      fn_name = "feedback_arc_set"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights, algo = algo),
+        recover_new = c("weights", "algo"),
+        recover_old = c("weights", "algo"),
+        match_names = c("weights", "algo"),
+        match_to = c("weights", "algo"),
+        defaults = list(weights = NULL, algo = c("approx_eades", "exact_ip")),
+        head_args = c("graph"),
+        fn_name = "feedback_arc_set"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3052,23 +3118,26 @@ feedback_vertex_set <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: feedback_vertex_set, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights, algo = algo),
-      recover_new = c("weights", "algo"),
-      recover_old = c("weights", "algo"),
-      match_names = c("weights", "algo"),
-      match_to = c("weights", "algo"),
-      defaults = list(weights = NULL, algo = c("exact_ip")),
-      head_args = c("graph"),
-      fn_name = "feedback_vertex_set"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights, algo = algo),
+        recover_new = c("weights", "algo"),
+        recover_old = c("weights", "algo"),
+        match_names = c("weights", "algo"),
+        match_to = c("weights", "algo"),
+        defaults = list(weights = NULL, algo = c("exact_ip")),
+        head_args = c("graph"),
+        fn_name = "feedback_vertex_set"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3134,23 +3203,26 @@ girth <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: girth, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(circle = circle),
-      recover_new = c("circle"),
-      recover_old = c("circle"),
-      match_names = c("circle"),
-      match_to = c("circle"),
-      defaults = list(circle = TRUE),
-      head_args = c("graph"),
-      fn_name = "girth"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(circle = circle),
+        recover_new = c("circle"),
+        recover_old = c("circle"),
+        match_names = c("circle"),
+        match_to = c("circle"),
+        defaults = list(circle = TRUE),
+        head_args = c("graph"),
+        fn_name = "girth"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3894,23 +3966,26 @@ components <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: components, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("weak", "strong")),
-      head_args = c("graph"),
-      fn_name = "components"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("weak", "strong")),
+        head_args = c("graph"),
+        fn_name = "components"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3942,23 +4017,26 @@ is_connected <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: is_connected, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("weak", "strong")),
-      head_args = c("graph"),
-      fn_name = "is_connected"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("weak", "strong")),
+        head_args = c("graph"),
+        fn_name = "is_connected"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -3978,23 +4056,26 @@ count_components <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: count_components, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("weak", "strong")),
-      head_args = c("graph"),
-      fn_name = "count_components"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("weak", "strong")),
+        head_args = c("graph"),
+        fn_name = "count_components"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -4057,23 +4138,26 @@ count_reachable <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: count_reachable, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode"),
-      recover_old = c("mode"),
-      match_names = c("mode"),
-      match_to = c("mode"),
-      defaults = list(mode = c("out", "in", "all", "total")),
-      head_args = c("graph"),
-      fn_name = "count_reachable"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode"),
+        recover_old = c("mode"),
+        match_names = c("mode"),
+        match_to = c("mode"),
+        defaults = list(mode = c("out", "in", "all", "total")),
+        head_args = c("graph"),
+        fn_name = "count_reachable"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -4131,23 +4215,26 @@ unfold_tree <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: unfold_tree, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode),
-      recover_new = c("mode", "roots"),
-      recover_old = c("mode", "roots"),
-      match_names = c("mode", "roots"),
-      match_to = c("mode", "roots"),
-      defaults = list(mode = c("all", "out", "in", "total")),
-      head_args = c("graph"),
-      fn_name = "unfold_tree"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode),
+        recover_new = c("mode", "roots"),
+        recover_old = c("mode", "roots"),
+        match_names = c("mode", "roots"),
+        match_to = c("mode", "roots"),
+        defaults = list(mode = c("all", "out", "in", "total")),
+        head_args = c("graph"),
+        fn_name = "unfold_tree"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -4423,23 +4510,26 @@ max_bipartite_match <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: max_bipartite_match, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(weights = weights, eps = eps),
-      recover_new = c("weights", "eps"),
-      recover_old = c("weights", "eps"),
-      match_names = c("weights", "eps"),
-      match_to = c("weights", "eps"),
-      defaults = list(weights = NULL, eps = NULL),
-      head_args = c("graph", "types"),
-      fn_name = "max_bipartite_match"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(weights = weights, eps = eps),
+        recover_new = c("weights", "eps"),
+        recover_old = c("weights", "eps"),
+        match_names = c("weights", "eps"),
+        match_to = c("weights", "eps"),
+        defaults = list(weights = NULL, eps = NULL),
+        head_args = c("graph", "types"),
+        fn_name = "max_bipartite_match"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -4503,23 +4593,26 @@ which_mutual <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: which_mutual, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(loops = loops),
-      recover_new = c("loops"),
-      recover_old = c("loops"),
-      match_names = c("loops"),
-      match_to = c("loops"),
-      defaults = list(loops = TRUE),
-      head_args = c("graph", "eids"),
-      fn_name = "which_mutual"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(loops = loops),
+        recover_new = c("loops"),
+        recover_old = c("loops"),
+        match_names = c("loops"),
+        match_to = c("loops"),
+        defaults = list(loops = TRUE),
+        head_args = c("graph", "eids"),
+        fn_name = "which_mutual"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -4620,31 +4713,34 @@ knn <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: knn, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        mode = mode,
-        neighbor.degree.mode = neighbor.degree.mode,
-        weights = weights
-      ),
-      recover_new = c("mode", "neighbor.degree.mode", "weights"),
-      recover_old = c("mode", "neighbor.degree.mode", "weights"),
-      match_names = c("mode", "neighbor.degree.mode", "weights"),
-      match_to = c("mode", "neighbor.degree.mode", "weights"),
-      defaults = list(
-        mode = c("all", "out", "in", "total"),
-        neighbor.degree.mode = c("all", "out", "in", "total"),
-        weights = NULL
-      ),
-      head_args = c("graph", "vids"),
-      fn_name = "knn"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          mode = mode,
+          neighbor.degree.mode = neighbor.degree.mode,
+          weights = weights
+        ),
+        recover_new = c("mode", "neighbor.degree.mode", "weights"),
+        recover_old = c("mode", "neighbor.degree.mode", "weights"),
+        match_names = c("mode", "neighbor.degree.mode", "weights"),
+        match_to = c("mode", "neighbor.degree.mode", "weights"),
+        defaults = list(
+          mode = c("all", "out", "in", "total"),
+          neighbor.degree.mode = c("all", "out", "in", "total"),
+          weights = NULL
+        ),
+        head_args = c("graph", "vids"),
+        fn_name = "knn"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/tkplot.R
+++ b/R/tkplot.R
@@ -536,23 +536,26 @@ tk_close <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: tk_close, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(window.close = window.close),
-      recover_new = c("window.close"),
-      recover_old = c("window.close"),
-      match_names = c("window.close"),
-      match_to = c("window.close"),
-      defaults = list(window.close = TRUE),
-      head_args = c("tkp.id"),
-      fn_name = "tk_close"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(window.close = window.close),
+        recover_new = c("window.close"),
+        recover_old = c("window.close"),
+        match_names = c("window.close"),
+        match_to = c("window.close"),
+        defaults = list(window.close = TRUE),
+        head_args = c("tkp.id"),
+        fn_name = "tk_close"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -592,23 +595,26 @@ tk_fit <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: tk_fit, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(width = width, height = height),
-      recover_new = c("width", "height"),
-      recover_old = c("width", "height"),
-      match_names = c("width", "height"),
-      match_to = c("width", "height"),
-      defaults = list(width = NULL, height = NULL),
-      head_args = c("tkp.id"),
-      fn_name = "tk_fit"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(width = width, height = height),
+        recover_new = c("width", "height"),
+        recover_old = c("width", "height"),
+        match_names = c("width", "height"),
+        match_to = c("width", "height"),
+        defaults = list(width = NULL, height = NULL),
+        head_args = c("tkp.id"),
+        fn_name = "tk_fit"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -710,23 +716,26 @@ tk_coords <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: tk_coords, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(norm = norm),
-      recover_new = c("norm"),
-      recover_old = c("norm"),
-      match_names = c("norm"),
-      match_to = c("norm"),
-      defaults = list(norm = FALSE),
-      head_args = c("tkp.id"),
-      fn_name = "tk_coords"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(norm = norm),
+        recover_new = c("norm"),
+        recover_old = c("norm"),
+        match_names = c("norm"),
+        match_to = c("norm"),
+        defaults = list(norm = FALSE),
+        head_args = c("tkp.id"),
+        fn_name = "tk_coords"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -767,23 +776,26 @@ tk_rotate <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: tk_rotate, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(degree = degree, rad = rad),
-      recover_new = c("degree", "rad"),
-      recover_old = c("degree", "rad"),
-      match_names = c("degree", "rad"),
-      match_to = c("degree", "rad"),
-      defaults = list(degree = NULL, rad = NULL),
-      head_args = c("tkp.id"),
-      fn_name = "tk_rotate"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(degree = degree, rad = rad),
+        recover_new = c("degree", "rad"),
+        recover_old = c("degree", "rad"),
+        match_names = c("degree", "rad"),
+        match_to = c("degree", "rad"),
+        defaults = list(degree = NULL, rad = NULL),
+        head_args = c("tkp.id"),
+        fn_name = "tk_rotate"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/topology.R
+++ b/R/topology.R
@@ -197,40 +197,43 @@ graph.subisomorphic.lad <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph.subisomorphic.lad, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    migrate_check_call_tags(
-      sys.call(),
-      c("t"),
-      "graph.subisomorphic.lad"
-    )
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        domains = domains,
-        induced = induced,
-        map = map,
-        all.maps = all.maps,
-        time.limit = time.limit
-      ),
-      recover_new = c("domains", "induced", "map", "all.maps", "time.limit"),
-      recover_old = c("domains", "induced", "map", "all.maps", "time.limit"),
-      match_names = c("domains", "induced", "map", "all.maps", "time.limit"),
-      match_to = c("domains", "induced", "map", "all.maps", "time.limit"),
-      defaults = list(
-        domains = NULL,
-        induced = FALSE,
-        map = TRUE,
-        all.maps = FALSE,
-        time.limit = Inf
-      ),
-      head_args = c("pattern", "target"),
-      fn_name = "graph.subisomorphic.lad"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      migrate_check_call_tags(
+        sys.call(),
+        c("t"),
+        "graph.subisomorphic.lad"
+      )
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          domains = domains,
+          induced = induced,
+          map = map,
+          all.maps = all.maps,
+          time.limit = time.limit
+        ),
+        recover_new = c("domains", "induced", "map", "all.maps", "time.limit"),
+        recover_old = c("domains", "induced", "map", "all.maps", "time.limit"),
+        match_names = c("domains", "induced", "map", "all.maps", "time.limit"),
+        match_to = c("domains", "induced", "map", "all.maps", "time.limit"),
+        defaults = list(
+          domains = NULL,
+          induced = FALSE,
+          map = TRUE,
+          all.maps = FALSE,
+          time.limit = Inf
+        ),
+        head_args = c("pattern", "target"),
+        fn_name = "graph.subisomorphic.lad"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -435,27 +438,30 @@ graph.isomorphic.bliss <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph.isomorphic.bliss, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(colors1 = colors1, colors2 = colors2, sh = sh),
-      recover_new = c("colors1", "colors2", "sh"),
-      recover_old = c("colors1", "colors2", "sh"),
-      match_names = c("colors1", "colors2", "sh"),
-      match_to = c("colors1", "colors2", "sh"),
-      defaults = list(
-        colors1 = NULL,
-        colors2 = NULL,
-        sh = c("fm", "f", "fs", "fl", "flm", "fsm")
-      ),
-      head_args = c("graph1", "graph2"),
-      fn_name = "graph.isomorphic.bliss"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(colors1 = colors1, colors2 = colors2, sh = sh),
+        recover_new = c("colors1", "colors2", "sh"),
+        recover_old = c("colors1", "colors2", "sh"),
+        match_names = c("colors1", "colors2", "sh"),
+        match_to = c("colors1", "colors2", "sh"),
+        defaults = list(
+          colors1 = NULL,
+          colors2 = NULL,
+          sh = c("fm", "f", "fs", "fl", "flm", "fsm")
+        ),
+        head_args = c("graph1", "graph2"),
+        fn_name = "graph.isomorphic.bliss"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -480,53 +486,56 @@ graph.isomorphic.vf2 <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph.isomorphic.vf2, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        vertex.color1 = vertex.color1,
-        vertex.color2 = vertex.color2,
-        edge.color1 = edge.color1,
-        edge.color2 = edge.color2
-      ),
-      recover_new = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      recover_old = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      match_names = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      match_to = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      defaults = list(
-        vertex.color1 = NULL,
-        vertex.color2 = NULL,
-        edge.color1 = NULL,
-        edge.color2 = NULL
-      ),
-      head_args = c("graph1", "graph2"),
-      fn_name = "graph.isomorphic.vf2"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          vertex.color1 = vertex.color1,
+          vertex.color2 = vertex.color2,
+          edge.color1 = edge.color1,
+          edge.color2 = edge.color2
+        ),
+        recover_new = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        recover_old = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        match_names = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        match_to = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        defaults = list(
+          vertex.color1 = NULL,
+          vertex.color2 = NULL,
+          edge.color1 = NULL,
+          edge.color2 = NULL
+        ),
+        head_args = c("graph1", "graph2"),
+        fn_name = "graph.isomorphic.vf2"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -560,53 +569,56 @@ graph.subisomorphic.vf2 <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph.subisomorphic.vf2, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        vertex.color1 = vertex.color1,
-        vertex.color2 = vertex.color2,
-        edge.color1 = edge.color1,
-        edge.color2 = edge.color2
-      ),
-      recover_new = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      recover_old = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      match_names = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      match_to = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      defaults = list(
-        vertex.color1 = NULL,
-        vertex.color2 = NULL,
-        edge.color1 = NULL,
-        edge.color2 = NULL
-      ),
-      head_args = c("graph1", "graph2"),
-      fn_name = "graph.subisomorphic.vf2"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          vertex.color1 = vertex.color1,
+          vertex.color2 = vertex.color2,
+          edge.color1 = edge.color1,
+          edge.color2 = edge.color2
+        ),
+        recover_new = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        recover_old = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        match_names = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        match_to = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        defaults = list(
+          vertex.color1 = NULL,
+          vertex.color2 = NULL,
+          edge.color1 = NULL,
+          edge.color2 = NULL
+        ),
+        head_args = c("graph1", "graph2"),
+        fn_name = "graph.subisomorphic.vf2"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -811,53 +823,56 @@ graph.count.isomorphisms.vf2 <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph.count.isomorphisms.vf2, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        vertex.color1 = vertex.color1,
-        vertex.color2 = vertex.color2,
-        edge.color1 = edge.color1,
-        edge.color2 = edge.color2
-      ),
-      recover_new = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      recover_old = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      match_names = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      match_to = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      defaults = list(
-        vertex.color1 = NULL,
-        vertex.color2 = NULL,
-        edge.color1 = NULL,
-        edge.color2 = NULL
-      ),
-      head_args = c("graph1", "graph2"),
-      fn_name = "graph.count.isomorphisms.vf2"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          vertex.color1 = vertex.color1,
+          vertex.color2 = vertex.color2,
+          edge.color1 = edge.color1,
+          edge.color2 = edge.color2
+        ),
+        recover_new = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        recover_old = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        match_names = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        match_to = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        defaults = list(
+          vertex.color1 = NULL,
+          vertex.color2 = NULL,
+          edge.color1 = NULL,
+          edge.color2 = NULL
+        ),
+        head_args = c("graph1", "graph2"),
+        fn_name = "graph.count.isomorphisms.vf2"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -971,53 +986,56 @@ graph.count.subisomorphisms.vf2 <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph.count.subisomorphisms.vf2, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(
-        vertex.color1 = vertex.color1,
-        vertex.color2 = vertex.color2,
-        edge.color1 = edge.color1,
-        edge.color2 = edge.color2
-      ),
-      recover_new = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      recover_old = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      match_names = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      match_to = c(
-        "vertex.color1",
-        "vertex.color2",
-        "edge.color1",
-        "edge.color2"
-      ),
-      defaults = list(
-        vertex.color1 = NULL,
-        vertex.color2 = NULL,
-        edge.color1 = NULL,
-        edge.color2 = NULL
-      ),
-      head_args = c("graph1", "graph2"),
-      fn_name = "graph.count.subisomorphisms.vf2"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(
+          vertex.color1 = vertex.color1,
+          vertex.color2 = vertex.color2,
+          edge.color1 = edge.color1,
+          edge.color2 = edge.color2
+        ),
+        recover_new = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        recover_old = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        match_names = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        match_to = c(
+          "vertex.color1",
+          "vertex.color2",
+          "edge.color1",
+          "edge.color2"
+        ),
+        defaults = list(
+          vertex.color1 = NULL,
+          vertex.color2 = NULL,
+          edge.color1 = NULL,
+          edge.color2 = NULL
+        ),
+        head_args = c("graph1", "graph2"),
+        fn_name = "graph.count.subisomorphisms.vf2"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1321,23 +1339,26 @@ graph_from_isomorphism_class <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: graph_from_isomorphism_class, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(directed = directed),
-      recover_new = c("directed"),
-      recover_old = c("directed"),
-      match_names = c("directed"),
-      match_to = c("directed"),
-      defaults = list(directed = TRUE),
-      head_args = c("size", "number"),
-      fn_name = "graph_from_isomorphism_class"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(directed = directed),
+        recover_new = c("directed"),
+        recover_old = c("directed"),
+        match_names = c("directed"),
+        match_to = c("directed"),
+        defaults = list(directed = TRUE),
+        head_args = c("size", "number"),
+        fn_name = "graph_from_isomorphism_class"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1465,23 +1486,26 @@ canonical_permutation <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: canonical_permutation, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(sh = sh),
-      recover_new = c("sh"),
-      recover_old = c("sh"),
-      match_names = c("sh"),
-      match_to = c("sh"),
-      defaults = list(sh = c("fm", "f", "fs", "fl", "flm", "fsm")),
-      head_args = c("graph", "colors"),
-      fn_name = "canonical_permutation"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(sh = sh),
+        recover_new = c("sh"),
+        recover_old = c("sh"),
+        match_names = c("sh"),
+        match_to = c("sh"),
+        defaults = list(sh = c("fm", "f", "fs", "fl", "flm", "fsm")),
+        head_args = c("graph", "colors"),
+        fn_name = "canonical_permutation"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1638,23 +1662,26 @@ count_automorphisms <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: count_automorphisms, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(sh = sh),
-      recover_new = c("sh"),
-      recover_old = c("sh"),
-      match_names = c("sh"),
-      match_to = c("sh"),
-      defaults = list(sh = c("fm", "f", "fs", "fl", "flm", "fsm")),
-      head_args = c("graph", "colors"),
-      fn_name = "count_automorphisms"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(sh = sh),
+        recover_new = c("sh"),
+        recover_old = c("sh"),
+        match_names = c("sh"),
+        match_to = c("sh"),
+        defaults = list(sh = c("fm", "f", "fs", "fl", "flm", "fsm")),
+        head_args = c("graph", "colors"),
+        fn_name = "count_automorphisms"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -1747,26 +1774,29 @@ automorphism_group <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: automorphism_group, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(sh = sh, details = details),
-      recover_new = c("sh", "details"),
-      recover_old = c("sh", "details"),
-      match_names = c("sh", "details"),
-      match_to = c("sh", "details"),
-      defaults = list(
-        sh = c("fm", "f", "fs", "fl", "flm", "fsm"),
-        details = FALSE
-      ),
-      head_args = c("graph", "colors"),
-      fn_name = "automorphism_group"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(sh = sh, details = details),
+        recover_new = c("sh", "details"),
+        recover_old = c("sh", "details"),
+        match_names = c("sh", "details"),
+        match_to = c("sh", "details"),
+        defaults = list(
+          sh = c("fm", "f", "fs", "fl", "flm", "fsm"),
+          details = FALSE
+        ),
+        head_args = c("graph", "colors"),
+        fn_name = "automorphism_group"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/R/trees.R
+++ b/R/trees.R
@@ -49,23 +49,26 @@ is_tree <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: is_tree, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, details = details),
-      recover_new = c("mode", "details"),
-      recover_old = c("mode", "details"),
-      match_names = c("mode", "details"),
-      match_to = c("mode", "details"),
-      defaults = list(mode = c("out", "in", "all", "total"), details = FALSE),
-      head_args = c("graph"),
-      fn_name = "is_tree"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, details = details),
+        recover_new = c("mode", "details"),
+        recover_old = c("mode", "details"),
+        match_names = c("mode", "details"),
+        match_to = c("mode", "details"),
+        defaults = list(mode = c("out", "in", "all", "total"), details = FALSE),
+        head_args = c("graph"),
+        fn_name = "is_tree"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -132,23 +135,26 @@ is_forest <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: is_forest, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(mode = mode, details = details),
-      recover_new = c("mode", "details"),
-      recover_old = c("mode", "details"),
-      match_names = c("mode", "details"),
-      match_to = c("mode", "details"),
-      defaults = list(mode = c("out", "in", "all", "total"), details = FALSE),
-      head_args = c("graph"),
-      fn_name = "is_forest"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(mode = mode, details = details),
+        recover_new = c("mode", "details"),
+        recover_old = c("mode", "details"),
+        match_names = c("mode", "details"),
+        match_to = c("mode", "details"),
+        defaults = list(mode = c("out", "in", "all", "total"), details = FALSE),
+        head_args = c("graph"),
+        fn_name = "is_forest"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 
@@ -223,23 +229,26 @@ sample_spanning_tree <- function(
 ) {
   # BEGIN GENERATED ARG_HANDLE: sample_spanning_tree, do not edit, see tools/generate-migrations.R
   if (...length() > 0L) {
-    .arg_handle <- migrate_recover_args(
-      list(...),
-      current = list(vid = vid),
-      recover_new = c("vid"),
-      recover_old = c("vid"),
-      match_names = c("vid"),
-      match_to = c("vid"),
-      defaults = list(vid = 0),
-      head_args = c("graph"),
-      fn_name = "sample_spanning_tree"
-    )
-    list2env(.arg_handle$values, environment())
-    lifecycle::deprecate_soft(
-      "3.0.0",
-      what = I(.arg_handle$what),
-      details = .arg_handle$details
-    )
+    .migrate_dots <- migrate_capture_dots()
+    if (length(.migrate_dots$values) > 0L) {
+      .arg_handle <- migrate_recover_args(
+        .migrate_dots,
+        current = list(vid = vid),
+        recover_new = c("vid"),
+        recover_old = c("vid"),
+        match_names = c("vid"),
+        match_to = c("vid"),
+        defaults = list(vid = 0),
+        head_args = c("graph"),
+        fn_name = "sample_spanning_tree"
+      )
+      list2env(.arg_handle$values, environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = I(.arg_handle$what),
+        details = .arg_handle$details
+      )
+    }
   }
   # END GENERATED ARG_HANDLE
 

--- a/tests/testthat/helper-test-functions.R
+++ b/tests/testthat/helper-test-functions.R
@@ -158,12 +158,27 @@ graphlets.project.old <- function(graph, cliques, iter, Mu = NULL) {
 # ---- test-migration-fixture.R -----------------------------------------------
 
 # Config equivalent to the fixture, for exercising the helper directly.
+# Minimal host for `migrate_capture_dots()`: the same shape as a migrated
+# function (head args, then `...`, then the recoverable tail), so the helper
+# sees a real `...` and can be checked directly.
+migrate_capture_dots_at <- function(a, ..., b = 1) {
+  migrate_capture_dots()
+}
+
 fixture_args <- function(
   dots,
-  current = list(weights = NULL, type = "out", directed = FALSE)
+  current = list(weights = NULL, type = "out", directed = FALSE),
+  pos = NULL
 ) {
+  # Callers pass the plain dots list; wrap it the way `migrate_capture_dots()`
+  # would. Unnamed slots take their ordinal in order unless `pos` overrides it
+  # (which is how an empty slot shifts the later positionals along).
+  if (is.null(pos)) {
+    unnamed <- !nzchar(rlang::names2(dots))
+    pos <- ifelse(unnamed, cumsum(unnamed), NA_integer_)
+  }
   migrate_recover_args(
-    dots,
+    list(values = dots, pos = as.integer(pos)),
     current = current,
     recover_new = c("weights", "type", "directed"),
     recover_old = c("weight", "kind", "directed"),

--- a/tests/testthat/test-migration-fixture.R
+++ b/tests/testthat/test-migration-fixture.R
@@ -99,6 +99,84 @@ test_that("recovery emits a single deprecation warning, not one per slot", {
   expect_length(warnings, 1L)
 })
 
+# ---- empty argument slots (#2646) -------------------------------------------
+
+# A call may leave a slot empty: a trailing comma, or a skipped positional,
+# which is what magrittr writes for `x %>% f(., , directed = TRUE)`. Those used
+# to match a formal by position and leave it missing; now they land in `...`.
+
+test_that("a trailing comma is not an argument to recover", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  expect_no_warning(res <- migration_fixture("g", 5, ))
+  expect_equal(
+    res,
+    list(graph = "g", n = 5, weights = NULL, type = "out", directed = FALSE)
+  )
+})
+
+test_that("a trailing comma after new-API arguments is ignored", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  expect_no_warning(res <- migration_fixture("g", 5, type = "in", ))
+  expect_equal(res$type, "in")
+})
+
+test_that("an empty slot still consumes its position during recovery", {
+  # Old signature f(graph, n, weight, kind, directed): the empty slot took
+  # `weight`, so "in"/TRUE must land on `type`/`directed`, not `weights`/`type`.
+  rlang::local_options(lifecycle_verbosity = "warning")
+  lifecycle::expect_deprecated(
+    res <- migration_fixture("g", 5, , "in", TRUE)
+  )
+  expect_equal(
+    res,
+    list(graph = "g", n = 5, weights = NULL, type = "in", directed = TRUE)
+  )
+})
+
+test_that("empty slots mixed with named recovery keep their offsets", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  lifecycle::expect_deprecated(
+    res <- migration_fixture("g", 5, , , TRUE)
+  )
+  expect_equal(res$directed, TRUE)
+  expect_equal(res$weights, NULL)
+  expect_equal(res$type, "out")
+})
+
+test_that("migrate_capture_dots() reports supplied dots and their positions", {
+  # `migrate_capture_dots_at()` (helper-test-functions.R) is a bare host
+  # function that returns `migrate_capture_dots()` from its own frame.
+  expect_equal(
+    migrate_capture_dots_at(1, 9, kind = "in"),
+    list(
+      values = list(9, kind = "in"),
+      pos = c(1L, NA_integer_)
+    )
+  )
+  expect_equal(
+    migrate_capture_dots_at(1, , 9),
+    list(
+      values = list(9),
+      pos = 2L
+    )
+  )
+  # Nothing but empty slots reads as no dots at all, so recovery never engages.
+  expect_equal(
+    migrate_capture_dots_at(1, ),
+    list(
+      values = list(),
+      pos = integer(0)
+    )
+  )
+  expect_equal(
+    migrate_capture_dots_at(1),
+    list(
+      values = list(),
+      pos = integer(0)
+    )
+  )
+})
+
 # ---- prefix-overlap fixture -------------------------------------------------
 
 # migration_fixture_prefix(dimvector, p, ..., dim = NULL, permutation = NULL):

--- a/tools/generate-migrations.R
+++ b/tools/generate-migrations.R
@@ -480,7 +480,10 @@ render_call_arg <- function(name, ctor, items, empty, trailing = ",") {
 # (caller_env(2)) resolves to the user's frame -- no `.user_env` threading needed.
 #
 # The whole thing is guarded by `...length() > 0L` so the common path (a correct
-# new-API call with nothing in `...`) skips the helper call entirely.
+# new-API call with nothing in `...`) skips the helper call entirely. The inner
+# gate handles a call whose only dots are empty argument slots -- a trailing
+# comma, or magrittr's `f(., , x = 1)` -- which are not arguments to recover:
+# `migrate_capture_dots()` drops them, and an all-empty `...` must not warn.
 render_arg_handle <- function(entry) {
   keep <- intersect(entry$tail, names(entry$defaults))
   default_items <- vapply(
@@ -508,11 +511,10 @@ render_arg_handle <- function(entry) {
       "  )"
     )
   }
-  c(
-    "if (...length() > 0L) {",
+  body <- c(
     guard,
     "  .arg_handle <- migrate_recover_args(",
-    "    list(...),",
+    "    .migrate_dots,",
     render_call_arg("current", "list", paste0(keep, " = ", keep), "list()"),
     render_call_arg("recover_new", "c", quote_items(entry$recover_new), "character(0)"),
     render_call_arg("recover_old", "c", quote_items(entry$recover_old), "character(0)"),
@@ -527,7 +529,14 @@ render_arg_handle <- function(entry) {
     paste0("    \"", entry$when, "\","),
     "    what = I(.arg_handle$what),",
     "    details = .arg_handle$details",
-    "  )",
+    "  )"
+  )
+  c(
+    "if (...length() > 0L) {",
+    "  .migrate_dots <- migrate_capture_dots()",
+    "  if (length(.migrate_dots$values) > 0L) {",
+    ifelse(nzchar(body), paste0("  ", body), body),
+    "  }",
     "}"
   )
 }


### PR DESCRIPTION
Fixes the four `argument is missing, with no default` revdep failures reported in #2646.

## The bug

A call may leave an argument slot empty — a trailing comma (`f(x, mode = "out", )`) or a skipped positional, which is what magrittr writes for `x %>% f(., , directed = FALSE)`. Under the old signatures those slots matched a formal by position and left it missing, so the formal's default applied.

Now that the optional arguments sit behind `...` (#2757–#2778), the empty slot lands in `...` instead, where the generated block's `list(...)` forces it:

```
Error in igraph::graph_from_adjacency_matrix(adjmatrix = x, mode = mode, weighted = TRUE, ) :
  argument is missing, with no default
Calls: ... -> <Anonymous> -> migrate_recover_args
```

Both shapes work on CRAN igraph 2.3.1 and error on `main` today:

```r
graph_from_adjacency_matrix(adjmatrix = m, mode = "undirected", weighted = TRUE, )
graph_from_data_frame(d, , directed = FALSE)
```

Four revdeps are affected: **tna** (31 test failures, plus examples and vignettes), **lagdynamics**, **modelbpp**, **NetSci**.

## The fix

`migrate_capture_dots()` replaces `list(...)` in the generated blocks. It reads the unevaluated dot expressions via `substitute(...())` — an empty slot is the empty symbol there — so missing-ness is decided without forcing anything, and only the supplied slots are then forced via `...elt()`.

Two details that the obvious "just drop the empty ones" version gets wrong:

- **Positional alignment.** An empty slot still consumed a formal under the old signature, so dropping it must not shift the later positionals along. The helper returns each supplied dot's ordinal among the unnamed slots (counting the empty ones), and `migrate_recover_args()` recovers into that slot rather than incrementing its own counter. `f(g, 5, , "in", TRUE)` recovers `"in"` and `TRUE` into the *second* and *third* recoverable arguments — what the old signature did.
- **No spurious deprecation.** A `...` holding nothing but empty slots reads as no dots at all, so recovery never engages and no warning fires; the formals just keep their defaults. The generated blocks gain an inner gate for that, which also keeps `migrate_check_call_tags()` firing only when recovery actually engages.

One more subtlety, flagged in a comment because it is easy to reintroduce: `quote(expr = )` is inlined rather than bound to a local, since evaluating a variable that holds the empty symbol is itself an "argument is missing" error.

## Changes

- `R/migrate-args.R` — new `migrate_capture_dots()`; `migrate_recover_args()` takes its result and uses the recorded ordinal for positional recovery.
- `tools/generate-migrations.R` — blocks call `migrate_capture_dots()` and gate on it.
- All 227 ARG_HANDLE blocks regenerated.
- New tests in `tests/testthat/test-migration-fixture.R` covering the trailing comma, a trailing comma after new-API arguments, an empty slot consuming its position, several empty slots, and `migrate_capture_dots()` directly.

## Verification

- Full `devtools::test()` suite green (no new failures; only the pre-existing skips for uninstalled optional packages).
- Both reproducers above, plus the exact call shapes from the tna, NetSci and modelbpp revdep logs, now behave as they do on CRAN 2.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)