### PR TITLE
ci: Move the `revdep2` library artifact steps to their Node 24 releases

### DIFF
--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -299,7 +299,7 @@ jobs:
       # dependency universe, gigabytes of it -- so it is kept exactly as long
       # as a plan would still reuse it, while the index that describes it is
       # cheap and outlives it.
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: revdep2-lib
@@ -308,7 +308,7 @@ jobs:
           retention-days: ${{ env.REVDEP2_PREBUILT_MAX_AGE_DAYS }}
           overwrite: true
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: revdep2-lib-index
@@ -401,7 +401,7 @@ jobs:
       # building the same packages the preflight built minutes ago. It is a
       # `needs`, so it is always there -- unless the preflight could not pack
       # one, which is a slower shard, not a broken one.
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: revdep2-lib


### PR DESCRIPTION
<!-- Prepared with Claude Code; see the session link at the bottom. -->

## Why the Node 20 warnings came back

#2813 moved the repository off Node 20.
#2814 reintroduced it two commits later:
the prebuilt-library steps it added to `revdep2.yaml`
were pinned to `actions/upload-artifact@v5` and `actions/download-artifact@v6`,
both of which still target Node 20,
while the other twenty-one artifact steps in the repository
were already on `@v6` / `@v7`.

So every preflight job has warned

```
Node.js 20 is deprecated. The following actions target Node.js 20
but are being forced to run on Node.js 24: actions/upload-artifact@v5.
```

and every shard job the same for `actions/download-artifact@v6`.

## The change

Three pins, all in `revdep2.yaml`:

| Step | Was | Now |
| --- | --- | --- |
| upload `revdep2-lib` | `upload-artifact@v5` | `upload-artifact@v6` |
| upload `revdep2-lib-index` | `upload-artifact@v5` | `upload-artifact@v6` |
| download `revdep2-lib` in a shard | `download-artifact@v6` | `download-artifact@v7` |

No inputs changed; the same input names are supported by the newer majors,
and the rest of the workflow already used them.
After this, the only remaining `@v5` pins are `actions/cache`,
where v5 *is* current and already runs on Node 24.

- [ ] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLy6bf4Zo8YWgv5Qb53nmY

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLy6bf4Zo8YWgv5Qb53nmY)_