### PR TITLE
ci(revdep2): Run several checks at once inside each shard

### DIFF
--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -31,6 +31,12 @@
 # never a job failure; the shard defers what its deadline cannot fit and says
 # so.
 #
+# Parallelism has two axes and they multiply: `max-parallel` shards run at
+# once, and each shard runs `check-workers` checks at once (the runner has
+# four cores and one R CMD check keeps about one busy). The plan sizes shards
+# on both, so a shard holds as much check work as its deadline and its workers
+# can really get through.
+#
 # The collect job folds every shard artifact (and, on a retry, the untouched
 # results of the run being retried) into revdepcheck-style reports (README.md,
 # problems.md, failures.md, cran.md), a machine-readable manifest, and the
@@ -100,6 +106,10 @@ on:
         description: "Shards to run concurrently, and so the wave size the plan cuts: set it to the concurrency the account really has, never more (GitHub queues past its own limit anyway)"
         type: string
         default: ""
+      check-workers:
+        description: "Checks one shard runs at once; the runner has four cores and one check keeps about one busy, so this multiplies with max-parallel"
+        type: string
+        default: ""
       refresh-baseline:
         description: "Re-check the CRAN version even where a baseline is reusable"
         type: boolean
@@ -143,6 +153,12 @@ env:
   REVDEP2_PART: ${{ inputs.part || '' }}
   REVDEP2_SHARD_BUDGET_MINUTES: ${{ inputs.shard-budget-minutes || vars.REVDEP2_SHARD_BUDGET_MINUTES || '45' }}
   REVDEP2_MAX_PARALLEL: ${{ inputs.max-parallel || vars.REVDEP2_MAX_PARALLEL || '20' }}
+  # Checks one shard runs at once. This is the second axis of parallelism, and
+  # it multiplies with the first: REVDEP2_MAX_PARALLEL shards, each running
+  # this many checks. The plan sizes shards on it and records it in plan.json,
+  # so a shard always runs what its size assumed. Two leaves headroom on a
+  # four-core, 16 GB runner; a check that compiles hard wants that headroom.
+  REVDEP2_CHECK_WORKERS: ${{ inputs.check-workers || vars.REVDEP2_CHECK_WORKERS || '2' }}
   # Check minutes one shard may be planned to hold. Only a batch too big for
   # one wave of REVDEP2_MAX_PARALLEL shards ever hits it, and then it decides
   # how many waves there are; empty means 80% of REVDEP2_DEADLINE_MINUTES.
@@ -571,8 +587,31 @@ jobs:
           TIMEOUT_MIN_MINUTES: ${{ env.REVDEP2_TIMEOUT_MIN_MINUTES }}
           DEADLINE_MINUTES: ${{ env.REVDEP2_DEADLINE_MINUTES }}
           PKG_SYSREQS: true
+          RESOURCE_LOG: ${{ runner.temp }}/results/resources.log
+        # Sampled and line-buffered for the same reason the preflight is: this
+        # job can be killed rather than fail, and then only what was already
+        # streamed survives. It matters more now that the shard runs several
+        # checks at once -- two concurrent checks share the runner's 16 GB, and
+        # the memory curve is what says whether that was the problem. Five
+        # minutes rather than the preflight's 30 seconds: this job runs for
+        # hours, and a check is not a thing that turns over quickly.
         run: |
-          Rscript ./.github/workflows/revdep2/shard.R
+          mkdir -p "${RUNNER_TEMP}/results"
+          watch=./.github/workflows/revdep2/watch-resources.sh
+          "${watch}" once "before the shard"
+          "${watch}" watch 300 "checking" &
+          watcher=$!
+          trap 'kill "${watcher}" 2> /dev/null || true' EXIT
+          unbuffered=""
+          if command -v stdbuf > /dev/null 2>&1; then
+            unbuffered="stdbuf -oL -eL"
+          fi
+          status=0
+          ${unbuffered} Rscript ./.github/workflows/revdep2/shard.R || status=$?
+          kill "${watcher}" 2> /dev/null || true
+          "${watch}" once "after the shard"
+          "${watch}" oom
+          exit "${status}"
         shell: bash
 
       # Named per attempt: a re-run of one shard must not overwrite the results

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -43,6 +43,7 @@ test      (one job per shard, max-parallel throttled, fail-fast: false)
   ├─ phase old: reuse baselines, check the rest against the CRAN version
   ├─ install the prebuilt dev binary
   ├─ phase new: check everything again, compare per package
+  │    (both phases run check-workers checks at once, heaviest first)
   └─ results + manifest.ndjson → revdep2-results-<shard>-<attempt>
 
 collect   (1 job, if: always() past plan/build/preflight)
@@ -105,6 +106,56 @@ The floor matters more than the factor:
 all of them compile-heavy (Stan models, mostly) and cheap by CRAN's numbers,
 13 with the floor as their entire budget.
 It is 20 minutes now, which covers every one of them.
+
+### Two axes of parallelism, and they multiply
+
+Checks run in parallel twice over,
+and the two are independent:
+
+* **across jobs.** `max-parallel` shards run at once — this is the sharding
+  the whole workflow is built around, and the section below is about how many
+  shards there should be.
+* **inside a job.** Each shard runs `check-workers` checks at once (default 2),
+  which is what `revdepcheck::revdep_check(num_workers =)` does on one machine.
+
+The second one exists because a hosted runner has four cores
+and one `R CMD check` keeps about one of them busy:
+a shard checking its packages strictly one at a time
+leaves most of the machine idle for its entire deadline.
+Two checks at once is a shard that gets through twice the work
+in the same deadline, which means half as many shards,
+which means half as many setups paid and fewer waves waited through.
+Two is the default rather than four
+because they share the runner's 16 GB,
+and a check that compiles hard wants that headroom;
+`check-workers` raises it for a batch known to be light.
+
+The plan is where the two meet.
+It weighs each package by what one check of it costs,
+then divides by `check-workers` to get what a *shard* spends on it,
+and sizes shards on that —
+so a shard is given as much check work
+as its deadline and its workers can really get through.
+The shard then reads the worker count back out of `plan.json`
+rather than from its own environment,
+because a shard that runs one at a time what was planned for two
+takes twice its estimate and defers the difference.
+
+The calibration keeps the division honest without being told to.
+Measured check times come from runs that ran under some worker count,
+so they already carry whatever contention that count caused:
+where checks do not contend, the measurement stays put
+and dividing by the worker count buys the whole factor;
+where they contend completely, the measurement doubles
+and the division gives back exactly what one worker would have done.
+Only the first run after the knob changes
+is estimated on the previous regime's numbers.
+
+Inside a shard the queue is heaviest-first.
+With one worker that only moved the log around;
+with several it decides the makespan,
+since starting the long checks last
+is how a phase ends with one straggler and idle workers.
 
 ### The shard count is bounded by the parallel capacity
 
@@ -452,7 +503,7 @@ Every artifact this workflow writes:
 | `revdep2-preflight` | `depfail.json`, `resources.log` | 30 days |
 | `revdep2-lib` | `library.tar` (the preflight's installed library), `lib.json` | 14 days |
 | `revdep2-lib-index` | `lib.json`: R series, platform, package versions | 30 days |
-| `revdep2-results-<shard>-<attempt>` | `manifest.ndjson`, `pkgs/<p>/{old,new}.rds`, kept check output | 30 days |
+| `revdep2-results-<shard>-<attempt>` | `manifest.ndjson`, `pkgs/<p>/{old,new}.rds`, kept check output, `resources.log` | 30 days |
 | `revdep2-report` | `README.md`, `problems.md`, `failures.md`, `cran.md`, `manifest.json`, all `pkgs/` | 90 days |
 | `revdep2-baseline` | `baseline.json`, `old-rds/<p>.rds` | 90 days |
 | `revdep2-timings` | `timings.json`: check seconds per package, cost per shard | 90 days |
@@ -567,6 +618,7 @@ the report is about *results*, a retry is about *coverage*.
 | A dependency fails the preflight | reported in the preflight summary and `depfail.json`; shards still try their own subset |
 | A pak install chunk fails | the chunk is reported and the rest still run; what is still missing is retried one package at a time |
 | The preflight job itself dies | the shards run anyway and install their own unions, the collector still reports; only the free rebuild and the early diagnosis are lost |
+| Two concurrent checks exhaust the runner's memory | the sampler's memory curve is in the log and in `resources.log`; lower `check-workers` |
 | A shard hits its deadline | remaining packages `deferred`; finished old-halves still uploaded and baseline-fed |
 | A shard job dies hard | the collector reconciles against the plan: its packages are reported `missing`, naming the shard, and `retry-run` re-checks exactly them |
 | Every shard dies | the report is still written, with every package `missing`; the artifact download is tolerated, not required |
@@ -679,6 +731,7 @@ at the next `if`.
 | Plan only | `dry-run` | — | false |
 | Check-time target per shard, up to one wave | `shard-budget-minutes` | `REVDEP2_SHARD_BUDGET_MINUTES` | 45 |
 | Concurrent shards, and so the wave size — set it to the concurrency the account really has, never more | `max-parallel` | `REVDEP2_MAX_PARALLEL` | 20 |
+| Checks one shard runs at once | `check-workers` | `REVDEP2_CHECK_WORKERS` | 2 |
 | Check minutes one shard may hold, which forces further waves | — | `REVDEP2_SHARD_CAPACITY_MINUTES` | 80% of the deadline |
 | Ignore reusable baselines | `refresh-baseline` | — | false |
 | Oldest reusable baseline | `baseline-max-age-days` | `REVDEP2_BASELINE_MAX_AGE_DAYS` | 30 days |

--- a/.github/workflows/revdep2/collect.R
+++ b/.github/workflows/revdep2/collect.R
@@ -270,6 +270,9 @@ shard_rows <- lapply(shard_timings, function(t) {
     index = t$index,
     packages = t$packages %||% 0,
     checks = t$checks %||% 0,
+    # How many checks ran at once, which is the difference between the work
+    # below and the wall clock it took.
+    check_workers = t$check_workers %||% 1,
     install_packages = t$install_packages %||% 0,
     restored = t$restored %||% 0,
     install_minutes = round(install, 2),

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -121,6 +121,11 @@ measured_max_age <- env_num("REVDEP2_MEASURED_MAX_AGE_DAYS", 60)
 recheck_report <- env_flag("REVDEP2_RECHECK_REPORT")
 report_dir <- env_chr("REVDEP2_REPORT_DIR", "revdep")
 overhead_minutes <- env_num("REVDEP2_PACKAGE_OVERHEAD_MINUTES", 0.5)
+# Checks a shard runs at once. A hosted runner has four cores and one
+# `R CMD check` keeps about one of them busy, so this is what decides how much
+# of a shard's deadline goes to waiting. It is planned here and carried in
+# plan.json, because the shard must run what its size assumed.
+check_workers <- max(1L, as.integer(env_num("REVDEP2_CHECK_WORKERS", 2)))
 retry_run <- env_chr("REVDEP2_RETRY_RUN")
 repo <- env_chr("GITHUB_REPOSITORY")
 timing_flavor <- env_chr("REVDEP2_TIMING_FLAVOR", "r-release-linux-x86_64")
@@ -792,10 +797,30 @@ inform(
 # package without a reusable baseline is checked twice.
 weight <- ((!reuse) + 1) * check_seconds / 60 + overhead_minutes
 
+# What a shard actually spends on a package, which is not the same number: a
+# shard runs `check_workers` checks at once, so `check_workers` packages
+# advance per minute of its deadline. Everything that models a shard's wall
+# clock -- how many shards the budget and the capacity ask for, and what the
+# greedy pass thinks a shard costs -- goes through `wall`; `weight` stays what
+# one check costs, because that is what the shard's own deadline test asks of
+# each package before it starts it.
+#
+# The calibration keeps this honest by itself. `check_seconds` is measured
+# from runs that ran under some worker count, so it already carries whatever
+# contention that count caused: with no contention the measurement stays put
+# and dividing by `check_workers` buys the full factor, with total contention
+# the measurement doubles and the division gives back exactly what one worker
+# would have done. Only the first run after the knob changes is estimated on
+# the old regime's numbers.
+wall <- weight / check_workers
+
 # ------------------------------------------------------------- partitioning --
 
 n <- length(packages)
 total_check <- sum(weight)
+# The wall clock those checks turn into, which is what the shard count and
+# every deadline here are measured against.
+total_wall <- sum(wall)
 
 # How many shards can actually run at the same time. Everything past that waits
 # for a lane, so the shard count is counted in waves of this size.
@@ -814,8 +839,8 @@ lanes <- max(1L, min(as.integer(max_parallel), as.integer(max_shards), n))
 # arrives having paid a second setup for the privilege. So beyond one wave the
 # capacity decides, and it decides in whole waves: as many as it takes to keep
 # every shard under its deadline, and not one more.
-by_budget <- max(1L, as.integer(ceiling(total_check / budget)))
-by_capacity <- max(1L, as.integer(ceiling(total_check / max(capacity, 1))))
+by_budget <- max(1L, as.integer(ceiling(total_wall / budget)))
+by_capacity <- max(1L, as.integer(ceiling(total_wall / max(capacity, 1))))
 # Neither dial may be violated inside a wave, so the larger of the two wins
 # there; a capacity smaller than the budget is a contradiction, and the one
 # that keeps shards inside their deadline is the one to honour.
@@ -828,16 +853,18 @@ max_k <- max(1L, min(as.integer(max_shards), n))
 k <- max(1L, min(k, max_k))
 inform(
   sprintf(
-    "%d packages, ~%.0f check minutes; budget %.0f min asks for %d shard(s), capacity %.0f min needs %d, %d lane(s) -> %d shard(s), ~%.0f check min each",
+    "%d packages, ~%.0f check minutes at %d worker(s) -> ~%.0f min of shard time; budget %.0f min asks for %d shard(s), capacity %.0f min needs %d, %d lane(s) -> %d shard(s), ~%.0f min each",
     n,
     total_check,
+    check_workers,
+    total_wall,
     budget,
     by_budget,
     capacity,
     by_capacity,
     lanes,
     k,
-    total_check / k
+    total_wall / k
   )
 )
 
@@ -860,8 +887,8 @@ partition <- function(k) {
     p <- ord[[i]]
     fresh <- sum(!have[dep_idx[[p]], s])
     assignment[[p]] <<- s
-    check_load[[s]] <<- check_load[[s]] + weight[[p]]
-    load[[s]] <<- load[[s]] + weight[[p]] + fresh * penalty
+    check_load[[s]] <<- check_load[[s]] + wall[[p]]
+    load[[s]] <<- load[[s]] + wall[[p]] + fresh * penalty
     have[dep_idx[[p]], s] <<- TRUE
   }
 
@@ -876,7 +903,7 @@ partition <- function(k) {
     for (i in seq(k + 1L, n)) {
       p <- ord[[i]]
       fresh <- colSums(!have[dep_idx[[p]], , drop = FALSE])
-      score <- load + weight[[p]] + fresh * penalty
+      score <- load + wall[[p]] + fresh * penalty
       place(i, which.min(score))
     }
   }
@@ -939,9 +966,11 @@ plan_too_big <- function() {
     "**Too big for one run — nothing was started.**",
     "",
     sprintf(
-      "%d packages need ~%.0f check minutes. At most %d shard%s can be planned (%s), which puts the heaviest at ~%.0f min: ~%.0f min of checks on top of ~%.0f min of setup and installs, against the %.0f min a shard has before its deadline starts deferring packages.",
+      "%d packages need ~%.0f check minutes, which %d worker(s) per shard turn into ~%.0f min of shard time. At most %d shard%s can be planned (%s), which puts the heaviest at ~%.0f min: ~%.0f min of checks on top of ~%.0f min of setup and installs, against the %.0f min a shard has before its deadline starts deferring packages.",
       n,
       total_check,
+      check_workers,
+      total_wall,
       max_k,
       if (max_k == 1) "" else "s",
       if (max_k < as.integer(max_shards)) {
@@ -1095,6 +1124,7 @@ plan <- list(
   ref = env_chr("GITHUB_REF_NAME"),
   which = which_input,
   depth = depth_raw,
+  check_workers = check_workers,
   levels = as.list(level_counts),
   selection = selection,
   part = part,
@@ -1315,6 +1345,15 @@ append_summary(c(
     parallel,
     budget,
     capacity
+  ),
+  # Two axes, and they multiply: `parallel` shards run at once, and each of
+  # them runs `check_workers` checks at once.
+  sprintf(
+    "| Checks at a time | %d per shard, so up to %d at once across the run (~%.0f check minutes become ~%.0f min of shard time) |",
+    check_workers,
+    parallel * check_workers,
+    total_check,
+    total_wall
   ),
   sprintf(
     "| Estimated wall clock | ~%.0f min (%d wave(s) of ~%.0f min) |",

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -41,6 +41,9 @@
 #   TIMEOUT_MIN_MINUTES    - floor for that timeout; CRAN's machines are not
 #                            these runners (default: 10)
 #   DEADLINE_MINUTES       - stop starting new checks past this (default: 300)
+#   REVDEP2_CHECK_WORKERS  - checks to run at once, when plan.json does not say
+#                            (default: 2); the plan's value wins, because the
+#                            shard was sized on it
 
 source(file.path(
   dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))),
@@ -61,6 +64,16 @@ out_dir <- env_chr("OUT_DIR", "results")
 timeout_factor <- env_num("TIMEOUT_FACTOR", 1.5)
 timeout_min_sec <- env_num("TIMEOUT_MIN_MINUTES", 10) * 60
 deadline <- Sys.time() + env_num("DEADLINE_MINUTES", 300) * 60
+# How many checks run at once here. It comes from the plan, because the plan
+# sized this shard on the assumption that it would: a shard told to run one at
+# a time what was planned for two takes twice as long as its estimate and
+# defers the difference.
+check_workers <- max(
+  1L,
+  as.integer(
+    plan$check_workers %||% env_num("REVDEP2_CHECK_WORKERS", 2)
+  )
+)
 
 shard <- Filter(function(s) s$index == shard_index, plan$shards)[[1]]
 members <- vapply(shard$packages, function(p) p$name, character(1))
@@ -317,7 +330,14 @@ out_of_time <- function(entry) {
   Sys.time() + budget_sec > deadline
 }
 
-run_check <- function(name, phase) {
+# One check, started in the background and left to run. A hosted runner has
+# four cores and one `R CMD check` keeps about one of them busy, so what
+# bounds a shard's wall clock is how many checks it will run at once, not the
+# machine. The checks are independent by construction -- separate processes,
+# a check directory each, and a library that nothing writes to while a phase
+# is running (the dev binary goes in *between* the phases, with the queue
+# drained) -- which is what makes running several of them at once safe.
+start_check <- function(name, phase) {
   checks_started <<- checks_started + 1L
   check_dir <- file.path(work, "check", name, phase)
   dir.create(check_dir, recursive = TRUE, showWarnings = FALSE)
@@ -328,28 +348,101 @@ run_check <- function(name, phase) {
     timeout_min_sec,
     timeout_factor * (get(name, envir = state)$t_total %||% 0)
   )
-  started <- Sys.time()
-  result <- tryCatch(
-    rcmdcheck::rcmdcheck(
-      sources[[name]],
-      args = c("--no-manual", "--as-cran"),
-      error_on = "never",
-      check_dir = check_dir,
-      timeout = timeout_sec
-    ),
-    error = function(e) e
+  list(
+    name = name,
+    phase = phase,
+    started = Sys.time(),
+    timeout = timeout_sec,
+    # callr rather than rcmdcheck's own process class: the child runs exactly
+    # the rcmdcheck() call this driver used to run inline, so the timeout, the
+    # arguments and the returned object are the same as they were, and its
+    # chatter goes to a file instead of a pipe this driver would have to keep
+    # draining.
+    process = callr::r_bg(
+      function(path, args, check_dir, timeout) {
+        rcmdcheck::rcmdcheck(
+          path,
+          args = args,
+          error_on = "never",
+          check_dir = check_dir,
+          timeout = timeout
+        )
+      },
+      args = list(
+        path = sources[[name]],
+        args = c("--no-manual", "--as-cran"),
+        check_dir = check_dir,
+        timeout = timeout_sec
+      ),
+      stdout = file.path(check_dir, "driver.log"),
+      stderr = "2>&1",
+      supervise = TRUE
+    )
   )
-  duration <- round(as.numeric(Sys.time() - started, units = "secs"))
+}
+
+# Collect a finished check, with the same result contract the inline version
+# had: an rcmdcheck object, or the condition that stopped it.
+finish_check <- function(job) {
+  result <- tryCatch(job$process$get_result(), error = function(e) e)
+  # callr reports a child's failure wrapped in its own condition; the check's
+  # own error is what the rest of this driver reads.
+  if (inherits(result, "error")) {
+    result <- result$parent %||% result
+  }
+  duration <- round(as.numeric(Sys.time() - job$started, units = "secs"))
   # Every check counts towards what this shard cost, including the ones that
-  # errored or timed out -- they spent the same minutes.
+  # errored or timed out -- they spent the same minutes. Under more than one
+  # worker these add up past the shard's own wall clock, which is the point:
+  # this is the work done, and the plan divides it by the worker count to get
+  # back to wall clock.
   check_seconds <<- check_seconds + duration
   attr(result, "duration") <- duration
   # A check that hits the timeout is killed, and rcmdcheck surfaces that as an
   # error rather than a result object; tell it apart from a genuine crash by
   # the clock.
   attr(result, "timed_out") <- inherits(result, "error") &&
-    duration >= timeout_sec - 1
+    duration >= job$timeout - 1
   result
+}
+
+# Run one phase's checks, `check_workers` at a time, handing each result to
+# `collect` in this process as it lands -- so everything that reads or writes
+# the shard's state still happens one at a time, in this driver, exactly as it
+# did when the checks themselves were sequential.
+#
+# The queue is heaviest-first. With one worker the order only moved the log
+# around; with several it decides the makespan, and starting the long checks
+# last is how a shard ends with one straggler and idle workers.
+run_phase <- function(pending, phase, collect) {
+  weight_of <- function(name) get(name, envir = state)$weight_minutes %||% 0
+  run_queue(
+    pending[order(-vapply(pending, weight_of, numeric(1)))],
+    workers = check_workers,
+    start = function(name) start_check(name, phase),
+    alive = function(job) job$process$is_alive(),
+    finish = function(job) collect(job$name, finish_check(job)),
+    skip = function(name) {
+      if (!out_of_time(get(name, envir = state))) {
+        return(FALSE)
+      }
+      inform(name, ": deferred (deadline)")
+      TRUE
+    },
+    # rcmdcheck enforces the timeout itself; this is the backstop for a child
+    # that does not come back from it, which under one worker merely ran long
+    # and now would hold a worker for the rest of the job.
+    tick = function(jobs) {
+      for (job in jobs) {
+        overdue <- as.numeric(Sys.time() - job$started, units = "secs") >
+          job$timeout + 300
+        if (overdue) {
+          inform(job$name, ": killing a check that outlived its timeout")
+          job$process$kill()
+        }
+      }
+    }
+  )
 }
 
 check_failure <- function(name, phase, result) {
@@ -386,6 +479,7 @@ pkg_out <- function(name) {
 # Phase 1: the CRAN version of the package under test is installed; reuse or
 # produce every package's old-version result.
 inform("Phase old: against ", package, " ", our_cran_version)
+to_check <- character()
 for (name in runnable) {
   entry <- get(name, envir = state)
   reused <- FALSE
@@ -411,25 +505,23 @@ for (name in runnable) {
     }
   }
   if (!reused) {
-    if (out_of_time(entry)) {
-      inform(name, ": deferred (deadline)")
-      next
-    }
-    old <- run_check(name, "old")
-    if (inherits(old, "error")) {
-      check_failure(name, "old", old)
-      next
-    }
-    saveRDS(old, file.path(pkg_out(name), "old.rds"))
-    update(
-      name,
-      status_old = counts(old),
-      t_old = attr(old, "duration"),
-      old_checked_at = now_utc()
-    )
-    inform(name, ": old ", counts(old), " (", attr(old, "duration"), "s)")
+    to_check <- c(to_check, name)
   }
 }
+run_phase(to_check, "old", function(name, old) {
+  if (inherits(old, "error")) {
+    check_failure(name, "old", old)
+    return(invisible())
+  }
+  saveRDS(old, file.path(pkg_out(name), "old.rds"))
+  update(
+    name,
+    status_old = counts(old),
+    t_old = attr(old, "duration"),
+    old_checked_at = now_utc()
+  )
+  inform(name, ": old ", counts(old), " (", attr(old, "duration"), "s)")
+})
 
 # Between the phases: the dev binary replaces the CRAN version.
 binary <- file.path(pkg_dir, meta$binary)
@@ -441,6 +533,7 @@ our_dev_version <- as.character(utils::packageVersion(package))
 
 # Phase 2: check against the dev version and compare.
 inform("Phase new: against ", package, " ", our_dev_version)
+to_check <- character()
 for (name in runnable) {
   entry <- get(name, envir = state)
   if (entry$result != "deferred") {
@@ -449,14 +542,12 @@ for (name in runnable) {
   if (!file.exists(file.path(pkg_out(name), "old.rds"))) {
     next # old phase never reached it; stays deferred
   }
-  if (out_of_time(entry)) {
-    inform(name, ": deferred (deadline)")
-    next
-  }
-  new <- run_check(name, "new")
+  to_check <- c(to_check, name)
+}
+run_phase(to_check, "new", function(name, new) {
   if (inherits(new, "error")) {
     check_failure(name, "new", new)
-    next
+    return(invisible())
   }
   saveRDS(new, file.path(pkg_out(name), "new.rds"))
   old <- readRDS(file.path(pkg_out(name), "old.rds"))
@@ -520,7 +611,7 @@ for (name in runnable) {
     }
     unlink(file.path(work, "check", name), recursive = TRUE)
   }
-}
+})
 
 # ---------------------------------------------------------------- manifest ---
 
@@ -549,6 +640,9 @@ write_json(
     index = shard_index,
     packages = length(members),
     checks = checks_started,
+    # Which regime produced the numbers below: `check_seconds` is the work
+    # done, and only this says how much wall clock that was.
+    check_workers = check_workers,
     install_packages = length(install),
     restored = length(restored),
     restore_seconds = restore_seconds,

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -987,6 +987,65 @@ install_in_chunks <- function(chunks, lib = NULL, upgrade = FALSE, label = "") {
   ok
 }
 
+# --------------------------------------------------------------- work queue --
+
+# A fixed-width queue: at most `workers` jobs in flight at a time.
+#
+#   start(item)   opens a job and returns whatever describes it
+#   alive(job)    TRUE while it is still running
+#   finish(job)   closes it -- called in this process, one job at a time, so a
+#                 caller's bookkeeping never needs a lock
+#   skip(item)    drops an item before it is ever started (a deadline, say)
+#   tick(jobs)    called on every idle pass, for whatever has to watch the
+#                 jobs in flight
+#
+# Everything specific to what is being run lives in those callbacks, which is
+# what makes this testable without running the real thing. `wait` is the idle
+# poll interval; the jobs here take minutes, so a second costs nothing.
+run_queue <- function(
+  items,
+  workers,
+  start,
+  alive,
+  finish,
+  skip = NULL,
+  tick = NULL,
+  wait = 1
+) {
+  queue <- as.list(items)
+  running <- list()
+  while (length(queue) > 0 || length(running) > 0) {
+    while (length(running) < workers && length(queue) > 0) {
+      item <- queue[[1]]
+      queue <- queue[-1]
+      if (!is.null(skip) && isTRUE(skip(item))) {
+        next
+      }
+      running[[length(running) + 1L]] <- start(item)
+    }
+    # Everything left was skipped rather than started; the outer condition
+    # ends the loop.
+    if (length(running) == 0) {
+      next
+    }
+    repeat {
+      done <- !vapply(running, alive, logical(1))
+      if (any(done)) {
+        break
+      }
+      if (!is.null(tick)) {
+        tick(running)
+      }
+      Sys.sleep(wait)
+    }
+    for (job in running[done]) {
+      finish(job)
+    }
+    running <- running[!done]
+  }
+  invisible(NULL)
+}
+
 # Fingerprint of the *versions* of everything a check installs, from CRAN
 # metadata. Two runs whose fingerprints agree resolved the same dependency
 # tree, so an old-version check result can be carried from one to the other.


### PR DESCRIPTION
Prepared with Claude Code.

## Where we were

Parallelism had one axis. `max-parallel` shards run at once — that is the sharding the whole workflow is built around — but inside a shard, `shard.R` called `rcmdcheck::rcmdcheck()` in a plain `for` loop, one package at a time. A hosted runner has four cores and one `R CMD check` keeps about one of them busy, so a shard left most of the machine idle for its entire 300-minute deadline.

The second axis is exactly what `revdepcheck::revdep_check(num_workers =)` does on a single machine, and it is what this adds.

## What changed

Each shard now runs `check-workers` checks at once, default 2.

A check goes into a `callr::r_bg()` background process running exactly the `rcmdcheck()` call the driver used to run inline, so the arguments, the timeout and the returned object are unchanged. Results are collected in the driver, one at a time, so nothing that reads or writes the shard's state ever runs concurrently. The checks are independent by construction: separate processes, a check directory each, and a library nothing writes to while a phase is running — the dev binary goes in *between* the phases, with the queue drained.

The queue is heaviest-first. With one worker that only moved the log around; with several it decides the makespan, since starting the long checks last is how a phase ends with one straggler and idle workers. It also means the packages a deadline defers are the cheap ones.

The mechanics live in `run_queue()` in `util.R` — a fixed-width queue with `start`/`alive`/`finish`/`skip`/`tick` callbacks — so the scheduling can be tested without running a single check.

## The plan is where the two axes meet

A package's weight is still what one check of it costs; that number goes into `plan.json` unchanged, because it is what the shard's own deadline test asks before starting a check. But the shard *sizing* now divides by the worker count, since that many packages advance per minute of a shard's deadline. On run 31270092803's numbers — 12263 check minutes, capacity 240, 20 lanes:

- 1 worker: 12263 min of shard time → 60 shards, 3 waves
- 2 workers: 6132 min → 40 shards, 2 waves
- 3 workers: 4088 min → 20 shards, 1 wave

Twenty fewer setups paid at two workers, and a wave less to wait through.

The shard reads the worker count back out of `plan.json` rather than its own environment: a shard running one at a time what was planned for two takes twice its estimate and defers the difference.

## The calibration stays honest by itself

Measured check times come from runs that ran under some worker count, so they already carry whatever contention that count caused. Where checks do not contend, the measurement stays put and dividing by the worker count buys the whole factor. Where they contend completely, the measurement doubles and the division gives back exactly what one worker would have done. Only the first run after the knob changes is estimated on the previous regime's numbers.

The worker count is recorded per shard in the timings artifact, so the regime behind a number is never a guess.

## Risk, and what watches it

Two concurrent checks share the runner's 16 GB, which is why the default is 2 rather than 4 — a check that compiles hard wants that headroom. The shard step now also gets the preflight's resource sampler and line-buffered output, so if two at once is too many the memory curve is in the log and in `resources.log` in the shard artifact, rather than being inferred from a bare `exit 143`. Lowering `check-workers` is then a one-input dispatch away.

## Testing

- `run_queue()`: concurrency never exceeds the cap (verified against a peak counter), `workers = 1` reproduces the old sequential order exactly, `skip()` drops items without starting or stalling them, and the all-skipped and empty-input cases terminate.
- The `callr` + `rcmdcheck` contract the shard depends on, against two real packages checked concurrently: both came back as `rcmdcheck` objects with parsed statuses, 53 s of check work in 27 s of wall clock. A check that cannot start returns the child's own condition, unwrapped from callr's, with `timed_out` correctly false.
- `plan.R` run end to end against CRAN at 1, 2 and 4 workers on the same five packages: 3, 2 and 1 shards, with per-package `weight_minutes` byte-identical across all three — the division moves the sizing and nothing else.

R sources parse and are `air`-formatted; the workflow parses as YAML and the changed step passes `bash -n`.

## A note on the branch

This is a second PR rather than more commits on #2830, which merged while this was being written; it is based on current `main` and includes it.

<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->

<!-- The following text must be left intact and the box checked before the PR can be merged. -->

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1xpHRV7yVfgtJg4vp9P7z)_