### PR TITLE
feat(ci): Size `revdep2` shards by the parallel capacity, calibrated from measured timings

### DIFF
--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -88,6 +88,10 @@ on:
         description: "Run id of an earlier revdep2 run; re-check only its not-ok packages"
         type: string
         default: ""
+      part:
+        description: "Check one G-th of the reverse dependencies, as 'i/G'; for a set too big for one run (the plan says when, and with which G)"
+        type: string
+        default: ""
       shard-budget-minutes:
         description: "Check-time target per shard; smaller buys wall clock with more shards, up to one wave of max-parallel"
         type: string
@@ -129,6 +133,7 @@ env:
   REVDEP2_WHICH: ${{ inputs.which || 'strong' }}
   REVDEP2_DEPTH: ${{ inputs.depth || '1' }}
   REVDEP2_RETRY_RUN: ${{ inputs.retry-run || '' }}
+  REVDEP2_PART: ${{ inputs.part || '' }}
   REVDEP2_SHARD_BUDGET_MINUTES: ${{ inputs.shard-budget-minutes || vars.REVDEP2_SHARD_BUDGET_MINUTES || '45' }}
   REVDEP2_MAX_PARALLEL: ${{ inputs.max-parallel || vars.REVDEP2_MAX_PARALLEL || '20' }}
   # Check minutes one shard may be planned to hold. Only a batch too big for
@@ -509,7 +514,11 @@ jobs:
           name: revdep2-plan
           path: ${{ runner.temp }}/plan
 
+      # Tolerated because a run in which no shard uploaded anything is still
+      # worth a report: the collector reconciles against the plan and names
+      # every package it never heard about, which is what `retry-run` needs.
       - uses: actions/download-artifact@v7
+        continue-on-error: true
         with:
           pattern: revdep2-results-*
           path: ${{ runner.temp }}/results

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -2,11 +2,15 @@
 # plan + build (parallel) -> preflight -> test (matrix) -> collect.
 #
 # The plan job enumerates the CRAN reverse dependencies of this package (to
-# any depth), weighs each one by the time CRAN's own Linux check machine
-# spends on it, decides which CRAN-baseline results from an earlier run are
-# still valid, and deals the packages into cost-balanced shards -- the
-# heaviest round-robin first, everything else placed where it shares the most
-# dependencies (see revdep2/README.md for the algorithm and its trade-offs).
+# any depth), weighs each one by what its check is expected to cost here --
+# what the last runs measured, or the time CRAN's own Linux check machine
+# spends on it, scaled to this one -- decides which CRAN-baseline results from
+# an earlier run are still valid, and deals the packages into cost-balanced
+# shards: the heaviest round-robin first, everything else placed where it
+# shares the most dependencies. The shard count follows the parallel capacity,
+# because only max-parallel shards ever run at once and every shard past that
+# pays another setup without starting any earlier (see revdep2/README.md for
+# the algorithm and its trade-offs).
 #
 # The build job compiles the dev version once into the binary artifact every
 # shard installs; it needs only the checkout, so it runs in parallel with
@@ -44,6 +48,8 @@
 #                     later runs to skip rebuilding what has not changed
 #   revdep2-lib-index what is in that library, so a plan can decide which runs
 #                     to take it from without downloading it
+#   revdep2-timings   what the checks and the shards actually cost, which is how
+#                     the next plan sizes its shards
 #
 # To re-check only what a run could not declare ok, dispatch again with
 # `retry-run: <run-id>`; the new report carries the old run's good results
@@ -83,11 +89,11 @@ on:
         type: string
         default: ""
       shard-budget-minutes:
-        description: "Check-time target per shard; smaller buys wall clock with more shards"
+        description: "Check-time target per shard; smaller buys wall clock with more shards, up to one wave of max-parallel"
         type: string
         default: ""
       max-parallel:
-        description: "Shards to run concurrently"
+        description: "Shards to run concurrently, and so the wave size the plan partitions into"
         type: string
         default: ""
       refresh-baseline:
@@ -125,6 +131,10 @@ env:
   REVDEP2_RETRY_RUN: ${{ inputs.retry-run || '' }}
   REVDEP2_SHARD_BUDGET_MINUTES: ${{ inputs.shard-budget-minutes || vars.REVDEP2_SHARD_BUDGET_MINUTES || '45' }}
   REVDEP2_MAX_PARALLEL: ${{ inputs.max-parallel || vars.REVDEP2_MAX_PARALLEL || '20' }}
+  # Check minutes one shard may be planned to hold. Only a batch too big for
+  # one wave of REVDEP2_MAX_PARALLEL shards ever hits it, and then it decides
+  # how many waves there are; empty means 80% of REVDEP2_DEADLINE_MINUTES.
+  REVDEP2_SHARD_CAPACITY_MINUTES: ${{ vars.REVDEP2_SHARD_CAPACITY_MINUTES || '' }}
   REVDEP2_REFRESH_BASELINE: ${{ inputs.refresh-baseline && '1' || '' }}
   REVDEP2_BASELINE_MAX_AGE_DAYS: ${{ inputs.baseline-max-age-days || vars.REVDEP2_BASELINE_MAX_AGE_DAYS || '30' }}
   REVDEP2_DRY_RUN: ${{ inputs.dry-run && '1' || '' }}
@@ -515,11 +525,15 @@ jobs:
 
       - name: Collect results
         env:
+          # To read how long the shard *jobs* took -- the minutes before their
+          # driver starts, which is what an extra shard really costs.
+          GH_TOKEN: ${{ github.token }}
           PLAN: ${{ runner.temp }}/plan/plan.json
           RESULTS_DIR: ${{ runner.temp }}/results
           RETRY_DIR: ${{ runner.temp }}/retry-report
           OUT_DIR: revdep
           BASELINE_OUT: ${{ runner.temp }}/baseline
+          TIMINGS_OUT: ${{ runner.temp }}/timings
         run: |
           Rscript ./.github/workflows/revdep2/collect.R
         shell: bash
@@ -537,5 +551,17 @@ jobs:
         with:
           name: revdep2-baseline
           path: ${{ runner.temp }}/baseline
+          retention-days: 90
+          overwrite: true
+
+      # What the run cost, per package and per shard. Small on purpose and
+      # separate from the report: the next plan downloads it to calibrate its
+      # cost model, and should not have to fetch a report to do so.
+      - uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: revdep2-timings
+          path: ${{ runner.temp }}/timings
+          if-no-files-found: ignore
           retention-days: 90
           overwrite: true

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -4,11 +4,13 @@
 package twice — once against the CRAN version, once against the checked-out
 dev version — and reports the difference,
 the way [revdepcheck](https://github.com/r-lib/revdepcheck) does,
-but spread over as many GitHub Actions jobs as the batch needs.
+but spread over as many GitHub Actions jobs as can actually run at once.
 The trade is deliberate:
 runner minutes are spent (duplicate setup, duplicate dependency installs)
-to buy wall clock,
-where the older `revdep.yaml` spends one job per package
+to buy wall clock —
+but only while a free lane makes that a trade at all,
+which is why the shard count follows `max-parallel` rather than the budget.
+The older `revdep.yaml` spends one job per package,
 and `revdepcheck::revdep_check()` spends one machine for everything.
 
 ## Topology
@@ -17,12 +19,15 @@ and `revdepcheck::revdep_check()` spends one machine for everything.
 plan      (1 job, ~2 min)              build  (1 job, parallel to plan)
   ├─ enumerate revdeps to `depth`,       └─ R CMD build
   │    or take the retry/explicit list        + R CMD INSTALL --build
-  ├─ weigh each by CRAN's check time             → revdep2-pkg artifact
+  ├─ weigh each by what its check cost           → revdep2-pkg artifact
+  │    here last time, else by CRAN's
+  │    time scaled to this machine
   ├─ walk earlier runs youngest first:
-  │    the baseline donor, and the
-  │    prebuilt libraries to unpack
+  │    the baseline donor, the prebuilt
+  │    libraries, the measured timings
   ├─ decide per package what is reusable
-  └─ partition into shards
+  └─ partition into as many shards as
+       one wave can run, in whole waves
        → plan.json (artifact) + matrix (job output)
 
 preflight (1 job; a dry run stops before it)
@@ -43,7 +48,9 @@ test      (one job per shard, max-parallel throttled, fail-fast: false)
 collect   (1 job, if: always() past plan/build/preflight)
   ├─ merge all shard attempts (+ carried results of a retried run)
   ├─ reports via revdepcheck: README.md, problems.md, failures.md, cran.md
-  └─ manifest.json, job summary, revdep2-report + revdep2-baseline artifacts
+  ├─ pool what every check and every shard cost, job durations included
+  └─ manifest.json, job summary, revdep2-report + revdep2-baseline
+       + revdep2-timings artifacts
 ```
 
 The workflow is dispatch-only — nothing runs on push —
@@ -72,24 +79,59 @@ Deeper levels break through their intermediaries,
 so their CRAN-vs-dev comparison stays meaningful,
 and their install closures pull the intermediaries in automatically.
 
-CRAN publishes per-package check times for each flavor;
-`tools::CRAN_check_results()` carries them as `T_total`.
-The planner takes the `r-release-linux-x86_64` flavor as the proxy
-for what a check costs here:
-one check ≈ `T_total`, a package without a reusable baseline pays two,
+A package's weight is what its two checks are expected to cost *here*.
+The best answer is what they cost here last time —
+the timings artifact below carries it per package.
+Where no run has checked the package yet,
+CRAN's own number stands in:
+`tools::CRAN_check_results()` publishes per-package check times per flavor as
+`T_total`,
+the planner takes the `r-release-linux-x86_64` flavor,
+and scales it by the ratio the last runs measured between CRAN's machine and
+this one
+(0.47 in the first calibrated run: these runners check faster than CRAN
+reports).
+Packages CRAN has no timing for either get the cohort median.
+A package without a reusable baseline is checked twice, so it weighs double,
 plus a small fixed overhead.
-Packages CRAN has no timing for get the cohort median.
-The same number sizes the per-check timeout:
-`max(REVDEP2_TIMEOUT_MIN_MINUTES, REVDEP2_TIMEOUT_FACTOR × T_total)`,
-so a package gets killed relative to what it normally costs,
-with the floor covering the gap between CRAN's machines and these runners.
 
-The shard count is demand-driven:
-the smallest `K` whose average check load fits `shard-budget-minutes`
-(default 45), capped by the 250-leg matrix limit.
-A smaller budget buys wall clock with more shards;
-the per-shard setup (~6 min: R, pandoc, TinyTeX, dependency install)
-is the price of each extra shard.
+The per-check timeout stays on CRAN's number and is not calibrated:
+`max(REVDEP2_TIMEOUT_MIN_MINUTES, REVDEP2_TIMEOUT_FACTOR × T_total)`.
+A timeout is a safety net for a check that has gone wrong,
+so it should be generous where the estimate is merely typical —
+and against the local estimate that same factor would be a third as forgiving.
+
+### The shard count is bounded by the parallel capacity
+
+Only `max-parallel` shards run at once (default 20),
+so shards come in waves of that size,
+and the shard after a full wave does not start any earlier for existing:
+it waits for a lane, and arrives having paid another setup
+(runner image, R, pandoc, TinyTeX, artifact downloads —
+charged at 6 minutes until a run measures it)
+plus its own dependency install.
+Splitting past one wave therefore buys nothing and costs per shard,
+which is what a 45-minute budget did to the 771-revdep batch:
+111 shards, six waves, 6 h 16 min end to end,
+for 2233 minutes of checking that one wave of 20 shards holds comfortably.
+
+So the count is decided in two steps:
+
+* **while one wave is enough, the budget decides.**
+  `ceil(check minutes / shard-budget-minutes)`, capped at `max-parallel`.
+  Below a full wave every extra shard really does start immediately,
+  so cutting finer buys wall clock, and a small batch stays cheap.
+* **past that, the capacity decides, in whole waves.**
+  `shard-capacity-minutes` (default 80% of the shard's own deadline,
+  so 240 min) is the most check time one shard may be given
+  before its deadline starts deferring packages.
+  The plan takes `ceil(check minutes / capacity)` shards,
+  rounded up to a whole number of waves,
+  and never more than the 250-leg matrix limit.
+
+The result is `max-parallel` shards for anything that fits in one wave,
+`2 × max-parallel` for twice that, and so on —
+the capacity is filled, and nothing is split for the sake of splitting.
 
 Assignment is greedy, in two phases:
 
@@ -104,6 +146,50 @@ Assignment is greedy, in two phases:
    The install penalty (default 2.5 s per package, from a warm binary cache)
    is what pulls packages with overlapping dependency trees together,
    so a shard's install phase is amortised over packages that share it.
+
+### Calibration: the plan learns from the last runs
+
+Three constants drive everything above,
+and all three used to be guesses:
+how fast a check runs here, what a shard costs before it checks anything,
+and what one more dependency costs to install.
+Guesses compound in the wrong direction —
+an overestimate of the check load asks for more shards than the capacity can
+run,
+and every one of those shards costs a setup it never earns back.
+
+So every run now measures itself.
+Each shard records what its phases cost
+(`timing.json`: unpack, install, checks, and its own wall time),
+the collector adds what the shards' *jobs* took —
+read off the API, because the minutes before the driver starts
+are invisible from inside it and are precisely the price of one more shard —
+and publishes the lot as `revdep2-timings`,
+a small artifact next to the report the way `revdep2-lib-index`
+sits next to the library.
+
+The next plan takes the youngest few of those
+(`REVDEP2_MEASURED_MAX_RUNS`, default 3, within
+`REVDEP2_MEASURED_MAX_AGE_DAYS`, default 60, same platform),
+and reduces them to medians:
+
+| Constant | Measured as | Fallback |
+| --- | --- | --- |
+| check scale | check seconds here ÷ `T_total` | 1 |
+| setup per shard | job minutes − driver minutes | 6 min |
+| install per dependency | install minutes ÷ packages installed | 2.5 s |
+
+Per-package measurements win over the scaled CRAN number wherever a run has
+one;
+the scale only prices the packages nobody has checked here yet.
+Pooling several runs rather than trusting the newest
+keeps a small retry run — which measures a handful of packages —
+from redefining the constants on its own.
+`REVDEP2_CHECK_SCALE`, `REVDEP2_SETUP_MINUTES` and `REVDEP2_INSTALL_SECONDS`
+override the measurement where a human knows better,
+and a fresh repository with no measured run at all
+simply plans on CRAN's numbers and the fallbacks,
+which is what the workflow did before.
 
 ### Why greedy, not an exact optimisation
 
@@ -254,6 +340,7 @@ Every artifact this workflow writes:
 | `revdep2-results-<shard>-<attempt>` | `manifest.ndjson`, `pkgs/<p>/{old,new}.rds`, kept check output | 30 days |
 | `revdep2-report` | `README.md`, `problems.md`, `failures.md`, `cran.md`, `manifest.json`, all `pkgs/` | 90 days |
 | `revdep2-baseline` | `baseline.json`, `old-rds/<p>.rds` | 90 days |
+| `revdep2-timings` | `timings.json`: check seconds per package, cost per shard | 90 days |
 
 The reports are revdepcheck's own,
 generated through its `results` injection point
@@ -279,11 +366,25 @@ revdepcheck cannot say any of that
 because the shim it is fed for an uncomparable package carries no detail;
 the manifest has it all.
 
+The summary closes with **What this run cost** —
+check speed against CRAN's numbers, shard job durations,
+setup and install cost —
+because those are the numbers the next plan is sized in,
+and they are worth reading next to the results they came from.
+
 To fetch a run's results:
 
 ```sh
 .github/workflows/revdep2/fetch.sh            # newest completed run
 .github/workflows/revdep2/fetch.sh <run-id>   # a specific one
+```
+
+It brings `timings.json` down with the report,
+so a plan can be replayed against exactly what that run measured:
+
+```sh
+REVDEP2_MEASURED_DIR=revdep OUT=plan.json \
+  Rscript .github/workflows/revdep2/plan.R
 ```
 
 To re-check only what a run could not declare ok —
@@ -309,6 +410,8 @@ so its report is complete again, not a fragment.
 | A shard job dies hard | its packages have no manifest entries; the collector reports what exists; `retry-run` re-plans the rest |
 | A shard is re-run | new artifact per attempt; the collector lets the later attempt win per package |
 | The baseline artifact is gone | planner reuses nothing, everything checked fresh |
+| No run has published timings yet | the plan uses CRAN's times unscaled and the fallback constants, and errs towards more shards |
+| The collector cannot read the job durations | setup stays at its default; check and install costs are still measured |
 | No earlier run has a usable library | shards still unpack this run's preflight library; only the preflight itself installs from scratch |
 | The preflight could not pack a library | the download step is skipped, shards fall back to the plan's donors and pak |
 | A donor's library artifact expires between plan and shard | that shard installs those packages itself; the run is unaffected |
@@ -336,13 +439,19 @@ at the next `if`.
 | Revdep depth (`1`, `2`, …, `all`) | `depth` | — | 1 |
 | Retry a run | `retry-run` | — | — |
 | Plan only | `dry-run` | — | false |
-| Check-time target per shard | `shard-budget-minutes` | `REVDEP2_SHARD_BUDGET_MINUTES` | 45 |
-| Concurrent shards | `max-parallel` | `REVDEP2_MAX_PARALLEL` | 20 |
+| Check-time target per shard, up to one wave | `shard-budget-minutes` | `REVDEP2_SHARD_BUDGET_MINUTES` | 45 |
+| Concurrent shards, and so the wave size | `max-parallel` | `REVDEP2_MAX_PARALLEL` | 20 |
+| Check minutes one shard may hold, which forces further waves | — | `REVDEP2_SHARD_CAPACITY_MINUTES` | 80% of the deadline |
 | Ignore reusable baselines | `refresh-baseline` | — | false |
 | Oldest reusable baseline | `baseline-max-age-days` | `REVDEP2_BASELINE_MAX_AGE_DAYS` | 30 days |
 | Runs donating prebuilt packages | — | `REVDEP2_PREBUILT_MAX_RUNS` | 5 (`0` disables) |
 | Oldest reusable prebuilt library | — | `REVDEP2_PREBUILT_MAX_AGE_DAYS` | 14 days |
 | Runs the history walk looks at | — | `REVDEP2_HISTORY_RUNS` | 40 |
+| Runs whose timings calibrate the cost model | — | `REVDEP2_MEASURED_MAX_RUNS` | 3 (`0` disables) |
+| Oldest measurement worth trusting | — | `REVDEP2_MEASURED_MAX_AGE_DAYS` | 60 days |
+| Check seconds here per CRAN second | — | `REVDEP2_CHECK_SCALE` | measured, else 1 |
+| Fixed cost of one shard | — | `REVDEP2_SETUP_MINUTES` | measured, else 6 min |
+| Cost of one more dependency install | — | `REVDEP2_INSTALL_SECONDS` | measured, else 2.5 s |
 | Per-check timeout factor | — | `REVDEP2_TIMEOUT_FACTOR` | 1.5 × CRAN time |
 | Per-check timeout floor | — | `REVDEP2_TIMEOUT_MIN_MINUTES` | 10 |
 | Shard graceful deadline | — | `REVDEP2_DEADLINE_MINUTES` | 300 |
@@ -377,11 +486,17 @@ that part is new here.
 
 ## Not yet validated
 
-1. The cost model's constants
-   (45 min budget, 6 min setup, 2.5 s per dependency install, 0.5 min
-   per-package overhead) are estimates, not fits.
-   Shard manifests record actual durations, so they can be fitted
-   from real runs the way duckdb-r recalibrated `each`.
+1. Three of the cost model's constants are now fitted from the last runs
+   (check scale, per-shard setup, per-dependency install);
+   the per-package overhead (0.5 min) and the budget itself
+   are still estimates.
+   The fit is a median, not a regression:
+   install cost in particular is charged per package
+   where it plainly is not linear in the package count,
+   and a shard holding twice as many packages installs a union
+   that is much less than twice as large.
+   The measured numbers are in each run's `revdep2-timings`,
+   so a better model can be fitted whenever the linear one is seen to hurt.
 2. Bioconductor revdeps are out of scope:
    enumeration, versions and fingerprints all come from CRAN metadata.
 3. The report generation leans on unexported revdepcheck internals

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -133,6 +133,52 @@ The result is `max-parallel` shards for anything that fits in one wave,
 `2 × max-parallel` for twice that, and so on —
 the capacity is filled, and nothing is split for the sake of splitting.
 
+Both steps count *check* minutes,
+but a shard also pays its setup and its installs inside the same deadline,
+and how much that is only a real partition can say
+(a shard's install union is not a per-package constant).
+So the greedy pass below runs, the heaviest shard's **full** estimate is
+compared against `REVDEP2_DEADLINE_MINUTES`,
+and a shard count that cannot hold it grows by another whole wave
+and partitions again.
+The 20% between `shard-capacity-minutes` and the deadline is the room
+this check normally finds sufficient;
+the re-partition is what happens when it is not.
+
+### When even the matrix is not enough
+
+A matrix holds at most 256 legs, so `max-shards` caps at 250,
+and 250 shards × 240 check minutes is the ceiling of one run:
+about 60 000 check minutes.
+Past that the plan **refuses to start**, with the numbers that make the case
+and the ways out — rather than dispatching a run
+that spends hours to report half its packages as `deferred`.
+
+The way out it recommends is `part`:
+
+```sh
+gh workflow run revdep2.yaml -f part=1/3
+gh workflow run revdep2.yaml -f part=2/3
+gh workflow run revdep2.yaml -f part=3/3
+```
+
+Each part is an ordinary, independent run with its own report.
+The cut is made on the weight-ordered package list, dealt round robin,
+so the parts are of similar size and no coordination is needed:
+every part re-derives the same order from the same CRAN metadata,
+and a part that is still too big refuses in turn and names a bigger `G`.
+Later parts start warmer than the first,
+because baselines and prebuilt libraries are shared through the usual
+artifacts.
+The plan prints the `G` it needs, so the number is never guessed.
+
+For scale: `tibble`'s 2398 strong reverse dependencies plan as
+250 shards in one wave (heaviest ~125 min) with `max-parallel: 250`,
+or 60 shards in three waves with the default 20 —
+roughly a quarter of what would trigger the refusal.
+Its 3266-package dependency universe, and the preflight that installs it,
+is the part of that run to worry about, not the shard count.
+
 Assignment is greedy, in two phases:
 
 1. **Round-robin the heavyweights.**
@@ -407,7 +453,9 @@ so its report is complete again, not a fragment.
 | A revdep's strong dependencies cannot install | `depfail`, check not attempted, named in the shard summary |
 | A dependency fails the preflight | reported in the preflight summary and `depfail.json`; shards still try their own subset |
 | A shard hits its deadline | remaining packages `deferred`; finished old-halves still uploaded and baseline-fed |
-| A shard job dies hard | its packages have no manifest entries; the collector reports what exists; `retry-run` re-plans the rest |
+| A shard job dies hard | the collector reconciles against the plan: its packages are reported `missing`, naming the shard, and `retry-run` re-checks exactly them |
+| Every shard dies | the report is still written, with every package `missing`; the artifact download is tolerated, not required |
+| The batch is too big for 250 shards | the plan refuses before anything starts, and names the `part` split that fits |
 | A shard is re-run | new artifact per attempt; the collector lets the later attempt win per package |
 | The baseline artifact is gone | planner reuses nothing, everything checked fresh |
 | No run has published timings yet | the plan uses CRAN's times unscaled and the fallback constants, and errs towards more shards |
@@ -438,6 +486,7 @@ at the next `if`.
 | Revdep set | `which` | — | `strong` |
 | Revdep depth (`1`, `2`, …, `all`) | `depth` | — | 1 |
 | Retry a run | `retry-run` | — | — |
+| One G-th of the revdeps, for a set too big for one run | `part` (`i/G`) | `REVDEP2_PART` | — |
 | Plan only | `dry-run` | — | false |
 | Check-time target per shard, up to one wave | `shard-budget-minutes` | `REVDEP2_SHARD_BUDGET_MINUTES` | 45 |
 | Concurrent shards, and so the wave size | `max-parallel` | `REVDEP2_MAX_PARALLEL` | 20 |

--- a/.github/workflows/revdep2/collect.R
+++ b/.github/workflows/revdep2/collect.R
@@ -124,6 +124,54 @@ if (nzchar(retry_dir) && file.exists(file.path(retry_dir, "manifest.json"))) {
   )
 }
 
+# Every package the plan named has to appear in the report, including the ones
+# whose shard uploaded nothing at all: a job that dies -- runner failure,
+# cancellation, the job timeout above the shard's own deadline -- takes its
+# manifest with it, and a package silently absent from a report reads as one
+# that was fine. `missing` is a not-ok result, so `retry-run` picks exactly
+# these up, the same way it picks up a deferral.
+missing <- 0L
+for (shard in plan$shards %||% list()) {
+  for (p in shard$packages %||% list()) {
+    if (!is.null(entries[[p$name]])) {
+      next
+    }
+    entries[[p$name]] <- list(
+      package = p$name,
+      version = p$version,
+      level = p$level %||% 0L,
+      shard = shard$index,
+      weight_minutes = p$weight_minutes,
+      t_total = p$t_total %||% 0,
+      dep_fingerprint = p$dep_fingerprint,
+      baseline_planned = isTRUE(p$baseline),
+      baseline_reused = FALSE,
+      result = "missing",
+      status = "",
+      status_old = "",
+      status_new = "",
+      new_issues = 0L,
+      t_old = NA,
+      t_new = NA,
+      old_checked_at = NA,
+      message = sprintf(
+        "shard %s uploaded no result for this package; its job did not finish",
+        shard$index
+      ),
+      our_cran_version = plan$cran_version,
+      our_dev_version = plan$dev_version,
+      carried = FALSE
+    )
+    missing <- missing + 1L
+  }
+}
+if (missing > 0) {
+  inform(
+    missing,
+    " planned package(s) have no result at all; reported as missing"
+  )
+}
+
 entries <- entries[order(names(entries))]
 results_tbl <- vapply(entries, function(e) e$result, character(1))
 
@@ -403,11 +451,13 @@ headline <- if (tally("newly_broken") > 0) {
 counts_df <- data.frame(
   Result = c(
     "ok", "newly broken", "failed to check",
-    "dependencies not installable", "shard error", "deferred"
+    "dependencies not installable", "shard error", "deferred",
+    "no result from its shard"
   ),
   Packages = c(
     tally("ok"), tally("newly_broken"), tally("failed"),
-    tally("depfail"), tally("error"), tally("deferred")
+    tally("depfail"), tally("error"), tally("deferred"),
+    tally("missing")
   )
 )
 counts_df <- counts_df[counts_df$Packages > 0 | counts_df$Result == "ok", ]
@@ -434,6 +484,7 @@ reason_of <- function(e) {
     e$result,
     deferred = "the shard hit its deadline before this package was checked",
     depfail = "dependencies could not be installed",
+    missing = "its shard uploaded no results; the job did not finish",
     sprintf("no reason recorded (result `%s`)", e$result)
   )
 }

--- a/.github/workflows/revdep2/collect.R
+++ b/.github/workflows/revdep2/collect.R
@@ -15,7 +15,9 @@
 # plus the baseline artifact content (baseline.json, old-rds/<p>.rds): every
 # reusable old-version result of this run, stamped with the metadata the next
 # plan compares against -- versions, R series, dependency fingerprint, and the
-# date the old check *actually* ran (reuse does not refresh it).
+# date the old check *actually* ran (reuse does not refresh it),
+# and timings.json: what the checks and the shards actually cost, which is what
+# the next plan calibrates its cost model with instead of guessing.
 #
 # Environment variables:
 #   RESULTS_DIR  - directory the shard artifacts were downloaded into (required)
@@ -23,6 +25,10 @@
 #   RETRY_DIR    - the revdep2-report artifact of the run being retried, if any
 #   OUT_DIR      - report directory (default: revdep)
 #   BASELINE_OUT - baseline directory (default: baseline)
+#   TIMINGS_OUT  - timings directory (default: timings)
+#
+# Reads GH_TOKEN, if it has one, only to ask the API how long the shard *jobs*
+# took: the part of a shard's cost that happens before its driver starts.
 #
 # Always exits zero: check results are the report's business, not the job
 # status's -- only a genuinely broken collector fails this job.
@@ -38,6 +44,7 @@ plan <- read_json(env_chr("PLAN", "plan.json"))
 retry_dir <- env_chr("RETRY_DIR")
 out_dir <- env_chr("OUT_DIR", "revdep")
 baseline_out <- env_chr("BASELINE_OUT", "baseline")
+timings_out <- env_chr("TIMINGS_OUT", "timings")
 
 dir.create(file.path(out_dir, "pkgs"), recursive = TRUE, showWarnings = FALSE)
 dir.create(
@@ -45,6 +52,7 @@ dir.create(
   recursive = TRUE,
   showWarnings = FALSE
 )
+dir.create(timings_out, recursive = TRUE, showWarnings = FALSE)
 
 # ------------------------------------------------------------------- merge ---
 
@@ -70,7 +78,15 @@ take <- function(entry, from) {
   }
 }
 
+shard_timings <- list()
 for (dir in shard_dirs) {
+  timing <- file.path(dir, "timing.json")
+  if (file.exists(timing)) {
+    row <- tryCatch(read_json(timing), error = function(e) NULL)
+    if (!is.null(row$index)) {
+      shard_timings[[as.character(row$index)]] <- row
+    }
+  }
   manifest <- file.path(dir, "manifest.ndjson")
   if (!file.exists(manifest)) {
     next
@@ -157,6 +173,95 @@ for (entry in entries) {
 }
 write_json(baseline, file.path(baseline_out, "baseline.json"))
 inform("Baseline carries ", length(baseline), " old-version result(s)")
+
+# ----------------------------------------------------------------- timings ---
+
+# What this run cost, in the form the next plan can use: one row per package
+# (seconds per check here, next to the seconds CRAN reports) and one per shard
+# (install, check, script and job minutes, next to what was predicted).
+#
+# The plan's cost model is three constants -- how fast checks run here, what a
+# shard costs before it checks anything, what one more dependency costs to
+# install -- and every one of them is measurable. Measuring them is what keeps
+# the shard count honest: a model that overestimates the work cuts it into more
+# shards than the parallel capacity can run, and each extra shard is another
+# setup paid for nothing.
+seconds_of <- function(entry) {
+  both <- suppressWarnings(as.numeric(c(entry$t_old, entry$t_new)))
+  both <- both[!is.na(both) & both > 0]
+  if (length(both) == 0) {
+    NULL
+  } else {
+    list(seconds = mean(both), checks = length(both))
+  }
+}
+package_rows <- list()
+for (entry in entries) {
+  measured <- seconds_of(entry)
+  if (is.null(measured)) {
+    next
+  }
+  package_rows[[length(package_rows) + 1]] <- list(
+    package = entry$package,
+    version = entry$version,
+    t_total = entry$t_total %||% 0,
+    checks = measured$checks,
+    seconds = round(measured$seconds, 1)
+  )
+}
+
+# The shard's own clock covers install and checks; the minutes before its
+# driver starts -- runner image, R, pandoc, TinyTeX, artifact downloads -- are
+# only visible from the API, and they are precisely the price of one more
+# shard.
+job_minutes <- run_shard_job_minutes(env_chr("GITHUB_RUN_ID"))
+shard_rows <- lapply(shard_timings, function(t) {
+  index <- as.character(t$index)
+  install <- ((t$restore_seconds %||% 0) + (t$install_seconds %||% 0)) / 60
+  list(
+    index = t$index,
+    packages = t$packages %||% 0,
+    checks = t$checks %||% 0,
+    install_packages = t$install_packages %||% 0,
+    restored = t$restored %||% 0,
+    install_minutes = round(install, 2),
+    check_minutes = round((t$check_seconds %||% 0) / 60, 2),
+    script_minutes = round((t$script_seconds %||% 0) / 60, 2),
+    job_minutes = if (index %in% names(job_minutes)) {
+      round(unname(job_minutes[[index]]), 2)
+    } else {
+      NULL
+    },
+    planned_minutes = t$planned_minutes,
+    planned_check_minutes = t$planned_check_minutes
+  )
+})
+shard_rows <- unname(shard_rows[order(as.numeric(names(shard_rows)))])
+
+timings <- list(
+  run_id = env_chr("GITHUB_RUN_ID"),
+  generated_at = now_utc(),
+  r_version = plan$r_version,
+  platform = R.version$platform,
+  timing_flavor = plan$timing_flavor,
+  packages = package_rows,
+  shards = shard_rows
+)
+cal <- calibration(list(timings))
+timings$calibration <- list(
+  check_scale = cal$check_scale,
+  setup_minutes = cal$setup_minutes,
+  install_seconds = cal$install_seconds
+)
+write_json(timings, file.path(timings_out, "timings.json"))
+inform(
+  "Timings: ",
+  length(package_rows),
+  " package(s), ",
+  length(shard_rows),
+  " shard(s)",
+  if (length(job_minutes) == 0) " (job durations unavailable)" else ""
+)
 
 # ----------------------------------------------------------------- reports ---
 
@@ -407,6 +512,71 @@ append_summary(c(
           nrow(unchecked_df) - nrow(shown)
         ))
       },
+      ""
+    )
+  },
+  # What the run cost, in the terms the next plan is sized in. A plan that
+  # overestimates buys shards it cannot run in parallel, so these three numbers
+  # are worth showing next to the results they came from.
+  if (length(package_rows) > 0 || length(shard_rows) > 0) {
+    or_unmeasured <- function(x, fmt, ...) {
+      if (is.null(x)) "not measured" else sprintf(fmt, x, ...)
+    }
+    # From the package rows, not the shard rows: a shard whose job died leaves
+    # no timing of its own, but the checks it did finish are still in the
+    # manifest the collector just merged.
+    check_minutes <- sum(vapply(
+      package_rows,
+      function(p) p$seconds * p$checks / 60,
+      numeric(1)
+    ))
+    job <- vapply(
+      shard_rows,
+      function(s) s$job_minutes %||% NA_real_,
+      numeric(1)
+    )
+    c(
+      "### What this run cost",
+      "",
+      md_table(data.frame(
+        Measured = c(
+          "Checks",
+          "Check speed",
+          "Shard jobs",
+          "Setup per shard",
+          "Install per dependency"
+        ),
+        Value = c(
+          sprintf(
+            "%d in %d package(s), ~%.0f min",
+            sum(vapply(package_rows, function(p) p$checks, numeric(1))),
+            length(package_rows),
+            check_minutes
+          ),
+          or_unmeasured(cal$check_scale, "%.2f x the time CRAN reports"),
+          if (all(is.na(job))) {
+            sprintf("%d shard(s), job durations unavailable", length(shard_rows))
+          } else {
+            sprintf(
+              "%d shard(s), median ~%.0f min, longest ~%.0f min",
+              length(shard_rows),
+              stats::median(job, na.rm = TRUE),
+              max(job, na.rm = TRUE)
+            )
+          },
+          or_unmeasured(
+            cal$setup_minutes,
+            "~%.1f min before the driver starts"
+          ),
+          or_unmeasured(cal$install_seconds, "~%.1f s")
+        ),
+        check.names = FALSE
+      )),
+      "",
+      sprintf(
+        "The next plan reads these from the `revdep2-timings` artifact of %s and sizes its shards with them.",
+        this_run_link("this run")
+      ),
       ""
     )
   },

--- a/.github/workflows/revdep2/fetch.sh
+++ b/.github/workflows/revdep2/fetch.sh
@@ -26,6 +26,12 @@ fi
 mkdir -p "${dir}"
 gh run download "${run}" --name revdep2-report --dir "${dir}"
 
+# What the run cost, next to what it found: this is the file the next plan
+# calibrates on, and having it locally makes a dry run reproducible with
+# REVDEP2_MEASURED_DIR="${dir}".
+gh run download "${run}" --name revdep2-timings --dir "${dir}" ||
+  echo "Run ${run} published no timings artifact." >&2
+
 echo
 echo "Results of run ${run} are in ${dir}/:"
 ls "${dir}"

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -1,10 +1,10 @@
 # Plan the sharded reverse-dependency check.
 #
 # Enumerates the reverse dependencies of the package in the current directory,
-# weighs each one by the time CRAN's own check machine spends on it, decides
-# which CRAN-baseline results from an earlier run can be reused, and partitions
-# the packages into cost-balanced shards. One shard becomes one matrix leg of
-# .github/workflows/revdep2.yaml.
+# weighs each one by what its check is expected to cost on these runners,
+# decides which CRAN-baseline results from an earlier run can be reused, and
+# partitions the packages into cost-balanced shards. One shard becomes one
+# matrix leg of .github/workflows/revdep2.yaml.
 #
 # The partitioning is greedy, in two phases (see revdep2/README.md for why
 # greedy beats an exact formulation here):
@@ -16,9 +16,17 @@
 #      for each dependency the shard does not already need. The penalty is what
 #      pulls packages with overlapping dependency trees onto the same shard.
 #
-# K itself is the smallest shard count whose average check load fits the
-# per-shard budget, capped by the matrix limit -- so wall clock is bought with
-# more shards until the budget says the shards are small enough.
+# K is bounded by the parallel capacity, not by the budget alone. Only
+# `max-parallel` shards ever run at once, so shard K+1 of a full wave does not
+# start any earlier for having been split off -- it just pays another setup.
+# The rule is therefore: as many shards as the budget wants while they all fit
+# in one wave, and beyond that, whole waves -- as many as the per-shard
+# capacity demands, and no more.
+#
+# The cost model behind all of it -- how fast a check runs here, what a shard
+# costs before it checks anything, what one more dependency costs to install --
+# is calibrated from the timings artifact of the last runs, and falls back to
+# CRAN's numbers and the defaults below when no run has measured anything yet.
 #
 # Environment variables (inputs):
 #   REVDEP2_PACKAGES        - explicit packages to check (comma/space separated;
@@ -28,8 +36,12 @@
 #   REVDEP2_RETRY_RUN       - run id of an earlier revdep2 run; check only the
 #                             packages that run could not declare ok
 #   REVDEP2_SHARD_BUDGET_MINUTES - check-time target per shard (default: 45)
+#   REVDEP2_SHARD_CAPACITY_MINUTES - check minutes one shard may be given at
+#                             most, which is what forces a second wave
+#                             (default: 80% of REVDEP2_DEADLINE_MINUTES)
 #   REVDEP2_MAX_SHARDS      - matrix legs to emit at most (default: 250)
-#   REVDEP2_MAX_PARALLEL    - legs to run concurrently (default: 20)
+#   REVDEP2_MAX_PARALLEL    - legs to run concurrently, and so the size of one
+#                             wave (default: 20)
 #   REVDEP2_REFRESH_BASELINE- if truthy, ignore reusable baselines and re-check
 #                             the CRAN version of everything
 #   REVDEP2_BASELINE_MAX_AGE_DAYS - oldest baseline worth reusing (default: 30)
@@ -39,8 +51,21 @@
 #                             (default: 14)
 #   REVDEP2_HISTORY_RUNS    - earlier runs the donor walk looks at at all
 #                             (default: 40)
+#   REVDEP2_MEASURED_MAX_RUNS - earlier runs whose measured timings calibrate
+#                             the cost model (default: 3; 0 disables)
+#   REVDEP2_MEASURED_MAX_AGE_DAYS - oldest measurement worth trusting
+#                             (default: 60)
+#   REVDEP2_MEASURED_DIR    - offline hook: a directory holding a timings.json,
+#                             used instead of walking the run history
+#   REVDEP2_CHECK_SCALE     - check seconds here per second CRAN reports;
+#                             overrides the measured value (default: measured,
+#                             else 1)
+#   REVDEP2_SETUP_MINUTES   - fixed cost of one shard before it checks anything;
+#                             overrides the measured value (default: measured,
+#                             else 6)
 #   REVDEP2_INSTALL_SECONDS - marginal install cost charged per dependency a
-#                             package adds to its shard (default: 2.5)
+#                             package adds to its shard; overrides the measured
+#                             value (default: measured, else 2.5)
 #   REVDEP2_TIMINGS_FILE    - offline hook: RDS or CSV with columns Package and
 #                             T_total, used instead of tools::CRAN_check_results()
 #   OUT                     - plan file to write (default: plan.json)
@@ -71,13 +96,18 @@ if (is.na(depth) || depth < 1) {
 budget <- env_num("REVDEP2_SHARD_BUDGET_MINUTES", 45)
 max_shards <- min(env_num("REVDEP2_MAX_SHARDS", 250), 250)
 max_parallel <- env_num("REVDEP2_MAX_PARALLEL", 20)
+# A shard stops starting checks at its own deadline and defers the rest, so the
+# deadline is what actually caps a shard's check load; the plan aims below it,
+# leaving the rest of the job for installing and for the checks running long.
+deadline_minutes <- env_num("REVDEP2_DEADLINE_MINUTES", 300)
+capacity <- env_num("REVDEP2_SHARD_CAPACITY_MINUTES", 0.8 * deadline_minutes)
 refresh_baseline <- env_flag("REVDEP2_REFRESH_BASELINE")
 baseline_max_age <- env_num("REVDEP2_BASELINE_MAX_AGE_DAYS", 30)
 max_prebuilt_runs <- env_num("REVDEP2_PREBUILT_MAX_RUNS", 5)
 prebuilt_max_age <- env_num("REVDEP2_PREBUILT_MAX_AGE_DAYS", 14)
 history_runs <- env_num("REVDEP2_HISTORY_RUNS", 40)
-install_seconds <- env_num("REVDEP2_INSTALL_SECONDS", 2.5)
-setup_minutes <- env_num("REVDEP2_SETUP_MINUTES", 6)
+max_measured_runs <- env_num("REVDEP2_MEASURED_MAX_RUNS", 3)
+measured_max_age <- env_num("REVDEP2_MEASURED_MAX_AGE_DAYS", 60)
 overhead_minutes <- env_num("REVDEP2_PACKAGE_OVERHEAD_MINUTES", 0.5)
 retry_run <- env_chr("REVDEP2_RETRY_RUN")
 repo <- env_chr("GITHUB_REPOSITORY")
@@ -109,22 +139,26 @@ plan_nothing <- function(reason) {
 # fetch artifacts too; what is planned here is *which* earlier runs to take
 # them from.
 #
-# One walk over the workflow's completed runs, youngest first, answers both
-# questions this plan asks of its history, and asks the API for a run's
+# One walk over the workflow's completed runs, youngest first, answers every
+# question this plan asks of its history, and asks the API for a run's
 # artifacts at most once:
 #
 #   * which run donates the CRAN baseline -- the newest one that still has it;
 #   * which runs donate prebuilt package libraries -- as many as it takes to
 #     cover everything this run installs, youngest first, each one credited
-#     only with what the younger ones did not already have.
+#     only with what the younger ones did not already have;
+#   * which runs donate measured timings -- the youngest few, whose numbers
+#     calibrate the cost model below.
 #
-# The walk stops as soon as it has both, and never looks at more than
+# The walk stops as soon as it has all of them, and never looks at more than
 # `history_runs` runs; reuse is an optimization, and an optimization does not
 # get to spend the planning budget.
-scan_history <- function(want_baseline, needed) {
+scan_history <- function(want_baseline, want_timings, needed) {
   empty <- list(
     baseline_run = NULL,
     prebuilt = list(),
+    timings = list(),
+    timings_runs = character(),
     scanned = 0L,
     missing = needed
   )
@@ -148,10 +182,13 @@ scan_history <- function(want_baseline, needed) {
   this_run <- env_chr("GITHUB_RUN_ID")
   baseline_run <- NULL
   prebuilt <- list()
+  timings <- list()
+  timings_runs <- character()
   scanned <- 0L
   for (row in rows) {
     if (
       !want_baseline &&
+        length(timings) >= want_timings &&
         (length(needed) == 0 || length(prebuilt) >= max_prebuilt_runs)
     ) {
       break
@@ -168,6 +205,25 @@ scan_history <- function(want_baseline, needed) {
     if (want_baseline && "revdep2-baseline" %in% artifacts) {
       baseline_run <- run
       want_baseline <- FALSE
+    }
+    # Timings age the way baselines do: a runner image moves, and with it what
+    # a check costs. They are tiny, so taking the youngest few and pooling them
+    # is cheaper than trusting a single run that may have been a small retry.
+    take_timings <- length(timings) < want_timings &&
+      "revdep2-timings" %in% artifacts &&
+      !is.na(created) &&
+      as.numeric(Sys.Date() - created) <= measured_max_age
+    if (take_timings) {
+      dir <- fetch_artifact_id(ids[["revdep2-timings"]], tempfile("timings-"))
+      measured <- read_timings(dir)
+      unlink(dir, recursive = TRUE)
+      if (
+        !is.null(measured) &&
+          identical(measured$platform, R.version$platform)
+      ) {
+        timings[[length(timings) + 1]] <- measured
+        timings_runs <- c(timings_runs, run)
+      }
     }
     # A library is only worth carrying while its binaries still match the R
     # series and the platform they were built for, and while the runner image
@@ -211,6 +267,8 @@ scan_history <- function(want_baseline, needed) {
   list(
     baseline_run = baseline_run,
     prebuilt = prebuilt,
+    timings = timings,
+    timings_runs = timings_runs,
     scanned = scanned,
     missing = needed
   )
@@ -409,12 +467,15 @@ universe <- unique(c(unlist(closure, use.names = FALSE), dev_closure))
 # ------------------------------------------------------------ earlier runs ---
 
 local_baseline <- env_chr("REVDEP2_BASELINE_DIR")
+local_measured <- env_chr("REVDEP2_MEASURED_DIR")
 history <- scan_history(
-  # A retried run donates its own baseline, and the two offline hooks bypass
-  # discovery entirely; the walk then only looks for prebuilt libraries.
+  # A retried run donates its own baseline, and the offline hooks bypass
+  # discovery entirely; whatever is supplied that way, the walk stops looking
+  # for.
   want_baseline = !refresh_baseline &&
     !nzchar(local_baseline) &&
     !nzchar(retry_run),
+  want_timings = if (nzchar(local_measured)) 0 else max_measured_runs,
   needed = universe
 )
 
@@ -556,22 +617,124 @@ if (length(prebuilt) > 0) {
   )
 }
 
-# Weight: one check of the revdep costs about what CRAN's Linux machine spends
-# on it end to end; a package without a reusable baseline is checked twice.
-weight <- ((!reuse) + 1) * t_total / 60 + overhead_minutes
+# ------------------------------------------------------------- calibration ---
+
+# CRAN's `T_total` ranks packages well and predicts minutes here badly: it
+# comes from a different machine under a different load, and it is the only
+# number available for a package this workflow has never checked. So the last
+# runs' own measurements come first, and CRAN's number is scaled by what those
+# runs say the ratio between the two is.
+#
+# Every constant is overridable by hand, and every fallback is the value that
+# was hard-coded before anything measured itself.
+measured_runs <- if (nzchar(local_measured)) {
+  # Offline hook for reading a downloaded revdep2-timings artifact, the way
+  # REVDEP2_BASELINE_DIR reads a downloaded baseline.
+  Filter(Negate(is.null), list(read_timings(local_measured)))
+} else {
+  history$timings
+}
+cal <- calibration(measured_runs)
+measured_seconds <- measured_check_seconds(measured_runs)
+
+check_scale <- env_num_opt("REVDEP2_CHECK_SCALE") %||% cal$check_scale %||% 1
+setup_minutes <- env_num_opt("REVDEP2_SETUP_MINUTES") %||%
+  cal$setup_minutes %||%
+  6
+install_seconds <- env_num_opt("REVDEP2_INSTALL_SECONDS") %||%
+  cal$install_seconds %||%
+  2.5
+
+if (length(measured_runs) > 0) {
+  inform(
+    sprintf(
+      "Calibrated from %d run(s) (%s): checks run at %.2fx their CRAN time, %.1f min setup per shard, %.1f s per dependency installed",
+      length(measured_runs),
+      paste(
+        if (nzchar(local_measured)) local_measured else history$timings_runs,
+        collapse = ", "
+      ),
+      check_scale,
+      setup_minutes,
+      install_seconds
+    )
+  )
+} else {
+  inform(
+    "No measured timings found; using CRAN check times as they are, with the default shard costs"
+  )
+}
+
+# What one check of each package is expected to cost *here*: what the last runs
+# measured, or CRAN's time scaled to this machine. The floor keeps a package
+# with an implausibly small measurement from looking free.
+check_seconds <- t_total * check_scale
+seen <- intersect(packages, names(measured_seconds))
+check_seconds[seen] <- measured_seconds[seen]
+check_seconds <- pmax(check_seconds, 30)
+timing_source <- ifelse(
+  packages %in% seen,
+  "measured",
+  ifelse(known, "cran", "median")
+)
+inform(
+  sum(packages %in% seen),
+  " of ",
+  length(packages),
+  " check times measured by an earlier run"
+)
+
+# Weight: one check of the revdep costs what it is expected to cost here; a
+# package without a reusable baseline is checked twice.
+weight <- ((!reuse) + 1) * check_seconds / 60 + overhead_minutes
 
 # ------------------------------------------------------------- partitioning --
 
 n <- length(packages)
 total_check <- sum(weight)
-k <- max(1L, min(as.integer(ceiling(total_check / budget)), max_shards, n))
+
+# How many shards can actually run at the same time. Everything past that waits
+# for a lane, so the shard count is counted in waves of this size.
+lanes <- max(1L, min(as.integer(max_parallel), as.integer(max_shards), n))
+
+# Two demands, and they do not agree once the batch is large:
+#
+#   * the budget wants shards of at most `budget` check minutes -- short legs,
+#     quick feedback, cheap re-runs;
+#   * the capacity says a shard can hold `capacity` check minutes before its
+#     own deadline starts deferring packages.
+#
+# While the budget's answer fits in one wave, it wins: those shards all start
+# at once, so cutting finer really does buy wall clock. Past that it stops
+# buying anything -- shard 21 of 40 waits for shard 1 to finish either way, and
+# arrives having paid a second setup for the privilege. So beyond one wave the
+# capacity decides, and it decides in whole waves: as many as it takes to keep
+# every shard under its deadline, and not one more.
+by_budget <- max(1L, as.integer(ceiling(total_check / budget)))
+by_capacity <- max(1L, as.integer(ceiling(total_check / max(capacity, 1))))
+# Neither dial may be violated inside a wave, so the larger of the two wins
+# there; a capacity smaller than the budget is a contradiction, and the one
+# that keeps shards inside their deadline is the one to honour.
+k <- if (max(by_budget, by_capacity) <= lanes) {
+  max(by_budget, by_capacity)
+} else {
+  lanes * as.integer(ceiling(by_capacity / lanes))
+}
+k <- max(1L, min(k, as.integer(max_shards), n))
+waves <- as.integer(ceiling(k / lanes))
 inform(
   sprintf(
-    "%d packages, ~%.0f check minutes, budget %.0f min/shard -> %d shard(s)",
+    "%d packages, ~%.0f check minutes; budget %.0f min asks for %d shard(s), capacity %.0f min needs %d, %d lane(s) -> %d shard(s) in %d wave(s), ~%.0f check min each",
     n,
     total_check,
     budget,
-    k
+    by_budget,
+    capacity,
+    by_capacity,
+    lanes,
+    k,
+    waves,
+    total_check / k
   )
 )
 
@@ -634,7 +797,8 @@ shard_list <- lapply(seq_len(k), function(s) {
         level = if (p %in% names(level_of)) unname(level_of[[p]]) else 0L,
         weight_minutes = round(unname(weight[[p]]), 2),
         t_total = unname(t_total[[p]]),
-        timing_source = if (known[[match(p, packages)]]) "cran" else "median",
+        check_seconds = round(unname(check_seconds[[p]])),
+        timing_source = timing_source[[match(p, packages)]],
         dep_fingerprint = unname(fingerprint[[p]]),
         baseline = unname(reuse[[p]])
       )
@@ -680,10 +844,26 @@ plan <- list(
     missing = length(history$missing),
     runs = prebuilt
   ),
+  calibration = list(
+    runs = if (nzchar(local_measured)) {
+      as.list(local_measured)
+    } else {
+      as.list(history$timings_runs)
+    },
+    max_runs = max_measured_runs,
+    max_age_days = measured_max_age,
+    packages_measured = sum(packages %in% seen),
+    check_scale = round(check_scale, 3),
+    setup_minutes = round(setup_minutes, 2),
+    install_seconds = round(install_seconds, 2)
+  ),
   params = list(
     shard_budget_minutes = budget,
+    shard_capacity_minutes = capacity,
     max_shards = max_shards,
     max_parallel = max_parallel,
+    lanes = lanes,
+    waves = waves,
     install_seconds_per_package = install_seconds,
     setup_minutes = setup_minutes,
     package_overhead_minutes = overhead_minutes
@@ -693,6 +873,7 @@ plan <- list(
     packages = n,
     check_minutes = round(total_check, 1),
     estimate_minutes = round(sum(load), 1),
+    wave_minutes = round(waves * max(load), 1),
     install_union = length(universe)
   ),
   dropped_unknown = as.list(dropped),
@@ -801,7 +982,47 @@ append_summary(c(
       "none"
     }
   ),
-  sprintf("| Shards | %d (max-parallel %d, budget %.0f min) |", k, parallel, budget),
+  sprintf(
+    "| Cost model | %s |",
+    if (length(measured_runs) > 0) {
+      sprintf(
+        "measured by %s: checks at %.2f&times; their CRAN time, %.1f min setup per shard, %.1f s per dependency installed (%d of %d packages timed here before)",
+        if (nzchar(local_measured)) {
+          sprintf("`%s`", local_measured)
+        } else {
+          sprintf(
+            "run%s %s",
+            if (length(history$timings_runs) > 1) "s" else "",
+            paste(
+              vapply(history$timings_runs, run_link, character(1)),
+              collapse = ", "
+            )
+          )
+        },
+        check_scale,
+        setup_minutes,
+        install_seconds,
+        sum(packages %in% seen),
+        n
+      )
+    } else {
+      "uncalibrated: CRAN check times as they are, default shard costs"
+    }
+  ),
+  sprintf(
+    "| Shards | %d in %d wave(s) of %d (budget %.0f min, capacity %.0f min per shard) |",
+    k,
+    waves,
+    parallel,
+    budget,
+    capacity
+  ),
+  sprintf(
+    "| Estimated wall clock | ~%.0f min (%d wave(s) of ~%.0f min) |",
+    waves * max(load),
+    waves,
+    max(load)
+  ),
   sprintf("| Estimated runner time | ~%.0f min |", sum(load)),
   "",
   md_table(summary_df)

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -35,6 +35,9 @@
 #                             Enhances dependents)
 #   REVDEP2_RETRY_RUN       - run id of an earlier revdep2 run; check only the
 #                             packages that run could not declare ok
+#   REVDEP2_PART            - "i/G": check one G-th of the batch, for a revdep
+#                             set too big for a single run (the plan refuses
+#                             such a batch and prints the G it needs)
 #   REVDEP2_SHARD_BUDGET_MINUTES - check-time target per shard (default: 45)
 #   REVDEP2_SHARD_CAPACITY_MINUTES - check minutes one shard may be given at
 #                             most, which is what forces a second wave
@@ -410,6 +413,65 @@ known <- !is.na(t_total)
 fallback <- if (any(known)) stats::median(t_total[known]) else 300
 t_total[!known] <- fallback
 t_total <- pmax(t_total, 60)
+
+# ---------------------------------------------------------------- parts -----
+
+# `part: i/G` takes one G-th of the batch, for a revdep set too big to check in
+# one run (see the refusal in the partitioning section, which computes G and
+# prints the dispatch lines). The cut is made here, on CRAN's times, because
+# everything downstream -- closures, the dependency universe, the prebuilt
+# lookup -- should see only the packages this run will check.
+#
+# Dealing the weight-ordered list round robin keeps the parts of similar size
+# without any coordination between the runs: each one re-derives the same
+# order from the same CRAN metadata. A package that moves between dispatches
+# can land in another part or in none; `retry-run` on the union is the sweep
+# for that, and nothing here depends on the parts being exact.
+part_input <- trimws(env_chr("REVDEP2_PART"))
+part <- NULL
+if (nzchar(part_input)) {
+  fields <- suppressWarnings(as.integer(strsplit(part_input, "/")[[1]]))
+  if (
+    length(fields) != 2 ||
+      anyNA(fields) ||
+      fields[[1]] < 1 ||
+      fields[[2]] < 1 ||
+      fields[[1]] > fields[[2]]
+  ) {
+    stop(
+      "REVDEP2_PART must be `i/G` with 1 <= i <= G, not ",
+      part_input,
+      call. = FALSE
+    )
+  }
+  part <- list(index = fields[[1]], of = fields[[2]])
+  mine <- order(-t_total)[
+    seq(part$index, length(packages), by = part$of)
+  ]
+  packages <- sort(packages[mine])
+  t_total <- t_total[packages]
+  known <- known[packages]
+  their_version <- their_version[packages]
+  suffix <- sprintf(", part %d of %d", part$index, part$of)
+  selection <- paste0(selection, suffix)
+  if (!is.null(selection_md)) {
+    selection_md <- paste0(selection_md, suffix)
+  }
+  inform(
+    "Part ",
+    part$index,
+    " of ",
+    part$of,
+    ": ",
+    length(packages),
+    " packages, ~",
+    round(sum(t_total) / 60),
+    " CRAN check minutes"
+  )
+  if (length(packages) == 0) {
+    plan_nothing(sprintf("part %d of %d is empty", part$index, part$of))
+  }
+}
 inform(
   sum(known),
   " of ",
@@ -720,11 +782,11 @@ k <- if (max(by_budget, by_capacity) <= lanes) {
 } else {
   lanes * as.integer(ceiling(by_capacity / lanes))
 }
-k <- max(1L, min(k, as.integer(max_shards), n))
-waves <- as.integer(ceiling(k / lanes))
+max_k <- max(1L, min(as.integer(max_shards), n))
+k <- max(1L, min(k, max_k))
 inform(
   sprintf(
-    "%d packages, ~%.0f check minutes; budget %.0f min asks for %d shard(s), capacity %.0f min needs %d, %d lane(s) -> %d shard(s) in %d wave(s), ~%.0f check min each",
+    "%d packages, ~%.0f check minutes; budget %.0f min asks for %d shard(s), capacity %.0f min needs %d, %d lane(s) -> %d shard(s), ~%.0f check min each",
     n,
     total_check,
     budget,
@@ -733,7 +795,6 @@ inform(
     by_capacity,
     lanes,
     k,
-    waves,
     total_check / k
   )
 )
@@ -742,38 +803,173 @@ dep_idx <- lapply(closure, function(deps) match(deps, universe))
 penalty <- install_seconds / 60
 
 ord <- order(-weight)
-assignment <- integer(n)
-load <- rep(setup_minutes + length(dev_closure) * penalty, k)
-check_load <- numeric(k)
-install_count <- rep(length(dev_closure), k)
-have <- matrix(FALSE, nrow = length(universe), ncol = k)
-have[match(dev_closure, universe), ] <- TRUE
 
-place <- function(i, s) {
-  p <- ord[[i]]
-  fresh <- sum(!have[dep_idx[[p]], s])
-  assignment[[p]] <<- s
-  check_load[[s]] <<- check_load[[s]] + weight[[p]]
-  load[[s]] <<- load[[s]] + weight[[p]] + fresh * penalty
-  install_count[[s]] <<- install_count[[s]] + fresh
-  have[dep_idx[[p]], s] <<- TRUE
-}
+# The greedy pass, for a given shard count. It is cheap enough (O(n x K) with a
+# bitmap per shard) to run more than once, which is what lets the deadline
+# check below see a real partition rather than an average.
+partition <- function(k) {
+  assignment <- integer(n)
+  load <- rep(setup_minutes + length(dev_closure) * penalty, k)
+  check_load <- numeric(k)
+  have <- matrix(FALSE, nrow = length(universe), ncol = k)
+  have[match(dev_closure, universe), ] <- TRUE
 
-# Phase 1: the K heaviest packages, dealt round-robin.
-for (i in seq_len(min(k, n))) {
-  place(i, i)
-}
-
-# Phase 2: everything else goes where it costs least, dependency reuse folded
-# into the price.
-if (n > k) {
-  for (i in seq(k + 1L, n)) {
+  place <- function(i, s) {
     p <- ord[[i]]
-    fresh <- colSums(!have[dep_idx[[p]], , drop = FALSE])
-    score <- load + weight[[p]] + fresh * penalty
-    place(i, which.min(score))
+    fresh <- sum(!have[dep_idx[[p]], s])
+    assignment[[p]] <<- s
+    check_load[[s]] <<- check_load[[s]] + weight[[p]]
+    load[[s]] <<- load[[s]] + weight[[p]] + fresh * penalty
+    have[dep_idx[[p]], s] <<- TRUE
   }
+
+  # Phase 1: the K heaviest packages, dealt round-robin.
+  for (i in seq_len(min(k, n))) {
+    place(i, i)
+  }
+
+  # Phase 2: everything else goes where it costs least, dependency reuse folded
+  # into the price.
+  if (n > k) {
+    for (i in seq(k + 1L, n)) {
+      p <- ord[[i]]
+      fresh <- colSums(!have[dep_idx[[p]], , drop = FALSE])
+      score <- load + weight[[p]] + fresh * penalty
+      place(i, which.min(score))
+    }
+  }
+
+  list(assignment = assignment, load = load, check_load = check_load)
 }
+
+# `capacity` bounds the *checks* a shard may hold; the shard also spends its
+# setup and its installs inside the same deadline, and only a real partition
+# says how much that is -- the install union of a shard is not a per-package
+# constant. So the estimate is checked against the deadline here, and a shard
+# count that cannot hold it grows by whole waves until it can.
+fit <- partition(k)
+while (max(fit$load) > deadline_minutes && k < max_k) {
+  grown <- min(as.integer(k + lanes), max_k)
+  inform(sprintf(
+    "Heaviest shard estimated at ~%.0f min, past the %.0f min deadline; growing to %d shard(s)",
+    max(fit$load),
+    deadline_minutes,
+    grown
+  ))
+  k <- grown
+  fit <- partition(k)
+}
+assignment <- fit$assignment
+load <- fit$load
+check_load <- fit$check_load
+waves <- as.integer(ceiling(k / lanes))
+
+# Out of room: the matrix limit (or the package count) caps the shards below
+# what the work needs, so every shard would run into its deadline and defer.
+# That is a plan worth refusing -- a run started this way spends hours to
+# report half its packages as deferred, and says so only at the end.
+#
+# How many runs it takes instead: splitting into G parts divides a shard's
+# check load by G, but not its setup or its installs, so the question is how
+# much of the deadline is left for checks once those are paid.
+plan_too_big <- function() {
+  worst <- which.max(load)
+  overhead <- load[[worst]] - check_load[[worst]]
+  headroom <- deadline_minutes - overhead
+  parts <- if (headroom <= 0) {
+    NA_integer_
+  } else {
+    max(2L, as.integer(ceiling(check_load[[worst]] / headroom)))
+  }
+  inform(sprintf(
+    "Too big for one run: %d shard(s) is the limit, and the heaviest would be ~%.0f min against a %.0f min deadline",
+    k,
+    load[[worst]],
+    deadline_minutes
+  ))
+  append_summary(c(
+    "## revdep2 plan",
+    "",
+    "**Too big for one run — nothing was started.**",
+    "",
+    sprintf(
+      "%d packages need ~%.0f check minutes. At most %d shard%s can be planned (%s), which puts the heaviest at ~%.0f min: ~%.0f min of checks on top of ~%.0f min of setup and installs, against the %.0f min a shard has before its deadline starts deferring packages.",
+      n,
+      total_check,
+      max_k,
+      if (max_k == 1) "" else "s",
+      if (max_k < as.integer(max_shards)) {
+        sprintf("one per package, and there are only %d", n)
+      } else {
+        sprintf("`max-shards`, itself capped at 250 by the matrix limit")
+      },
+      load[[worst]],
+      check_load[[worst]],
+      overhead,
+      deadline_minutes
+    ),
+    "",
+    if (is.na(parts)) {
+      c(
+        sprintf(
+          "Setup and installs alone (~%.0f min) already exceed the deadline, so splitting the packages will not help: raise `REVDEP2_DEADLINE_MINUTES` (and the job's `timeout-minutes`, up to GitHub's 6 h ceiling) first.",
+          overhead
+        ),
+        ""
+      )
+    } else {
+      c(
+        sprintf("Split it into %d runs, each an independent report:", parts),
+        "",
+        "```sh",
+        paste0(
+          sprintf(
+            "gh workflow run revdep2.yaml -f part=%d/%d",
+            seq_len(parts),
+            parts
+          ),
+          collapse = "\n"
+        ),
+        "```",
+        "",
+        paste(
+          "The parts are cut from the same weight-ordered list, dealt round",
+          "robin, so they are of similar size and together cover everything —",
+          "and each part re-plans itself, so a part that is still too big says",
+          "so in turn. They share baselines and prebuilt libraries through the",
+          "usual artifacts, so the later parts start warmer than the first."
+        ),
+        ""
+      )
+    },
+    "Or keep it in one run by making the shards fit:",
+    "",
+    sprintf(
+      "* `max-parallel` above %d does not change this — the limit is how many shards may exist (250), not how many run at once.",
+      max_parallel
+    ),
+    sprintf(
+      "* raise `shard-capacity-minutes` (now %.0f) only together with `REVDEP2_DEADLINE_MINUTES` (now %.0f) and the shard job's `timeout-minutes` (350): the deadline is what a shard actually has.",
+      capacity,
+      deadline_minutes
+    ),
+    "* pass an explicit `packages` list, or a smaller `depth`, to check less.",
+    ""
+  ))
+  quit(save = "no", status = 1)
+}
+if (max(load) > deadline_minutes) {
+  plan_too_big()
+}
+
+inform(sprintf(
+  "%d shard(s) in %d wave(s); heaviest ~%.0f min (checks ~%.0f, deadline %.0f)",
+  k,
+  waves,
+  max(load),
+  max(check_load),
+  deadline_minutes
+))
 
 # ------------------------------------------------------------------ output ---
 
@@ -827,6 +1023,7 @@ plan <- list(
   depth = depth_raw,
   levels = as.list(level_counts),
   selection = selection,
+  part = part,
   generated_at = now_utc(),
   timing_flavor = timing_flavor,
   retry_of = if (nzchar(retry_run)) run_id_chr(retry_run) else "0",
@@ -1025,5 +1222,21 @@ append_summary(c(
   ),
   sprintf("| Estimated runner time | ~%.0f min |", sum(load)),
   "",
+  # A run in more than one wave is waiting on lanes, not on work, and the
+  # dispatch form is where that is fixed -- so say it here, with the number.
+  if (waves > 1) {
+    c(
+      sprintf(
+        "These %d shards run %d at a time, so %d waves. Dispatching with `max-parallel: %d` would run them in one, at roughly %.0f min instead of %.0f — worth it if that many runners are available.",
+        k,
+        lanes,
+        waves,
+        k,
+        max(load),
+        waves * max(load)
+      ),
+      ""
+    )
+  },
   md_table(summary_df)
 ))

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -21,6 +21,11 @@
 # util.R): this run's preflight library, and then the earlier runs the plan
 # picked. pak only has to build what neither of them had.
 #
+# What each phase costs is recorded in timing.json next to the results: the
+# collector folds it into the run's timings artifact, and the next plan sizes
+# its shards from what this one measured rather than from CRAN's numbers and a
+# guess.
+#
 # Environment variables:
 #   SHARD                  - shard index from plan.json (required)
 #   PLAN                   - plan file (default: plan.json)
@@ -41,6 +46,11 @@ source(file.path(
   dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))),
   "util.R"
 ))
+
+script_started <- Sys.time()
+elapsed <- function(from) {
+  round(as.numeric(difftime(Sys.time(), from, units = "secs")), 1)
+}
 
 shard_index <- as.integer(env_chr("SHARD"))
 stopifnot(!is.na(shard_index))
@@ -132,10 +142,12 @@ install <- unlist(shard$install, use.names = FALSE)
 # could not supply. pak still resolves the whole set afterwards; the point is
 # to skip *building* what has not changed, not to skip resolving it.
 lib <- .libPaths()[[1]]
+restore_started <- Sys.time()
 restored <- c(
   restore_local_library(env_chr("LIB_DIR"), lib, install),
   restore_prebuilt(plan, lib, install)
 )
+restore_seconds <- elapsed(restore_started)
 inform(
   length(restored),
   " dependency binaries restored, ",
@@ -149,6 +161,7 @@ inform(
 upgrade <- length(restored) > 0
 
 inform("Installing ", length(install), " dependencies")
+install_started <- Sys.time()
 bulk_ok <- tryCatch(
   {
     pak::pkg_install(install, ask = FALSE, upgrade = upgrade)
@@ -172,6 +185,15 @@ if (!bulk_ok) {
     )
   }
 }
+
+install_seconds <- elapsed(install_started)
+inform(
+  "Dependencies ready after ",
+  round(install_seconds / 60, 1),
+  " min (",
+  round(restore_seconds / 60, 1),
+  " min unpacking prebuilt)"
+)
 
 installed <- rownames(utils::installed.packages())
 our_version <- function() {
@@ -281,6 +303,7 @@ runnable <- names(sources)
 # attempt the first check of a phase, or a mis-budgeted shard would make no
 # progress at all and a retry would repeat the mistake.
 checks_started <- 0L
+check_seconds <- 0
 out_of_time <- function(entry) {
   if (checks_started == 0L) {
     return(FALSE)
@@ -312,6 +335,9 @@ run_check <- function(name, phase) {
     error = function(e) e
   )
   duration <- round(as.numeric(Sys.time() - started, units = "secs"))
+  # Every check counts towards what this shard cost, including the ones that
+  # errored or timed out -- they spent the same minutes.
+  check_seconds <<- check_seconds + duration
   attr(result, "duration") <- duration
   # A check that hits the timeout is killed, and rcmdcheck surfaces that as an
   # error rather than a result object; tell it apart from a genuine crash by
@@ -505,6 +531,32 @@ for (entry in entries) {
     append = TRUE
   )
 }
+
+# ----------------------------------------------------------------- timings ---
+
+# What this shard cost, next to what the plan thought it would: the collector
+# pools these into the run's timings artifact, and the next plan calibrates its
+# cost model from them. The job's own minutes -- the runner image, R, TinyTeX,
+# the artifact downloads before this script even starts -- are not visible from
+# here; the collector reads those off the API and adds them.
+write_json(
+  list(
+    index = shard_index,
+    packages = length(members),
+    checks = checks_started,
+    install_packages = length(install),
+    restored = length(restored),
+    restore_seconds = restore_seconds,
+    install_seconds = install_seconds,
+    check_seconds = round(check_seconds, 1),
+    script_seconds = elapsed(script_started),
+    started_at = format(script_started, "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+    finished_at = now_utc(),
+    planned_minutes = shard$estimate_minutes,
+    planned_check_minutes = shard$check_minutes
+  ),
+  file.path(out_dir, "timing.json")
+)
 
 # ------------------------------------------------------------------ summary --
 

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -733,6 +733,8 @@ dep_fingerprint <- function(deps, db) {
 #   depfail      -- dependencies could not be installed, check not attempted
 #   deferred     -- shard deadline hit before this package was checked
 #   error        -- the shard driver itself broke on this package
+#   missing      -- the plan named it, no shard ever reported it: the job died
+#                   (assigned by the collector, never by a shard)
 classify_status <- function(status, new_issues) {
   if (status %in% c("+", "-")) {
     if (identical(status, "-") && new_issues > 0) "newly_broken" else "ok"

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -12,8 +12,16 @@ env_chr <- function(name, default = "") {
 }
 
 env_num <- function(name, default) {
+  value <- env_num_opt(name)
+  if (is.null(value)) default else value
+}
+
+# The same, but NULL when the variable is unset or unusable -- so a caller can
+# tell "not given" from "given the value that happens to be the default", which
+# is what an explicit knob overriding a measurement needs to know.
+env_num_opt <- function(name) {
   value <- suppressWarnings(as.numeric(env_chr(name)))
-  if (length(value) != 1 || is.na(value)) default else value
+  if (length(value) != 1 || is.na(value)) NULL else value
 }
 
 env_flag <- function(name) {
@@ -506,6 +514,153 @@ restore_prebuilt <- function(plan, lib, wanted) {
     inform("Prebuilt: restored ", length(got), " package(s) from run ", run_id)
   }
   restored
+}
+
+# --------------------------------------------------------- measured timings --
+
+# What a run measured about itself, so the next plan can stop guessing.
+#
+# The collector writes one `timings.json` per run -- a row per package (how
+# long its checks actually took here, next to what CRAN reports for it) and a
+# row per shard (job, install and check minutes, next to what the plan
+# predicted) -- and publishes it as the small `revdep2-timings` artifact,
+# separate from the report the way `revdep2-lib-index` is separate from the
+# library: a plan reads it without downloading anything else.
+#
+# Three constants come out of it, each a median over what actually happened,
+# and each NULL when the runs measured nothing usable -- the caller keeps its
+# default then. `runs` is youngest first; a younger measurement of a package
+# wins, and the constants pool every row there is.
+
+read_timings <- function(dir) {
+  if (!nzchar(dir %||% "")) {
+    return(NULL)
+  }
+  path <- file.path(dir, "timings.json")
+  if (!file.exists(path)) {
+    return(NULL)
+  }
+  tryCatch(read_json(path), error = function(e) NULL)
+}
+
+# Seconds one check of a package took here, per package, youngest run first.
+measured_check_seconds <- function(runs) {
+  out <- stats::setNames(numeric(), character())
+  for (run in runs) {
+    for (row in run$packages %||% list()) {
+      seconds <- suppressWarnings(as.numeric(row$seconds %||% NA))
+      if (
+        is.null(row$package) ||
+          row$package %in% names(out) ||
+          is.na(seconds) ||
+          seconds <= 0
+      ) {
+        next
+      }
+      out[[row$package]] <- seconds
+    }
+  }
+  out
+}
+
+# The medians the plan's cost model runs on:
+#   check_scale     - check seconds here per second CRAN reports (T_total);
+#                     these runners are not CRAN's machines
+#   setup_minutes   - per-shard fixed cost, from job start to the driver's
+#                     first line: the runner image, R, TinyTeX, the artifacts
+#   install_seconds - marginal cost of one more dependency in a shard's union
+calibration <- function(runs) {
+  scales <- numeric()
+  setups <- numeric()
+  installs <- numeric()
+  packages <- 0L
+  shards <- 0L
+  for (run in runs) {
+    for (row in run$packages %||% list()) {
+      seconds <- suppressWarnings(as.numeric(row$seconds %||% NA))
+      cran <- suppressWarnings(as.numeric(row$t_total %||% NA))
+      packages <- packages + 1L
+      if (!is.na(seconds) && !is.na(cran) && seconds > 0 && cran > 0) {
+        scales <- c(scales, seconds / cran)
+      }
+    }
+    for (row in run$shards %||% list()) {
+      shards <- shards + 1L
+      job <- suppressWarnings(as.numeric(row$job_minutes %||% NA))
+      script <- suppressWarnings(as.numeric(row$script_minutes %||% NA))
+      if (!is.na(job) && !is.na(script) && job >= script) {
+        setups <- c(setups, job - script)
+      }
+      minutes <- suppressWarnings(as.numeric(row$install_minutes %||% NA))
+      count <- suppressWarnings(as.numeric(row$install_packages %||% NA))
+      if (!is.na(minutes) && !is.na(count) && count > 0) {
+        installs <- c(installs, minutes * 60 / count)
+      }
+    }
+  }
+  median_or_null <- function(x) {
+    if (length(x) == 0) NULL else unname(stats::median(x))
+  }
+  list(
+    check_scale = median_or_null(scales),
+    setup_minutes = median_or_null(setups),
+    install_seconds = median_or_null(installs),
+    packages = packages,
+    shards = shards,
+    runs = length(runs)
+  )
+}
+
+# How long each shard's *job* took, by shard index. The driver can time itself,
+# but not the minutes before it starts -- the runner image, R, pandoc, TinyTeX,
+# the artifact downloads. That gap is exactly the per-shard setup cost the plan
+# charges for every extra shard, so it is measured here, in the one job that
+# runs after all the shards and can still ask the API about them.
+run_shard_job_minutes <- function(run_id) {
+  empty <- stats::setNames(numeric(), character())
+  if (!gh_ok() || !nzchar(gh_repo())) {
+    return(empty)
+  }
+  rows <- character()
+  for (page in 1:5) {
+    got <- gh_lines(
+      "api",
+      sprintf(
+        "repos/%s/actions/runs/%s/jobs?per_page=100&page=%d",
+        gh_repo(),
+        run_id,
+        page
+      ),
+      "--jq",
+      ".jobs[] | [.name, .started_at, .completed_at] | @tsv"
+    )
+    got <- if (is.null(got)) character() else got[nzchar(got)]
+    rows <- c(rows, got)
+    if (length(got) < 100) {
+      break
+    }
+  }
+  out <- empty
+  stamp <- function(x) {
+    as.POSIXct(x, format = "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+  }
+  for (row in rows) {
+    fields <- strsplit(row, "\t", fixed = TRUE)[[1]]
+    if (length(fields) < 3 || !grepl("^shard [0-9]+ ", fields[[1]])) {
+      next
+    }
+    index <- sub("^shard ([0-9]+) .*$", "\\1", fields[[1]])
+    from <- stamp(fields[[2]])
+    to <- stamp(fields[[3]])
+    if (is.na(from) || is.na(to) || to < from) {
+      next
+    }
+    minutes <- as.numeric(difftime(to, from, units = "mins"))
+    # A re-run reports the later attempt last; it is the one that produced the
+    # artifact the collector is reading.
+    out[[index]] <- minutes
+  }
+  out
 }
 
 # ------------------------------------------------------------ CRAN metadata --


### PR DESCRIPTION
<!-- Prepared with Claude Code; the analysis, the code and this description were generated by an LLM and reviewed by a human before merging. -->

Only `max-parallel` shards (20) ever run at once, but the plan cut purely by `shard-budget-minutes`. Run 31048405399 therefore ran 111 shards in six waves — 6 h 16 min end to end — where every shard past the first 20 waited for a lane and arrived having paid another setup.

That run also showed the cost model was wrong by more than a factor of two: it planned 4991 check minutes, the checks took 2233. Per shard: 45 min planned, ~21 min actual.

## The shard count now follows the capacity

While the budget's answer fits in one wave it still wins, so small batches stay cheap and fine-grained. Beyond that the plan emits whole waves — as many as `shard-capacity-minutes` (default 80% of the shard's 300-minute deadline) requires, and no more. Same batch: 40 shards in 2 waves uncalibrated, 20 shards in one wave once calibrated (~145 check minutes each).

`max-parallel` is not a dial that buys parallelism, and the docs say so plainly: GitHub caps concurrent jobs per account, so setting it above what the account really has just cuts more shards, each paying its own setup while it queues. The default of 20 sits under the cap deliberately, leaving room for the rest of the repository's CI.

The count is chosen on check minutes, but a shard also pays its setup and installs inside the same deadline, and only a real partition says how much that is — a shard's install union is not a per-package constant. The greedy pass is now a function that can run more than once: the heaviest shard's full estimate is compared against the deadline, and a count that cannot hold it grows by a whole wave and partitions again.

## The cost model measures itself

Three constants used to be guesses. Each shard now records what its phases cost (`timing.json`: unpack, install, checks, its own wall time); the collector adds the shard *job* durations read off the API — the minutes before the driver starts are invisible from inside it and are exactly what an extra shard costs — and publishes `revdep2-timings`, a small artifact next to the report. The next plan picks it up in the same history walk that already finds the baseline and prebuilt libraries, and reduces the youngest few runs to medians:

- check scale: check seconds here ÷ CRAN's `T_total` — 0.47, fallback 1
- setup per shard: job minutes − driver minutes — fallback 6 min
- install per dependency: install minutes ÷ packages installed — fallback 2.5 s

Per-package measurements replace CRAN's number where a run has them; the scale only prices packages never checked here. Worked example, `abess` (CRAN `T_total` 364 s): the old plan weighed it 2 × 364/60 + 0.5 = 12.6 min; it actually took 203 s and 190 s, so it now weighs 7.1 min from its own measurement, or 6.2 min from the scaled CRAN number if it had never been checked here.

`REVDEP2_CHECK_SCALE`, `REVDEP2_SETUP_MINUTES` and `REVDEP2_INSTALL_SECONDS` override the measurements. With no timings artifact the plan behaves exactly as before. The per-check timeout deliberately stays on CRAN's unscaled number: a safety net for a check that has gone wrong should stay generous, and at 0.47 the same factor would be a third as forgiving.

## A batch too big for the matrix is refused, not truncated

250 shards × 240 check minutes is the ceiling of one run. Past it the count used to be capped silently, every shard ran into its deadline, and the run said so only hours later. The plan now refuses before anything starts and recommends the new `part` input: `part=1/3`, `2/3`, `3/3` are three ordinary independent runs, cut from the same weight-ordered list dealt round robin, so they need no coordination — each re-derives the same order from the same CRAN metadata — and each re-plans itself, so a part that is still too big refuses in turn with a bigger G.

A split buys a run that *fits* — shards inside their deadline, a report per part, retry granularity — not wall clock: the parts draw on the same account concurrency and add a preflight each. And one case a split cannot fix at all: a package is never divided across shards, so where a single package is what breaks the deadline, the refusal names it and points at `REVDEP2_DEADLINE_MINUTES` and the job timeout above it, or an explicit `packages` list.

For scale, `tibble` at the default 20 lanes:

- 2398 strong revdeps, 14 035 check minutes on CRAN's numbers → 60 shards in three waves (~13 h); 40 shards in two (~7 h) calibrated.
- 3032 with `which: most`, 18 515 check minutes → 80 shards in four waves (~17 h); 40 shards in two (~9 h) calibrated.

Both are well inside the refusal, and neither is short — but the shard count is not what makes them long. What bounds such a run is the account's concurrency, the serial preflight over a 3675-package dependency universe, and the heaviest single package (`duckdb` alone is a 171-minute leg of the `most` plan on CRAN's numbers).

## Partial results survive a dead shard

A shard whose job dies used to take its packages out of the report entirely. The collector now reconciles against the plan: a package no shard reported is `missing`, naming the shard, which puts it in the counts, in the "could not be checked" table, and in what `retry-run` re-checks. The results download is tolerated rather than required, so even a run where every shard died still reports. A run in more than one wave also says so in the summary, with what would and would not shorten it.

## Verification

Offline, against fixtures built from run 31048405399's real manifest and from live CRAN metadata: calibrated (20 shards / 1 wave), uncalibrated (40 / 2), forced multi-wave, a 4-package batch, capacity below budget, manual overrides, a 200-minute setup forcing growth to 40 shards, and both refusal paths (exit 1, no job outputs, downstream jobs skipped). The three `part` plans were checked to be disjoint and to cover the batch exactly, balanced within ~10% by check minutes. Both `tibble` sets were planned end to end (36 s for the largest, inside the plan job's budget). Plus a collect→plan round trip through a generated `timings.json`, a simulated dead shard (8 packages reported `missing`, retry selects exactly those 8), and unit tests for the job-duration parsing, median pooling, and missing/broken-input paths. `air format --check` is clean and the workflow YAML parses.

Not verified: a live run. The wave arithmetic and the artifact plumbing are exercised offline, but the first real run is what confirms the install cost holds up when a shard's dependency union grows from ~300 to ~500 packages — the model charges that linearly, which `revdep2/README.md` flags as the weakest remaining assumption.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.