### PR TITLE
fix(ci): Quote `gh` arguments in the `revdep2` plan job

### DIFF
--- a/.github/workflows/revdep2/build.R
+++ b/.github/workflows/revdep2/build.R
@@ -42,7 +42,8 @@ build_lib <- tempfile("lib-")
 dir.create(build_lib)
 status <- system2(
   "R",
-  c("CMD", "INSTALL", "--build", "-l", build_lib, tarball)
+  # Quoted: system2() quotes the command, but not the arguments.
+  c("CMD", "INSTALL", "--build", "-l", shQuote(build_lib), shQuote(tarball))
 )
 if (status != 0) {
   stop("R CMD INSTALL --build failed", call. = FALSE)

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -88,9 +88,25 @@ plan_nothing <- function(reason) {
 
 gh_ok <- nzchar(Sys.which("gh")) && nzchar(env_chr("GH_TOKEN", env_chr("GITHUB_TOKEN")))
 
+# `gh`, with its arguments quoted for the shell: system2() quotes the command
+# but hands the arguments to `sh` as written, and these carry `?`, `&`, `|`,
+# quotes and spaces. Unquoted, an API path ends at its first `&`, and what
+# follows becomes a second command the shell cannot find.
+#
+# Every failure -- no gh, no network, an API error, a token without
+# `actions: read` -- becomes NULL, including the ones system2() raises instead
+# of returning: a command the shell cannot run exits 127, which `stdout = TRUE`
+# turns into an R error rather than a status. Baseline discovery is an
+# optimization and must never fail the plan.
 gh_lines <- function(...) {
-  out <- suppressWarnings(system2("gh", c(...), stdout = TRUE, stderr = NULL))
-  if (!is.null(attr(out, "status")) && attr(out, "status") != 0) NULL else out
+  out <- tryCatch(
+    suppressWarnings(
+      system2("gh", shQuote(c(...)), stdout = TRUE, stderr = NULL)
+    ),
+    error = function(e) NULL
+  )
+  status <- attr(out, "status")
+  if (is.null(out) || (!is.null(status) && status != 0)) NULL else out
 }
 
 # Fetch one artifact of one run into a directory; NULL when it does not exist,
@@ -109,19 +125,26 @@ fetch_artifact <- function(run_id, name, dest) {
     return(NULL)
   }
   zip <- tempfile(fileext = ".zip")
-  status <- suppressWarnings(system2(
-    "gh",
-    c("api", sprintf("repos/%s/actions/artifacts/%s/zip", repo, ids[[1]])),
-    stdout = zip,
-    stderr = NULL
+  args <- shQuote(c(
+    "api",
+    sprintf("repos/%s/actions/artifacts/%s/zip", repo, ids[[1]])
   ))
-  if (!identical(status, 0L) || !file.exists(zip)) {
+  status <- tryCatch(
+    suppressWarnings(system2("gh", args, stdout = zip, stderr = NULL)),
+    error = function(e) 1L
+  )
+  if (!identical(as.integer(status), 0L) || !file.exists(zip)) {
     return(NULL)
   }
   dir.create(dest, recursive = TRUE, showWarnings = FALSE)
-  utils::unzip(zip, exdir = dest)
+  # A gh that wrote an error body instead of the artifact leaves something that
+  # is not a zip; that is a missing baseline, not a usable one.
+  extracted <- tryCatch(
+    suppressWarnings(utils::unzip(zip, exdir = dest)),
+    error = function(e) character()
+  )
   unlink(zip)
-  dest
+  if (length(extracted) == 0) NULL else dest
 }
 
 # Newest completed run of this workflow that still holds a baseline artifact.

--- a/.github/workflows/revdep2/preflight.R
+++ b/.github/workflows/revdep2/preflight.R
@@ -80,7 +80,8 @@ load_batch <- function(pkgs) {
   )
   out <- suppressWarnings(system2(
     "Rscript",
-    c("--vanilla", script, pkgs),
+    # Quoted: system2() quotes the command, but not the arguments.
+    shQuote(c("--vanilla", script, pkgs)),
     stdout = TRUE,
     stderr = TRUE
   ))


### PR DESCRIPTION
The first dispatch of `revdep2` ([run 31042822399](https://github.com/igraph/rigraph/actions/runs/31042822399), a dry run) failed in the plan job:

```
770 reverse dependencies (strong, depth 1)
767 of 770 check times known from CRAN; median fallback 118s for the rest
Computing dependency closures
Error in `<current-expression>` : error in running command
Calls: find_baseline_run -> gh_lines
```

Planning got all the way to baseline discovery and died there; `build` was skipped as a dry run, and `preflight`, `test` and `collect` were skipped because `plan` failed.

## Cause

`system2()` quotes the *command* but hands the *arguments* to `sh` as written. `gh_lines()` passes an API path and a jq program, so the shell saw:

```sh
'gh' api repos/igraph/rigraph/actions/workflows/revdep2.yaml/runs?status=completed&per_page=40 --jq .workflow_runs[].id 2>/dev/null
```

The `&` ends the command. What follows — `per_page=40 --jq .workflow_runs[].id` — is parsed as a second command named `--jq`, which the shell cannot find, so it exits 127. With `stdout = TRUE`, R turns a 127 into an *error* rather than a status, which is why `gh_lines()`'s own status check never got a chance to return `NULL`.

The per-run artifact lookup was broken the same way, one step further along: its jq program carries `|`, quotes and spaces, so it died with `sh: 1: Syntax error: word unexpected`.

Reproduced locally against a stub `gh` that echoes its `argv`:

```
== unquoted ==  "ERROR: error in running command"
== shQuoted ==  ARGV: [api] [repos/…/runs?status=completed&per_page=40] [--jq] [.workflow_runs[].id]
```

## Changes

- `shQuote()` the arguments of both `gh` calls in `plan.R`.
- Make baseline discovery unable to fail the plan. Reusing an earlier run's CRAN results is an optimization; `gh_lines()` now also catches the errors `system2()` raises instead of returning, so a missing `gh`, a dead network, an API error or a token without `actions: read` all degrade to "no baseline" as intended.
- `fetch_artifact()` treats an artifact that does not unzip (a `gh` that wrote an error body instead of the zip) as missing, rather than letting an `unzip` warning stand in for a baseline.
- Quote the paths `build.R` and `preflight.R` hand to `system2()` — same defect class, not yet reached by a run.

## Verification

`plan.R` run end to end against a stub `gh` and a fabricated `revdep2-baseline` artifact, with `REVDEP2_TIMINGS_FILE` standing in for the CRAN timings download:

- **Happy path**: all five `gh` calls arrive with `argv` intact — run listing → per-run artifact lookup (skipping the run without a baseline) → zip download → unzip → manifest read → staleness verdicts (`Baseline donor: run 222 (1 entries)`), plan written, exit 0.
- **`gh` exits 127** (the failure that killed the run): `No earlier run with a baseline artifact found`, plan written, exit 0.
- **Download returns an error body instead of a zip**: `Baseline artifact of run 222 is unavailable; reusing nothing`, plan written, exit 0.

Only the plan job's inputs are affected; the sharding, weighting and reporting logic is untouched. Worth a fresh `dry-run: true` dispatch after merge to confirm against the real API.

The scripts in `.github/workflows/revdep2/` are not air-formatted on `main`; this diff is kept to the fix rather than carrying a whole-directory reformat, and the new lines are already in the shape `air format` produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DGRJMnFeuarUedUV2JjHDM

---
_Generated by [Claude Code](https://claude.ai/code/session_01DGRJMnFeuarUedUV2JjHDM)_