### PR TITLE
feat(ci): Reuse prebuilt packages in `revdep2` instead of rebuilding them

### DIFF
--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -13,7 +13,11 @@
 # planning. The preflight job installs and loads the whole dependency
 # universe -- every package any revdep needs -- so broken dependencies surface
 # before the first check minute is spent, and the pak cache the shards restore
-# is warm.
+# is warm. Its library is published too: the plan walks earlier runs
+# youngest first until their libraries cover everything this run installs, and
+# the preflight and the shards unpack those instead of building the same
+# packages again. pak still runs over the whole set afterwards, because CRAN
+# moves between runs and what changed has to be built after all.
 #
 # Each test shard installs its dependency union, checks every one of its
 # packages against the CRAN version (or reuses a baseline), swaps in the dev
@@ -35,6 +39,10 @@
 #                     revdep's version, our CRAN version, the R series and the
 #                     resolved dependency versions all still match (and the
 #                     result is younger than baseline-max-age-days)
+#   revdep2-lib       the preflight's installed dependency library, unpacked by
+#                     later runs to skip rebuilding what has not changed
+#   revdep2-lib-index what is in that library, so a plan can decide which runs
+#                     to take it from without downloading it
 #
 # To re-check only what a run could not declare ok, dispatch again with
 # `retry-run: <run-id>`; the new report carries the old run's good results
@@ -119,6 +127,11 @@ env:
   REVDEP2_REFRESH_BASELINE: ${{ inputs.refresh-baseline && '1' || '' }}
   REVDEP2_BASELINE_MAX_AGE_DAYS: ${{ inputs.baseline-max-age-days || vars.REVDEP2_BASELINE_MAX_AGE_DAYS || '30' }}
   REVDEP2_DRY_RUN: ${{ inputs.dry-run && '1' || '' }}
+  # Prebuilt dependency libraries of earlier runs: how many runs may donate one
+  # (0 turns reuse off), and how old a library may be before its binaries are
+  # no longer trusted against the current runner image.
+  REVDEP2_PREBUILT_MAX_RUNS: ${{ vars.REVDEP2_PREBUILT_MAX_RUNS || '5' }}
+  REVDEP2_PREBUILT_MAX_AGE_DAYS: ${{ vars.REVDEP2_PREBUILT_MAX_AGE_DAYS || '14' }}
   # Per-check timeout: factor times the package's CRAN check time, but never
   # below the floor -- CRAN's machines are not these runners.
   REVDEP2_TIMEOUT_FACTOR: ${{ vars.REVDEP2_TIMEOUT_FACTOR || '1.5' }}
@@ -230,6 +243,8 @@ jobs:
 
     permissions:
       contents: read
+      # To download the prebuilt library artifacts of the runs the plan picked.
+      actions: read
 
     steps:
       - uses: actions/checkout@v6
@@ -262,8 +277,11 @@ jobs:
 
       - name: Install and load every dependency
         env:
+          GH_TOKEN: ${{ github.token }}
           PLAN: ${{ runner.temp }}/plan/plan.json
           OUT_DIR: ${{ runner.temp }}/preflight
+          LIB_OUT: ${{ runner.temp }}/lib
+          LIB_INDEX_OUT: ${{ runner.temp }}/lib-index
           PKG_SYSREQS: true
         run: |
           Rscript ./.github/workflows/revdep2/preflight.R
@@ -273,6 +291,28 @@ jobs:
         with:
           name: revdep2-preflight
           path: ${{ runner.temp }}/preflight
+          retention-days: 30
+          overwrite: true
+
+      # The library the next runs unpack. It is the big one -- a whole
+      # dependency universe, gigabytes of it -- so it is kept exactly as long
+      # as a plan would still reuse it, while the index that describes it is
+      # cheap and outlives it.
+      - uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: revdep2-lib
+          path: ${{ runner.temp }}/lib
+          if-no-files-found: ignore
+          retention-days: ${{ env.REVDEP2_PREBUILT_MAX_AGE_DAYS }}
+          overwrite: true
+
+      - uses: actions/upload-artifact@v5
+        if: always()
+        with:
+          name: revdep2-lib-index
+          path: ${{ runner.temp }}/lib-index
+          if-no-files-found: ignore
           retention-days: 30
           overwrite: true
 
@@ -295,7 +335,8 @@ jobs:
 
     permissions:
       contents: read
-      # To download the baseline artifact, which lives on an earlier run.
+      # To download the baseline and prebuilt-library artifacts, which live on
+      # earlier runs.
       actions: read
 
     strategy:
@@ -368,6 +409,8 @@ jobs:
 
       - name: Check the shard
         env:
+          # To fetch the prebuilt libraries of the runs the plan picked.
+          GH_TOKEN: ${{ github.token }}
           SHARD: ${{ matrix.shard }}
           PLAN: ${{ runner.temp }}/plan/plan.json
           PKG_DIR: ${{ runner.temp }}/pkg

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -13,11 +13,12 @@
 # planning. The preflight job installs and loads the whole dependency
 # universe -- every package any revdep needs -- so broken dependencies surface
 # before the first check minute is spent, and the pak cache the shards restore
-# is warm. Its library is published too: the plan walks earlier runs
-# youngest first until their libraries cover everything this run installs, and
-# the preflight and the shards unpack those instead of building the same
-# packages again. pak still runs over the whole set afterwards, because CRAN
-# moves between runs and what changed has to be built after all.
+# is warm. Its library is published too, and unpacked rather than rebuilt
+# twice over: every shard takes this run's preflight library, and the plan
+# walks earlier runs youngest first for whatever that leaves -- until their
+# libraries cover everything this run installs, or the history runs out. pak
+# still runs over the whole set afterwards, because CRAN moves between runs
+# and what changed has to be built after all.
 #
 # Each test shard installs its dependency union, checks every one of its
 # packages against the CRAN version (or reuses a baseline), swaps in the dev
@@ -396,6 +397,16 @@ jobs:
           name: revdep2-pkg
           path: ${{ runner.temp }}/pkg
 
+      # This run's own preflight library: the shard unpacks it instead of
+      # building the same packages the preflight built minutes ago. It is a
+      # `needs`, so it is always there -- unless the preflight could not pack
+      # one, which is a slower shard, not a broken one.
+      - uses: actions/download-artifact@v6
+        continue-on-error: true
+        with:
+          name: revdep2-lib
+          path: ${{ runner.temp }}/lib
+
       # The baseline lives on an earlier run; absence is not an error, the
       # shard just checks the CRAN version fresh.
       - uses: actions/download-artifact@v6
@@ -414,6 +425,7 @@ jobs:
           SHARD: ${{ matrix.shard }}
           PLAN: ${{ runner.temp }}/plan/plan.json
           PKG_DIR: ${{ runner.temp }}/pkg
+          LIB_DIR: ${{ runner.temp }}/lib
           BASELINE_DIR: ${{ runner.temp }}/baseline
           OUT_DIR: ${{ runner.temp }}/results
           TIMEOUT_FACTOR: ${{ env.REVDEP2_TIMEOUT_FACTOR }}

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -18,16 +18,22 @@ plan      (1 job, ~2 min)              build  (1 job, parallel to plan)
   ├─ enumerate revdeps to `depth`,       └─ R CMD build
   │    or take the retry/explicit list        + R CMD INSTALL --build
   ├─ weigh each by CRAN's check time             → revdep2-pkg artifact
-  ├─ resolve the baseline donor run,
-  │    decide per package what is reusable
+  ├─ walk earlier runs youngest first:
+  │    the baseline donor, and the
+  │    prebuilt libraries to unpack
+  ├─ decide per package what is reusable
   └─ partition into shards
        → plan.json (artifact) + matrix (job output)
 
 preflight (1 job; a dry run stops before it)
-  └─ install + load *every* dependency any revdep needs
-       → depfail.json, warm pak cache (saved under the plan hash)
+  ├─ unpack the prebuilt packages the plan found
+  ├─ install + load *every* dependency any revdep needs
+  └─ pack the library for the next run
+       → depfail.json, revdep2-lib(-index),
+         warm pak cache (saved under the plan hash)
 
 test      (one job per shard, max-parallel throttled, fail-fast: false)
+  ├─ unpack the prebuilt packages the plan found
   ├─ install the shard's dependency union (pak, sysreqs on, warm cache)
   ├─ phase old: reuse baselines, check the rest against the CRAN version
   ├─ install the prebuilt dev binary
@@ -157,9 +163,69 @@ a result ages from the day it actually ran.
 
 Baselines are looked up newest-run-first across the workflow's history
 (any branch — the dev code plays no part in an old check),
+in the same single walk that picks the prebuilt libraries below,
 and a retried run's own report doubles as its donor.
 A missing, expired, or partially unusable baseline is never an error;
 the affected packages are simply checked fresh.
+
+## Prebuilt packages, and which runs they come from
+
+Installing the dependency universe is the other half of the bill.
+Every shard installs its own union,
+and the preflight installs all of it once before them,
+so a package that CRAN has not touched since the last run
+is built again in every one of those jobs, every run,
+for a result that is byte-for-byte what the last run already had.
+
+So the preflight publishes what it installed.
+Its library is packed into `revdep2-lib`
+(one uncompressed `library.tar` — `upload-artifact` zips what it uploads,
+and deflating gigabytes twice buys nothing),
+next to `revdep2-lib-index`,
+a small `lib.json` naming the R series, the platform,
+and every package version in it.
+The index is a separate artifact on purpose:
+a later plan reads it to decide what a run is good for
+without downloading the library it describes.
+
+The plan then walks the workflow's completed runs, youngest first,
+and takes libraries until it has covered
+every package this run will install,
+or has run out of runs:
+
+* a run only donates while its library is younger than
+  `REVDEP2_PREBUILT_MAX_AGE_DAYS` (default 14)
+  and its index reports the same R series and platform —
+  binaries are only portable that far;
+* each donor is credited only with the packages
+  no younger donor already had,
+  so a run that adds nothing is never downloaded;
+* at most `REVDEP2_PREBUILT_MAX_RUNS` runs donate (default 5, `0` turns
+  reuse off) — every extra donor is another full library download.
+
+What it settles lands in `plan.json` as `prebuilt.runs`,
+and the preflight and every shard unpack from exactly that list,
+taking only the packages they need
+and never overwriting what is already in their library
+(pak and everything the job itself installed stays untouched).
+
+**pak still runs over the whole set afterwards.**
+Unpacking is not installing:
+CRAN moves between runs, and a package whose version changed
+has to be built after all.
+The install runs with `upgrade = TRUE` whenever anything was restored,
+because the plan's dependency fingerprints — the ones that decide
+baseline reuse — are computed from CRAN *now*,
+and `upgrade = FALSE` would quietly freeze the donor's versions instead.
+Reuse therefore skips *building* what has not changed;
+it never skips resolving it.
+
+The one failure mode reuse introduces is a stale binary:
+a runner image moves under a package that was compiled against the old one.
+The preflight load-tests everything it installs anyway,
+so it catches exactly that — a restored package that will not load
+is thrown away, rebuilt from source, and load-tested again
+before it counts as a dependency failure.
 
 ## Results, artifacts, tooling
 
@@ -170,6 +236,8 @@ Every artifact this workflow writes:
 | `revdep2-plan` | `plan.json` | 30 days |
 | `revdep2-pkg` | source tarball, platform binary, `meta.json` | 30 days |
 | `revdep2-preflight` | `depfail.json` | 30 days |
+| `revdep2-lib` | `library.tar` (the preflight's installed library), `lib.json` | 14 days |
+| `revdep2-lib-index` | `lib.json`: R series, platform, package versions | 30 days |
 | `revdep2-results-<shard>-<attempt>` | `manifest.ndjson`, `pkgs/<p>/{old,new}.rds`, kept check output | 30 days |
 | `revdep2-report` | `README.md`, `problems.md`, `failures.md`, `cran.md`, `manifest.json`, all `pkgs/` | 90 days |
 | `revdep2-baseline` | `baseline.json`, `old-rds/<p>.rds` | 90 days |
@@ -209,6 +277,9 @@ so its report is complete again, not a fragment.
 | A shard job dies hard | its packages have no manifest entries; the collector reports what exists; `retry-run` re-plans the rest |
 | A shard is re-run | new artifact per attempt; the collector lets the later attempt win per package |
 | The baseline artifact is gone | planner reuses nothing, everything checked fresh |
+| No earlier run has a usable library | nothing is unpacked, pak installs everything from scratch |
+| A donor's library artifact expires between plan and shard | that shard installs those packages itself; the run is unaffected |
+| A restored binary will not load | the preflight rebuilds it from source and re-tests; only a second failure is a `depfail` |
 | CRAN bumps a dependency mid-run | shards install what resolves at their start; the recorded fingerprint is the plan's — next run re-fingerprints |
 | The package is not on CRAN | plan emits zero shards, run ends green |
 | `collect` finds new problems | reported in the summary and the report artifact; the run stays green |
@@ -227,6 +298,9 @@ so its report is complete again, not a fragment.
 | Concurrent shards | `max-parallel` | `REVDEP2_MAX_PARALLEL` | 20 |
 | Ignore reusable baselines | `refresh-baseline` | — | false |
 | Oldest reusable baseline | `baseline-max-age-days` | `REVDEP2_BASELINE_MAX_AGE_DAYS` | 30 days |
+| Runs donating prebuilt packages | — | `REVDEP2_PREBUILT_MAX_RUNS` | 5 (`0` disables) |
+| Oldest reusable prebuilt library | — | `REVDEP2_PREBUILT_MAX_AGE_DAYS` | 14 days |
+| Runs the history walk looks at | — | `REVDEP2_HISTORY_RUNS` | 40 |
 | Per-check timeout factor | — | `REVDEP2_TIMEOUT_FACTOR` | 1.5 × CRAN time |
 | Per-check timeout floor | — | `REVDEP2_TIMEOUT_MIN_MINUTES` | 10 |
 | Shard graceful deadline | — | `REVDEP2_DEADLINE_MINUTES` | 300 |
@@ -275,3 +349,10 @@ that part is new here.
    and whose availability is per-repository;
    an orphan branch (the `rcc` model) would be durable and fetchable
    but grows the repository.
+5. Prebuilt-library reuse trades download for build:
+   every shard fetches each donor library whole,
+   because artifacts cannot be fetched in part.
+   That is a clear win where the runner has no binaries to install from
+   and a marginal one where it does,
+   and the crossover has not been measured —
+   `REVDEP2_PREBUILT_MAX_RUNS=0` turns it off if it ever stops paying.

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -33,7 +33,7 @@ preflight (1 job; a dry run stops before it)
          warm pak cache (saved under the plan hash)
 
 test      (one job per shard, max-parallel throttled, fail-fast: false)
-  ├─ unpack the prebuilt packages the plan found
+  ├─ unpack this run's preflight library, then the plan's donors
   ├─ install the shard's dependency union (pak, sysreqs on, warm cache)
   ├─ phase old: reuse baselines, check the rest against the CRAN version
   ├─ install the prebuilt dev binary
@@ -170,12 +170,14 @@ the affected packages are simply checked fresh.
 
 ## Prebuilt packages, and which runs they come from
 
-Installing the dependency universe is the other half of the bill.
-Every shard installs its own union,
-and the preflight installs all of it once before them,
-so a package that CRAN has not touched since the last run
-is built again in every one of those jobs, every run,
-for a result that is byte-for-byte what the last run already had.
+Installing the dependency universe is the other half of the bill,
+and it is paid twice over.
+The preflight installs all of it,
+then every shard installs its own union again —
+so on a runner with no binaries to install from,
+one package is compiled once in the preflight
+and once more in each of the twenty shards,
+every run, for a result identical each time.
 
 So the preflight publishes what it installed.
 Its library is packed into `revdep2-lib`
@@ -188,7 +190,16 @@ The index is a separate artifact on purpose:
 a later plan reads it to decide what a run is good for
 without downloading the library it describes.
 
-The plan then walks the workflow's completed runs, youngest first,
+That artifact is reused twice, and the first one needs no history at all:
+**every shard unpacks its own run's preflight library** —
+`preflight` is a `needs` of `test`, so it is simply downloaded —
+and only then falls back to earlier runs
+for whatever the preflight could not supply.
+This is the half that pays on the very first run:
+the compile happens once in the preflight
+instead of once more in each shard.
+
+For the rest, the plan walks the workflow's completed runs, youngest first,
 and takes libraries until it has covered
 every package this run will install,
 or has run out of runs:
@@ -204,10 +215,12 @@ or has run out of runs:
   reuse off) — every extra donor is another full library download.
 
 What it settles lands in `plan.json` as `prebuilt.runs`,
-and the preflight and every shard unpack from exactly that list,
-taking only the packages they need
-and never overwriting what is already in their library
-(pak and everything the job itself installed stays untouched).
+and the preflight and every shard unpack from exactly that list —
+the shards after their own run's library, for the gaps it leaves.
+Every unpack takes only the packages that job needs,
+and never overwrites what is already in the library
+or loaded in the session
+(pak and everything the job installed for itself stays untouched).
 
 **pak still runs over the whole set afterwards.**
 Unpacking is not installing:
@@ -277,7 +290,8 @@ so its report is complete again, not a fragment.
 | A shard job dies hard | its packages have no manifest entries; the collector reports what exists; `retry-run` re-plans the rest |
 | A shard is re-run | new artifact per attempt; the collector lets the later attempt win per package |
 | The baseline artifact is gone | planner reuses nothing, everything checked fresh |
-| No earlier run has a usable library | nothing is unpacked, pak installs everything from scratch |
+| No earlier run has a usable library | shards still unpack this run's preflight library; only the preflight itself installs from scratch |
+| The preflight could not pack a library | the download step is skipped, shards fall back to the plan's donors and pak |
 | A donor's library artifact expires between plan and shard | that shard installs those packages itself; the run is unaffected |
 | A restored binary will not load | the preflight rebuilds it from source and re-tests; only a second failure is a `depfail` |
 | CRAN bumps a dependency mid-run | shards install what resolves at their start; the recorded fingerprint is the plan's — next run re-fingerprints |

--- a/.github/workflows/revdep2/build.R
+++ b/.github/workflows/revdep2/build.R
@@ -8,7 +8,10 @@
 # Environment variables:
 #   OUT_DIR  - where the tarball, binary and metadata land (default: pkg)
 
-source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
+source(file.path(
+  dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))),
+  "util.R"
+))
 
 out_dir <- env_chr("OUT_DIR", "pkg")
 dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
@@ -60,7 +63,11 @@ write_json(
     package = package,
     dev_version = dev_version,
     sha = head_sha,
-    r_version = paste(R.version$major, sub("[.].*$", "", R.version$minor), sep = "."),
+    r_version = paste(
+      R.version$major,
+      sub("[.].*$", "", R.version$minor),
+      sep = "."
+    ),
     platform = R.version$platform,
     tarball = tarball,
     binary = file.path("bin", binary),

--- a/.github/workflows/revdep2/collect.R
+++ b/.github/workflows/revdep2/collect.R
@@ -27,7 +27,10 @@
 # Always exits zero: check results are the report's business, not the job
 # status's -- only a genuinely broken collector fails this job.
 
-source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
+source(file.path(
+  dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))),
+  "util.R"
+))
 
 results_dir <- env_chr("RESULTS_DIR")
 stopifnot(nzchar(results_dir))
@@ -37,7 +40,11 @@ out_dir <- env_chr("OUT_DIR", "revdep")
 baseline_out <- env_chr("BASELINE_OUT", "baseline")
 
 dir.create(file.path(out_dir, "pkgs"), recursive = TRUE, showWarnings = FALSE)
-dir.create(file.path(baseline_out, "old-rds"), recursive = TRUE, showWarnings = FALSE)
+dir.create(
+  file.path(baseline_out, "old-rds"),
+  recursive = TRUE,
+  showWarnings = FALSE
+)
 
 # ------------------------------------------------------------------- merge ---
 
@@ -74,7 +81,13 @@ for (dir in shard_dirs) {
     }
   }
 }
-inform("Collected ", length(entries), " package(s) from ", length(shard_dirs), " shard artifact(s)")
+inform(
+  "Collected ",
+  length(entries),
+  " package(s) from ",
+  length(shard_dirs),
+  " shard artifact(s)"
+)
 
 # A retried run reports the whole picture: results the retry did not touch are
 # carried over from the earlier run's report, marked as such.
@@ -87,7 +100,12 @@ if (nzchar(retry_dir) && file.exists(file.path(retry_dir, "manifest.json"))) {
       carried <- carried + 1L
     }
   }
-  inform("Carried ", carried, " untouched result(s) over from run ", plan$retry_of)
+  inform(
+    "Carried ",
+    carried,
+    " untouched result(s) over from run ",
+    plan$retry_of
+  )
 }
 
 entries <- entries[order(names(entries))]
@@ -115,10 +133,17 @@ write_json(unname(entries), file.path(out_dir, "manifest.json"))
 baseline <- list()
 for (entry in entries) {
   rds <- file.path(out_dir, "pkgs", entry$package, "old.rds")
-  if (!file.exists(rds) || is.null(entry$old_checked_at) || is.na(entry$old_checked_at)) {
+  if (
+    !file.exists(rds) ||
+      is.null(entry$old_checked_at) ||
+      is.na(entry$old_checked_at)
+  ) {
     next
   }
-  file.copy(rds, file.path(baseline_out, "old-rds", paste0(entry$package, ".rds")))
+  file.copy(
+    rds,
+    file.path(baseline_out, "old-rds", paste0(entry$package, ".rds"))
+  )
   baseline[[length(baseline) + 1]] <- list(
     package = entry$package,
     version = entry$version,
@@ -207,20 +232,34 @@ if (has_revdepcheck) {
     file.path(out_dir, "README.md")
   )
   writeLines(
-    capture_report(revdepcheck::cloud_report_problems, pkg = ".", results = results),
+    capture_report(
+      revdepcheck::cloud_report_problems,
+      pkg = ".",
+      results = results
+    ),
     file.path(out_dir, "problems.md")
   )
   writeLines(
-    capture_report(revdepcheck::cloud_report_failures, pkg = ".", results = results),
+    capture_report(
+      revdepcheck::cloud_report_failures,
+      pkg = ".",
+      results = results
+    ),
     file.path(out_dir, "failures.md")
   )
   writeLines(
-    capture_report(revdepcheck::revdep_report_cran, pkg = ".", results = results),
+    capture_report(
+      revdepcheck::revdep_report_cran,
+      pkg = ".",
+      results = results
+    ),
     file.path(out_dir, "cran.md")
   )
   inform("Reports written to ", out_dir)
 } else {
-  inform("revdepcheck is not installed; writing the manifest-derived summary only")
+  inform(
+    "revdepcheck is not installed; writing the manifest-derived summary only"
+  )
   df <- data.frame(
     package = names(entries),
     version = vapply(entries, function(e) e$version %||% "?", character(1)),
@@ -243,12 +282,14 @@ not_ok <- sum(results_tbl != "ok")
 headline <- if (tally("newly_broken") > 0) {
   sprintf(
     "**%d of %d packages newly broken.**",
-    tally("newly_broken"), length(entries)
+    tally("newly_broken"),
+    length(entries)
   )
 } else if (not_ok > 0) {
   sprintf(
     "No new breakage; %d of %d packages could not be fully checked.",
-    not_ok, length(entries)
+    not_ok,
+    length(entries)
   )
 } else {
   sprintf("All good: no new problems in %d packages.", length(entries))
@@ -302,6 +343,10 @@ append_summary(c(
 ))
 
 inform(
-  length(entries), " package(s): ", sum(results_tbl == "ok"), " ok, ",
-  not_ok, " with findings -- see the summary and the revdep2-report artifact"
+  length(entries),
+  " package(s): ",
+  sum(results_tbl == "ok"),
+  " ok, ",
+  not_ok,
+  " with findings -- see the summary and the revdep2-report artifact"
 )

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -33,6 +33,12 @@
 #   REVDEP2_REFRESH_BASELINE- if truthy, ignore reusable baselines and re-check
 #                             the CRAN version of everything
 #   REVDEP2_BASELINE_MAX_AGE_DAYS - oldest baseline worth reusing (default: 30)
+#   REVDEP2_PREBUILT_MAX_RUNS - earlier runs whose prebuilt package libraries
+#                             this run may reuse (default: 5; 0 disables)
+#   REVDEP2_PREBUILT_MAX_AGE_DAYS - oldest prebuilt library worth reusing
+#                             (default: 14)
+#   REVDEP2_HISTORY_RUNS    - earlier runs the donor walk looks at at all
+#                             (default: 40)
 #   REVDEP2_INSTALL_SECONDS - marginal install cost charged per dependency a
 #                             package adds to its shard (default: 2.5)
 #   REVDEP2_TIMINGS_FILE    - offline hook: RDS or CSV with columns Package and
@@ -61,6 +67,9 @@ max_shards <- min(env_num("REVDEP2_MAX_SHARDS", 250), 250)
 max_parallel <- env_num("REVDEP2_MAX_PARALLEL", 20)
 refresh_baseline <- env_flag("REVDEP2_REFRESH_BASELINE")
 baseline_max_age <- env_num("REVDEP2_BASELINE_MAX_AGE_DAYS", 30)
+max_prebuilt_runs <- env_num("REVDEP2_PREBUILT_MAX_RUNS", 5)
+prebuilt_max_age <- env_num("REVDEP2_PREBUILT_MAX_AGE_DAYS", 14)
+history_runs <- env_num("REVDEP2_HISTORY_RUNS", 40)
 install_seconds <- env_num("REVDEP2_INSTALL_SECONDS", 2.5)
 setup_minutes <- env_num("REVDEP2_SETUP_MINUTES", 6)
 overhead_minutes <- env_num("REVDEP2_PACKAGE_OVERHEAD_MINUTES", 0.5)
@@ -84,96 +93,99 @@ plan_nothing <- function(reason) {
   quit(save = "no", status = 0)
 }
 
-# --------------------------------------------------------------- gh helper ----
+# ------------------------------------------------------------ run history ----
 
-gh_ok <- nzchar(Sys.which("gh")) && nzchar(env_chr("GH_TOKEN", env_chr("GITHUB_TOKEN")))
-
-# `gh`, with its arguments quoted for the shell: system2() quotes the command
-# but hands the arguments to `sh` as written, and these carry `?`, `&`, `|`,
-# quotes and spaces. Unquoted, an API path ends at its first `&`, and what
-# follows becomes a second command the shell cannot find.
+# The gh plumbing itself lives in util.R, because the preflight and the shards
+# fetch artifacts too; what is planned here is *which* earlier runs to take
+# them from.
 #
-# Every failure -- no gh, no network, an API error, a token without
-# `actions: read` -- becomes NULL, including the ones system2() raises instead
-# of returning: a command the shell cannot run exits 127, which `stdout = TRUE`
-# turns into an R error rather than a status. Baseline discovery is an
-# optimization and must never fail the plan.
-gh_lines <- function(...) {
-  out <- tryCatch(
-    suppressWarnings(
-      system2("gh", shQuote(c(...)), stdout = TRUE, stderr = NULL)
-    ),
-    error = function(e) NULL
-  )
-  status <- attr(out, "status")
-  if (is.null(out) || (!is.null(status) && status != 0)) NULL else out
-}
-
-# Fetch one artifact of one run into a directory; NULL when it does not exist,
-# has expired, or cannot be downloaded.
-fetch_artifact <- function(run_id, name, dest) {
-  if (!gh_ok || !nzchar(repo)) {
-    return(NULL)
+# One walk over the workflow's completed runs, youngest first, answers both
+# questions this plan asks of its history, and asks the API for a run's
+# artifacts at most once:
+#
+#   * which run donates the CRAN baseline -- the newest one that still has it;
+#   * which runs donate prebuilt package libraries -- as many as it takes to
+#     cover everything this run installs, youngest first, each one credited
+#     only with what the younger ones did not already have.
+#
+# The walk stops as soon as it has both, and never looks at more than
+# `history_runs` runs; reuse is an optimization, and an optimization does not
+# get to spend the planning budget.
+scan_history <- function(want_baseline, needed) {
+  empty <- list(baseline_run = NULL, prebuilt = list(), scanned = 0L, missing = needed)
+  if (!gh_ok() || !nzchar(repo)) {
+    return(empty)
   }
-  ids <- gh_lines(
-    "api",
-    sprintf("repos/%s/actions/runs/%s/artifacts?per_page=100", repo, run_id),
-    "--jq",
-    sprintf('.artifacts[] | select(.name == "%s" and .expired == false) | .id', name)
-  )
-  if (length(ids) == 0 || !nzchar(ids[[1]])) {
-    return(NULL)
-  }
-  zip <- tempfile(fileext = ".zip")
-  args <- shQuote(c(
-    "api",
-    sprintf("repos/%s/actions/artifacts/%s/zip", repo, ids[[1]])
-  ))
-  status <- tryCatch(
-    suppressWarnings(system2("gh", args, stdout = zip, stderr = NULL)),
-    error = function(e) 1L
-  )
-  if (!identical(as.integer(status), 0L) || !file.exists(zip)) {
-    return(NULL)
-  }
-  dir.create(dest, recursive = TRUE, showWarnings = FALSE)
-  # A gh that wrote an error body instead of the artifact leaves something that
-  # is not a zip; that is a missing baseline, not a usable one.
-  extracted <- tryCatch(
-    suppressWarnings(utils::unzip(zip, exdir = dest)),
-    error = function(e) character()
-  )
-  unlink(zip)
-  if (length(extracted) == 0) NULL else dest
-}
-
-# Newest completed run of this workflow that still holds a baseline artifact.
-find_baseline_run <- function() {
-  if (!gh_ok || !nzchar(repo)) {
-    return(NULL)
-  }
-  runs <- gh_lines(
+  rows <- gh_lines(
     "api",
     sprintf(
-      "repos/%s/actions/workflows/revdep2.yaml/runs?status=completed&per_page=40",
-      repo
+      "repos/%s/actions/workflows/revdep2.yaml/runs?status=completed&per_page=%d",
+      repo, history_runs
     ),
     "--jq",
-    ".workflow_runs[].id"
+    ".workflow_runs[] | [.id, .created_at] | @tsv"
   )
+  rows <- rows[nzchar(rows)]
+  if (length(rows) == 0) {
+    return(empty)
+  }
   this_run <- env_chr("GITHUB_RUN_ID")
-  for (run in setdiff(as.character(runs), this_run)) {
-    hits <- gh_lines(
-      "api",
-      sprintf("repos/%s/actions/runs/%s/artifacts?per_page=100", repo, run),
-      "--jq",
-      '.artifacts[] | select(.name == "revdep2-baseline" and .expired == false) | .id'
-    )
-    if (length(hits) > 0 && nzchar(hits[[1]])) {
-      return(run)
+  baseline_run <- NULL
+  prebuilt <- list()
+  scanned <- 0L
+  for (row in rows) {
+    if (!want_baseline && (length(needed) == 0 || length(prebuilt) >= max_prebuilt_runs)) {
+      break
+    }
+    fields <- strsplit(row, "\t", fixed = TRUE)[[1]]
+    run <- fields[[1]]
+    if (identical(run, this_run)) {
+      next
+    }
+    created <- suppressWarnings(as.Date(fields[[2]]))
+    scanned <- scanned + 1L
+    ids <- run_artifacts(run)
+    artifacts <- names(ids)
+    if (want_baseline && "revdep2-baseline" %in% artifacts) {
+      baseline_run <- run
+      want_baseline <- FALSE
+    }
+    # A library is only worth carrying while its binaries still match the R
+    # series and the platform they were built for, and while the runner image
+    # they were built on is plausibly the current one -- which is what the age
+    # cap stands in for, the same way it does for baselines.
+    take_library <- length(needed) > 0 &&
+      length(prebuilt) < max_prebuilt_runs &&
+      all(c("revdep2-lib", "revdep2-lib-index") %in% artifacts) &&
+      !is.na(created) &&
+      as.numeric(Sys.Date() - created) <= prebuilt_max_age
+    if (take_library) {
+      dir <- fetch_artifact_id(ids[["revdep2-lib-index"]], tempfile("lib-index-"))
+      index_path <- if (is.null(dir)) NULL else file.path(dir, "lib.json")
+      index <- if (!is.null(index_path) && file.exists(index_path)) read_json(index_path) else NULL
+      unlink(dir, recursive = TRUE)
+      if (!is.null(index) &&
+        identical(index$r_version, r_version) &&
+        identical(index$platform, R.version$platform)) {
+        have <- vapply(index$packages, function(e) e$package, character(1))
+        gain <- intersect(needed, have)
+        if (length(gain) > 0) {
+          prebuilt[[length(prebuilt) + 1]] <- list(
+            run_id = run,
+            created_at = fields[[2]],
+            packages = as.list(gain)
+          )
+          needed <- setdiff(needed, gain)
+        }
+      }
     }
   }
-  NULL
+  list(
+    baseline_run = baseline_run,
+    prebuilt = prebuilt,
+    scanned = scanned,
+    missing = needed
+  )
 }
 
 # ------------------------------------------------- the package under test ----
@@ -327,11 +339,26 @@ dev_closure <- sort(setdiff(
   base_packages()
 ))
 
+# Everything this run installs anywhere: the union of the revdeps' closures
+# and the dev version's own dependencies. It prices the partitioning penalty
+# below, and it is the set the prebuilt libraries of earlier runs are matched
+# against.
+universe <- unique(c(unlist(closure, use.names = FALSE), dev_closure))
+
+# ------------------------------------------------------------ earlier runs ---
+
+local_baseline <- env_chr("REVDEP2_BASELINE_DIR")
+history <- scan_history(
+  # A retried run donates its own baseline, and the two offline hooks bypass
+  # discovery entirely; the walk then only looks for prebuilt libraries.
+  want_baseline = !refresh_baseline && !nzchar(local_baseline) && !nzchar(retry_run),
+  needed = universe
+)
+
 # ---------------------------------------------------------------- baseline ---
 
 baseline_run <- 0L
 baseline_manifest <- list()
-local_baseline <- env_chr("REVDEP2_BASELINE_DIR")
 if (refresh_baseline) {
   inform("Baseline reuse disabled by input")
 } else if (nzchar(local_baseline)) {
@@ -348,7 +375,7 @@ if (refresh_baseline) {
     inform("Baseline from ", local_baseline, " (", length(baseline_manifest), " entries)")
   }
 } else {
-  donor <- if (nzchar(retry_run)) retry_run else find_baseline_run()
+  donor <- if (nzchar(retry_run)) retry_run else history$baseline_run
   if (is.null(donor) || !nzchar(donor)) {
     inform("No earlier run with a baseline artifact found")
   } else {
@@ -414,6 +441,32 @@ if (baseline_run > 0) {
   )
 }
 
+# --------------------------------------------------------------- prebuilt ---
+
+# What the preflight and the shards will unpack instead of building. Recording
+# it here rather than letting every job walk the history itself keeps the
+# decision in one place, makes it inspectable in the plan and the summary, and
+# spends the API calls once.
+prebuilt <- history$prebuilt
+prebuilt_covered <- length(universe) - length(history$missing)
+if (length(prebuilt) > 0) {
+  inform(
+    "Prebuilt libraries: ", prebuilt_covered, " of ", length(universe),
+    " packages from ", length(prebuilt), " run(s) (",
+    paste(
+      vapply(
+        prebuilt,
+        function(d) sprintf("%s: %d", d$run_id, length(d$packages)),
+        character(1)
+      ),
+      collapse = ", "
+    ),
+    ")"
+  )
+} else if (max_prebuilt_runs > 0) {
+  inform("No reusable prebuilt package library found; everything is installed fresh")
+}
+
 # Weight: one check of the revdep costs about what CRAN's Linux machine spends
 # on it end to end; a package without a reusable baseline is checked twice.
 weight <- ((!reuse) + 1) * t_total / 60 + overhead_minutes
@@ -430,7 +483,6 @@ inform(
   )
 )
 
-universe <- unique(c(unlist(closure, use.names = FALSE), dev_closure))
 dep_idx <- lapply(closure, function(deps) match(deps, universe))
 penalty <- install_seconds / 60
 
@@ -528,6 +580,14 @@ plan <- list(
     reused = sum(reuse),
     fresh = sum(!reuse)
   ),
+  prebuilt = list(
+    max_runs = max_prebuilt_runs,
+    max_age_days = prebuilt_max_age,
+    runs_scanned = history$scanned,
+    covered = prebuilt_covered,
+    missing = length(history$missing),
+    runs = prebuilt
+  ),
   params = list(
     shard_budget_minutes = budget,
     max_shards = max_shards,
@@ -613,6 +673,20 @@ append_summary(c(
         if (baseline_run > 0) sprintf("run %d", baseline_run) else "local",
         sum(reuse),
         sum(!reuse)
+      )
+    } else {
+      "none"
+    }
+  ),
+  sprintf(
+    "| Prebuilt packages | %s |",
+    if (length(prebuilt) > 0) {
+      sprintf(
+        "%d of %d from run%s %s",
+        prebuilt_covered,
+        length(universe),
+        if (length(prebuilt) > 1) "s" else "",
+        paste(vapply(prebuilt, function(d) d$run_id, character(1)), collapse = ", ")
       )
     } else {
       "none"

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -49,10 +49,16 @@
 # discovery, uses the `gh` CLI with GH_TOKEN. Without gh or a token the plan
 # simply reuses nothing.
 
-source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
+source(file.path(
+  dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))),
+  "util.R"
+))
 
 out_path <- env_chr("OUT", "plan.json")
-which_input <- match.arg(env_chr("REVDEP2_WHICH", "strong"), c("strong", "most"))
+which_input <- match.arg(
+  env_chr("REVDEP2_WHICH", "strong"),
+  c("strong", "most")
+)
 depth_raw <- tolower(env_chr("REVDEP2_DEPTH", "1"))
 depth <- if (depth_raw %in% c("all", "max", "inf", "infinity")) {
   Inf
@@ -77,7 +83,11 @@ retry_run <- env_chr("REVDEP2_RETRY_RUN")
 repo <- env_chr("GITHUB_REPOSITORY")
 timing_flavor <- env_chr("REVDEP2_TIMING_FLAVOR", "r-release-linux-x86_64")
 
-r_version <- paste(R.version$major, sub("[.].*$", "", R.version$minor), sep = ".")
+r_version <- paste(
+  R.version$major,
+  sub("[.].*$", "", R.version$minor),
+  sep = "."
+)
 
 # ------------------------------------------------------------ empty plans ----
 
@@ -112,7 +122,12 @@ plan_nothing <- function(reason) {
 # `history_runs` runs; reuse is an optimization, and an optimization does not
 # get to spend the planning budget.
 scan_history <- function(want_baseline, needed) {
-  empty <- list(baseline_run = NULL, prebuilt = list(), scanned = 0L, missing = needed)
+  empty <- list(
+    baseline_run = NULL,
+    prebuilt = list(),
+    scanned = 0L,
+    missing = needed
+  )
   if (!gh_ok() || !nzchar(repo)) {
     return(empty)
   }
@@ -120,7 +135,8 @@ scan_history <- function(want_baseline, needed) {
     "api",
     sprintf(
       "repos/%s/actions/workflows/revdep2.yaml/runs?status=completed&per_page=%d",
-      repo, history_runs
+      repo,
+      history_runs
     ),
     "--jq",
     ".workflow_runs[] | [.id, .created_at] | @tsv"
@@ -134,7 +150,10 @@ scan_history <- function(want_baseline, needed) {
   prebuilt <- list()
   scanned <- 0L
   for (row in rows) {
-    if (!want_baseline && (length(needed) == 0 || length(prebuilt) >= max_prebuilt_runs)) {
+    if (
+      !want_baseline &&
+        (length(needed) == 0 || length(prebuilt) >= max_prebuilt_runs)
+    ) {
       break
     }
     fields <- strsplit(row, "\t", fixed = TRUE)[[1]]
@@ -160,13 +179,22 @@ scan_history <- function(want_baseline, needed) {
       !is.na(created) &&
       as.numeric(Sys.Date() - created) <= prebuilt_max_age
     if (take_library) {
-      dir <- fetch_artifact_id(ids[["revdep2-lib-index"]], tempfile("lib-index-"))
+      dir <- fetch_artifact_id(
+        ids[["revdep2-lib-index"]],
+        tempfile("lib-index-")
+      )
       index_path <- if (is.null(dir)) NULL else file.path(dir, "lib.json")
-      index <- if (!is.null(index_path) && file.exists(index_path)) read_json(index_path) else NULL
+      index <- if (!is.null(index_path) && file.exists(index_path)) {
+        read_json(index_path)
+      } else {
+        NULL
+      }
       unlink(dir, recursive = TRUE)
-      if (!is.null(index) &&
-        identical(index$r_version, r_version) &&
-        identical(index$platform, R.version$platform)) {
+      if (
+        !is.null(index) &&
+          identical(index$r_version, r_version) &&
+          identical(index$platform, R.version$platform)
+      ) {
         have <- vapply(index$packages, function(e) e$package, character(1))
         gain <- intersect(needed, have)
         if (length(gain) > 0) {
@@ -197,7 +225,10 @@ inform("Package under test: ", package, " ", dev_version)
 
 db <- cran_db()
 if (!package %in% rownames(db)) {
-  plan_nothing(sprintf("%s is not on CRAN, so it has no CRAN reverse dependencies", package))
+  plan_nothing(sprintf(
+    "%s is not on CRAN, so it has no CRAN reverse dependencies",
+    package
+  ))
 }
 cran_version <- unname(db[package, "Version"])
 inform("CRAN version: ", cran_version)
@@ -229,9 +260,16 @@ while (level < depth && length(frontier) > 0) {
 revdeps <- sort(names(level_of))
 level_counts <- table(level_of)
 inform(
-  length(revdeps), " reverse dependencies (", which_input, ", depth ", depth_raw,
+  length(revdeps),
+  " reverse dependencies (",
+  which_input,
+  ", depth ",
+  depth_raw,
   if (length(level_counts) > 1) {
-    paste0("; ", paste0("level ", names(level_counts), ": ", level_counts, collapse = ", "))
+    paste0(
+      "; ",
+      paste0("level ", names(level_counts), ": ", level_counts, collapse = ", ")
+    )
   } else {
     ""
   },
@@ -240,7 +278,10 @@ inform(
 
 selection <- "all"
 retry_manifest <- NULL
-packages_input <- trimws(strsplit(env_chr("REVDEP2_PACKAGES"), "[,[:space:]]+")[[1]])
+packages_input <- trimws(strsplit(
+  env_chr("REVDEP2_PACKAGES"),
+  "[,[:space:]]+"
+)[[1]])
 packages_input <- packages_input[nzchar(packages_input)]
 
 if (length(packages_input) > 0) {
@@ -251,7 +292,11 @@ if (length(packages_input) > 0) {
   dir <- fetch_artifact(retry_run, "revdep2-report", tempfile("retry-"))
   manifest_path <- if (is.null(dir)) NULL else file.path(dir, "manifest.json")
   if (is.null(manifest_path) || !file.exists(manifest_path)) {
-    stop("Cannot fetch the revdep2-report artifact of run ", retry_run, call. = FALSE)
+    stop(
+      "Cannot fetch the revdep2-report artifact of run ",
+      retry_run,
+      call. = FALSE
+    )
   }
   retry_manifest <- read_json(manifest_path)
   results <- vapply(retry_manifest, function(e) e$result, character(1))
@@ -259,8 +304,12 @@ if (length(packages_input) > 0) {
     vapply(results, needs_recheck, logical(1))
   ]
   inform(
-    "Retrying ", length(candidates), " of ", length(retry_manifest),
-    " packages from run ", retry_run
+    "Retrying ",
+    length(candidates),
+    " of ",
+    length(retry_manifest),
+    " packages from run ",
+    retry_run
   )
 } else {
   candidates <- revdeps
@@ -300,8 +349,13 @@ fallback <- if (any(known)) stats::median(t_total[known]) else 300
 t_total[!known] <- fallback
 t_total <- pmax(t_total, 60)
 inform(
-  sum(known), " of ", length(packages), " check times known from CRAN; ",
-  "median fallback ", round(fallback), "s for the rest"
+  sum(known),
+  " of ",
+  length(packages),
+  " check times known from CRAN; ",
+  "median fallback ",
+  round(fallback),
+  "s for the rest"
 )
 
 # --------------------------------------------------------------- closures ----
@@ -326,7 +380,10 @@ parse_dep_field <- function(field) {
   names <- trimws(sub("[([].*$", "", entries))
   names[nzchar(names) & names != "R"]
 }
-dev_deps <- unique(unlist(lapply(c("Depends", "Imports", "LinkingTo"), parse_dep_field)))
+dev_deps <- unique(unlist(lapply(
+  c("Depends", "Imports", "LinkingTo"),
+  parse_dep_field
+)))
 dev_deps <- intersect(dev_deps, rownames(db))
 dev_closure <- sort(setdiff(
   unique(c(
@@ -351,7 +408,9 @@ local_baseline <- env_chr("REVDEP2_BASELINE_DIR")
 history <- scan_history(
   # A retried run donates its own baseline, and the two offline hooks bypass
   # discovery entirely; the walk then only looks for prebuilt libraries.
-  want_baseline = !refresh_baseline && !nzchar(local_baseline) && !nzchar(retry_run),
+  want_baseline = !refresh_baseline &&
+    !nzchar(local_baseline) &&
+    !nzchar(retry_run),
   needed = universe
 )
 
@@ -372,7 +431,13 @@ if (refresh_baseline) {
       entries,
       vapply(entries, function(e) e$package, character(1))
     )
-    inform("Baseline from ", local_baseline, " (", length(baseline_manifest), " entries)")
+    inform(
+      "Baseline from ",
+      local_baseline,
+      " (",
+      length(baseline_manifest),
+      " entries)"
+    )
   }
 } else {
   donor <- if (nzchar(retry_run)) retry_run else history$baseline_run
@@ -382,7 +447,11 @@ if (refresh_baseline) {
     dir <- fetch_artifact(donor, "revdep2-baseline", tempfile("baseline-"))
     manifest_path <- if (is.null(dir)) NULL else file.path(dir, "baseline.json")
     if (is.null(manifest_path) || !file.exists(manifest_path)) {
-      inform("Baseline artifact of run ", donor, " is unavailable; reusing nothing")
+      inform(
+        "Baseline artifact of run ",
+        donor,
+        " is unavailable; reusing nothing"
+      )
     } else {
       baseline_run <- as.integer(donor)
       entries <- read_json(manifest_path)
@@ -390,7 +459,13 @@ if (refresh_baseline) {
         entries,
         vapply(entries, function(e) e$package, character(1))
       )
-      inform("Baseline donor: run ", donor, " (", length(baseline_manifest), " entries)")
+      inform(
+        "Baseline donor: run ",
+        donor,
+        " (",
+        length(baseline_manifest),
+        " entries)"
+      )
     }
   }
 }
@@ -431,8 +506,11 @@ reuse <- verdicts == "reuse"
 if (baseline_run > 0) {
   stale <- table(verdicts[!reuse])
   inform(
-    "Baseline: ", sum(reuse), " reusable, ",
-    sum(!reuse), " to check fresh",
+    "Baseline: ",
+    sum(reuse),
+    " reusable, ",
+    sum(!reuse),
+    " to check fresh",
     if (length(stale) > 0) {
       paste0(" (", paste(names(stale), stale, sep = ": ", collapse = ", "), ")")
     } else {
@@ -451,8 +529,13 @@ prebuilt <- history$prebuilt
 prebuilt_covered <- length(universe) - length(history$missing)
 if (length(prebuilt) > 0) {
   inform(
-    "Prebuilt libraries: ", prebuilt_covered, " of ", length(universe),
-    " packages from ", length(prebuilt), " run(s) (",
+    "Prebuilt libraries: ",
+    prebuilt_covered,
+    " of ",
+    length(universe),
+    " packages from ",
+    length(prebuilt),
+    " run(s) (",
     paste(
       vapply(
         prebuilt,
@@ -464,7 +547,9 @@ if (length(prebuilt) > 0) {
     ")"
   )
 } else if (max_prebuilt_runs > 0) {
-  inform("No reusable prebuilt package library found; everything is installed fresh")
+  inform(
+    "No reusable prebuilt package library found; everything is installed fresh"
+  )
 }
 
 # Weight: one check of the revdep costs about what CRAN's Linux machine spends
@@ -479,7 +564,10 @@ k <- max(1L, min(as.integer(ceiling(total_check / budget)), max_shards, n))
 inform(
   sprintf(
     "%d packages, ~%.0f check minutes, budget %.0f min/shard -> %d shard(s)",
-    n, total_check, budget, k
+    n,
+    total_check,
+    budget,
+    k
   )
 )
 
@@ -617,7 +705,11 @@ matrix <- list(
   include = lapply(shard_list, function(s) {
     list(
       shard = s$index,
-      label = sprintf("%d pkgs, ~%.0f min", length(s$packages), s$estimate_minutes)
+      label = sprintf(
+        "%d pkgs, ~%.0f min",
+        length(s$packages),
+        s$estimate_minutes
+      )
     )
   })
 )
@@ -638,8 +730,14 @@ top <- function(s) {
 summary_df <- data.frame(
   Shard = vapply(shard_list, function(s) s$index, integer(1)),
   Packages = vapply(shard_list, function(s) length(s$packages), integer(1)),
-  `Check est.` = sprintf("~%.0f min", vapply(shard_list, function(s) s$check_minutes, numeric(1))),
-  `Total est.` = sprintf("~%.0f min", vapply(shard_list, function(s) s$estimate_minutes, numeric(1))),
+  `Check est.` = sprintf(
+    "~%.0f min",
+    vapply(shard_list, function(s) s$check_minutes, numeric(1))
+  ),
+  `Total est.` = sprintf(
+    "~%.0f min",
+    vapply(shard_list, function(s) s$estimate_minutes, numeric(1))
+  ),
   Installs = vapply(shard_list, function(s) s$install_packages, integer(1)),
   Heaviest = vapply(shard_list, top, character(1)),
   check.names = FALSE

--- a/.github/workflows/revdep2/preflight.R
+++ b/.github/workflows/revdep2/preflight.R
@@ -22,7 +22,10 @@
 #   LIB_INDEX_OUT - where a copy of lib.json alone lands, for the small
 #                   artifact a later plan reads without the tar
 
-source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
+source(file.path(
+  dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))),
+  "util.R"
+))
 
 plan <- read_json(env_chr("PLAN", "plan.json"))
 out_dir <- env_chr("OUT_DIR", "preflight")
@@ -38,7 +41,11 @@ failures <- list()
 # package whose version changed has to be built after all -- but everything
 # unchanged is now already there, and is skipped.
 restored <- restore_prebuilt(plan, lib, install_union)
-inform("Preflight: ", length(restored), " package(s) restored from earlier runs")
+inform(
+  "Preflight: ",
+  length(restored),
+  " package(s) restored from earlier runs"
+)
 
 # With a restored library, `upgrade = FALSE` would freeze whatever version the
 # donor happened to hold; the plan's dependency fingerprints are computed from
@@ -131,12 +138,18 @@ for (chunk in chunks) {
 # mode reuse introduces, and it is cheap to undo.
 stale <- intersect(names(load_failures), restored)
 if (length(stale) > 0) {
-  inform("Preflight: rebuilding ", length(stale), " restored package(s) that would not load")
+  inform(
+    "Preflight: rebuilding ",
+    length(stale),
+    " restored package(s) that would not load"
+  )
   unlink(file.path(lib, stale), recursive = TRUE)
   for (p in stale) {
     tryCatch(
       pak::pkg_install(p, lib = lib, ask = FALSE, upgrade = FALSE),
-      error = function(e) inform("Could not reinstall ", p, ": ", conditionMessage(e))
+      error = function(e) {
+        inform("Could not reinstall ", p, ": ", conditionMessage(e))
+      }
     )
   }
   for (p in stale) {
@@ -167,7 +180,11 @@ lib_out <- env_chr("LIB_OUT")
 index_out <- env_chr("LIB_INDEX_OUT")
 packed <- character()
 if (nzchar(lib_out)) {
-  packed <- pack_library(lib, lib_out, if (nzchar(index_out)) index_out else NULL)
+  packed <- pack_library(
+    lib,
+    lib_out,
+    if (nzchar(index_out)) index_out else NULL
+  )
   inform("Preflight: published ", length(packed), " package(s) for later runs")
 }
 

--- a/.github/workflows/revdep2/preflight.R
+++ b/.github/workflows/revdep2/preflight.R
@@ -11,9 +11,16 @@
 # its own check with an install log, which is the result a report can work
 # with.
 #
+# The library this job ends up with is also the run's contribution to the next
+# one: it is packed into the revdep2-lib artifact, which later runs unpack
+# instead of building the same packages again (see util.R).
+#
 # Environment variables:
-#   PLAN     - plan.json from plan.R (default: plan.json)
-#   OUT_DIR  - where depfail.json lands (default: preflight)
+#   PLAN       - plan.json from plan.R (default: plan.json)
+#   OUT_DIR    - where depfail.json lands (default: preflight)
+#   LIB_OUT    - where library.tar and lib.json land; empty skips packing
+#   LIB_INDEX_OUT - where a copy of lib.json alone lands, for the small
+#                   artifact a later plan reads without the tar
 
 source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
 
@@ -26,10 +33,22 @@ lib <- file.path(env_chr("RUNNER_TEMP", tempdir()), "revdep2-preflight-lib")
 dir.create(lib, recursive = TRUE, showWarnings = FALSE)
 failures <- list()
 
+# What earlier runs already built, unpacked before pak sees the library. pak
+# still resolves the whole union afterwards -- CRAN moves between runs, and a
+# package whose version changed has to be built after all -- but everything
+# unchanged is now already there, and is skipped.
+restored <- restore_prebuilt(plan, lib, install_union)
+inform("Preflight: ", length(restored), " package(s) restored from earlier runs")
+
+# With a restored library, `upgrade = FALSE` would freeze whatever version the
+# donor happened to hold; the plan's dependency fingerprints are computed from
+# CRAN *now*, so the library has to follow CRAN now.
+upgrade <- length(restored) > 0
+
 inform("Preflight: installing ", length(install_union), " packages")
 installed_ok <- tryCatch(
   {
-    pak::pkg_install(install_union, lib = lib, ask = FALSE)
+    pak::pkg_install(install_union, lib = lib, ask = FALSE, upgrade = upgrade)
     TRUE
   },
   error = function(e) {
@@ -46,7 +65,7 @@ if (!installed_ok) {
     }
     result <- tryCatch(
       {
-        pak::pkg_install(p, lib = lib, ask = FALSE)
+        pak::pkg_install(p, lib = lib, ask = FALSE, upgrade = upgrade)
         NULL
       },
       error = function(e) conditionMessage(e)
@@ -88,6 +107,7 @@ load_batch <- function(pkgs) {
   loaded <- sub("^LOADED ", "", grep("^LOADED ", out, value = TRUE))
   list(failed = setdiff(pkgs, loaded), log = out)
 }
+load_failures <- list()
 chunks <- split(installed, ceiling(seq_along(installed) / 40))
 for (chunk in chunks) {
   first <- load_batch(chunk)
@@ -97,16 +117,59 @@ for (chunk in chunks) {
   for (p in first$failed) {
     single <- load_batch(p)
     if (length(single$failed) > 0) {
-      failures[[length(failures) + 1]] <- list(
-        package = p,
-        phase = "load",
-        message = paste(utils::tail(sanitize_log(single$log), 20), collapse = "\n")
+      load_failures[[p]] <- paste(
+        utils::tail(sanitize_log(single$log), 20),
+        collapse = "\n"
       )
     }
   }
 }
 
+# A restored package that will not load is a stale binary, not a broken
+# package: the runner image moved under it. Throw it away, let pak build it
+# from source, and judge it on the second attempt -- this is the one failure
+# mode reuse introduces, and it is cheap to undo.
+stale <- intersect(names(load_failures), restored)
+if (length(stale) > 0) {
+  inform("Preflight: rebuilding ", length(stale), " restored package(s) that would not load")
+  unlink(file.path(lib, stale), recursive = TRUE)
+  for (p in stale) {
+    tryCatch(
+      pak::pkg_install(p, lib = lib, ask = FALSE, upgrade = FALSE),
+      error = function(e) inform("Could not reinstall ", p, ": ", conditionMessage(e))
+    )
+  }
+  for (p in stale) {
+    retried <- load_batch(p)
+    if (length(retried$failed) == 0) {
+      load_failures[[p]] <- NULL
+    } else {
+      load_failures[[p]] <- paste(
+        utils::tail(sanitize_log(retried$log), 20),
+        collapse = "\n"
+      )
+    }
+  }
+}
+for (p in names(load_failures)) {
+  failures[[length(failures) + 1]] <- list(
+    package = p,
+    phase = "load",
+    message = load_failures[[p]]
+  )
+}
+
 write_json(failures, file.path(out_dir, "depfail.json"))
+
+# ------------------------------------------------------------------ library --
+
+lib_out <- env_chr("LIB_OUT")
+index_out <- env_chr("LIB_INDEX_OUT")
+packed <- character()
+if (nzchar(lib_out)) {
+  packed <- pack_library(lib, lib_out, if (nzchar(index_out)) index_out else NULL)
+  inform("Preflight: published ", length(packed), " package(s) for later runs")
+}
 
 append_summary(c(
   "## revdep2 preflight",
@@ -114,6 +177,13 @@ append_summary(c(
   sprintf(
     "Installed and loaded %d dependencies: %d could not be installed or loaded.",
     length(install_union), length(failures)
+  ),
+  "",
+  sprintf(
+    "%d package(s) came prebuilt from earlier runs%s; %d are published for the next one.",
+    length(restored),
+    if (length(stale) > 0) sprintf(" (%d rebuilt after failing to load)", length(stale)) else "",
+    length(packed)
   ),
   ""
 ))

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -17,6 +17,10 @@
 # an old-version result whose new-version counterpart was cut off -- are still
 # uploaded, so nothing decided is lost to the deadline.
 #
+# Before installing anything, the shard unpacks the prebuilt dependencies the
+# plan found on earlier runs (see util.R); pak then only has to build what
+# CRAN has changed since.
+#
 # Environment variables:
 #   SHARD                  - shard index from plan.json (required)
 #   PLAN                   - plan file (default: plan.json)
@@ -107,10 +111,23 @@ counts <- function(x) {
 # ---------------------------------------------------------------- install ----
 
 install <- unlist(shard$install, use.names = FALSE)
+
+# What earlier runs already built, unpacked into the library pak installs
+# into. pak still resolves the whole set afterwards -- CRAN moves between
+# runs, and a package whose version changed has to be built anyway -- but
+# everything unchanged is already there, and is skipped.
+restored <- restore_prebuilt(plan, .libPaths()[[1]], install)
+inform(length(restored), " dependency binaries restored from earlier runs")
+
+# With a restored library, `upgrade = FALSE` would freeze whatever version the
+# donor happened to hold; the plan's dependency fingerprints are computed from
+# CRAN *now*, so the library has to follow CRAN now.
+upgrade <- length(restored) > 0
+
 inform("Installing ", length(install), " dependencies")
 bulk_ok <- tryCatch(
   {
-    pak::pkg_install(install, ask = FALSE)
+    pak::pkg_install(install, ask = FALSE, upgrade = upgrade)
     TRUE
   },
   error = function(e) {
@@ -124,7 +141,7 @@ if (!bulk_ok) {
       next
     }
     tryCatch(
-      pak::pkg_install(p, ask = FALSE),
+      pak::pkg_install(p, ask = FALSE, upgrade = upgrade),
       error = function(e) inform("Could not install ", p, ": ", conditionMessage(e))
     )
   }

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -17,14 +17,16 @@
 # an old-version result whose new-version counterpart was cut off -- are still
 # uploaded, so nothing decided is lost to the deadline.
 #
-# Before installing anything, the shard unpacks the prebuilt dependencies the
-# plan found on earlier runs (see util.R); pak then only has to build what
-# CRAN has changed since.
+# Before installing anything, the shard unpacks prebuilt dependencies (see
+# util.R): this run's preflight library, and then the earlier runs the plan
+# picked. pak only has to build what neither of them had.
 #
 # Environment variables:
 #   SHARD                  - shard index from plan.json (required)
 #   PLAN                   - plan file (default: plan.json)
 #   PKG_DIR                - the revdep2-pkg artifact: meta.json, bin/ (required)
+#   LIB_DIR                - the revdep2-lib artifact of *this* run: the
+#                            preflight's library; may be missing or empty
 #   BASELINE_DIR           - the revdep2-baseline artifact of the donor run;
 #                            may be missing or empty, then everything is fresh
 #   OUT_DIR                - results directory, uploaded as the shard artifact
@@ -123,12 +125,23 @@ counts <- function(x) {
 
 install <- unlist(shard$install, use.names = FALSE)
 
-# What earlier runs already built, unpacked into the library pak installs
-# into. pak still resolves the whole set afterwards -- CRAN moves between
-# runs, and a package whose version changed has to be built anyway -- but
-# everything unchanged is already there, and is skipped.
-restored <- restore_prebuilt(plan, .libPaths()[[1]], install)
-inform(length(restored), " dependency binaries restored from earlier runs")
+# What is already built, unpacked into the library pak installs into: this
+# run's own preflight library first -- it is the freshest there is, and
+# without it every shard would rebuild what the preflight compiled minutes
+# ago -- then the earlier runs the plan picked, for whatever the preflight
+# could not supply. pak still resolves the whole set afterwards; the point is
+# to skip *building* what has not changed, not to skip resolving it.
+lib <- .libPaths()[[1]]
+restored <- c(
+  restore_local_library(env_chr("LIB_DIR"), lib, install),
+  restore_prebuilt(plan, lib, install)
+)
+inform(
+  length(restored),
+  " dependency binaries restored, ",
+  length(install) - length(restored),
+  " left to pak"
+)
 
 # With a restored library, `upgrade = FALSE` would freeze whatever version the
 # donor happened to hold; the plan's dependency fingerprints are computed from

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -35,7 +35,10 @@
 #                            these runners (default: 10)
 #   DEADLINE_MINUTES       - stop starting new checks past this (default: 300)
 
-source(file.path(dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))), "util.R"))
+source(file.path(
+  dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))),
+  "util.R"
+))
 
 shard_index <- as.integer(env_chr("SHARD"))
 stopifnot(!is.na(shard_index))
@@ -59,8 +62,14 @@ work <- file.path(env_chr("RUNNER_TEMP", tempdir()), "revdep2-work")
 dir.create(work, recursive = TRUE, showWarnings = FALSE)
 
 inform(
-  "Shard ", shard_index, ": ", length(members), " package(s), ",
-  "estimated ~", shard$estimate_minutes, " min"
+  "Shard ",
+  shard_index,
+  ": ",
+  length(members),
+  " package(s), ",
+  "estimated ~",
+  shard$estimate_minutes,
+  " min"
 )
 
 # The running state per package; every entry ends up as one manifest line.
@@ -104,7 +113,9 @@ counts <- function(x) {
   }
   sprintf(
     "%dE %dW %dN",
-    length(x$errors), length(x$warnings), length(x$notes)
+    length(x$errors),
+    length(x$warnings),
+    length(x$notes)
   )
 }
 
@@ -142,28 +153,36 @@ if (!bulk_ok) {
     }
     tryCatch(
       pak::pkg_install(p, ask = FALSE, upgrade = upgrade),
-      error = function(e) inform("Could not install ", p, ": ", conditionMessage(e))
+      error = function(e) {
+        inform("Could not install ", p, ": ", conditionMessage(e))
+      }
     )
   }
 }
 
 installed <- rownames(utils::installed.packages())
 our_version <- function() {
-  tryCatch(as.character(utils::packageVersion(package)), error = function(e) NA_character_)
+  tryCatch(as.character(utils::packageVersion(package)), error = function(e) {
+    NA_character_
+  })
 }
 our_cran_version <- our_version()
 if (!identical(our_cran_version, plan$cran_version)) {
   # The library must hold the *CRAN release* for the old phase; the resolver
   # may have kept some other version it found satisfactory.
   inform(
-    "Installed version is ", our_cran_version, ", plan expected ",
-    plan$cran_version, "; reinstalling from the repositories"
+    "Installed version is ",
+    our_cran_version,
+    ", plan expected ",
+    plan$cran_version,
+    "; reinstalling from the repositories"
   )
   utils::install.packages(package)
   our_cran_version <- our_version()
   if (!identical(our_cran_version, plan$cran_version)) {
     inform(
-      "Note: old checks run against ", our_cran_version,
+      "Note: old checks run against ",
+      our_cran_version,
       " (the repositories lag CRAN)"
     )
   }
@@ -174,7 +193,12 @@ if (!identical(our_cran_version, plan$cran_version)) {
 # with _R_CHECK_FORCE_SUGGESTS_=false, the way CRAN treats unavailable ones.
 db <- cran_db()
 strong_missing <- function(name) {
-  strong <- tools::package_dependencies(name, db = db, which = "strong", recursive = TRUE)[[1]]
+  strong <- tools::package_dependencies(
+    name,
+    db = db,
+    which = "strong",
+    recursive = TRUE
+  )[[1]]
   setdiff(intersect(strong, rownames(db)), c(installed, base_packages()))
 }
 runnable <- character()
@@ -184,9 +208,17 @@ for (name in members) {
     update(
       name,
       result = "depfail",
-      message = paste("Dependencies not installed:", paste(missing, collapse = ", "))
+      message = paste(
+        "Dependencies not installed:",
+        paste(missing, collapse = ", ")
+      )
     )
-    inform(name, ": dependencies missing (", paste(missing, collapse = ", "), ")")
+    inform(
+      name,
+      ": dependencies missing (",
+      paste(missing, collapse = ", "),
+      ")"
+    )
   } else {
     runnable <- c(runnable, name)
   }
@@ -212,11 +244,19 @@ for (name in runnable) {
     error = function(e) NULL
   )
   if (is.null(tarball)) {
-    update(name, result = "error", message = "Source tarball could not be downloaded")
+    update(
+      name,
+      result = "error",
+      message = "Source tarball could not be downloaded"
+    )
     inform(name, ": source download failed")
   } else {
     sources[[name]] <- tarball
-    actual <- sub(sprintf("^%s_(.*)[.]tar[.]gz$", name), "\\1", basename(tarball))
+    actual <- sub(
+      sprintf("^%s_(.*)[.]tar[.]gz$", name),
+      "\\1",
+      basename(tarball)
+    )
     update(name, version = actual)
   }
 }
@@ -263,7 +303,8 @@ run_check <- function(name, phase) {
   # A check that hits the timeout is killed, and rcmdcheck surfaces that as an
   # error rather than a result object; tell it apart from a genuine crash by
   # the clock.
-  attr(result, "timed_out") <- inherits(result, "error") && duration >= timeout_sec - 1
+  attr(result, "timed_out") <- inherits(result, "error") &&
+    duration >= timeout_sec - 1
   result
 }
 
@@ -273,10 +314,19 @@ check_failure <- function(name, phase, result) {
       name,
       result = "failed",
       message = sprintf(
-        "%s check timed out after %ds", phase, attr(result, "duration")
+        "%s check timed out after %ds",
+        phase,
+        attr(result, "duration")
       )
     )
-    inform(name, ": ", phase, " check timed out (", attr(result, "duration"), "s)")
+    inform(
+      name,
+      ": ",
+      phase,
+      " check timed out (",
+      attr(result, "duration"),
+      "s)"
+    )
   } else {
     update(name, result = "error", message = conditionMessage(result))
     inform(name, ": ", phase, " check errored: ", conditionMessage(result))
@@ -372,7 +422,12 @@ for (name in runnable) {
     error = function(e) NULL
   )
   if (is.null(cmp)) {
-    update(name, result = "failed", status_new = counts(new), t_new = attr(new, "duration"))
+    update(
+      name,
+      result = "failed",
+      status_new = counts(new),
+      t_new = attr(new, "duration")
+    )
   } else {
     new_issues <- sum(cmp$cmp$change == 1)
     update(
@@ -386,9 +441,16 @@ for (name in runnable) {
   }
   entry <- get(name, envir = state)
   inform(
-    name, ": ", entry$result,
-    " (old ", entry$status_old, ", new ", entry$status_new,
-    ", ", attr(new, "duration"), "s)"
+    name,
+    ": ",
+    entry$result,
+    " (old ",
+    entry$status_old,
+    ", new ",
+    entry$status_new,
+    ", ",
+    attr(new, "duration"),
+    "s)"
   )
 
   # The parsed results carry everything the reports need; raw check output is
@@ -472,6 +534,8 @@ for (entry in entries) {
 }
 
 inform(
-  "Shard ", shard_index, " done: ",
+  "Shard ",
+  shard_index,
+  " done: ",
   paste(names(table(results)), table(results), sep = "=", collapse = ", ")
 )

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -320,6 +320,76 @@ pack_library <- function(lib, dest, index_dest = NULL) {
   names(versions)
 }
 
+# The packages of `lib` a caller may still want: everything not already
+# installed there, and nothing this session has loaded -- a package must never
+# be overwritten underneath the driver that is using it.
+missing_from <- function(lib, wanted) {
+  setdiff(
+    unique(unlist(wanted, use.names = FALSE)),
+    c(list.dirs(lib, full.names = FALSE, recursive = FALSE), loadedNamespaces())
+  )
+}
+
+# Extract `take` out of a packed library into `lib`, and report what landed.
+unpack_library <- function(tarball, lib, take) {
+  dir.create(lib, recursive = TRUE, showWarnings = FALSE)
+  members <- tempfile("members-")
+  writeLines(take, members)
+  on.exit(unlink(members))
+  # A member the index promised but the tar does not hold makes tar exit
+  # non-zero after extracting the rest; what actually landed is the answer, so
+  # the status is not consulted.
+  system2(
+    "tar",
+    # Quoted: system2() quotes the command, but not the arguments.
+    shQuote(c("-xf", tarball, "-C", lib, "-T", members)),
+    stdout = NULL,
+    stderr = NULL
+  )
+  got <- intersect(take, list.dirs(lib, full.names = FALSE, recursive = FALSE))
+  # A half-extracted package directory is worse than none: drop anything
+  # without a DESCRIPTION and let pak install it properly.
+  broken <- got[!file.exists(file.path(lib, got, "DESCRIPTION"))]
+  if (length(broken) > 0) {
+    unlink(file.path(lib, broken), recursive = TRUE)
+    inform("Prebuilt: discarded ", length(broken), " incomplete package(s)")
+  }
+  setdiff(got, broken)
+}
+
+# Unpack a library artifact this job already has on disk -- in practice this
+# run's own preflight library, handed to the shards through the workflow.
+#
+# This is the reuse that pays on the very first run: without it every shard
+# rebuilds from source what the preflight of the same run compiled minutes
+# earlier, once per shard.
+restore_local_library <- function(dir, lib, wanted) {
+  tarball <- file.path(dir, "library.tar")
+  if (!nzchar(dir) || !file.exists(tarball)) {
+    return(character())
+  }
+  take <- missing_from(lib, wanted)
+  index <- file.path(dir, "lib.json")
+  if (file.exists(index)) {
+    have <- vapply(
+      read_json(index)$packages,
+      function(e) e$package,
+      character(1)
+    )
+    take <- intersect(take, have)
+  }
+  if (length(take) == 0) {
+    return(character())
+  }
+  got <- unpack_library(tarball, lib, take)
+  inform(
+    "Prebuilt: restored ",
+    length(got),
+    " package(s) from this run's preflight"
+  )
+  got
+}
+
 # Unpack what earlier runs already built into `lib`, taking only the packages
 # in `wanted` that are not there yet.
 #
@@ -330,23 +400,16 @@ pack_library <- function(lib, dest, index_dest = NULL) {
 # skip resolving it.
 restore_prebuilt <- function(plan, lib, wanted) {
   donors <- plan$prebuilt$runs %||% list()
-  wanted <- unique(unlist(wanted, use.names = FALSE))
-  if (length(donors) == 0 || length(wanted) == 0) {
+  if (length(donors) == 0 || length(unlist(wanted)) == 0) {
     return(character())
   }
   dir.create(lib, recursive = TRUE, showWarnings = FALSE)
-  present <- function() {
-    list.dirs(lib, full.names = FALSE, recursive = FALSE)
-  }
   restored <- character()
   for (donor in donors) {
     run_id <- as.character(donor$run_id)
-    # Whatever is in the library already stays, and so does anything this
-    # session has loaded: a package must never be overwritten underneath the
-    # driver that is using it. A younger donor has priority over an older one.
-    take <- setdiff(
-      intersect(unlist(donor$packages, use.names = FALSE), wanted),
-      c(present(), loadedNamespaces())
+    take <- intersect(
+      unlist(donor$packages, use.names = FALSE),
+      missing_from(lib, wanted)
     )
     if (length(take) == 0) {
       next
@@ -359,31 +422,12 @@ restore_prebuilt <- function(plan, lib, wanted) {
       unlink(dir, recursive = TRUE)
       next
     }
-    members <- tempfile("members-")
-    writeLines(take, members)
-    # A member the index promised but the tar does not hold makes tar exit
-    # non-zero after extracting the rest; what actually landed is the answer,
-    # so the status is not consulted.
-    system2(
-      "tar",
-      # Quoted: system2() quotes the command, but not the arguments.
-      shQuote(c("-xf", tarball, "-C", lib, "-T", members)),
-      stdout = NULL,
-      stderr = NULL
-    )
-    unlink(c(dir, members), recursive = TRUE)
-    got <- intersect(take, present())
+    got <- unpack_library(tarball, lib, take)
+    unlink(dir, recursive = TRUE)
     restored <- c(restored, got)
     inform("Prebuilt: restored ", length(got), " package(s) from run ", run_id)
   }
-  # A half-extracted package directory is worse than none: drop anything
-  # without a DESCRIPTION and let pak install it properly.
-  broken <- restored[!file.exists(file.path(lib, restored, "DESCRIPTION"))]
-  if (length(broken) > 0) {
-    unlink(file.path(lib, broken), recursive = TRUE)
-    inform("Prebuilt: discarded ", length(broken), " incomplete package(s)")
-  }
-  setdiff(restored, broken)
+  restored
 }
 
 # ------------------------------------------------------------ CRAN metadata --

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -69,7 +69,9 @@ md_table <- function(df) {
   rule <- paste0("|", paste(rep(" --- ", ncol(df)), collapse = "|"), "|")
   rows <- vapply(
     seq_len(nrow(df)),
-    function(i) paste0("| ", paste(esc(unlist(df[i, ])), collapse = " | "), " |"),
+    function(i) {
+      paste0("| ", paste(esc(unlist(df[i, ])), collapse = " | "), " |")
+    },
     character(1)
   )
   c(header, rule, rows)
@@ -86,7 +88,10 @@ md_details <- function(title, lines, max_lines = 80) {
   lines <- sanitize_log(lines)
   omitted <- character()
   if (length(lines) > max_lines) {
-    omitted <- sprintf("... (%d earlier lines omitted)", length(lines) - max_lines)
+    omitted <- sprintf(
+      "... (%d earlier lines omitted)",
+      length(lines) - max_lines
+    )
     lines <- utils::tail(lines, max_lines)
   }
   c(
@@ -114,7 +119,8 @@ gh_repo <- function() {
 }
 
 gh_ok <- function() {
-  nzchar(Sys.which("gh")) && nzchar(env_chr("GH_TOKEN", env_chr("GITHUB_TOKEN")))
+  nzchar(Sys.which("gh")) &&
+    nzchar(env_chr("GH_TOKEN", env_chr("GITHUB_TOKEN")))
 }
 
 # `gh`, with its arguments quoted for the shell: system2() quotes the command
@@ -145,7 +151,11 @@ run_artifacts <- function(run_id) {
   }
   out <- gh_lines(
     "api",
-    sprintf("repos/%s/actions/runs/%s/artifacts?per_page=100", gh_repo(), run_id),
+    sprintf(
+      "repos/%s/actions/runs/%s/artifacts?per_page=100",
+      gh_repo(),
+      run_id
+    ),
     "--jq",
     ".artifacts[] | select(.expired == false) | [.name, .id] | @tsv"
   )
@@ -169,7 +179,12 @@ unzip_into <- function(zip, dest) {
     status <- tryCatch(
       suppressWarnings(
         # Quoted: system2() quotes the command, but not the arguments.
-        system2("unzip", shQuote(c("-q", "-o", zip, "-d", dest)), stdout = NULL, stderr = NULL)
+        system2(
+          "unzip",
+          shQuote(c("-q", "-o", zip, "-d", dest)),
+          stdout = NULL,
+          stderr = NULL
+        )
       ),
       error = function(e) 1L
     )
@@ -250,18 +265,27 @@ pack_library <- function(lib, dest, index_dest = NULL) {
   index <- list(
     run_id = env_chr("GITHUB_RUN_ID"),
     created_at = now_utc(),
-    r_version = paste(R.version$major, sub("[.].*$", "", R.version$minor), sep = "."),
+    r_version = paste(
+      R.version$major,
+      sub("[.].*$", "", R.version$minor),
+      sep = "."
+    ),
     platform = R.version$platform,
     count = length(versions),
     packages = unname(Map(
       function(p, v) list(package = p, version = unname(v)),
-      names(versions), versions
+      names(versions),
+      versions
     ))
   )
   write_json(index, file.path(dest, "lib.json"))
   if (!is.null(index_dest)) {
     dir.create(index_dest, recursive = TRUE, showWarnings = FALSE)
-    file.copy(file.path(dest, "lib.json"), file.path(index_dest, "lib.json"), overwrite = TRUE)
+    file.copy(
+      file.path(dest, "lib.json"),
+      file.path(index_dest, "lib.json"),
+      overwrite = TRUE
+    )
   }
   if (length(versions) == 0) {
     inform("Nothing to pack: ", lib, " holds no installed packages")
@@ -282,8 +306,16 @@ pack_library <- function(lib, dest, index_dest = NULL) {
     return(character())
   }
   inform(
-    "Packed ", length(versions), " package(s) into ", basename(tarball),
-    " (", format(structure(file.size(tarball), class = "object_size"), units = "auto"), ")"
+    "Packed ",
+    length(versions),
+    " package(s) into ",
+    basename(tarball),
+    " (",
+    format(
+      structure(file.size(tarball), class = "object_size"),
+      units = "auto"
+    ),
+    ")"
   )
   names(versions)
 }

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -102,6 +102,258 @@ md_details <- function(title, lines, max_lines = 80) {
   )
 }
 
+# --------------------------------------------------------- gh and artifacts --
+
+# The plan resolves donor runs through the API, and the preflight and the
+# shards fetch artifacts off them. Everything here is an optimization: a
+# missing gh, a token without `actions: read`, an expired artifact, a network
+# hiccup -- all of them have to end as "reuse nothing", never as a failure.
+
+gh_repo <- function() {
+  env_chr("GITHUB_REPOSITORY")
+}
+
+gh_ok <- function() {
+  nzchar(Sys.which("gh")) && nzchar(env_chr("GH_TOKEN", env_chr("GITHUB_TOKEN")))
+}
+
+# `gh`, with its arguments quoted for the shell: system2() quotes the command
+# but hands the arguments to `sh` as written, and these carry `?`, `&`, `|`,
+# quotes and spaces. Unquoted, an API path ends at its first `&`, and what
+# follows becomes a second command the shell cannot find.
+#
+# Every failure becomes NULL, including the ones system2() raises instead of
+# returning: a command the shell cannot run exits 127, which `stdout = TRUE`
+# turns into an R error rather than a status.
+gh_lines <- function(...) {
+  out <- tryCatch(
+    suppressWarnings(
+      system2("gh", shQuote(c(...)), stdout = TRUE, stderr = NULL)
+    ),
+    error = function(e) NULL
+  )
+  status <- attr(out, "status")
+  if (is.null(out) || (!is.null(status) && status != 0)) NULL else out
+}
+
+# The unexpired artifacts of one run, as a named character vector of ids;
+# empty when the run has none or when gh cannot say. One API call per run, so
+# a walk over the run history calls this once per run and asks it everything.
+run_artifacts <- function(run_id) {
+  if (!gh_ok() || !nzchar(gh_repo())) {
+    return(character())
+  }
+  out <- gh_lines(
+    "api",
+    sprintf("repos/%s/actions/runs/%s/artifacts?per_page=100", gh_repo(), run_id),
+    "--jq",
+    ".artifacts[] | select(.expired == false) | [.name, .id] | @tsv"
+  )
+  out <- out[nzchar(out)]
+  if (length(out) == 0) {
+    return(character())
+  }
+  parts <- strsplit(out, "\t", fixed = TRUE)
+  stats::setNames(
+    vapply(parts, function(p) p[[2]], character(1)),
+    vapply(parts, function(p) p[[1]], character(1))
+  )
+}
+
+# utils::unzip() refuses archives above 4 GB, which a library artifact reaches
+# without trying; the system unzip has no such limit, so prefer it and keep
+# the internal one for a runner without it.
+unzip_into <- function(zip, dest) {
+  dir.create(dest, recursive = TRUE, showWarnings = FALSE)
+  if (nzchar(Sys.which("unzip"))) {
+    status <- tryCatch(
+      suppressWarnings(
+        # Quoted: system2() quotes the command, but not the arguments.
+        system2("unzip", shQuote(c("-q", "-o", zip, "-d", dest)), stdout = NULL, stderr = NULL)
+      ),
+      error = function(e) 1L
+    )
+    return(identical(as.integer(status), 0L))
+  }
+  # A gh that wrote an error body instead of the artifact leaves something
+  # that is not a zip; that is a missing artifact, not a usable one.
+  extracted <- tryCatch(
+    suppressWarnings(utils::unzip(zip, exdir = dest)),
+    error = function(e) character()
+  )
+  length(extracted) > 0
+}
+
+# Download one artifact by id into a directory; NULL when it cannot be had.
+fetch_artifact_id <- function(id, dest) {
+  if (!gh_ok() || !nzchar(gh_repo())) {
+    return(NULL)
+  }
+  zip <- tempfile(fileext = ".zip")
+  # Quoted: system2() quotes the command, but not the arguments.
+  args <- shQuote(c("api", sprintf("repos/%s/actions/artifacts/%s/zip", gh_repo(), id)))
+  status <- tryCatch(
+    suppressWarnings(system2("gh", args, stdout = zip, stderr = NULL)),
+    error = function(e) 1L
+  )
+  if (!identical(as.integer(status), 0L) || !file.exists(zip)) {
+    unlink(zip)
+    return(NULL)
+  }
+  ok <- unzip_into(zip, dest)
+  unlink(zip)
+  if (ok) dest else NULL
+}
+
+# Fetch one named artifact of one run; NULL when the run does not have it, it
+# has expired, or it cannot be downloaded.
+fetch_artifact <- function(run_id, name, dest) {
+  ids <- run_artifacts(run_id)
+  id <- unname(ids[names(ids) == name])
+  if (length(id) == 0) {
+    return(NULL)
+  }
+  fetch_artifact_id(id[[1]], dest)
+}
+
+# ------------------------------------------------------ prebuilt libraries --
+
+# A run's installed dependency library, carried to the next run as an
+# artifact: one tar of the package directories, plus the index a later plan
+# reads to decide which packages that run is good for.
+#
+# The tar is stored uncompressed on purpose -- upload-artifact zips what it
+# uploads, and deflating a few gigabytes twice buys nothing. Packing the
+# directories by name (rather than the library itself) keeps the member paths
+# at `<package>/...`, which is what a partial extraction asks for.
+
+# Package directories of `lib` that look installed, with their versions.
+library_versions <- function(lib) {
+  pkgs <- list.dirs(lib, full.names = FALSE, recursive = FALSE)
+  pkgs <- pkgs[file.exists(file.path(lib, pkgs, "DESCRIPTION"))]
+  versions <- vapply(
+    pkgs,
+    function(p) {
+      tryCatch(
+        unname(read.dcf(file.path(lib, p, "DESCRIPTION"), "Version")[1, 1]),
+        error = function(e) NA_character_
+      )
+    },
+    character(1)
+  )
+  versions[!is.na(versions)]
+}
+
+pack_library <- function(lib, dest, index_dest = NULL) {
+  versions <- library_versions(lib)
+  dir.create(dest, recursive = TRUE, showWarnings = FALSE)
+  index <- list(
+    run_id = env_chr("GITHUB_RUN_ID"),
+    created_at = now_utc(),
+    r_version = paste(R.version$major, sub("[.].*$", "", R.version$minor), sep = "."),
+    platform = R.version$platform,
+    count = length(versions),
+    packages = unname(Map(
+      function(p, v) list(package = p, version = unname(v)),
+      names(versions), versions
+    ))
+  )
+  write_json(index, file.path(dest, "lib.json"))
+  if (!is.null(index_dest)) {
+    dir.create(index_dest, recursive = TRUE, showWarnings = FALSE)
+    file.copy(file.path(dest, "lib.json"), file.path(index_dest, "lib.json"), overwrite = TRUE)
+  }
+  if (length(versions) == 0) {
+    inform("Nothing to pack: ", lib, " holds no installed packages")
+    return(character())
+  }
+  members <- tempfile("members-")
+  writeLines(names(versions), members)
+  on.exit(unlink(members))
+  tarball <- file.path(dest, "library.tar")
+  status <- system2(
+    "tar",
+    # Quoted: system2() quotes the command, but not the arguments.
+    shQuote(c("-cf", tarball, "-C", lib, "-T", members))
+  )
+  if (!identical(as.integer(status), 0L) || !file.exists(tarball)) {
+    inform("Packing ", lib, " failed; this run contributes no prebuilt library")
+    unlink(tarball)
+    return(character())
+  }
+  inform(
+    "Packed ", length(versions), " package(s) into ", basename(tarball),
+    " (", format(structure(file.size(tarball), class = "object_size"), units = "auto"), ")"
+  )
+  names(versions)
+}
+
+# Unpack what earlier runs already built into `lib`, taking only the packages
+# in `wanted` that are not there yet.
+#
+# The plan named the donor runs, youngest first, and which packages each one
+# is good for; a younger donor always wins, and a donor that has nothing left
+# to give is never downloaded. Whatever lands here is still handed to pak
+# afterwards: the point is to skip *building* what has not changed, not to
+# skip resolving it.
+restore_prebuilt <- function(plan, lib, wanted) {
+  donors <- plan$prebuilt$runs %||% list()
+  wanted <- unique(unlist(wanted, use.names = FALSE))
+  if (length(donors) == 0 || length(wanted) == 0) {
+    return(character())
+  }
+  dir.create(lib, recursive = TRUE, showWarnings = FALSE)
+  present <- function() {
+    list.dirs(lib, full.names = FALSE, recursive = FALSE)
+  }
+  restored <- character()
+  for (donor in donors) {
+    run_id <- as.character(donor$run_id)
+    # Whatever is in the library already stays, and so does anything this
+    # session has loaded: a package must never be overwritten underneath the
+    # driver that is using it. A younger donor has priority over an older one.
+    take <- setdiff(
+      intersect(unlist(donor$packages, use.names = FALSE), wanted),
+      c(present(), loadedNamespaces())
+    )
+    if (length(take) == 0) {
+      next
+    }
+    inform("Prebuilt: fetching ", length(take), " package(s) from run ", run_id)
+    dir <- fetch_artifact(run_id, "revdep2-lib", tempfile("prebuilt-"))
+    tarball <- if (is.null(dir)) NULL else file.path(dir, "library.tar")
+    if (is.null(tarball) || !file.exists(tarball)) {
+      inform("Prebuilt: run ", run_id, " no longer has a library artifact")
+      unlink(dir, recursive = TRUE)
+      next
+    }
+    members <- tempfile("members-")
+    writeLines(take, members)
+    # A member the index promised but the tar does not hold makes tar exit
+    # non-zero after extracting the rest; what actually landed is the answer,
+    # so the status is not consulted.
+    system2(
+      "tar",
+      # Quoted: system2() quotes the command, but not the arguments.
+      shQuote(c("-xf", tarball, "-C", lib, "-T", members)),
+      stdout = NULL,
+      stderr = NULL
+    )
+    unlink(c(dir, members), recursive = TRUE)
+    got <- intersect(take, present())
+    restored <- c(restored, got)
+    inform("Prebuilt: restored ", length(got), " package(s) from run ", run_id)
+  }
+  # A half-extracted package directory is worse than none: drop anything
+  # without a DESCRIPTION and let pak install it properly.
+  broken <- restored[!file.exists(file.path(lib, restored, "DESCRIPTION"))]
+  if (length(broken) > 0) {
+    unlink(file.path(lib, broken), recursive = TRUE)
+    inform("Prebuilt: discarded ", length(broken), " incomplete package(s)")
+  }
+  setdiff(restored, broken)
+}
+
 # ------------------------------------------------------------ CRAN metadata --
 
 cran_repo <- function() {


### PR DESCRIPTION
## Summary

`revdep2` currently installs its dependency universe from scratch, twice over:
the preflight installs all of it,
and then every shard installs its own union again.
Where the runner has no binaries to install from,
one package is compiled once in the preflight
and once more in each of the twenty shards — every run,
for a result identical each time.

This PR makes the preflight publish the library it installs,
and has the shards and later runs unpack it instead of rebuilding it.

## How it works

**Producing.** The preflight packs its library into `revdep2-lib`
(a single uncompressed `library.tar` — `upload-artifact` zips what it uploads,
so deflating gigabytes twice buys nothing),
next to `revdep2-lib-index`,
a small `lib.json` naming the R series, the platform and every package version.
The index is a separate artifact so a later plan can decide
what a run is good for *without* downloading the library it describes.

**Reusing within the run.** `preflight` is a `needs` of `test`,
so each shard simply downloads that artifact and unpacks what it needs
before pak runs — no history, no API, no donor resolution.
This is the half that pays on the very first run.

**Reusing across runs.** For whatever this run's preflight could not supply,
the plan walks the workflow's completed runs, youngest first,
taking libraries until they cover every package the run installs
or the history is exhausted:

* a run only donates while its index reports the same R series and platform,
  and its library is younger than `REVDEP2_PREBUILT_MAX_AGE_DAYS` (14) —
  binaries are only portable that far;
* each donor is credited only with what no younger donor already had,
  so a run that adds nothing is never downloaded;
* at most `REVDEP2_PREBUILT_MAX_RUNS` runs donate (5, `0` disables) —
  every extra donor is another full library download.

The decision lands in `plan.json` as `prebuilt.runs`,
so preflight and shards unpack from one resolved list
and the API calls are spent once.
Baseline discovery folds into the same walk
(one artifact listing per run instead of two).

**pak still runs over the whole set.**
Unpacking is not installing: CRAN moves between runs,
and a package whose version changed has to be built after all.
The install switches to `upgrade = TRUE` whenever anything was restored,
because the dependency fingerprints that decide baseline reuse
are computed from CRAN *now*,
and `upgrade = FALSE` would quietly freeze the donor's versions instead.
Reuse skips *building* what has not changed; it never skips resolving it.

**Safety.** An unpack never overwrites a package already in the library
or loaded in the session, and half-extracted directories are discarded
so pak installs them properly.
The one new failure mode is a stale binary
whose runner image has moved on;
since the preflight already load-tests everything it installs,
it now throws such a package away, rebuilds it from source
and re-tests it before counting it as a dependency failure.

## Changes

* `revdep2.yaml` — publish `revdep2-lib` / `revdep2-lib-index` from the preflight,
  download this run's library in the shards,
  `actions: read` and `GH_TOKEN` where artifacts are now fetched,
  and the `REVDEP2_PREBUILT_MAX_RUNS` / `REVDEP2_PREBUILT_MAX_AGE_DAYS` /
  `REVDEP2_HISTORY_RUNS` knobs.
* `plan.R` — `scan_history()`: one youngest-first walk over the run history
  for the baseline donor and the prebuilt donors; result in `plan.json`
  and the job summary.
* `util.R` — the gh plumbing (moved here from `plan.R`, since the preflight
  and the shards need it too), plus `pack_library()`, `unpack_library()`,
  `restore_local_library()` and `restore_prebuilt()`.
* `preflight.R` — restore, install with `upgrade`, rebuild restored packages
  that will not load, publish the library.
* `shard.R` — restore this run's library, then the donors, then pak.
* `README.md` — the new section, artifact table, failure modes and knobs.

A separate `style:` commit runs `air` over the `revdep2` scripts,
which CI's `air format .` covers but which predate that being true for them.
Drop it if you would rather leave those files alone.

## Verification

Run against a stubbed `gh` and a real packed library, locally:

* the history walk — two donors credited disjointly, early stop at full
  coverage, donor cap, `MAX_RUNS=0`, age and R-series mismatches skipped,
  and a graceful no-`gh` path;
* `preflight.R` end to end — restored 2 of 3, pak reported `kept 2, added 1`,
  load-tested, republished library and index;
* the shard's restore step — all of its packages taken from this run's
  preflight library, donors then downloading nothing;
* unpack edge cases — `beta` never dragging `beta2` along, installed and
  loaded packages never overwritten, missing members, empty library.

Not exercised: a full `shard.R` run (needs real revdep checks),
and the real artifact download path — the fetch went through a stub.

- [ ] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

https://claude.ai/code/session_01RAf8kqJ8NYs5nrSegfqJDB
