### PR TITLE
ci: Move remaining Node 20 actions to their Node 24 releases

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -234,7 +234,7 @@ jobs:
           echo -n "${{ steps.commit.outputs.sha }}" > rcc-smoke-sha.txt
         shell: bash
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: rcc-smoke-sha
           path: rcc-smoke-sha.txt

--- a/.github/workflows/check/action.yml
+++ b/.github/workflows/check/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - name: Upload check results
       if: failure()
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: ${{ inputs.results }}-results
         path: check

--- a/.github/workflows/commit-suggest.yaml
+++ b/.github/workflows/commit-suggest.yaml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: changes-patch
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/commit/action.yml
+++ b/.github/workflows/commit/action.yml
@@ -95,7 +95,7 @@ runs:
 
     - name: Upload patch artifact
       if: steps.check.outputs.has_changes == 'true' && steps.repo-state.outputs.foreign == 'true'
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: changes-patch
         path: changes.patch

--- a/.github/workflows/covr/action.yml
+++ b/.github/workflows/covr/action.yml
@@ -40,7 +40,7 @@ runs:
 
     - name: Upload test results
       if: failure()
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: coverage-test-failures
         path: ${{ runner.temp }}/package

--- a/.github/workflows/pkgdown-deploy/action.yml
+++ b/.github/workflows/pkgdown-deploy/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Deploy site
-      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
       with:
         timeout_minutes: 15
         max_attempts: 10

--- a/.github/workflows/revdep.yaml
+++ b/.github/workflows/revdep.yaml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.package }}-results
           path: revdep/${{ matrix.package }}

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -170,7 +170,7 @@ jobs:
           Rscript ./.github/workflows/revdep2/plan.R
         shell: bash
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         if: steps.plan.outputs.shards != '0'
         with:
           name: revdep2-plan
@@ -209,7 +209,7 @@ jobs:
           Rscript ./.github/workflows/revdep2/build.R
         shell: bash
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: revdep2-pkg
           path: ${{ runner.temp }}/pkg
@@ -246,14 +246,14 @@ jobs:
           install.packages("jsonlite")
         shell: Rscript {0}
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v7
         with:
           name: revdep2-plan
           path: ${{ runner.temp }}/plan
 
       # The preflight downloads every dependency binary once; saving the pak
       # cache under the plan's hash hands the shards a warm start.
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.cache/R/pkgcache
           key: revdep2-pak-${{ needs.plan.outputs.plan_hash }}
@@ -269,7 +269,7 @@ jobs:
           Rscript ./.github/workflows/revdep2/preflight.R
         shell: bash
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         with:
           name: revdep2-preflight
           path: ${{ runner.temp }}/preflight
@@ -338,26 +338,26 @@ jobs:
           install.packages(c("jsonlite", "rcmdcheck"))
         shell: Rscript {0}
 
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: ~/.cache/R/pkgcache
           key: revdep2-pak-${{ needs.plan.outputs.plan_hash }}
           restore-keys: |
             revdep2-pak-
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v7
         with:
           name: revdep2-plan
           path: ${{ runner.temp }}/plan
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v7
         with:
           name: revdep2-pkg
           path: ${{ runner.temp }}/pkg
 
       # The baseline lives on an earlier run; absence is not an error, the
       # shard just checks the CRAN version fresh.
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v7
         if: needs.plan.outputs.baseline_run != '0'
         continue-on-error: true
         with:
@@ -384,7 +384,7 @@ jobs:
       # Named per attempt: a re-run of one shard must not overwrite the results
       # the other shards uploaded in the first attempt; the collector reads
       # every attempt and lets the later one win per package.
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: revdep2-results-${{ matrix.shard }}-${{ github.run_attempt }}
@@ -439,17 +439,17 @@ jobs:
           pak::pkg_install("krlmlr/revdepcheck")
         shell: Rscript {0}
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v7
         with:
           name: revdep2-plan
           path: ${{ runner.temp }}/plan
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v7
         with:
           pattern: revdep2-results-*
           path: ${{ runner.temp }}/results
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v7
         if: env.REVDEP2_RETRY_RUN != ''
         continue-on-error: true
         with:
@@ -469,7 +469,7 @@ jobs:
           Rscript ./.github/workflows/revdep2/collect.R
         shell: bash
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: revdep2-report
@@ -477,7 +477,7 @@ jobs:
           retention-days: 90
           overwrite: true
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: revdep2-baseline

--- a/.github/workflows/update-citation-cff.yaml
+++ b/.github/workflows/update-citation-cff.yaml
@@ -27,7 +27,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
GitHub is retiring the Node 20 action runtime,
so every action we pin needs a release that declares `runs.using: node24`.

Version numbers are a poor proxy for that,
so the runtime of each pinned action was read from its upstream `action.yml`.
That turned up the main surprise:
`actions/upload-artifact@v5` and `actions/download-artifact@v6`,
which this repository had already adopted,
are still Node 20 actions.
Their first Node 24 majors are v6 and v7.

## Changes

| Action | Before | After | Workflows |
|---|---|---|---|
| `actions/upload-artifact` | v5 | v6 | `revdep2`, `revdep`, `R-CMD-check`, `check`, `commit`, `covr` |
| `actions/download-artifact` | v6 | v7 | `revdep2`, `commit-suggest` |
| `actions/cache`, `actions/cache/restore` | v4 | v5 | `revdep2` |
| `actions/checkout` | v3 (Node 16) | v6 | `update-citation-cff` |
| `nick-fields/retry` | v3.0.2 | v4.0.0 | `pkgdown-deploy` |

Each action moves to the *first* Node 24 major rather than the newest tag.
`upload-artifact@v7` changes upload semantics
(`archive: false`, artifact name taken from the uploaded filename),
and `download-artifact@v8` turns digest mismatches into hard errors
and stops unzipping based on the `Content-Type` header.
Neither buys anything here.

The `update-citation-cff` checkout moves to v6
to match every other workflow in the repository.

## Not changed

`thollander/actions-comment-pull-request` in `commit-suggest` is Node 20,
and has no Node 24 release yet — even `main` still declares `node20` —
so its pin stays as is.

Everything else already runs on Node 24 or is a composite or Docker action:
`actions/checkout@v6`, `codecov/codecov-action`, `step-security/harden-runner`,
`hendrikmuhs/ccache-action`, `peter-evans/create-pull-request`,
`krlmlr/lock-threads`, `posit-dev/setup-air`,
and all `r-lib/actions` and `r-hub/actions` steps.

## Test plan

Every input the workflows pass was checked against the new versions:
`overwrite`, `retention-days`, `if-no-files-found`, `compression-level`
for `upload-artifact`;
`pattern`, `run-id`, `github-token`, `merge-multiple` for `download-artifact`;
`restore-keys` for `cache`;
and `timeout_minutes`, `max_attempts`, `command` for `retry`.
All are still supported, so no call sites needed adjusting.
CI exercises the artifact, cache, and checkout paths on this PR;
the `revdep2` sharding path needs a manual `workflow_dispatch` run.

LLM disclosure: prepared with Claude Code.

- [ ] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

https://claude.ai/code/session_01Nq9PwEbCX7HT4MqPNUn74X