### PR TITLE
ci(revdep2): Install in chunks, and diagnose a preflight that is killed rather than failed

### DIFF
--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -115,6 +115,13 @@ on:
 
 name: revdep2
 
+# GitHub does not show a run the inputs it was dispatched with, so the two
+# that decide how much work the run is -- how wide the net is cast, and how
+# deep -- go into the run's own title, where the run list and every link to it
+# carry them. "Was that depth 2 or the whole closure?" is otherwise only
+# answerable by reading the plan job's log.
+run-name: "revdep2 ${{ inputs.packages && format('({0})', inputs.packages) || format('({0}, depth {1})', inputs.which || 'strong', inputs.depth || '1') }}${{ inputs['retry-run'] && format(', retry of {0}', inputs['retry-run']) || '' }}${{ inputs['dry-run'] && ', dry run' || '' }}"
+
 # Read-only by default; every job opts back into what it actually needs.
 # Note that for a pull request from a fork GitHub caps the token at read-only
 # regardless of what is requested here.
@@ -327,6 +334,25 @@ jobs:
           restore-keys: |
             revdep2-pak-
 
+      # The install is wrapped rather than run bare, because when this job
+      # dies the wrapping is the only diagnosis there is: run 31270092803
+      # spent ten minutes inside pak and then hit `exit 143` -- the runner
+      # shut down -- with nothing in the log between the two, and no
+      # post-step ran to say what it had run out of.
+      #
+      # Three things address that, all of them live rather than after the
+      # fact, because a runner that is shut down never reaches "after":
+      #
+      #  * a sampler prints memory, swap, disk and the largest processes every
+      #    30 s, so a kill has a curve leading up to it;
+      #  * `stdbuf` makes R line-buffered. R block-buffers stdout when it is
+      #    not a terminal, so pak's progress is flushed on exit -- which is
+      #    the one thing a killed process does not do, and why those ten
+      #    minutes were blank while the `message()` calls around them (stderr,
+      #    unbuffered) came through;
+      #  * the kernel's own OOM log is read afterwards when there still is an
+      #    afterwards, which separates "this job asked for too much memory"
+      #    from "the host went away".
       - name: Install and load every dependency
         env:
           GH_TOKEN: ${{ github.token }}
@@ -335,18 +361,35 @@ jobs:
           LIB_OUT: ${{ runner.temp }}/lib
           LIB_INDEX_OUT: ${{ runner.temp }}/lib-index
           PKG_SYSREQS: true
+          RESOURCE_LOG: ${{ runner.temp }}/preflight/resources.log
         run: |
-          Rscript ./.github/workflows/revdep2/preflight.R
+          mkdir -p "${RUNNER_TEMP}/preflight"
+          watch=./.github/workflows/revdep2/watch-resources.sh
+          "${watch}" once "before the install"
+          "${watch}" watch 30 "installing" &
+          watcher=$!
+          trap 'kill "${watcher}" 2> /dev/null || true' EXIT
+          unbuffered=""
+          if command -v stdbuf > /dev/null 2>&1; then
+            unbuffered="stdbuf -oL -eL"
+          fi
+          status=0
+          ${unbuffered} Rscript ./.github/workflows/revdep2/preflight.R || status=$?
+          kill "${watcher}" 2> /dev/null || true
+          "${watch}" once "after the install"
+          exit "${status}"
         shell: bash
 
       # Runs even when the install step died, because "how much disk and
       # memory were left" is the first question about a job that was killed
-      # rather than failed.
+      # rather than failed. It cannot run when the *runner* died -- hence the
+      # sampler above -- but it is what answers the question in every case
+      # where the job merely failed.
       - name: Report what the install consumed
         if: always()
         run: |
-          df -h / /mnt || true
-          free -g || true
+          ./.github/workflows/revdep2/watch-resources.sh once "after the job"
+          ./.github/workflows/revdep2/watch-resources.sh oom
           du -sh ~/.cache/R/pkgcache "${RUNNER_TEMP}/lib" 2>/dev/null || true
         shell: bash
 

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -565,6 +565,7 @@ the report is about *results*, a retry is about *coverage*.
 | A check times out | rcmdcheck kills it at `max(floor, factor × its CRAN time)`; compared as `t-`, reported `failed` |
 | A revdep's strong dependencies cannot install | `depfail`, check not attempted, named in the shard summary |
 | A dependency fails the preflight | reported in the preflight summary and `depfail.json`; shards still try their own subset |
+| A pak install chunk fails | the chunk is reported and the rest still run; what is still missing is retried one package at a time |
 | The preflight job itself dies | the shards run anyway and install their own unions, the collector still reports; only the free rebuild and the early diagnosis are lost |
 | A shard hits its deadline | remaining packages `deferred`; finished old-halves still uploaded and baseline-fed |
 | A shard job dies hard | the collector reconciles against the plan: its packages are reported `missing`, naming the shard, and `retry-run` re-checks exactly them |
@@ -616,6 +617,30 @@ so three things are arranged to be *live* rather than after the fact:
   which separates "this job asked for too much memory"
   from "the host went away".
 
+The install itself is also cut down to a size pak handles predictably.
+One `pak::pkg_install()` call for a few thousand refs
+resolves all of them before it installs any of them,
+and that resolution is the part that stops degrading gracefully:
+the run above spent ten minutes in it
+without a single install starting.
+So both the preflight and the shards install in chunks of
+`REVDEP2_INSTALL_CHUNK` packages (100),
+ordered so that every strong dependency inside the set
+is installed before the package that needs it —
+each chunk then resolves against a library where its dependencies already are.
+The ordering is on strong dependencies only:
+Suggests are in the set because a revdep's *check* needs them,
+not its installation,
+and they are what would make the graph cyclic.
+Packages a cycle or a gap in the index leaves unordered go last, together.
+
+That also changes what a failure costs.
+Whatever earlier chunks installed is on disk
+and is skipped on the next attempt,
+so a chunk that dies costs a chunk rather than the job —
+and the log names which one,
+where a single opaque call could only go quiet.
+
 The same principle applies to everything these scripts swallow.
 Fetching an artifact is an optimization,
 so its failure never stops a run —
@@ -660,6 +685,7 @@ at the next `if`.
 | Runs donating prebuilt packages | — | `REVDEP2_PREBUILT_MAX_RUNS` | 5 (`0` disables) |
 | Oldest reusable prebuilt library | — | `REVDEP2_PREBUILT_MAX_AGE_DAYS` | 14 days |
 | Runs the history walk looks at | — | `REVDEP2_HISTORY_RUNS` | 40 |
+| Packages per `pak::pkg_install()` call | — | `REVDEP2_INSTALL_CHUNK` | 100 |
 | Wall clock past which the plan warns (never refuses) | — | `REVDEP2_LONG_RUN_HOURS` | 12 h |
 | Runs whose timings calibrate the cost model | — | `REVDEP2_MEASURED_MAX_RUNS` | 3 (`0` disables) |
 | Oldest measurement worth trusting | — | `REVDEP2_MEASURED_MAX_AGE_DAYS` | 60 days |

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -449,7 +449,7 @@ Every artifact this workflow writes:
 | --- | --- | --- |
 | `revdep2-plan` | `plan.json` | 30 days |
 | `revdep2-pkg` | source tarball, platform binary, `meta.json` | 30 days |
-| `revdep2-preflight` | `depfail.json` | 30 days |
+| `revdep2-preflight` | `depfail.json`, `resources.log` | 30 days |
 | `revdep2-lib` | `library.tar` (the preflight's installed library), `lib.json` | 14 days |
 | `revdep2-lib-index` | `lib.json`: R series, platform, package versions | 30 days |
 | `revdep2-results-<shard>-<attempt>` | `manifest.ndjson`, `pkgs/<p>/{old,new}.rds`, kept check output | 30 days |
@@ -581,6 +581,54 @@ the report is about *results*, a retry is about *coverage*.
 | CRAN bumps a dependency mid-run | shards install what resolves at their start; the recorded fingerprint is the plan's — next run re-fingerprints |
 | The package is not on CRAN | plan emits zero shards, run ends green |
 | `collect` finds new problems | reported in the summary and the report artifact; the run stays green |
+
+### When a job is killed rather than failed
+
+A job that *fails* leaves a diagnosis:
+the step reports its error,
+the `if: always()` steps run,
+and the artifacts are uploaded.
+A job that is *killed* leaves almost nothing.
+`The runner has received a shutdown signal` and `exit code 143`
+is the whole of it —
+no post-step runs,
+nothing is uploaded,
+and the only record that survives
+is whatever had already been streamed to the log.
+
+The preflight is where that happens,
+because it is the one job that takes on the entire dependency universe at once,
+so three things are arranged to be *live* rather than after the fact:
+
+- `watch-resources.sh` samples memory, swap, disk, load
+  and the three largest processes every 30 seconds
+  while the install runs,
+  so a kill has a curve leading up to it
+  instead of a blank.
+- The R script runs under `stdbuf -oL`.
+  R block-buffers stdout when it is not a terminal
+  and flushes it on exit,
+  which a killed process never reaches —
+  that is why pak's progress used to vanish
+  while the `message()` calls around it, on unbuffered stderr, came through.
+- Afterwards, when there is an afterwards,
+  the kernel's own OOM log is read,
+  which separates "this job asked for too much memory"
+  from "the host went away".
+
+The same principle applies to everything these scripts swallow.
+Fetching an artifact is an optimization,
+so its failure never stops a run —
+which is exactly why it has to say *which* failure it was.
+An artifact that has really expired,
+a `gh` that could not download it,
+a truncated zip,
+an `unzip` that refused it,
+and a tar that ran out of disk
+each name themselves now;
+before, all of them printed
+"no longer has a library artifact",
+including the cases where the artifact was demonstrably still there.
 
 Run ids are strings everywhere in these scripts,
 never integers, and `"0"` is the "no such run" sentinel

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -1227,19 +1227,26 @@ append_summary(c(
   "| --- | --- |",
   sprintf("| Package | `%s` %s (CRAN: %s) |", package, dev_version, cran_version),
   sprintf("| Selection | %s |", selection_md %||% selection),
+  # The dispatch inputs that decide how wide the net was, echoed verbatim.
+  # GitHub does not show a run which inputs it was given, and a plan that says
+  # only "all" and a package count leaves "was that depth 2 or the whole
+  # closure?" unanswerable from the run page -- which is a question worth
+  # asking, since the two differ by hours.
   sprintf(
-    "| Packages to check | %d (of %d revdeps%s) |",
-    n,
-    length(revdeps),
-    if (length(level_counts) > 1) {
+    "| Reverse dependencies | `which: %s`, `depth: %s`%s%s |",
+    which_input,
+    depth_raw,
+    if (identical(depth, Inf)) " (the full transitive closure)" else "",
+    if (length(level_counts) > 0) {
       paste0(
-        "; ",
+        " &mdash; ",
         paste0("level ", names(level_counts), ": ", level_counts, collapse = ", ")
       )
     } else {
       ""
     }
   ),
+  sprintf("| Packages to check | %d (of %d revdeps) |", n, length(revdeps)),
   sprintf(
     "| Baseline | %s |",
     if (length(baseline_manifest) > 0) {

--- a/.github/workflows/revdep2/preflight.R
+++ b/.github/workflows/revdep2/preflight.R
@@ -40,11 +40,19 @@ failures <- list()
 # still resolves the whole union afterwards -- CRAN moves between runs, and a
 # package whose version changed has to be built after all -- but everything
 # unchanged is now already there, and is skipped.
+promised <- unique(unlist(
+  lapply(plan$prebuilt$runs %||% list(), function(d) {
+    unlist(d$packages, use.names = FALSE)
+  }),
+  use.names = FALSE
+))
 restored <- restore_prebuilt(plan, lib, install_union)
 inform(
   "Preflight: ",
   length(restored),
-  " package(s) restored from earlier runs"
+  " of the ",
+  length(intersect(promised, install_union)),
+  " package(s) the plan expected were restored from earlier runs"
 )
 
 # With a restored library, `upgrade = FALSE` would freeze whatever version the
@@ -52,7 +60,21 @@ inform(
 # CRAN *now*, so the library has to follow CRAN now.
 upgrade <- length(restored) > 0
 
-inform("Preflight: installing ", length(install_union), " packages")
+# This one call is the whole job, and the place it has died: pak resolves
+# every one of these refs before it installs anything, and the resolution of a
+# few thousand is where a run that is killed rather than failed gets killed.
+# So say what it is about to attempt, and how long it took to either finish or
+# die -- the workflow's resource sampler supplies the other half of that
+# picture, a memory curve on the same clock.
+inform(
+  "Preflight: installing ",
+  length(install_union),
+  " packages (",
+  length(missing_from(lib, install_union)),
+  " not in the library yet), upgrade = ",
+  upgrade
+)
+install_started <- Sys.time()
 installed_ok <- tryCatch(
   {
     pak::pkg_install(install_union, lib = lib, ask = FALSE, upgrade = upgrade)
@@ -63,6 +85,11 @@ installed_ok <- tryCatch(
     FALSE
   }
 )
+inform(sprintf(
+  "Preflight: the bulk install %s after %.1f min",
+  if (installed_ok) "finished" else "failed",
+  as.numeric(difftime(Sys.time(), install_started, units = "mins"))
+))
 if (!installed_ok) {
   # One bad package must not hide the state of the other thousand: retry each
   # missing package on its own and record exactly which ones will not install.

--- a/.github/workflows/revdep2/preflight.R
+++ b/.github/workflows/revdep2/preflight.R
@@ -60,35 +60,36 @@ inform(
 # CRAN *now*, so the library has to follow CRAN now.
 upgrade <- length(restored) > 0
 
-# This one call is the whole job, and the place it has died: pak resolves
-# every one of these refs before it installs anything, and the resolution of a
-# few thousand is where a run that is killed rather than failed gets killed.
-# So say what it is about to attempt, and how long it took to either finish or
-# die -- the workflow's resource sampler supplies the other half of that
+# This install is the whole job, and the place it has died: handed the whole
+# universe at once, pak resolves every one of those refs before it installs
+# any of them, and the resolution of a few thousand is where a run that is
+# killed rather than failed gets killed. So it goes in dependency order, a
+# hundred at a time (see install_chunks() in util.R), which keeps every
+# resolution small and turns a fatal ten minutes of silence into a chunk
+# counter -- the workflow's resource sampler supplies the other half of that
 # picture, a memory curve on the same clock.
+chunk_size <- env_num("REVDEP2_INSTALL_CHUNK", 100)
+chunks <- install_chunks(install_union, cran_db(), chunk_size)
 inform(
   "Preflight: installing ",
   length(install_union),
   " packages (",
   length(missing_from(lib, install_union)),
-  " not in the library yet), upgrade = ",
+  " not in the library yet) in ",
+  length(chunks),
+  " chunk(s) of at most ",
+  chunk_size,
+  ", dependencies first; upgrade = ",
   upgrade
 )
 install_started <- Sys.time()
-installed_ok <- tryCatch(
-  {
-    pak::pkg_install(install_union, lib = lib, ask = FALSE, upgrade = upgrade)
-    TRUE
-  },
-  error = function(e) {
-    inform("Bulk install failed: ", conditionMessage(e))
-    FALSE
-  }
-)
+installed_ok <- install_in_chunks(chunks, lib, upgrade, "Preflight")
 inform(sprintf(
-  "Preflight: the bulk install %s after %.1f min",
+  "Preflight: the install %s after %.1f min; %d of %d packages are in the library",
   if (installed_ok) "finished" else "failed",
-  as.numeric(difftime(Sys.time(), install_started, units = "mins"))
+  as.numeric(difftime(Sys.time(), install_started, units = "mins")),
+  length(install_union) - length(missing_from(lib, install_union)),
+  length(install_union)
 ))
 if (!installed_ok) {
   # One bad package must not hide the state of the other thousand: retry each

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -160,18 +160,23 @@ inform(
 # CRAN *now*, so the library has to follow CRAN now.
 upgrade <- length(restored) > 0
 
-inform("Installing ", length(install), " dependencies")
-install_started <- Sys.time()
-bulk_ok <- tryCatch(
-  {
-    pak::pkg_install(install, ask = FALSE, upgrade = upgrade)
-    TRUE
-  },
-  error = function(e) {
-    inform("Bulk install failed: ", conditionMessage(e))
-    FALSE
-  }
+# In dependency order, a hundred at a time, for the same reason the preflight
+# does it: one pak call for the whole set is one resolution of the whole set,
+# and that is the part that stops degrading gracefully as the set grows. A
+# shard's union is a fraction of the preflight's, but it is the same call.
+chunk_size <- env_num("REVDEP2_INSTALL_CHUNK", 100)
+chunks <- install_chunks(install, cran_db(), chunk_size)
+inform(
+  "Installing ",
+  length(install),
+  " dependencies in ",
+  length(chunks),
+  " chunk(s) of at most ",
+  chunk_size,
+  ", dependencies first"
 )
+install_started <- Sys.time()
+bulk_ok <- install_in_chunks(chunks, upgrade = upgrade)
 if (!bulk_ok) {
   for (p in install) {
     if (requireNamespace(p, quietly = TRUE)) {

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -256,12 +256,50 @@ run_artifacts <- function(run_id) {
   )
 }
 
+# Everything below reports why it could not do its job, not only that it
+# could not. These fetches are optimizations, so a failure is swallowed and
+# the run continues -- which is exactly the situation where a silent one is
+# expensive: a prebuilt library that does not arrive costs an hour of
+# rebuilding, and the causes (an artifact that really is gone, a download
+# that failed, a truncated zip, an unzip that refused it) call for entirely
+# different fixes and used to look identical in the log.
+
+# The last few lines of what a command wrote to stderr, which is where every
+# one of these tools says what went wrong.
+stderr_tail <- function(path, n = 3) {
+  if (!file.exists(path)) {
+    return("")
+  }
+  lines <- tryCatch(readLines(path, warn = FALSE), error = function(e) {
+    character()
+  })
+  paste(utils::tail(lines[nzchar(trimws(lines))], n), collapse = "; ")
+}
+
+format_bytes <- function(n) {
+  if (!is.finite(n) || n < 0) {
+    return("unknown size")
+  }
+  if (n >= 1024^3) {
+    sprintf("%.2f GiB", n / 1024^3)
+  } else if (n >= 1024^2) {
+    sprintf("%.1f MiB", n / 1024^2)
+  } else {
+    sprintf("%.0f B", n)
+  }
+}
+
 # utils::unzip() refuses archives above 4 GB, which a library artifact reaches
 # without trying; the system unzip has no such limit, so prefer it and keep
 # the internal one for a runner without it.
+#
+# Returns TRUE, or a string saying why not -- both are truthy in R, so callers
+# must test with isTRUE().
 unzip_into <- function(zip, dest) {
   dir.create(dest, recursive = TRUE, showWarnings = FALSE)
   if (nzchar(Sys.which("unzip"))) {
+    err <- tempfile(fileext = ".err")
+    on.exit(unlink(err), add = TRUE)
     status <- tryCatch(
       suppressWarnings(
         # Quoted: system2() quotes the command, but not the arguments.
@@ -269,12 +307,20 @@ unzip_into <- function(zip, dest) {
           "unzip",
           shQuote(c("-q", "-o", zip, "-d", dest)),
           stdout = NULL,
-          stderr = NULL
+          stderr = err
         )
       ),
       error = function(e) 1L
     )
-    return(identical(as.integer(status), 0L))
+    if (identical(as.integer(status), 0L)) {
+      return(TRUE)
+    }
+    detail <- stderr_tail(err)
+    return(sprintf(
+      "unzip exited %d%s",
+      as.integer(status),
+      if (nzchar(detail)) paste0(": ", detail) else ""
+    ))
   }
   # A gh that wrote an error body instead of the artifact leaves something
   # that is not a zip; that is a missing artifact, not a usable one.
@@ -282,39 +328,75 @@ unzip_into <- function(zip, dest) {
     suppressWarnings(utils::unzip(zip, exdir = dest)),
     error = function(e) character()
   )
-  length(extracted) > 0
+  if (length(extracted) > 0) TRUE else "utils::unzip() extracted nothing"
 }
 
-# Download one artifact by id into a directory; NULL when it cannot be had.
-fetch_artifact_id <- function(id, dest) {
+# Download one artifact by id into a directory; NULL when it cannot be had,
+# with a line in the log saying which of the ways it failed.
+fetch_artifact_id <- function(id, dest, what = paste("artifact", id)) {
   if (!gh_ok() || !nzchar(gh_repo())) {
+    inform(what, ": not fetched (no gh, or no token with `actions: read`)")
     return(NULL)
   }
   zip <- tempfile(fileext = ".zip")
+  on.exit(unlink(zip), add = TRUE)
+  err <- tempfile(fileext = ".err")
+  on.exit(unlink(err), add = TRUE)
+  started <- Sys.time()
   # Quoted: system2() quotes the command, but not the arguments.
   args <- shQuote(c("api", sprintf("repos/%s/actions/artifacts/%s/zip", gh_repo(), id)))
   status <- tryCatch(
-    suppressWarnings(system2("gh", args, stdout = zip, stderr = NULL)),
+    suppressWarnings(system2("gh", args, stdout = zip, stderr = err)),
     error = function(e) 1L
   )
-  if (!identical(as.integer(status), 0L) || !file.exists(zip)) {
-    unlink(zip)
+  elapsed <- as.numeric(difftime(Sys.time(), started, units = "secs"))
+  bytes <- if (file.exists(zip)) file.size(zip) else 0
+  if (!identical(as.integer(status), 0L) || bytes == 0) {
+    detail <- stderr_tail(err)
+    inform(sprintf(
+      "%s: download failed after %.0f s -- gh exited %d, %s written%s",
+      what,
+      elapsed,
+      as.integer(status),
+      format_bytes(bytes),
+      if (nzchar(detail)) paste0(": ", detail) else ""
+    ))
     return(NULL)
   }
-  ok <- unzip_into(zip, dest)
-  unlink(zip)
-  if (ok) dest else NULL
+  inform(sprintf(
+    "%s: downloaded %s in %.0f s (%.0f MB/s)",
+    what,
+    format_bytes(bytes),
+    elapsed,
+    bytes / 1e6 / max(elapsed, 1)
+  ))
+  unpacked <- unzip_into(zip, dest)
+  if (!isTRUE(unpacked)) {
+    inform(what, ": the download is not usable -- ", unpacked)
+    return(NULL)
+  }
+  dest
 }
 
 # Fetch one named artifact of one run; NULL when the run does not have it, it
-# has expired, or it cannot be downloaded.
+# has expired, or it cannot be downloaded -- and the log says which.
 fetch_artifact <- function(run_id, name, dest) {
   ids <- run_artifacts(run_id)
   id <- unname(ids[names(ids) == name])
+  what <- sprintf("%s of run %s", name, run_id)
   if (length(id) == 0) {
+    inform(
+      what,
+      ": the run has no unexpired artifact by that name",
+      if (length(ids) > 0) {
+        paste0(" (it has: ", paste(sort(names(ids)), collapse = ", "), ")")
+      } else {
+        " (and none at all, or gh could not list them)"
+      }
+    )
     return(NULL)
   }
-  fetch_artifact_id(id[[1]], dest)
+  fetch_artifact_id(id[[1]], dest, what)
 }
 
 # ------------------------------------------------------ prebuilt libraries --
@@ -424,15 +506,28 @@ unpack_library <- function(tarball, lib, take) {
   on.exit(unlink(members))
   # A member the index promised but the tar does not hold makes tar exit
   # non-zero after extracting the rest; what actually landed is the answer, so
-  # the status is not consulted.
+  # the status is not consulted. Its complaints still are, when fewer packages
+  # land than were asked for: "no space left on device" and "member not found"
+  # are the same shortfall here and the same silence before.
+  err <- tempfile(fileext = ".err")
+  on.exit(unlink(err), add = TRUE)
   system2(
     "tar",
     # Quoted: system2() quotes the command, but not the arguments.
     shQuote(c("-xf", tarball, "-C", lib, "-T", members)),
     stdout = NULL,
-    stderr = NULL
+    stderr = err
   )
   got <- intersect(take, list.dirs(lib, full.names = FALSE, recursive = FALSE))
+  if (length(got) < length(take)) {
+    detail <- stderr_tail(err)
+    inform(sprintf(
+      "Prebuilt: tar produced %d of %d requested package(s)%s",
+      length(got),
+      length(take),
+      if (nzchar(detail)) paste0("; tar said: ", detail) else ""
+    ))
+  }
   # A half-extracted package directory is worse than none: drop anything
   # without a DESCRIPTION and let pak install it properly.
   broken <- got[!file.exists(file.path(lib, got, "DESCRIPTION"))]
@@ -501,17 +596,41 @@ restore_prebuilt <- function(plan, lib, wanted) {
       next
     }
     inform("Prebuilt: fetching ", length(take), " package(s) from run ", run_id)
+    started <- Sys.time()
     dir <- fetch_artifact(run_id, "revdep2-lib", tempfile("prebuilt-"))
     tarball <- if (is.null(dir)) NULL else file.path(dir, "library.tar")
     if (is.null(tarball) || !file.exists(tarball)) {
-      inform("Prebuilt: run ", run_id, " no longer has a library artifact")
+      # Three different failures used to share one message, and the one that
+      # actually happened -- the artifact was there, the download or the
+      # unpacking was not -- was the one the message denied.
+      inform(sprintf(
+        "Prebuilt: nothing restored from run %s after %.0f s; %s",
+        run_id,
+        as.numeric(difftime(Sys.time(), started, units = "secs")),
+        if (is.null(dir)) {
+          "see the reason above"
+        } else {
+          paste0(
+            "the artifact unpacked to ",
+            paste(list.files(dir), collapse = ", "),
+            ", which has no library.tar"
+          )
+        }
+      ))
       unlink(dir, recursive = TRUE)
       next
     }
     got <- unpack_library(tarball, lib, take)
+    inform(sprintf(
+      "Prebuilt: restored %d of %d package(s) from run %s in %.0f s (%s tarball)",
+      length(got),
+      length(take),
+      run_id,
+      as.numeric(difftime(Sys.time(), started, units = "secs")),
+      format_bytes(file.size(tarball))
+    ))
     unlink(dir, recursive = TRUE)
     restored <- c(restored, got)
-    inform("Prebuilt: restored ", length(got), " package(s) from run ", run_id)
   }
   restored
 }

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -901,6 +901,92 @@ install_closure <- function(packages, db) {
   })
 }
 
+# The same set, cut into installable pieces: chunks of at most `size`,
+# ordered so that every strong dependency inside the set is installed before
+# the package that needs it.
+#
+# One pak call for a few thousand refs means one resolution of a few thousand
+# refs, and that is where the preflight of run 31270092803 died: ten minutes
+# inside pak, not one install started, then the runner was shut down. The
+# resolution is the part that does not degrade gracefully, so it is the part
+# that is kept small -- each chunk resolves against a library where its
+# dependencies already are.
+#
+# It also changes what a failure costs. Whatever earlier chunks installed is
+# on disk and is skipped on the next attempt, so a chunk that dies costs a
+# chunk; and the log says which one, which a single opaque call never could.
+#
+# Ordering is on strong dependencies only. Suggests are in the set because a
+# revdep's *check* needs them, not its installation, and they are what makes
+# the graph cyclic -- ordering on them would order on nothing.
+install_chunks <- function(pkgs, db, size = 100) {
+  pkgs <- unique(pkgs)
+  if (length(pkgs) == 0) {
+    return(list())
+  }
+  deps <- tools::package_dependencies(pkgs, db = db, which = "strong")
+  index <- stats::setNames(seq_along(pkgs), pkgs)
+  needs <- lapply(pkgs, function(p) {
+    unname(index[intersect(deps[[p]] %||% character(), pkgs)])
+  })
+  done <- logical(length(pkgs))
+  order <- integer()
+  repeat {
+    ready <- which(!done & vapply(needs, function(d) all(done[d]), logical(1)))
+    if (length(ready) == 0) {
+      break
+    }
+    done[ready] <- TRUE
+    order <- c(order, ready)
+  }
+  # A cycle, or a dependency this index cannot describe, leaves packages that
+  # never become ready. They go last, together, for pak to sort out among
+  # themselves -- which is what it was doing for the whole set before.
+  order <- c(order, which(!done))
+  unname(split(pkgs[order], ceiling(seq_along(order) / size)))
+}
+
+# Install one chunked set, reporting each chunk as it lands. Returns TRUE when
+# every chunk succeeded; a caller that cares which packages are missing asks
+# the library, not this.
+install_in_chunks <- function(chunks, lib = NULL, upgrade = FALSE, label = "") {
+  ok <- TRUE
+  prefix <- if (nzchar(label)) paste0(label, ": ") else ""
+  for (i in seq_along(chunks)) {
+    started <- Sys.time()
+    chunk_ok <- tryCatch(
+      {
+        if (is.null(lib)) {
+          pak::pkg_install(chunks[[i]], ask = FALSE, upgrade = upgrade)
+        } else {
+          pak::pkg_install(
+            chunks[[i]],
+            lib = lib,
+            ask = FALSE,
+            upgrade = upgrade
+          )
+        }
+        TRUE
+      },
+      error = function(e) {
+        inform(prefix, "chunk ", i, " failed: ", conditionMessage(e))
+        FALSE
+      }
+    )
+    ok <- ok && chunk_ok
+    inform(sprintf(
+      "%schunk %d/%d (%d packages) %s after %.1f min",
+      prefix,
+      i,
+      length(chunks),
+      length(chunks[[i]]),
+      if (chunk_ok) "installed" else "failed",
+      as.numeric(difftime(Sys.time(), started, units = "mins"))
+    ))
+  }
+  ok
+}
+
 # Fingerprint of the *versions* of everything a check installs, from CRAN
 # metadata. Two runs whose fingerprints agree resolved the same dependency
 # tree, so an old-version check result can be carried from one to the other.

--- a/.github/workflows/revdep2/watch-resources.sh
+++ b/.github/workflows/revdep2/watch-resources.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# What the machine has left, sampled while the work is still running.
+#
+# A job that is killed rather than failed takes its post-steps with it: when
+# the runner receives a shutdown signal, `if: always()` steps never run, the
+# artifact is never uploaded, and the only record that survives is what was
+# already streamed to the log. So the numbers that explain such a death have
+# to be emitted *during* the work, not after it -- which is what this does.
+#
+# Usage:
+#   watch-resources.sh once  [label]              one sample, labelled
+#   watch-resources.sh watch [seconds] [label]    a sample every `seconds`,
+#                                                 until the process is killed
+#   watch-resources.sh oom                        what the kernel killed, if
+#                                                 anything -- the difference
+#                                                 between "out of memory" and
+#                                                 "the host went away"
+#
+# Every sample also goes to $RESOURCE_LOG when that is set, so a job that does
+# reach its upload step carries the series in its artifact too.
+
+set -u
+
+mode="${1:-once}"
+
+emit() {
+  printf '[resources] %s\n' "$1"
+  if [ -n "${RESOURCE_LOG:-}" ]; then
+    mkdir -p "$(dirname "${RESOURCE_LOG}")" 2> /dev/null || true
+    printf '%s\n' "$1" >> "${RESOURCE_LOG}" || true
+  fi
+}
+
+# One line: clock, memory, swap, disk on the two filesystems that fill up
+# here, load, and the three largest processes -- which is what names the
+# thing that grew just before the machine stopped answering.
+sample() {
+  local label="${1:-}"
+  local mem disk load top
+
+  mem=$(awk '
+    /^MemTotal:/     { total = $2 }
+    /^MemAvailable:/ { avail = $2 }
+    /^SwapTotal:/    { swap_total = $2 }
+    /^SwapFree:/     { swap_free = $2 }
+    END {
+      printf "mem %.1f/%.1fG used, %.1fG available; swap %.1f/%.1fG used",
+        (total - avail) / 1048576, total / 1048576, avail / 1048576,
+        (swap_total - swap_free) / 1048576, swap_total / 1048576
+    }' /proc/meminfo)
+
+  # `/mnt` is the runner's large ephemeral disk, and `/` the one everything
+  # here actually writes to; duplicates collapse, so naming a path twice or
+  # naming one that does not exist costs nothing.
+  disk=$(df -BG --output=target,avail \
+    / /mnt "${RUNNER_TEMP:-/tmp}" "${TMPDIR:-/tmp}" 2> /dev/null |
+    awk 'NR > 1 && !seen[$1]++ { printf "%s %s free; ", $1, $2 }' |
+    sed 's/; $//')
+
+  load=$(cut -d ' ' -f 1-3 < /proc/loadavg)
+
+  top=$(ps -eo rss=,comm= --sort=-rss 2> /dev/null |
+    head -n 3 |
+    awk '{ printf "%s %.1fG; ", $2, $1 / 1048576 }' |
+    sed 's/; $//')
+
+  emit "$(date -u +%H:%M:%S)${label:+ ${label}} -- ${mem}; ${disk}; load ${load}; largest: ${top}"
+}
+
+case "${mode}" in
+  once)
+    sample "${2:-}"
+    ;;
+  watch)
+    interval="${2:-30}"
+    label="${3:-}"
+    while true; do
+      sample "${label}"
+      sleep "${interval}"
+    done
+    ;;
+  oom)
+    # `dmesg` needs privileges on a stock kernel; on a hosted runner sudo is
+    # passwordless, and where it is not, saying so beats saying nothing.
+    if kills=$(sudo -n dmesg 2> /dev/null |
+      grep -iE 'out of memory|oom-kill|oom_reaper|killed process' |
+      tail -n 5) && [ -n "${kills}" ]; then
+      emit "the kernel reports out-of-memory kills:"
+      printf '[resources] %s\n' "${kills}"
+    elif [ -n "${kills:-}" ]; then
+      emit "no out-of-memory kills in dmesg"
+    else
+      emit "no out-of-memory kills in dmesg (or dmesg is not readable here)"
+    fi
+    ;;
+  *)
+    echo "usage: watch-resources.sh {once [label]|watch [seconds] [label]|oom}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Prepared with Claude Code.

## Why

In run 31270092803 the preflight died with `The runner has received a shutdown signal` and `exit code 143`, ten minutes into `pak::pkg_install()` of 4406 packages — and left nothing to diagnose it with.

When the *runner* goes away (rather than the job failing), no post-step runs: `Report what the install consumed` never executed, no artifact was uploaded, and the log jumps straight from pak's last metadata line at 17:49:53 to the kill at 18:00:22. Those ten minutes are blank because R block-buffers stdout when it is not a terminal and flushes on exit — which a killed process never reaches. Only the `message()` calls around pak, on unbuffered stderr, came through, which is why `Preflight: installing 4406 packages` is visible and pak's own progress is not.

The same run also shows why a swallowed failure has to say *which* failure it was. The preflight reported `Prebuilt: run 31196400789 no longer has a library artifact` and then rebuilt 1990 packages from scratch — but that run's `revdep2-lib` (artifact 9003559942, 2.4 GiB) was present and unexpired the whole time, and does not expire until 2026-08-21. That message was the single catch-all for four different causes: a `gh` download that failed, a truncated zip, an `unzip` that refused the archive, and an artifact that really was gone. It named the only one that was not true.

## Install in chunks, dependencies first

pak resolves every ref it is handed before it installs any of them, and that resolution is the part that stops degrading gracefully as the set grows — ten minutes on 4406 refs with not one install started.

So the preflight and the shards now install in chunks of `REVDEP2_INSTALL_CHUNK` (100), ordered so that every strong dependency inside the set is installed before the package that needs it (`install_chunks()` in `util.R`). Each chunk then resolves against a library where its dependencies already are, which keeps every resolution small.

Ordering is on strong dependencies only. Suggests are in the set because a revdep's *check* needs them, not its installation, and they are what would make the graph cyclic. Packages that a cycle or a gap in the index leaves unordered go last, together — which is what pak was being asked to do for the whole set before.

It also changes what a failure costs. Whatever earlier chunks installed stays on disk and is skipped on the next attempt, so a chunk that dies costs a chunk rather than the job; the per-chunk line says which one and how long it took. The per-package retry that follows a failed install is unchanged — it already skips whatever is present.

Verified against the real set: the 4406 packages of that run's universe order into 45 chunks in under two seconds, with no package placed before one of its strong dependencies.

## Diagnostics

Live rather than after the fact, since a shut-down runner never reaches "after":

- **`revdep2/watch-resources.sh`** (new) samples memory, swap, disk on `/` and `/mnt`, load, and the three largest processes. The preflight starts it in the background at 30 s intervals for the duration of the install; every sample goes to the log and to `resources.log` in the `revdep2-preflight` artifact. A kill now has a curve leading up to it.
- **The install runs under `stdbuf -oL`**, so pak's progress reaches the log as it happens. It falls back to plain `Rscript` if `stdbuf` is absent, and the step still propagates R's exit status.
- **The kernel's OOM log is read** when there is an afterwards, which separates "this job asked for too much memory" from "the host went away".

Swallowed artifact failures now name themselves, in `util.R`:

- `fetch_artifact_id()` reports the bytes written, the elapsed time and the throughput on success; on failure, gh's exit status and the tail of its stderr.
- `fetch_artifact()` distinguishes "the run has no unexpired artifact by that name" — listing the ones it does have — from a download that failed.
- `unzip_into()` returns `TRUE` or the reason, with unzip's stderr, instead of a bare logical.
- `unpack_library()` reports tar's complaint when fewer packages land than were asked for, which is how `no space left on device` would surface.
- `restore_prebuilt()` says how long the attempt took and which of those things happened.

And the preflight logs how many packages the plan promised versus how many were actually restored, how many of the union are not in the library yet, and how long the install ran before it finished or died.

## The run's inputs are now visible on the run

GitHub does not show a run which `workflow_dispatch` inputs it was given, so `which` and `depth` go into the run name (`revdep2 (most, depth 2)`) and into a `Reverse dependencies` row of the plan summary, alongside the per-level counts. "Was that depth 2 or the whole closure?" is now answerable from the run page instead of only from the plan job's log.

## What this does not do

It does not claim to know what killed the runner. Chunked resolution is the leading fix if pak's resolution was the problem, but the evidence to say so does not exist yet — that is what the sampler and the OOM check are for. If the next run still dies, the memory curve will say whether swap, a larger runner, or a smaller chunk is the answer.

Nor does it change the fact that the shards run past a dead preflight — that is deliberate and already documented (`revdep2.yaml`, the `test` job's `if:`, and the "Failure modes" table). The preflight is an optimization and an early diagnosis: a shard installs its own dependency union anyway, and that union is a fraction of the universe the preflight takes on. A failed preflight costs the run the free rebuild and the warm cache, not its results.

## Testing

Exercised locally against real data and a real pak:

- `install_chunks()` over the 4406-package universe of run 31270092803: 45 chunks, every chunk within the size bound, the flattened order a permutation of the input, and zero packages placed before one of their strong dependencies. Empty and single-package inputs handled.
- `install_in_chunks()` installing into a scratch library, and a chunk with an unresolvable ref: the chunk is reported as failed, the return value is `FALSE`, and nothing propagates.
- `format_bytes()`, `stderr_tail()`, `unzip_into()` on both a valid archive and a non-zip, `fetch_artifact_id()` without a token, `unpack_library()` asking for a member the tar does not hold, `restore_prebuilt()` against an unreachable donor.
- The wrapped preflight step end to end under `bash -e -o pipefail`, confirming the sampler starts and stops and that R's exit status still fails the step.

R sources parse and are `air`-formatted; the workflow parses as YAML.

<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->

<!-- The following text must be left intact and the box checked before the PR can be merged. -->

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.