### PR TITLE
fix(ci): Check `windows-11-arm` with `error_on = "error"`

### DIFF
--- a/.github/workflows/versions-matrix/action.R
+++ b/.github/workflows/versions-matrix/action.R
@@ -57,7 +57,29 @@ linux_arm64 <- data.frame(os = "ubuntu-26.04-arm", r = r_versions[1:2])
 # aarch64 Windows binaries, and setup-r's `use-public-rspm: true` enables PPM on
 # x86_64 Windows only, so dependencies are compiled from source on this runner
 # and it is the slowest entry in the matrix.
-windows_arm64 <- data.frame(os = "windows-11-arm", r = r_versions[2])
+#
+# Strictness note: this is the one entry that checks with `error_on = "error"`
+# instead of the default `"note"`, requested through the generic "env" field.
+# The aarch64 Rtools45 is documented as experimental, and its Fortran driver
+# makes `R CMD check` report a WARNING for every package that ships Fortran
+# sources: `flang` there is LLVM's `flang-new` invoked as
+# `aarch64-w64-mingw32-flang`, which loads the llvm-mingw configuration files
+# for that triple, and those add link-time flags (`-lc++`, `-rtlib=compiler-rt`,
+# `-pthread`) to every invocation, including the compile-only ones. The driver
+# then warns that each of them is unused, and `[-Wunused-command-line-argument]`
+# is one of the patterns `R CMD check` collects as a "significant warning" from
+# the installation log. Nothing in the package can suppress those: flang 19
+# rejects `-Qunused-arguments` ("unknown argument") and
+# `-Wno-unused-command-line-argument` ("Only `-Werror` is supported currently"),
+# and `--no-default-config` would drop the `-target` line that the same
+# configuration files supply. Errors -- a build that fails, a test that fails,
+# an example that fails -- still fail this entry, which is what it is here to
+# catch. Drop the "env" field once the toolchain stops emitting the warnings.
+windows_arm64 <- data.frame(
+  os = "windows-11-arm",
+  r = r_versions[2],
+  env = 'RCMDCHECK_ERROR_ON="error"'
+)
 
 include_list <- list(
   macos,


### PR DESCRIPTION
Prepared with Claude Code. One of two PRs unbreaking `rcc` on `main`; the R-devel half is #2823.

`rcc: windows-11-arm (4.6)` fails on every run with `Status: 1 WARNING`, from the installation step:

```
* checking whether package 'igraph' can be installed ... [361s] WARNING
Found the following significant warnings:
  aarch64-w64-mingw32-flang: warning: -lc++: 'linker' input unused [-Wunused-command-line-argument]
  aarch64-w64-mingw32-flang: warning: argument unused during compilation: '-rtlib=compiler-rt' [-Wunused-command-line-argument]
  aarch64-w64-mingw32-flang: warning: argument unused during compilation: '-pthread' [-Wunused-command-line-argument]
```

The aarch64 Rtools45 compiles Fortran with LLVM's `flang-new`, invoked as `aarch64-w64-mingw32-flang`. That driver loads the llvm-mingw configuration files for the triple, and those add link-time flags (`-lc++`, `-rtlib=compiler-rt`, `-pthread`) to every invocation — including the compile-only ones R uses to turn the vendored ARPACK `.f` sources into `.o`. The driver then warns that each of them is unused, and `": warning: .* \[-Wunused-command-line-argument\]"` is one of the patterns `R CMD check` collects as a "significant warning" from `00install.out`. Any package shipping Fortran is affected; the aarch64 Rtools45 is documented as experimental.

Nothing on the package side suppresses this — verified against flang 19.1.1, the same major version Rtools45-aarch64 ships:

- `-Qunused-arguments` → `flang-new: error: unknown argument: '-Qunused-arguments'`
- `-Wno-unused-command-line-argument` → ``error: Only `-Werror` is supported currently.`` (and the driver still emits the warnings)
- `-w`, `-Wno-error` → no effect on driver-level diagnostics
- `--no-default-config` is accepted, but the same configuration files also carry the `-target aarch64-w64-mingw32` line, so dropping them risks compiling for the wrong target

So this relaxes that one matrix entry to `error_on = "error"` through the existing generic `env` field, with the rationale recorded next to the entry. A failing build, a failing test, a failing example still fail the job — which is exactly what the comment above that entry says it is there to catch.

Testing: #2822 carries this commit and trims the matrix to `windows-11-arm` alone, without the smoke test. Do not merge that one.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.