### PR TITLE
fix(ci): Carry `revdep2` run ids as strings, and make its summary self-contained

### DIFF
--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -260,6 +260,25 @@ generated through its `results` injection point
 (`cloud_report_summary()` and friends),
 so `README.md` reads exactly like a local `revdep_check()`'s.
 
+The job summary embeds that report,
+with two changes that a summary needs and a file does not.
+Its links are rewritten:
+a summary is served from the run's own URL,
+where revdepcheck's `problems.md#pkg` resolves to `/actions/runs/problems.md`
+and 404s,
+so package names point at CRAN instead
+and the report files are named where they actually live —
+the `revdep2-report` artifact of the run.
+And its "Failed to check" section is replaced
+by a **Could not be checked** table
+listing, per package, the version, the shard,
+the check counts of whichever phase ran, and *why* —
+the timeout and its duration, the dependencies that would not install,
+whether installation failed under the dev version only or under both.
+revdepcheck cannot say any of that
+because the shim it is fed for an uncomparable package carries no detail;
+the manifest has it all.
+
 To fetch a run's results:
 
 ```sh
@@ -297,6 +316,15 @@ so its report is complete again, not a fragment.
 | CRAN bumps a dependency mid-run | shards install what resolves at their start; the recorded fingerprint is the plan's — next run re-fingerprints |
 | The package is not on CRAN | plan emits zero shards, run ends green |
 | `collect` finds new problems | reported in the summary and the report artifact; the run stays green |
+
+Run ids are strings everywhere in these scripts,
+never integers, and `"0"` is the "no such run" sentinel
+that `plan.json` and the plan job's outputs use.
+GitHub's run ids passed `.Machine$integer.max` in 2026,
+so `as.integer("31048405399")` is a silent `NA`
+that only surfaces as `missing value where TRUE/FALSE needed`
+at the next `if`.
+`run_id_chr()` and `has_run()` in `util.R` are how they are handled.
 
 ## Knobs
 

--- a/.github/workflows/revdep2/collect.R
+++ b/.github/workflows/revdep2/collect.R
@@ -307,6 +307,45 @@ counts_df <- data.frame(
 )
 counts_df <- counts_df[counts_df$Packages > 0 | counts_df$Result == "ok", ]
 
+# Packages that produced no comparison at all. revdepcheck lists them too, but
+# only as bare names under "Failed to check" -- no version it could resolve and
+# no reason, because the shim it is fed carries neither. The manifest has both,
+# so that section is dropped from the embedded report and this table takes its
+# place.
+unchecked <- Filter(
+  function(e) !e$result %in% c("ok", "newly_broken"),
+  unname(entries)
+)
+reason_of <- function(e) {
+  message <- gsub("[[:space:]]+", " ", trimws(e$message %||% ""))
+  # Results carried over from an older run predate the shard recording one.
+  if (!nzchar(message) && nzchar(e$status %||% "")) {
+    message <- status_message(e$status)
+  }
+  if (nzchar(message)) {
+    return(message)
+  }
+  switch(
+    e$result,
+    deferred = "the shard hit its deadline before this package was checked",
+    depfail = "dependencies could not be installed",
+    sprintf("no reason recorded (result `%s`)", e$result)
+  )
+}
+unchecked_df <- data.frame(
+  Package = vapply(unchecked, function(e) cran_link(e$package), character(1)),
+  Version = vapply(unchecked, function(e) e$version %||% "?", character(1)),
+  Result = vapply(unchecked, function(e) e$result, character(1)),
+  Shard = vapply(
+    unchecked,
+    function(e) as.character(e$shard %||% ""),
+    character(1)
+  ),
+  Old = vapply(unchecked, function(e) e$status_old %||% "", character(1)),
+  New = vapply(unchecked, function(e) e$status_new %||% "", character(1)),
+  Reason = vapply(unchecked, reason_of, character(1))
+)
+
 # The report itself, nested under this section: headings demoted two levels,
 # and the platform preamble dropped -- the sentence above already says what
 # was compared against what.
@@ -315,6 +354,17 @@ revdeps_at <- grep("^# Revdeps", readme)[1]
 if (!is.na(revdeps_at)) {
   readme <- readme[seq(revdeps_at, length(readme))]
 }
+readme <- drop_section(readme, "^## Failed to check")
+# revdepcheck's tables link into the sibling report files, which is right
+# inside the artifact and wrong here: a job summary is served from the run's
+# own URL, where `problems.md#pkg` resolves to /actions/runs/problems.md and
+# 404s. The package's CRAN page is the reachable equivalent; where the details
+# actually live is said once, below.
+readme <- gsub(
+  "\\[([^][]+)\\]\\([^)]*[.]md(#[^)]*)?\\)",
+  "[\\1](https://cran.r-project.org/package=\\1)",
+  readme
+)
 readme <- gsub("^(#+)(\\s)", "##\\1\\2", readme)
 
 run_id <- env_chr("GITHUB_RUN_ID")
@@ -324,7 +374,11 @@ append_summary(c(
   sprintf(
     "`%s` %s (dev) vs %s (CRAN), R %s%s.",
     plan$package, plan$dev_version, plan$cran_version, plan$r_version,
-    if (plan$retry_of > 0) sprintf(", retry of run %d", plan$retry_of) else ""
+    if (has_run(plan$retry_of)) {
+      sprintf(", retry of run %s", run_link(plan$retry_of))
+    } else {
+      ""
+    }
   ),
   "",
   headline,
@@ -333,11 +387,39 @@ append_summary(c(
   "",
   readme,
   "",
+  if (nrow(unchecked_df) > 0) {
+    # A run where everything defers would put every revdep in this table; the
+    # summary has a size limit, and losing it whole is worse than a cut list.
+    shown <- utils::head(unchecked_df, 200)
+    c(
+      sprintf("### Could not be checked (%d)", nrow(unchecked_df)),
+      "",
+      paste(
+        "No comparison was produced for these, so they say nothing about the",
+        "dev version either way. The shard job named in `Shard` has the full",
+        "check log for each."
+      ),
+      "",
+      md_table(shown),
+      if (nrow(shown) < nrow(unchecked_df)) {
+        c("", sprintf(
+          "... and %d more; the full list is `manifest.json` in the report artifact.",
+          nrow(unchecked_df) - nrow(shown)
+        ))
+      },
+      ""
+    )
+  },
   "### Getting the results",
+  "",
+  sprintf(
+    "The full report -- `problems.md`, `failures.md`, `cran.md` and every check's output -- is the `revdep2-report` artifact of %s.",
+    this_run_link("this run")
+  ),
   "",
   "```sh",
   sprintf("gh run download %s --name revdep2-report --dir revdep/", run_id),
-  sprintf("# retry everything that is not ok:"),
+  "# retry everything that is not ok:",
   sprintf("gh workflow run revdep2.yaml -f retry-run=%s", run_id),
   "```"
 ))

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -276,7 +276,10 @@ inform(
   ")"
 )
 
+# `selection` goes into plan.json, so it stays plain; `selection_md` is the
+# same thing with the run id clickable, for the job summary.
 selection <- "all"
+selection_md <- NULL
 retry_manifest <- NULL
 packages_input <- trimws(strsplit(
   env_chr("REVDEP2_PACKAGES"),
@@ -289,6 +292,7 @@ if (length(packages_input) > 0) {
   candidates <- unique(packages_input)
 } else if (nzchar(retry_run)) {
   selection <- sprintf("retry of run %s", retry_run)
+  selection_md <- sprintf("retry of run %s", run_link(retry_run))
   dir <- fetch_artifact(retry_run, "revdep2-report", tempfile("retry-"))
   manifest_path <- if (is.null(dir)) NULL else file.path(dir, "manifest.json")
   if (is.null(manifest_path) || !file.exists(manifest_path)) {
@@ -416,7 +420,7 @@ history <- scan_history(
 
 # ---------------------------------------------------------------- baseline ---
 
-baseline_run <- 0L
+baseline_run <- "0"
 baseline_manifest <- list()
 if (refresh_baseline) {
   inform("Baseline reuse disabled by input")
@@ -453,7 +457,7 @@ if (refresh_baseline) {
         " is unavailable; reusing nothing"
       )
     } else {
-      baseline_run <- as.integer(donor)
+      baseline_run <- run_id_chr(donor)
       entries <- read_json(manifest_path)
       baseline_manifest <- setNames(
         entries,
@@ -503,7 +507,7 @@ baseline_verdict <- function(p) {
 }
 verdicts <- vapply(packages, baseline_verdict, character(1))
 reuse <- verdicts == "reuse"
-if (baseline_run > 0) {
+if (has_run(baseline_run)) {
   stale <- table(verdicts[!reuse])
   inform(
     "Baseline: ",
@@ -661,7 +665,7 @@ plan <- list(
   selection = selection,
   generated_at = now_utc(),
   timing_flavor = timing_flavor,
-  retry_of = if (nzchar(retry_run)) as.integer(retry_run) else 0L,
+  retry_of = if (nzchar(retry_run)) run_id_chr(retry_run) else "0",
   baseline = list(
     run_id = baseline_run,
     max_age_days = baseline_max_age,
@@ -718,7 +722,7 @@ set_output("matrix", jsonlite::toJSON(matrix, auto_unbox = TRUE))
 set_output("shards", as.character(k))
 set_output("packages", as.character(n))
 set_output("max_parallel", as.character(parallel))
-set_output("baseline_run", as.character(baseline_run))
+set_output("baseline_run", baseline_run)
 set_output("plan_hash", plan_hash)
 
 # ------------------------------------------------------------------ summary --
@@ -749,7 +753,7 @@ append_summary(c(
   "| | |",
   "| --- | --- |",
   sprintf("| Package | `%s` %s (CRAN: %s) |", package, dev_version, cran_version),
-  sprintf("| Selection | %s |", selection),
+  sprintf("| Selection | %s |", selection_md %||% selection),
   sprintf(
     "| Packages to check | %d (of %d revdeps%s) |",
     n,
@@ -768,7 +772,11 @@ append_summary(c(
     if (length(baseline_manifest) > 0) {
       sprintf(
         "%s: %d reused, %d fresh",
-        if (baseline_run > 0) sprintf("run %d", baseline_run) else "local",
+        if (has_run(baseline_run)) {
+          paste("run", run_link(baseline_run))
+        } else {
+          "local"
+        },
         sum(reuse),
         sum(!reuse)
       )
@@ -784,7 +792,10 @@ append_summary(c(
         prebuilt_covered,
         length(universe),
         if (length(prebuilt) > 1) "s" else "",
-        paste(vapply(prebuilt, function(d) d$run_id, character(1)), collapse = ", ")
+        paste(
+          vapply(prebuilt, function(d) run_link(d$run_id), character(1)),
+          collapse = ", "
+        )
       )
     } else {
       "none"

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -439,7 +439,8 @@ for (name in runnable) {
       name,
       result = "failed",
       status_new = counts(new),
-      t_new = attr(new, "duration")
+      t_new = attr(new, "duration"),
+      message = "both checks ran, but their results could not be compared"
     )
   } else {
     new_issues <- sum(cmp$cmp$change == 1)
@@ -449,7 +450,10 @@ for (name in runnable) {
       status = cmp$status,
       status_new = counts(new),
       new_issues = new_issues,
-      t_new = attr(new, "duration")
+      t_new = attr(new, "duration"),
+      # An install failure or a timeout leaves nothing to compare, so the
+      # result is only "failed"; say which one it was.
+      message = status_message(cmp$status)
     )
   }
   entry <- get(name, envir = state)
@@ -532,16 +536,25 @@ for (entry in entries) {
   if (entry$result %in% c("ok", "deferred")) {
     next
   }
+  # The reason goes in the title, where `md_details()` cannot tail it away;
+  # the body is the check log where there is one, because the reason alone
+  # rarely says which check step broke.
   log <- file.path(out_dir, "pkgs", entry$package, "new-check", "00check.log")
-  lines <- if (nzchar(entry$message)) {
-    strsplit(entry$message, "\n")[[1]]
-  } else if (file.exists(log)) {
+  reason <- gsub("\n", " ", entry$message %||% "")
+  lines <- if (file.exists(log)) {
     readLines(log, warn = FALSE)
+  } else if (nzchar(reason)) {
+    strsplit(entry$message, "\n")[[1]]
   } else {
     "(no log captured)"
   }
   append_summary(md_details(
-    sprintf("<code>%s</code> &mdash; %s", entry$package, entry$result),
+    sprintf(
+      "<code>%s</code> &mdash; %s%s",
+      entry$package,
+      entry$result,
+      if (nzchar(reason)) paste0(": ", md_escape_html(reason)) else ""
+    ),
     lines
   ))
 }

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -28,6 +28,62 @@ now_utc <- function() {
   format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
 }
 
+# ---------------------------------------------------------------- run ids ----
+
+# GitHub run ids passed `.Machine$integer.max` in 2026, so they are carried as
+# strings everywhere here: `as.integer("31048405399")` is a silent NA, and an
+# NA reaching `if (run > 0)` takes the whole planning job down. "0" is the
+# "no such run" sentinel the workflow's job outputs and plan.json use.
+run_id_chr <- function(x) {
+  if (is.null(x) || length(x) != 1 || is.na(x)) "0" else trimws(as.character(x))
+}
+
+has_run <- function(x) {
+  id <- run_id_chr(x)
+  nzchar(id) && !identical(id, "0")
+}
+
+# ------------------------------------------------------- links in summaries --
+
+# A job summary is rendered at the run's own URL, so every link it carries has
+# to be absolute; relative ones resolve against /actions/runs/<id> and 404.
+
+# A run id, linked to its page; plain text off GitHub (a local run).
+run_link <- function(x) {
+  id <- run_id_chr(x)
+  if (!nzchar(gh_repo())) {
+    return(id)
+  }
+  sprintf(
+    "[%s](%s/%s/actions/runs/%s)",
+    id,
+    env_chr("GITHUB_SERVER_URL", "https://github.com"),
+    gh_repo(),
+    id
+  )
+}
+
+# This run's page, where its artifacts are.
+this_run_link <- function(text = env_chr("GITHUB_RUN_ID", "local")) {
+  id <- run_id_chr(env_chr("GITHUB_RUN_ID"))
+  if (!has_run(id) || !nzchar(gh_repo())) {
+    return(text)
+  }
+  sprintf(
+    "[%s](%s/%s/actions/runs/%s)",
+    text,
+    env_chr("GITHUB_SERVER_URL", "https://github.com"),
+    gh_repo(),
+    id
+  )
+}
+
+# A revdep, linked to its CRAN page -- the one page about it that is reachable
+# from a job summary, and the one that names its maintainer.
+cran_link <- function(package) {
+  sprintf("[%s](https://cran.r-project.org/package=%s)", package, package)
+}
+
 # ------------------------------------------------------------------- JSON ----
 
 write_json <- function(x, path) {
@@ -75,6 +131,28 @@ md_table <- function(df) {
     character(1)
   )
   c(header, rule, rows)
+}
+
+# Drop one markdown section: the first heading matching `heading`, and
+# everything under it up to the next heading of any level.
+drop_section <- function(lines, heading) {
+  at <- grep(heading, lines)
+  if (length(at) == 0) {
+    return(lines)
+  }
+  from <- at[[1]]
+  later <- grep("^#+[[:space:]]", lines)
+  later <- later[later > from]
+  to <- if (length(later) == 0) length(lines) else later[[1]] - 1L
+  lines[-seq(from, to)]
+}
+
+# Text going into an HTML fragment of a summary (a <summary> title, say),
+# where markdown's escaping does not apply.
+md_escape_html <- function(x) {
+  x <- gsub("&", "&amp;", x, fixed = TRUE)
+  x <- gsub("<", "&lt;", x, fixed = TRUE)
+  gsub(">", "&gt;", x, fixed = TRUE)
 }
 
 # Strip ANSI escapes and carriage returns before quoting logs into markdown.
@@ -506,6 +584,23 @@ classify_status <- function(status, new_issues) {
   } else {
     "failed"
   }
+}
+
+# What a status that `classify_status()` can only call "failed" actually means,
+# in words. A reader of the summary has to tell "broken under the dev version"
+# apart from "broken everywhere" without opening the artifact, and the one word
+# in the manifest cannot say it. Empty for the two statuses that compared.
+status_message <- function(status) {
+  switch(
+    status,
+    "+" = ,
+    "-" = "",
+    "i-" = "installs against the CRAN version, fails to install against the dev version",
+    "i+" = "fails to install against either version",
+    "t-" = "check timed out against the dev version, not against the CRAN version",
+    "t+" = "check timed out against both versions",
+    sprintf("check comparison inconclusive (status `%s`)", status)
+  )
 }
 
 needs_recheck <- function(result) {


### PR DESCRIPTION
<!-- Prepared with Claude Code; see the session link at the bottom. -->

## The workflow was failing

[Run 31084790490](https://github.com/igraph/rigraph/actions/runs/31084790490/job/92561611348)
died in `plan.R` with `missing value where TRUE/FALSE needed`,
one line after finding its baseline donor:

```
Baseline donor: run 31048405399 (745 entries)
Warning message:
NAs introduced by coercion to integer range
Error in if (baseline_run > 0) { : missing value where TRUE/FALSE needed
```

`baseline_run <- as.integer(donor)`.
GitHub's run ids passed `.Machine$integer.max` in 2026,
so `as.integer("31048405399")` is a silent `NA`
that only surfaces at the next `if`.
This would have hit every run from now on
that finds a baseline to reuse.

Run ids are strings everywhere in these scripts now —
`plan.json`, the plan job's outputs, the summaries —
with `"0"` as the "no such run" sentinel
and `run_id_chr()` / `has_run()` in `util.R` to handle them.

## Every link in the summary was broken

Checked against the report artifact of
[run 31048405399](https://github.com/igraph/rigraph/actions/runs/31048405399).
Its summary contained exactly 23 links,
all of the form `[archeofrag](problems.md#archeofrag)` —
right inside the report artifact,
wrong in a job summary served from `/actions/runs/<id>`,
where they resolve to `github.com/igraph/rigraph/actions/runs/problems.md`.
Nothing else was linked at all:
the baseline run, the prebuilt donor runs, the retried run and the artifact
were bare numbers or prose.

Now package names link to their CRAN page,
run ids link to their run pages,
and the summary says once
that `problems.md` and friends live in the `revdep2-report` artifact.
A regenerated summary has no relative links left.

## Packages that could not be checked said nothing useful

All 30 of them appeared as a bare name with version `?` and no reason:
revdepcheck's "Failed to check" table is fed a shim
that carries neither.
That section is dropped from the embedded report
and replaced by a table built from the manifest,
which had the detail all along:

| Package | Version | Result | Shard | Old | New | Reason |
| --- | --- | --- | --- | --- | --- | --- |
| basket | 0.10.11 | failed | 26 | | | old check timed out after 601s |
| dogesr | 0.5.2 | depfail | 56 | | | Dependencies not installed: rmarkdown, tibble, … |
| hespdiv | 1.2.10 | error | 101 | | | Source tarball could not be downloaded |
| optbdmaeAT | 1.0.2 | failed | 38 | 1E 0W 0N | 1E 0W 0N | fails to install against either version |

That last row needed a change in `shard.R`:
an `i+` / `i-` / `t+` / `t-` comparison recorded no message at all,
so three packages had no reason to report.
The shard records it now,
which also makes an `i-` (installs under CRAN igraph, fails under dev)
readable as distinct from an `i+` (broken either way).
The shard summary puts the same reason in the `<details>` title,
where the log tail cannot cut it off.

I left the `failed` classification of `i-` alone.
Arguably that one is `newly_broken` —
installation regressing under the dev version is a real regression —
but that changes what the reports and the retry selection mean,
so it is worth deciding separately.

## How it was verified

No revdep2 run is needed to see the fix work:

- `plan.R` run against a stubbed `gh`
  serving run 31048405399's real `revdep2-baseline` and `revdep2-report` artifacts.
  Both the baseline-donor path and the `retry-run` path plan through;
  before this branch, both died on the `as.integer()`.
- `collect.R` run against that run's real 770-entry manifest,
  with and without unchecked packages.
  The generated summary contains no relative links.
- `https://cran.r-project.org/package=<pkg>` confirmed as the right link shape
  (200 for a real package, 404 for a bogus one).

- [ ] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLy6bf4Zo8YWgv5Qb53nmY