### PR TITLE
fix(ci): Point the ccache-wrapped compiler variables at a wrapper script

### DIFF
--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -169,7 +169,7 @@ runs:
 
     - name: Use ccache for compiling R code, and parallelize
       run: |
-        mkdir -p ~/.R
+        mkdir -p ~/.R ~/.R/bin
         # Infer each compiler default for the active R version from R CMD config,
         # then prepend ccache. Reading the resolved defaults preserves the
         # standard flags R selects per version (e.g. -std=gnu2x for C, -std=gnu++17
@@ -182,17 +182,36 @@ runs:
         # CXXnnSTD variable (CXX17STD = -std=gnu++17, ...) and applies it on top
         # at compile time, so wrapping only CXXnn with ccache is correct and we
         # must NOT pin -std here ourselves.
+        # The value is a wrapper script rather than a bare "ccache <compiler>"
+        # because not every consumer of these variables treats them as a full
+        # command line. R-devel's "checking compiled code" preprocesses the R
+        # headers with tools:::ccE(), which since r90356 reads the compiler from
+        # `R CMD config CC` and since r90359 truncates it at the first space
+        # (src/library/tools/R/apitools.R). For "ccache gcc -std=gnu2x" that
+        # leaves the bare "ccache", which clears the Sys.which() guard because
+        # ccache is a real program, then fails with "invalid option -- 'E'";
+        # R CMD check reports the resulting output as a NOTE. A single-token CC
+        # that is also a real compiler driver satisfies both readings.
         empty_makevars="$(mktemp)"
         for var in CC CXX CXX11 CXX14 CXX17 CXX20 CXX23; do
           val="$(R_MAKEVARS_USER="$empty_makevars" R CMD config "$var" 2>/dev/null || true)"
           if [ -n "$val" ]; then
-            echo "$var = ccache $val" >> ~/.R/Makevars
+            wrapper=~/.R/bin/ccache-"$var"
+            printf '#!/bin/sh\nexec ccache %s "$@"\n' "$val" > "$wrapper"
+            chmod +x "$wrapper"
+            echo "$var = $wrapper" >> ~/.R/Makevars
           fi
         done
         rm -f "$empty_makevars"
         echo 'MAKEFLAGS = -j2' >> ~/.R/Makevars
         echo "===== generated ~/.R/Makevars ====="
         cat ~/.R/Makevars
+        echo "===== generated ~/.R/bin wrappers ====="
+        for wrapper in ~/.R/bin/ccache-*; do
+          [ -f "$wrapper" ] || continue
+          echo "--- $wrapper"
+          cat "$wrapper"
+        done
         echo "==================================="
 
         echo 'CCACHE_SLOPPINESS=locale,time_macros' | tee -a $GITHUB_ENV


### PR DESCRIPTION
Prepared with Claude Code. One of two PRs unbreaking `rcc` on `main`; the `windows-11-arm` half is #2821.

`rcc: ubuntu-26.04 (devel)` started failing with R-devel r90366 (2026-08-06), with `Status: 1 NOTE` from `checking compiled code`, repeated dozens of times:

```
ccache: invalid option -- 'E'
Warning in system(cmd, intern = TRUE) :
  running command 'ccache -E -I/opt/R/devel/lib/R/include /tmp/.../file....h  -DR_INTERFACE_PTRS' had status 1
```

The install action writes `CC = ccache gcc -std=gnu2x` (and the same for the C++ variants) into `~/.R/Makevars`. That reads correctly only if the consumer treats the value as a whole command line. R-devel's `checking compiled code` preprocesses the R headers with the *first word* alone, so it runs `ccache -E ...`, which is ccache's own option parser rejecting `-E`. The resulting warning output is non-empty, so `R CMD check` turns it into a NOTE — one with no findings in it, which is the tell.

The fix writes one small wrapper script per variable and points the variable at it, so the value is a single token that runs ccache internally and works whichever way it is read.

Ruled out: `cc` on the runner resolving to ccache through the masquerade symlinks. `/usr/lib/ccache/cc -E …` works fine — ccache only rejects `-E` when invoked under its own name, which is what the log shows.

Verified locally that `R CMD SHLIB` still compiles and links through the wrapper, that `R CMD config CC` returns the wrapper, that `using C compiler: 'gcc ...'` is still reported correctly, and that both `ccache gcc … -E` and the wrapper accept the preprocessing invocation.

Testing: #2824 carries this commit and trims the matrix to `ubuntu-26.04` R-devel alone, without the smoke test. Do not merge that one.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmSX7BpDELCDras4pvRGby)_