### PR TITLE
fix(ci): Let a `revdep2` run survive its preflight, and finish the shard-count follow-ups

### DIFF
--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -97,7 +97,7 @@ on:
         type: string
         default: ""
       max-parallel:
-        description: "Shards to run concurrently, and so the wave size the plan partitions into"
+        description: "Shards to run concurrently, and so the wave size the plan cuts: set it to the concurrency the account really has, never more (GitHub queues past its own limit anyway)"
         type: string
         default: ""
       refresh-baseline:

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -255,6 +255,11 @@ jobs:
 
     runs-on: ubuntu-26.04
 
+    # This job installs the whole dependency universe; when that goes wrong it
+    # tends to go wrong slowly. Below the 6 h ceiling so it ends as a failure
+    # with logs rather than as a hard kill.
+    timeout-minutes: 300
+
     name: "Preflight all dependencies"
 
     permissions:
@@ -266,6 +271,24 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
+
+      # A runner ships with ~25 GB of toolchains this job will never use, and
+      # a dependency universe of a few thousand packages -- sources, binaries,
+      # build directories and the installed library at once -- is the one job
+      # here that can plausibly fill the disk. Reclaiming the space is cheap
+      # insurance; printing what is left makes the next failure diagnosable
+      # instead of a bare exit 143.
+      - name: Make room for the dependency universe
+        run: |
+          before=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL \
+            /usr/local/share/powershell /usr/share/swift || true
+          sudo docker image prune --all --force > /dev/null 2>&1 || true
+          after=$(df -BG --output=avail / | tail -1 | tr -dc '0-9')
+          echo "Free disk: ${before}G -> ${after}G"
+          free -g
+        shell: bash
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -303,10 +326,23 @@ jobs:
           Rscript ./.github/workflows/revdep2/preflight.R
         shell: bash
 
+      # Runs even when the install step died, because "how much disk and
+      # memory were left" is the first question about a job that was killed
+      # rather than failed.
+      - name: Report what the install consumed
+        if: always()
+        run: |
+          df -h / /mnt || true
+          free -g || true
+          du -sh ~/.cache/R/pkgcache "${RUNNER_TEMP}/lib" 2>/dev/null || true
+        shell: bash
+
       - uses: actions/upload-artifact@v6
+        if: always()
         with:
           name: revdep2-preflight
           path: ${{ runner.temp }}/preflight
+          if-no-files-found: ignore
           retention-days: 30
           overwrite: true
 
@@ -338,7 +374,19 @@ jobs:
       - build
       - preflight
 
-    if: needs.plan.outputs.shards != '0'
+    # The preflight is an optimization and an early diagnosis, not a
+    # prerequisite: a shard installs its own dependency union anyway, and that
+    # union is a fraction of the universe the preflight takes on (~500 of 4400
+    # in the run that made this necessary). So a preflight that dies must not
+    # take the checks with it -- `!cancelled()` is what lets this job run past
+    # a failed `needs`, and the dry-run guard has to be spelled out because a
+    # skipped preflight no longer skips this job either.
+    if: >-
+      !cancelled()
+      && needs.plan.result == 'success'
+      && needs.build.result == 'success'
+      && needs.plan.outputs.shards != '0'
+      && inputs.dry-run != true
 
     runs-on: ubuntu-26.04
 
@@ -470,10 +518,18 @@ jobs:
       - test
 
     # `always()` so a run with red shards still reports -- a broken revdep is
-    # the result this workflow exists to surface. Guarded on the earlier
-    # stages having succeeded, because without a plan and a binary there is
-    # nothing to collect; a dry run skips preflight and therefore this too.
-    if: always() && needs.plan.result == 'success' && needs.build.result == 'success' && needs.preflight.result == 'success' && needs.plan.outputs.shards != '0'
+    # the result this workflow exists to surface. Guarded on the plan and the
+    # binary, because without those there is nothing to collect, and on the
+    # dry-run input, which is now the only thing that stops this job from
+    # reporting: the preflight's result is deliberately not consulted, since a
+    # run whose preflight died still has shards, results, and packages to
+    # account for.
+    if: >-
+      always()
+      && needs.plan.result == 'success'
+      && needs.build.result == 'success'
+      && needs.plan.outputs.shards != '0'
+      && inputs.dry-run != true
 
     runs-on: ubuntu-26.04
 

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -30,7 +30,7 @@ plan      (1 job, ~2 min)              build  (1 job, parallel to plan)
        one wave can run, in whole waves
        → plan.json (artifact) + matrix (job output)
 
-preflight (1 job; a dry run stops before it)
+preflight (1 job; a dry run stops before it; failure does not stop the run)
   ├─ unpack the prebuilt packages the plan found
   ├─ install + load *every* dependency any revdep needs
   └─ pack the library for the next run
@@ -383,6 +383,18 @@ This is the half that pays on the very first run:
 the compile happens once in the preflight
 instead of once more in each shard.
 
+It is a `needs`, but not a prerequisite.
+`test` runs on `!cancelled()` past a failed preflight
+and `collect` does not consult its result at all,
+because the preflight buys two things —
+a free rebuild for the shards, and dependency failures diagnosed early —
+and neither is worth the run.
+A shard installs its own union regardless,
+and that union is a fraction of what the preflight takes on:
+in the run that made this necessary,
+a median of 478 packages against the preflight's 4397.
+Losing the preflight makes a run slower and blinder, not void.
+
 For the rest, the plan walks the workflow's completed runs, youngest first,
 and takes libraries until it has covered
 every package this run will install,
@@ -504,6 +516,7 @@ so its report is complete again, not a fragment.
 | A check times out | rcmdcheck kills it at `max(floor, factor × its CRAN time)`; compared as `t-`, reported `failed` |
 | A revdep's strong dependencies cannot install | `depfail`, check not attempted, named in the shard summary |
 | A dependency fails the preflight | reported in the preflight summary and `depfail.json`; shards still try their own subset |
+| The preflight job itself dies | the shards run anyway and install their own unions, the collector still reports; only the free rebuild and the early diagnosis are lost |
 | A shard hits its deadline | remaining packages `deferred`; finished old-halves still uploaded and baseline-fed |
 | A shard job dies hard | the collector reconciles against the plan: its packages are reported `missing`, naming the shard, and `retry-run` re-checks exactly them |
 | Every shard dies | the report is still written, with every package `missing`; the artifact download is tolerated, not required |
@@ -548,6 +561,7 @@ at the next `if`.
 | Runs donating prebuilt packages | — | `REVDEP2_PREBUILT_MAX_RUNS` | 5 (`0` disables) |
 | Oldest reusable prebuilt library | — | `REVDEP2_PREBUILT_MAX_AGE_DAYS` | 14 days |
 | Runs the history walk looks at | — | `REVDEP2_HISTORY_RUNS` | 40 |
+| Wall clock past which the plan warns (never refuses) | — | `REVDEP2_LONG_RUN_HOURS` | 12 h |
 | Runs whose timings calibrate the cost model | — | `REVDEP2_MEASURED_MAX_RUNS` | 3 (`0` disables) |
 | Oldest measurement worth trusting | — | `REVDEP2_MEASURED_MAX_AGE_DAYS` | 60 days |
 | Check seconds here per CRAN second | — | `REVDEP2_CHECK_SCALE` | measured, else 1 |

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -104,9 +104,20 @@ and against the local estimate that same factor would be a third as forgiving.
 ### The shard count is bounded by the parallel capacity
 
 Only `max-parallel` shards run at once (default 20),
-so shards come in waves of that size,
-and the shard after a full wave does not start any earlier for existing:
-it waits for a lane, and arrives having paid another setup
+so shards come in waves of that size.
+That default is not arbitrary and raising it is not free:
+GitHub caps how many jobs an account may run concurrently
+(20 on the free plan, more on paid ones),
+and 20 leaves room for the rest of the repository's CI.
+Past that ceiling GitHub queues jobs whatever `max-parallel` says —
+so a plan told it has more lanes than the account really has
+does not get them, it just cuts more shards,
+each paying its own setup while it waits for one.
+**`max-parallel` should be the concurrency that actually exists, never more.**
+
+Waves are what makes the shard count a real decision:
+a shard after a full wave does not start any earlier for existing.
+It waits for a lane, and arrives having paid another setup
 (runner image, R, pandoc, TinyTeX, artifact downloads —
 charged at 6 minutes until a run measures it)
 plus its own dependency install.
@@ -154,6 +165,11 @@ Past that the plan **refuses to start**, with the numbers that make the case
 and the ways out — rather than dispatching a run
 that spends hours to report half its packages as `deferred`.
 
+That ceiling is about the matrix, not about patience.
+At 20 lanes, 250 shards is thirteen waves;
+a batch anywhere near the limit is a multi-day run long before it is
+an impossible one, and the wave count in the plan summary is what says so.
+
 The way out it recommends is `part`:
 
 ```sh
@@ -172,25 +188,48 @@ because baselines and prebuilt libraries are shared through the usual
 artifacts.
 The plan prints the `G` it needs, so the number is never guessed.
 
-For scale, the largest set anyone here runs — `tibble`'s, on CRAN's numbers
-with nothing measured yet:
+**What a split does not buy is wall clock.**
+Run back to back or at the same time, the parts draw on the same account
+concurrency, so the total time is what it always was —
+plus one more preflight per part.
+What it buys is a run that fits: shards inside their deadline,
+a report per part rather than one that lands hours late and half `deferred`,
+and a retry granularity that is a part rather than the whole set.
+That is also why the refusal is the only place `part` is recommended:
+a batch that fits should stay one run.
 
-* 2398 strong revdeps, 14 035 check minutes:
-  250 shards in one wave, heaviest ~125 min, with `max-parallel: 250`;
-  60 shards in three waves with the default 20.
+For scale, the largest set anyone here runs — `tibble`'s,
+planned at the default 20 lanes:
+
+* 2398 strong revdeps, 14 035 check minutes on CRAN's numbers:
+  60 shards in three waves, ~13 h;
+  40 shards in two waves, ~7 h, once the 0.47 measured scale applies.
 * 3032 with `which: most` (Suggests included), 18 515 check minutes:
-  250 shards in one wave, heaviest ~171 min;
-  80 shards in four waves at the default 20.
+  80 shards in four waves, ~17 h;
+  40 shards in two waves, ~9 h, calibrated.
 
-Both are about a quarter of what would trigger the refusal,
-and both halve again once measurements replace CRAN's times.
-Two things bound such a run before the shard count does:
-its 3675-package dependency universe, and the preflight that installs it;
-and the heaviest single package, which is never split across shards —
-`duckdb` alone accounts for that 171-minute leg,
-and it is the floor no shard count gets under.
-The refusal names such a package rather than recommending a split
-that cannot help.
+Both are well inside the refusal, which is about the matrix limit —
+but neither is short, and shard *count* is not what makes them long.
+Three things bound such a run before the shard count does:
+
+* **the lanes.** Wall clock is roughly total work ÷ concurrency,
+  and concurrency is the account's ceiling
+  (20 concurrent jobs on a free plan, more on paid ones).
+  Nothing in this plan changes that number:
+  splitting into more shards, or into `part` runs, only adds setups.
+* **the preflight**, which installs the whole 3675-package dependency
+  universe in one job before any shard starts, and is not parallel at all.
+* **the heaviest single package**, which is never split across shards.
+  `duckdb` alone is a 171-minute leg of the `most` plan on CRAN's numbers;
+  no shard count gets under it, and the refusal names such a package
+  rather than recommending a split that cannot help.
+
+The capacity-bound plans above also sit close to their deadline by design
+(the `most` one is planned at ~91% of it):
+filling the capacity is what keeps the wave count down,
+and a shard that overruns anyway defers the rest for `retry-run`
+rather than losing it.
+`shard-capacity-minutes` is the dial to lower if that trade reads wrong.
 
 Assignment is greedy, in two phases:
 
@@ -502,7 +541,7 @@ at the next `if`.
 | One G-th of the revdeps, for a set too big for one run | `part` (`i/G`) | `REVDEP2_PART` | — |
 | Plan only | `dry-run` | — | false |
 | Check-time target per shard, up to one wave | `shard-budget-minutes` | `REVDEP2_SHARD_BUDGET_MINUTES` | 45 |
-| Concurrent shards, and so the wave size | `max-parallel` | `REVDEP2_MAX_PARALLEL` | 20 |
+| Concurrent shards, and so the wave size — set it to the concurrency the account really has, never more | `max-parallel` | `REVDEP2_MAX_PARALLEL` | 20 |
 | Check minutes one shard may hold, which forces further waves | — | `REVDEP2_SHARD_CAPACITY_MINUTES` | 80% of the deadline |
 | Ignore reusable baselines | `refresh-baseline` | — | false |
 | Oldest reusable baseline | `baseline-max-age-days` | `REVDEP2_BASELINE_MAX_AGE_DAYS` | 30 days |

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -172,12 +172,25 @@ because baselines and prebuilt libraries are shared through the usual
 artifacts.
 The plan prints the `G` it needs, so the number is never guessed.
 
-For scale: `tibble`'s 2398 strong reverse dependencies plan as
-250 shards in one wave (heaviest ~125 min) with `max-parallel: 250`,
-or 60 shards in three waves with the default 20 —
-roughly a quarter of what would trigger the refusal.
-Its 3266-package dependency universe, and the preflight that installs it,
-is the part of that run to worry about, not the shard count.
+For scale, the largest set anyone here runs — `tibble`'s, on CRAN's numbers
+with nothing measured yet:
+
+* 2398 strong revdeps, 14 035 check minutes:
+  250 shards in one wave, heaviest ~125 min, with `max-parallel: 250`;
+  60 shards in three waves with the default 20.
+* 3032 with `which: most` (Suggests included), 18 515 check minutes:
+  250 shards in one wave, heaviest ~171 min;
+  80 shards in four waves at the default 20.
+
+Both are about a quarter of what would trigger the refusal,
+and both halve again once measurements replace CRAN's times.
+Two things bound such a run before the shard count does:
+its 3675-package dependency universe, and the preflight that installs it;
+and the heaviest single package, which is never split across shards —
+`duckdb` alone accounts for that 171-minute leg,
+and it is the floor no shard count gets under.
+The refusal names such a package rather than recommending a split
+that cannot help.
 
 Assignment is greedy, in two phases:
 

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -1245,17 +1245,19 @@ append_summary(c(
   ),
   sprintf("| Estimated runner time | ~%.0f min |", sum(load)),
   "",
-  # A run in more than one wave is waiting on lanes, not on work, and the
-  # dispatch form is where that is fixed -- so say it here, with the number.
+  # More than one wave means the run is bound by how many jobs may run at
+  # once, and that ceiling is the account's, not this workflow's: past it
+  # GitHub queues jobs no matter what `max-parallel` says, and a plan told it
+  # has more lanes than it does just cuts more shards, each paying its own
+  # setup while it waits. So state the fact and the condition, not a knob to
+  # turn.
   if (waves > 1) {
     c(
       sprintf(
-        "These %d shards run %d at a time, so %d waves. Dispatching with `max-parallel: %d` would run them in one, at roughly %.0f min instead of %.0f — worth it if that many runners are available.",
+        "These %d shards run %d at a time, so %d waves, ~%.0f min. Raising `max-parallel` shortens that only if the account can really run more jobs at once (GitHub queues past its own concurrency limit either way); a `part` split does not shorten it at all, since the parts compete for the same lanes.",
         k,
         lanes,
         waves,
-        k,
-        max(load),
         waves * max(load)
       ),
       ""

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -42,6 +42,9 @@
 #   REVDEP2_SHARD_CAPACITY_MINUTES - check minutes one shard may be given at
 #                             most, which is what forces a second wave
 #                             (default: 80% of REVDEP2_DEADLINE_MINUTES)
+#   REVDEP2_LONG_RUN_HOURS  - estimated wall clock past which the plan warns in
+#                             the job summary; it never refuses for length
+#                             alone (default: 12)
 #   REVDEP2_MAX_SHARDS      - matrix legs to emit at most (default: 250)
 #   REVDEP2_MAX_PARALLEL    - legs to run concurrently, and so the size of one
 #                             wave (default: 20)
@@ -994,6 +997,15 @@ inform(sprintf(
   deadline_minutes
 ))
 
+# A plan can fit the matrix and still be a bad idea: `which: most` at `depth:
+# 2` is 3419 packages and about 22 hours of waves here, which is a run nobody
+# is watching by the end and a day of artifacts riding on one preflight. It is
+# a legitimate thing to ask for, so this warns rather than refuses -- but it
+# warns where the dispatcher will see it, not only in the wave line.
+wall_minutes <- waves * max(load)
+long_run_hours <- env_num("REVDEP2_LONG_RUN_HOURS", 12)
+long_run <- wall_minutes > long_run_hours * 60
+
 # ------------------------------------------------------------------ output ---
 
 shard_list <- lapply(seq_len(k), function(s) {
@@ -1151,6 +1163,27 @@ append_summary(c(
   "## revdep2 plan",
   "",
   if (env_flag("REVDEP2_DRY_RUN")) c("**Dry run: planning only, no checks started.**", ""),
+  if (long_run) {
+    c(
+      sprintf(
+        "> **This plan is about %.0f hours of wall clock** — %d shards, %d waves of %d. It fits, and it will run; the note is that %s.",
+        wall_minutes / 60,
+        k,
+        waves,
+        lanes,
+        if (length(measured_runs) == 0) {
+          "nothing is measured yet, so it is priced on CRAN's times, which have run about twice the local cost \u2014 the same plan calibrated is roughly half this"
+        } else {
+          "a run this long rides on one preflight and a day of artifacts"
+        }
+      ),
+      sprintf(
+        "> A narrower `which` or `depth` is the dial; `part=i/%d` splits it into runs that each report on their own, without making the total any shorter.",
+        max(2L, as.integer(ceiling(wall_minutes / (long_run_hours * 60))))
+      ),
+      ""
+    )
+  },
   "| | |",
   "| --- | --- |",
   sprintf("| Package | `%s` %s (CRAN: %s) |", package, dev_version, cran_version),

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -876,7 +876,11 @@ plan_too_big <- function() {
   worst <- which.max(load)
   overhead <- load[[worst]] - check_load[[worst]]
   headroom <- deadline_minutes - overhead
-  parts <- if (headroom <= 0) {
+  # A package is never split across shards, so one package heavier than the
+  # room a shard has is a wall that no number of parts gets around. Say which
+  # package, and stop recommending a split that cannot work.
+  giants <- names(weight)[weight > headroom]
+  parts <- if (headroom <= 0 || length(giants) > 0) {
     NA_integer_
   } else {
     max(2L, as.integer(ceiling(check_load[[worst]] / headroom)))
@@ -909,11 +913,30 @@ plan_too_big <- function() {
       deadline_minutes
     ),
     "",
-    if (is.na(parts)) {
+    if (headroom <= 0) {
       c(
         sprintf(
           "Setup and installs alone (~%.0f min) already exceed the deadline, so splitting the packages will not help: raise `REVDEP2_DEADLINE_MINUTES` (and the job's `timeout-minutes`, up to GitHub's 6 h ceiling) first.",
           overhead
+        ),
+        ""
+      )
+    } else if (length(giants) > 0) {
+      # Naming them matters: this is the one case where the operator has to
+      # decide something (wait longer, or check less), and the decision is
+      # about these packages specifically.
+      c(
+        sprintf(
+          "%s alone %s more than the ~%.0f min a shard has left for checks, and a package is never split across shards — so no `part` split helps here.",
+          paste0("`", paste(utils::head(sort(giants), 5), collapse = "`, `"), "`"),
+          if (length(giants) == 1) "needs" else "need",
+          headroom
+        ),
+        "",
+        sprintf(
+          "Raise `REVDEP2_DEADLINE_MINUTES` (now %.0f) and the shard job's `timeout-minutes` (now 350, GitHub's ceiling is 6 h), or leave %s out of the run with an explicit `packages` list.",
+          deadline_minutes,
+          if (length(giants) == 1) "it" else "them"
         ),
         ""
       )


### PR DESCRIPTION
<!-- Prepared with Claude Code; the analysis, the code and this description were generated by an LLM and reviewed by a human before merging. -->

Follow-up to #2819, which was squash-merged two commits early — the last two of that branch never landed, so they are here too.

## What run 31179716166 showed

Dispatched with `which: most`, `depth: 2`: 3419 packages (1006 at level 1, 2413 at level 2), a 4397-package dependency universe, 100 shards in 5 waves. `plan` and `build` succeeded. Then the preflight, installing all 4397 packages from scratch, was killed 11.5 minutes into the install:

```
##[error]The runner has received a shutdown signal. This can happen when the
runner service is stopped, or a manually started runner is canceled.
##[error]Process completed with exit code 143
```

No cause is recoverable from the logs — the step printed 1.7 kB total and nothing between "Updating metadata database ... done" and the kill. Disk (14 GB free on the runner) and memory are the plausible candidates and neither was recorded.

The expensive part, though, is not the cause. `test` had the preflight as a `needs`, and `collect` required `needs.preflight.result == 'success'`, so a run that already had a plan, a built dev binary, a reusable baseline of 745 results and 100 shards of work reported **nothing at all**, 15 minutes in.

## The preflight is an optimization, not a prerequisite

It buys the shards a free rebuild and surfaces broken dependencies before check minutes are spent. A shard installs its own union regardless, and that union is a fraction of what the preflight takes on — a median of 478 packages against 4397 in that run. So:

- `test` runs past a failed preflight (`!cancelled()` instead of the implicit skip);
- `collect` no longer consults the preflight's result.

Both conditions now spell out the dry-run guard, which until now came for free from the skipped preflight — without it, a dry run would have started checking.

## Making the next preflight failure diagnosable

- Reclaim the ~25 GB of preinstalled toolchains (Android SDK, .NET, GHC, CodeQL, …) the job will never use, before installing anything.
- Print free disk and memory before the install and again after it, `if: always()`, plus the size of the pak cache and the packed library.
- `timeout-minutes: 300` on the job, so a slow death ends as a failure with logs rather than a kill.

If it was disk, that fixes it. If it was memory, the next occurrence says so instead of leaving an exit code.

## A day-long plan should say so

That run would have taken ~21 h had the preflight survived, and only the wave line mentioned it. The plan now warns in the job summary past `REVDEP2_LONG_RUN_HOURS` (12 by default), names the dials that shorten it (`which`, `depth`) and the one that does not (`part` — the parts share the same concurrency), and says when the estimate is uncalibrated. Reproduced offline against the same inputs:

> **This plan is about 24 hours of wall clock** — 120 shards, 6 waves of 20. It fits, and it will run; the note is that nothing is measured yet, so it is priced on CRAN's times, which have run about twice the local cost — the same plan calibrated is roughly half this.

It is uncalibrated because no run has yet published a `revdep2-timings` artifact: run 31048405399 predates it, and every run since has failed. The first run that reaches `collect` fixes that on its own.

## Carried over from #2819

- The refusal no longer recommends a `part` split where a **single package** is what breaks the deadline (a package is never divided across shards) — it names the packages and points at the deadline or an explicit `packages` list.
- `max-parallel` is documented as the concurrency the account actually has, never more: GitHub queues past its own limit, so a larger value only cuts more shards, each paying its own setup while it waits. The `tibble` figures in the README are re-stated at the default 20 lanes.

## Verification

The plan side is exercised offline against live CRAN metadata, including a reproduction of run 31179716166's own inputs (`most`, depth 2 → 3419 packages, 120 shards, 6 waves, warning fires), plus the earlier suite: calibrated/uncalibrated, part splits, forced growth, both refusal paths, dead-shard reconciliation, and the util unit tests. `air format --check` is clean; the workflow YAML parses and the two rewritten `if:` expressions were checked after parsing.

Not verified: the workflow-level behaviour itself. That a failed preflight now lets `test` and `collect` through is a GitHub expression change, and only a real run proves it — the cheapest proof is a dispatch with `which: strong`, `depth: 1`, which is the ~20-shard case this all assumes.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DdNk5vJPSUidKGdnAYt7Dv)_