### PR TITLE
DO NOT MERGE — test only: `windows-11-arm` without the smoke test

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -73,6 +73,11 @@ jobs:
     # mutate the repo. Revisit once the arm image is generally available.
     runs-on: ubuntu-26.04
 
+    # DO NOT MERGE -- this branch exists to exercise the windows-11-arm entry
+    # on its own. Skipping the smoke test also skips rcc-smoke-check-matrix and
+    # rcc-suggests, which both depend on it.
+    if: false
+
     outputs:
       sha: ${{ steps.commit.outputs.sha }}
       versions-matrix: ${{ steps.versions-matrix.outputs.matrix }}
@@ -378,12 +383,10 @@ jobs:
           matrix: ${{ needs.rcc-smoke.outputs.dep-suggests-matrix }}
 
   rcc-full:
-    needs:
-      - rcc-smoke
-
+    # DO NOT MERGE -- `needs: rcc-smoke` and the `if:` guard on the generated
+    # matrix are removed so that this job runs on its own, without the smoke
+    # test in front of it.
     runs-on: ${{ matrix.os }}
-
-    if: ${{ needs.rcc-smoke.outputs.versions-matrix != '' }}
 
     name: 'rcc: ${{ matrix.os }} (${{ matrix.r }}) ${{ matrix.desc }}'
 
@@ -396,12 +399,17 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.rcc-smoke.outputs.versions-matrix)}}
+      # DO NOT MERGE -- the generated matrix is replaced by the single entry
+      # under test. `env` is verbatim what
+      # .github/workflows/versions-matrix/action.R now emits for this entry.
+      matrix:
+        include:
+          - os: windows-11-arm
+            r: "4.6"
+            env: RCMDCHECK_ERROR_ON="error"
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.rcc-smoke.outputs.sha }}
 
       - name: Apply environment variables from the test matrix
         # Generic: matrix entries defined in .github/versions-matrix.R can

--- a/.github/workflows/versions-matrix/action.R
+++ b/.github/workflows/versions-matrix/action.R
@@ -57,7 +57,29 @@ linux_arm64 <- data.frame(os = "ubuntu-26.04-arm", r = r_versions[1:2])
 # aarch64 Windows binaries, and setup-r's `use-public-rspm: true` enables PPM on
 # x86_64 Windows only, so dependencies are compiled from source on this runner
 # and it is the slowest entry in the matrix.
-windows_arm64 <- data.frame(os = "windows-11-arm", r = r_versions[2])
+#
+# Strictness note: this is the one entry that checks with `error_on = "error"`
+# instead of the default `"note"`, requested through the generic "env" field.
+# The aarch64 Rtools45 is documented as experimental, and its Fortran driver
+# makes `R CMD check` report a WARNING for every package that ships Fortran
+# sources: `flang` there is LLVM's `flang-new` invoked as
+# `aarch64-w64-mingw32-flang`, which loads the llvm-mingw configuration files
+# for that triple, and those add link-time flags (`-lc++`, `-rtlib=compiler-rt`,
+# `-pthread`) to every invocation, including the compile-only ones. The driver
+# then warns that each of them is unused, and `[-Wunused-command-line-argument]`
+# is one of the patterns `R CMD check` collects as a "significant warning" from
+# the installation log. Nothing in the package can suppress those: flang 19
+# rejects `-Qunused-arguments` ("unknown argument") and
+# `-Wno-unused-command-line-argument` ("Only `-Werror` is supported currently"),
+# and `--no-default-config` would drop the `-target` line that the same
+# configuration files supply. Errors -- a build that fails, a test that fails,
+# an example that fails -- still fail this entry, which is what it is here to
+# catch. Drop the "env" field once the toolchain stops emitting the warnings.
+windows_arm64 <- data.frame(
+  os = "windows-11-arm",
+  r = r_versions[2],
+  env = 'RCMDCHECK_ERROR_ON="error"'
+)
 
 include_list <- list(
   macos,


### PR DESCRIPTION
**Do not merge.** This PR exists only to exercise #2821 on the affected platform, and it carries CI scaffolding that must never reach `main`.

It contains the single commit of #2821 plus one throwaway commit on top that:

- skips `rcc-smoke` (`if: false`), which also skips `rcc-smoke-check-matrix` and `rcc-suggests`, since both depend on it;
- drops `rcc-full`'s `needs: rcc-smoke` and the `if:` guard on the generated matrix, so it runs on its own;
- replaces the generated matrix with the single entry under test, `windows-11-arm` on R 4.6, whose `env` value is verbatim what `.github/workflows/versions-matrix/action.R` now emits for it;
- checks out the PR head directly instead of the SHA the smoke test would have produced.

So the only job that runs is `rcc: windows-11-arm (4.6)`. Expected outcome: `Status: 1 WARNING` for the flang unused-argument diagnostics, as on `main` today, but the job green, because `error_on` is now `"error"` for this entry.

The R-devel half of the breakage is #2823, with its own checker in #2824.

Close this once #2821 is settled.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.