### PR TITLE
DO NOT MERGE — test only: `ubuntu-26.04` R-devel without the smoke test

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -73,6 +73,11 @@ jobs:
     # mutate the repo. Revisit once the arm image is generally available.
     runs-on: ubuntu-26.04
 
+    # DO NOT MERGE -- this branch exists to exercise the ubuntu-26.04 R-devel
+    # entry on its own. Skipping the smoke test also skips
+    # rcc-smoke-check-matrix and rcc-suggests, which both depend on it.
+    if: false
+
     outputs:
       sha: ${{ steps.commit.outputs.sha }}
       versions-matrix: ${{ steps.versions-matrix.outputs.matrix }}
@@ -378,12 +383,10 @@ jobs:
           matrix: ${{ needs.rcc-smoke.outputs.dep-suggests-matrix }}
 
   rcc-full:
-    needs:
-      - rcc-smoke
-
+    # DO NOT MERGE -- `needs: rcc-smoke` and the `if:` guard on the generated
+    # matrix are removed so that this job runs on its own, without the smoke
+    # test in front of it.
     runs-on: ${{ matrix.os }}
-
-    if: ${{ needs.rcc-smoke.outputs.versions-matrix != '' }}
 
     name: 'rcc: ${{ matrix.os }} (${{ matrix.r }}) ${{ matrix.desc }}'
 
@@ -396,12 +399,17 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.rcc-smoke.outputs.versions-matrix)}}
+      # DO NOT MERGE -- the generated matrix is replaced by the single entry
+      # under test, verbatim what
+      # .github/workflows/versions-matrix/action.R emits for `linux_devel`.
+      matrix:
+        include:
+          - os: ubuntu-26.04
+            r: devel
+            http-user-agent: release
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.rcc-smoke.outputs.sha }}
 
       - name: Apply environment variables from the test matrix
         # Generic: matrix entries defined in .github/versions-matrix.R can

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -169,7 +169,7 @@ runs:
 
     - name: Use ccache for compiling R code, and parallelize
       run: |
-        mkdir -p ~/.R
+        mkdir -p ~/.R ~/.R/bin
         # Infer each compiler default for the active R version from R CMD config,
         # then prepend ccache. Reading the resolved defaults preserves the
         # standard flags R selects per version (e.g. -std=gnu2x for C, -std=gnu++17
@@ -182,17 +182,36 @@ runs:
         # CXXnnSTD variable (CXX17STD = -std=gnu++17, ...) and applies it on top
         # at compile time, so wrapping only CXXnn with ccache is correct and we
         # must NOT pin -std here ourselves.
+        # The value is a wrapper script rather than a bare "ccache <compiler>"
+        # because not every consumer of these variables treats them as a full
+        # command line. R-devel's "checking compiled code" preprocesses the R
+        # headers with tools:::ccE(), which since r90356 reads the compiler from
+        # `R CMD config CC` and since r90359 truncates it at the first space
+        # (src/library/tools/R/apitools.R). For "ccache gcc -std=gnu2x" that
+        # leaves the bare "ccache", which clears the Sys.which() guard because
+        # ccache is a real program, then fails with "invalid option -- 'E'";
+        # R CMD check reports the resulting output as a NOTE. A single-token CC
+        # that is also a real compiler driver satisfies both readings.
         empty_makevars="$(mktemp)"
         for var in CC CXX CXX11 CXX14 CXX17 CXX20 CXX23; do
           val="$(R_MAKEVARS_USER="$empty_makevars" R CMD config "$var" 2>/dev/null || true)"
           if [ -n "$val" ]; then
-            echo "$var = ccache $val" >> ~/.R/Makevars
+            wrapper=~/.R/bin/ccache-"$var"
+            printf '#!/bin/sh\nexec ccache %s "$@"\n' "$val" > "$wrapper"
+            chmod +x "$wrapper"
+            echo "$var = $wrapper" >> ~/.R/Makevars
           fi
         done
         rm -f "$empty_makevars"
         echo 'MAKEFLAGS = -j2' >> ~/.R/Makevars
         echo "===== generated ~/.R/Makevars ====="
         cat ~/.R/Makevars
+        echo "===== generated ~/.R/bin wrappers ====="
+        for wrapper in ~/.R/bin/ccache-*; do
+          [ -f "$wrapper" ] || continue
+          echo "--- $wrapper"
+          cat "$wrapper"
+        done
         echo "==================================="
 
         echo 'CCACHE_SLOPPINESS=locale,time_macros' | tee -a $GITHUB_ENV


### PR DESCRIPTION
**Do not merge.** This PR exists only to exercise #2823 on the affected platform, and it carries CI scaffolding that must never reach `main`.

It contains the single commit of #2823 plus one throwaway commit on top that:

- skips `rcc-smoke` (`if: false`), which also skips `rcc-smoke-check-matrix` and `rcc-suggests`, since both depend on it;
- drops `rcc-full`'s `needs: rcc-smoke` and the `if:` guard on the generated matrix, so it runs on its own;
- replaces the generated matrix with the single entry under test, `ubuntu-26.04` on R-devel, verbatim what `.github/workflows/versions-matrix/action.R` emits for `linux_devel`;
- checks out the PR head directly instead of the SHA the smoke test would have produced.

So the only job that runs is `rcc: ubuntu-26.04 (devel)`. Expected outcome: green, with no `ccache: invalid option -- 'E'` in the log and `checking compiled code ... OK`.

The `windows-11-arm` half of the breakage is #2821, with its own checker in #2822.

Close this once #2823 is settled.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmSX7BpDELCDras4pvRGby)_