### PR TITLE
DO NOT MERGE — control for #2823: `ubuntu-26.04` R-devel on unpatched `main`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -73,6 +73,11 @@ jobs:
     # mutate the repo. Revisit once the arm image is generally available.
     runs-on: ubuntu-26.04
 
+    # DO NOT MERGE -- this branch exists to exercise the ubuntu-26.04 R-devel
+    # entry on its own. Skipping the smoke test also skips
+    # rcc-smoke-check-matrix and rcc-suggests, which both depend on it.
+    if: false
+
     outputs:
       sha: ${{ steps.commit.outputs.sha }}
       versions-matrix: ${{ steps.versions-matrix.outputs.matrix }}
@@ -378,12 +383,10 @@ jobs:
           matrix: ${{ needs.rcc-smoke.outputs.dep-suggests-matrix }}
 
   rcc-full:
-    needs:
-      - rcc-smoke
-
+    # DO NOT MERGE -- `needs: rcc-smoke` and the `if:` guard on the generated
+    # matrix are removed so that this job runs on its own, without the smoke
+    # test in front of it.
     runs-on: ${{ matrix.os }}
-
-    if: ${{ needs.rcc-smoke.outputs.versions-matrix != '' }}
 
     name: 'rcc: ${{ matrix.os }} (${{ matrix.r }}) ${{ matrix.desc }}'
 
@@ -396,12 +399,17 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix: ${{fromJson(needs.rcc-smoke.outputs.versions-matrix)}}
+      # DO NOT MERGE -- the generated matrix is replaced by the single entry
+      # under test, verbatim what
+      # .github/workflows/versions-matrix/action.R emits for `linux_devel`.
+      matrix:
+        include:
+          - os: ubuntu-26.04
+            r: devel
+            http-user-agent: release
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ needs.rcc-smoke.outputs.sha }}
 
       - name: Apply environment variables from the test matrix
         # Generic: matrix entries defined in .github/versions-matrix.R can


### PR DESCRIPTION
**Do not merge.** Control run for #2823, in response to the "might well be transient" question.

This is `main` plus the same scaffolding commit as #2824 — skip the smoke test, hardcode the matrix to the single `linux_devel` entry — but **without** the ccache wrapper fix. So #2824 and this PR run the same job, at the same time, against the same R-devel snapshot, and differ only in the fix.

- this PR fails with `ccache: invalid option -- 'E'` and #2824 passes → not transient, the fix is what makes the difference;
- both pass → the failure on `main` was tied to a particular R-devel snapshot and has since gone away; #2823 is then a robustness change rather than a fix, and can be judged on that basis;
- both fail → the diagnosis is wrong and #2823 should be reworked.

Close once #2823 is settled.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmSX7BpDELCDras4pvRGby)_