### PR TITLE
ci(revdep2): Put a clock on every call that can hang

### DIFF
--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -312,10 +312,15 @@ jobs:
         with:
           use-public-rspm: true
 
-      - name: Install pak and jsonlite
+      # callr (and the processx it brings) is what puts a clock on the calls
+      # that have none of their own: pak's install runs in a callr child that
+      # can be killed, and the load test runs under a processx timeout. pak
+      # vendors its own copy of both and exports neither, so they are
+      # installed here in their own right.
+      - name: Install pak, jsonlite and callr
         run: |
           install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))
-          install.packages("jsonlite")
+          install.packages(c("jsonlite", "callr"))
         shell: Rscript {0}
 
       - name: Download the shard plan

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -566,6 +566,9 @@ the report is about *results*, a retry is about *coverage*.
 | A revdep's strong dependencies cannot install | `depfail`, check not attempted, named in the shard summary |
 | A dependency fails the preflight | reported in the preflight summary and `depfail.json`; shards still try their own subset |
 | A pak install chunk fails | the chunk is reported and the rest still run; what is still missing is retried one package at a time |
+| A pak install chunk never returns | killed at `REVDEP2_INSTALL_TIMEOUT_MINUTES`, tree and all; the next chunk starts a fresh pak |
+| The installs cannot finish inside the job | no chunk is started past `REVDEP2_INSTALL_DEADLINE_MINUTES`; what did install is still load-tested, packed and published |
+| A dependency's `loadNamespace()` hangs | the batch times out and is retried one package at a time, so the culprit is named as a load failure |
 | The preflight job itself dies | the shards run anyway and install their own unions, the collector still reports; only the free rebuild and the early diagnosis are lost |
 | A shard hits its deadline | remaining packages `deferred`; finished old-halves still uploaded and baseline-fed |
 | A shard job dies hard | the collector reconciles against the plan: its packages are reported `missing`, naming the shard, and `retry-run` re-checks exactly them |
@@ -641,6 +644,53 @@ so a chunk that dies costs a chunk rather than the job —
 and the log names which one,
 where a single opaque call could only go quiet.
 
+### Nothing waits for ever
+
+A hang is not a crash, and the difference matters:
+a job that fails is over in a minute and says why,
+a job that hangs holds a runner
+until someone notices and cancels it.
+Run 31276552027 spent 76 minutes that way —
+`pak::pkg_install()` on chunk 21 of 45 never returned,
+at one busy core and flat memory,
+after chunks 14 and 20 had already failed
+with "error in pak subprocess".
+There was no loop to break;
+the call simply did not come back,
+and nothing in these scripts had a clock.
+
+Now everything that calls out has one:
+
+- **each pak install** runs in a `callr` child
+  and is killed at `REVDEP2_INSTALL_TIMEOUT_MINUTES` (20).
+  It is killed with `kill_tree()`, not `kill()`,
+  because what wedges is pak's *own* subprocess —
+  a grandchild, which outlives a plain kill of its parent.
+  The child inherits stdout and stderr,
+  so pak's progress still streams to the job log
+  with nobody draining a pipe.
+- **each load-test batch** runs under a `processx` timeout
+  (`REVDEP2_LOAD_TIMEOUT_MINUTES`, 10).
+  `loadNamespace()` is not a thing that necessarily returns:
+  a package whose `.onLoad` waits on a lock, a port or a display
+  hangs the child for good.
+- **the installs as a whole** stop at
+  `REVDEP2_INSTALL_DEADLINE_MINUTES` (210),
+  below the job's own 300.
+  That is a different question from the per-call limit:
+  one bounds a single call, the other stops 45 of them
+  from adding up past what the job has —
+  and what it cuts off is named,
+  while the packages that did install
+  are still load-tested, packed and published.
+
+Running each install in its own child buys one more thing.
+A wedged pak subprocess used to poison every call after it,
+which is the likeliest reason chunk 21 hung
+where 14 and 20 had merely failed.
+Each chunk now starts a fresh R and a fresh pak,
+so a bad one is contained to itself.
+
 The same principle applies to everything these scripts swallow.
 Fetching an artifact is an optimization,
 so its failure never stops a run —
@@ -686,6 +736,9 @@ at the next `if`.
 | Oldest reusable prebuilt library | — | `REVDEP2_PREBUILT_MAX_AGE_DAYS` | 14 days |
 | Runs the history walk looks at | — | `REVDEP2_HISTORY_RUNS` | 40 |
 | Packages per `pak::pkg_install()` call | — | `REVDEP2_INSTALL_CHUNK` | 100 |
+| Time limit on one `pak::pkg_install()` call | — | `REVDEP2_INSTALL_TIMEOUT_MINUTES` | 20 |
+| Wall clock past which no further install is started | — | `REVDEP2_INSTALL_DEADLINE_MINUTES` | 210 |
+| Time limit on one load-test batch | — | `REVDEP2_LOAD_TIMEOUT_MINUTES` | 10 |
 | Wall clock past which the plan warns (never refuses) | — | `REVDEP2_LONG_RUN_HOURS` | 12 h |
 | Runs whose timings calibrate the cost model | — | `REVDEP2_MEASURED_MAX_RUNS` | 3 (`0` disables) |
 | Oldest measurement worth trusting | — | `REVDEP2_MEASURED_MAX_AGE_DAYS` | 60 days |

--- a/.github/workflows/revdep2/preflight.R
+++ b/.github/workflows/revdep2/preflight.R
@@ -21,6 +21,11 @@
 #   LIB_OUT    - where library.tar and lib.json land; empty skips packing
 #   LIB_INDEX_OUT - where a copy of lib.json alone lands, for the small
 #                   artifact a later plan reads without the tar
+#
+# Nothing here waits without a clock: REVDEP2_INSTALL_TIMEOUT_MINUTES bounds
+# one pak call, REVDEP2_LOAD_TIMEOUT_MINUTES one load-test batch, and
+# REVDEP2_INSTALL_DEADLINE_MINUTES the installs together -- see the README's
+# "Nothing waits for ever".
 
 source(file.path(
   dirname(sub("--file=", "", grep("^--file=", commandArgs(), value = TRUE))),
@@ -69,6 +74,12 @@ upgrade <- length(restored) > 0
 # counter -- the workflow's resource sampler supplies the other half of that
 # picture, a memory curve on the same clock.
 chunk_size <- env_num("REVDEP2_INSTALL_CHUNK", 100)
+# Past this, no further chunk is started. The job's own `timeout-minutes` is
+# 300 and cancels everything; this stops earlier and on purpose, so that the
+# packages that did install are still load-tested, packed and published
+# instead of dying with the job.
+install_deadline <- Sys.time() +
+  env_num("REVDEP2_INSTALL_DEADLINE_MINUTES", 210) * 60
 chunks <- install_chunks(install_union, cran_db(), chunk_size)
 inform(
   "Preflight: installing ",
@@ -83,7 +94,13 @@ inform(
   upgrade
 )
 install_started <- Sys.time()
-installed_ok <- install_in_chunks(chunks, lib, upgrade, "Preflight")
+installed_ok <- install_in_chunks(
+  chunks,
+  lib,
+  upgrade,
+  "Preflight",
+  deadline = install_deadline
+)
 inform(sprintf(
   "Preflight: the install %s after %.1f min; %d of %d packages are in the library",
   if (installed_ok) "finished" else "failed",
@@ -94,22 +111,32 @@ inform(sprintf(
 if (!installed_ok) {
   # One bad package must not hide the state of the other thousand: retry each
   # missing package on its own and record exactly which ones will not install.
-  for (p in install_union) {
-    if (dir.exists(file.path(lib, p))) {
-      next
+  # Bounded twice over -- one package may not hang the retry, and the retry as
+  # a whole may not eat the minutes the load test and the library packing still
+  # need. What the deadline cuts off is named rather than reported as failing.
+  retry <- missing_from(lib, install_union)
+  inform("Preflight: retrying ", length(retry), " package(s) one at a time")
+  for (i in seq_along(retry)) {
+    if (Sys.time() > install_deadline) {
+      inform(sprintf(
+        "Preflight: the install deadline passed; %d of %d package(s) not retried",
+        length(retry) - i + 1L,
+        length(retry)
+      ))
+      break
     }
-    result <- tryCatch(
-      {
-        pak::pkg_install(p, lib = lib, ask = FALSE, upgrade = upgrade)
-        NULL
-      },
-      error = function(e) conditionMessage(e)
+    run <- pak_install(
+      retry[[i]],
+      lib = lib,
+      upgrade = upgrade,
+      timeout_seconds = install_timeout_seconds(),
+      label = paste("Preflight: installing", retry[[i]])
     )
-    if (!is.null(result)) {
+    if (!run$ok) {
       failures[[length(failures) + 1]] <- list(
-        package = p,
+        package = retry[[i]],
         phase = "install",
-        message = result
+        message = run$message
       )
     }
   }
@@ -120,6 +147,15 @@ if (!installed_ok) {
 # namespace names itself.
 installed <- intersect(install_union, rownames(utils::installed.packages(lib)))
 inform("Preflight: loading ", length(installed), " packages")
+
+# Bounded, because `loadNamespace()` is not a thing that necessarily returns:
+# a package whose .onLoad waits on a lock, a port or a display hangs the child
+# for ever, and this used to wait for it with no clock -- the same unbounded
+# wait that cost run 31276552027 its preflight, one call further on. A batch
+# that runs out of time is retried package by package, which is already how a
+# failing batch names its culprit; a single package that then times out is a
+# load failure like any other, with "timed out" as its reason.
+load_timeout_sec <- env_num("REVDEP2_LOAD_TIMEOUT_MINUTES", 10) * 60
 load_batch <- function(pkgs) {
   script <- tempfile(fileext = ".R")
   writeLines(
@@ -132,15 +168,31 @@ load_batch <- function(pkgs) {
     ),
     script
   )
-  out <- suppressWarnings(system2(
-    "Rscript",
-    # Quoted: system2() quotes the command, but not the arguments.
-    shQuote(c("--vanilla", script, pkgs)),
-    stdout = TRUE,
-    stderr = TRUE
-  ))
+  args <- c("--vanilla", script, pkgs)
+  if (requireNamespace("processx", quietly = TRUE)) {
+    # processx runs the command directly rather than through a shell, so the
+    # arguments need no quoting of their own.
+    run <- processx::run(
+      "Rscript",
+      args,
+      timeout = load_timeout_sec,
+      error_on_status = FALSE,
+      stderr_to_stdout = TRUE
+    )
+    out <- strsplit(run$stdout %||% "", "\n", fixed = TRUE)[[1]]
+    timed_out <- isTRUE(run$timeout)
+  } else {
+    out <- suppressWarnings(system2(
+      "Rscript",
+      # Quoted: system2() quotes the command, but not the arguments.
+      shQuote(args),
+      stdout = TRUE,
+      stderr = TRUE
+    ))
+    timed_out <- FALSE
+  }
   loaded <- sub("^LOADED ", "", grep("^LOADED ", out, value = TRUE))
-  list(failed = setdiff(pkgs, loaded), log = out)
+  list(failed = setdiff(pkgs, loaded), log = out, timed_out = timed_out)
 }
 load_failures <- list()
 chunks <- split(installed, ceiling(seq_along(installed) / 40))
@@ -152,10 +204,11 @@ for (chunk in chunks) {
   for (p in first$failed) {
     single <- load_batch(p)
     if (length(single$failed) > 0) {
-      load_failures[[p]] <- paste(
-        utils::tail(sanitize_log(single$log), 20),
-        collapse = "\n"
-      )
+      load_failures[[p]] <- if (isTRUE(single$timed_out)) {
+        sprintf("loading timed out after %.0f min", load_timeout_sec / 60)
+      } else {
+        paste(utils::tail(sanitize_log(single$log), 20), collapse = "\n")
+      }
     }
   }
 }
@@ -173,12 +226,16 @@ if (length(stale) > 0) {
   )
   unlink(file.path(lib, stale), recursive = TRUE)
   for (p in stale) {
-    tryCatch(
-      pak::pkg_install(p, lib = lib, ask = FALSE, upgrade = FALSE),
-      error = function(e) {
-        inform("Could not reinstall ", p, ": ", conditionMessage(e))
-      }
+    run <- pak_install(
+      p,
+      lib = lib,
+      upgrade = FALSE,
+      timeout_seconds = install_timeout_seconds(),
+      label = paste("Preflight: rebuilding", p)
     )
+    if (!run$ok) {
+      inform("Could not reinstall ", p, ": ", run$message)
+    }
   }
   for (p in stale) {
     retried <- load_batch(p)

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -176,18 +176,30 @@ inform(
   ", dependencies first"
 )
 install_started <- Sys.time()
-bulk_ok <- install_in_chunks(chunks, upgrade = upgrade)
+# The deadline is the shard's own: an install that runs into it leaves no time
+# to check anything, so it stops and lets the checks report what they can
+# rather than being cancelled with the job.
+bulk_ok <- install_in_chunks(
+  chunks,
+  lib = lib,
+  upgrade = upgrade,
+  deadline = deadline
+)
 if (!bulk_ok) {
   for (p in install) {
-    if (requireNamespace(p, quietly = TRUE)) {
+    if (requireNamespace(p, quietly = TRUE) || Sys.time() > deadline) {
       next
     }
-    tryCatch(
-      pak::pkg_install(p, ask = FALSE, upgrade = upgrade),
-      error = function(e) {
-        inform("Could not install ", p, ": ", conditionMessage(e))
-      }
+    run <- pak_install(
+      p,
+      lib = lib,
+      upgrade = upgrade,
+      timeout_seconds = install_timeout_seconds(),
+      label = paste("installing", p)
     )
+    if (!run$ok) {
+      inform("Could not install ", p, ": ", run$message)
+    }
   }
 }
 

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -949,42 +949,165 @@ install_chunks <- function(pkgs, db, size = 100) {
 # Install one chunked set, reporting each chunk as it lands. Returns TRUE when
 # every chunk succeeded; a caller that cares which packages are missing asks
 # the library, not this.
-install_in_chunks <- function(chunks, lib = NULL, upgrade = FALSE, label = "") {
+# Run `fun` in a child R process and give up on it after `timeout_seconds`.
+#
+# Nothing this workflow calls out to has a time limit of its own, and in run
+# 31276552027 that cost a job: `pak::pkg_install()` on chunk 21 never returned,
+# and the preflight sat at one busy core and flat memory for 76 minutes until
+# it was cancelled by hand. There is no loop to break there -- the call simply
+# does not come back -- so the only thing that helps is a clock.
+#
+# Two details make this work where `tryCatch` and `setTimeLimit` do not. The
+# child inherits this process's stdout and stderr, so pak's progress still
+# streams to the job log with nobody draining a pipe; and it is killed with
+# `kill_tree()`, because what wedges is pak's *own* subprocess, a grandchild,
+# which outlives a plain kill of its parent.
+#
+# It also isolates the calls from each other. Chunks 14 and 20 of that run had
+# already failed with "error in pak subprocess" before 21 hung, and one wedged
+# pak subprocess used to poison every call after it; now each one starts a
+# fresh R and a fresh pak.
+#
+# callr comes with rcmdcheck, and the preflight installs it outright. Where it
+# is missing there is no way to bound anything, so the call is made inline --
+# the old behaviour, announced rather than silent.
+run_with_timeout <- function(fun, args = list(), timeout_seconds, label = "") {
+  if (!requireNamespace("callr", quietly = TRUE)) {
+    inform(label, ": callr is not installed, running without a time limit")
+    message <- tryCatch(
+      {
+        do.call(fun, args)
+        ""
+      },
+      error = function(e) conditionMessage(e)
+    )
+    return(list(ok = !nzchar(message), timed_out = FALSE, message = message))
+  }
+  process <- callr::r_bg(
+    fun,
+    args = args,
+    stdout = "",
+    stderr = "2>&1",
+    supervise = TRUE
+  )
+  process$wait(timeout = timeout_seconds * 1000)
+  if (process$is_alive()) {
+    process$kill_tree()
+    process$wait(timeout = 10000)
+    return(list(
+      ok = FALSE,
+      timed_out = TRUE,
+      message = sprintf(
+        "no output and no result after %s; killed",
+        format_duration(timeout_seconds)
+      )
+    ))
+  }
+  message <- tryCatch(
+    {
+      process$get_result()
+      ""
+    },
+    # callr reports a child's failure wrapped in its own condition, and the
+    # wrapper is three lines of scaffolding around the one line that says what
+    # broke -- which is the line that ends up in depfail.json.
+    error = function(e) conditionMessage(e$parent %||% e)
+  )
+  list(ok = !nzchar(message), timed_out = FALSE, message = message)
+}
+
+format_duration <- function(seconds) {
+  if (seconds < 90) {
+    sprintf("%.0f s", seconds)
+  } else {
+    sprintf("%.0f min", seconds / 60)
+  }
+}
+
+# One pak install, bounded. Separate from install_in_chunks() because the
+# per-package retry after a failed chunk needs exactly the same treatment: it
+# is the same call, one package at a time, and it used to be just as
+# unbounded.
+pak_install <- function(
+  pkgs,
+  lib = NULL,
+  upgrade = FALSE,
+  timeout_seconds,
+  label = ""
+) {
+  run_with_timeout(
+    function(pkgs, lib, upgrade) {
+      if (is.null(lib)) {
+        pak::pkg_install(pkgs, ask = FALSE, upgrade = upgrade)
+      } else {
+        pak::pkg_install(pkgs, lib = lib, ask = FALSE, upgrade = upgrade)
+      }
+      invisible(NULL)
+    },
+    args = list(pkgs = pkgs, lib = lib, upgrade = upgrade),
+    timeout_seconds = timeout_seconds,
+    label = label
+  )
+}
+
+# `deadline` is the wall clock past which no further chunk is started. It is
+# not a second timeout but the answer to a different question: the per-chunk
+# limit stops one call from running for ever, and this stops 45 of them from
+# adding up past what the job has. What is left unattempted is named, and the
+# caller still gets to pack and publish what did install.
+install_in_chunks <- function(
+  chunks,
+  lib = NULL,
+  upgrade = FALSE,
+  label = "",
+  timeout_seconds = install_timeout_seconds(),
+  deadline = NULL
+) {
   ok <- TRUE
   prefix <- if (nzchar(label)) paste0(label, ": ") else ""
   for (i in seq_along(chunks)) {
+    if (!is.null(deadline) && Sys.time() > deadline) {
+      inform(sprintf(
+        "%sthe install deadline passed; %d of %d chunk(s) not attempted",
+        prefix,
+        length(chunks) - i + 1L,
+        length(chunks)
+      ))
+      return(FALSE)
+    }
     started <- Sys.time()
-    chunk_ok <- tryCatch(
-      {
-        if (is.null(lib)) {
-          pak::pkg_install(chunks[[i]], ask = FALSE, upgrade = upgrade)
-        } else {
-          pak::pkg_install(
-            chunks[[i]],
-            lib = lib,
-            ask = FALSE,
-            upgrade = upgrade
-          )
-        }
-        TRUE
-      },
-      error = function(e) {
-        inform(prefix, "chunk ", i, " failed: ", conditionMessage(e))
-        FALSE
-      }
+    run <- pak_install(
+      chunks[[i]],
+      lib = lib,
+      upgrade = upgrade,
+      timeout_seconds = timeout_seconds,
+      label = sprintf("%schunk %d/%d", prefix, i, length(chunks))
     )
-    ok <- ok && chunk_ok
+    if (!run$ok) {
+      inform(prefix, "chunk ", i, " failed: ", run$message)
+    }
+    ok <- ok && run$ok
     inform(sprintf(
       "%schunk %d/%d (%d packages) %s after %.1f min",
       prefix,
       i,
       length(chunks),
       length(chunks[[i]]),
-      if (chunk_ok) "installed" else "failed",
+      if (run$ok) {
+        "installed"
+      } else if (run$timed_out) {
+        "timed out"
+      } else {
+        "failed"
+      },
       as.numeric(difftime(Sys.time(), started, units = "mins"))
     ))
   }
   ok
+}
+
+install_timeout_seconds <- function() {
+  env_num("REVDEP2_INSTALL_TIMEOUT_MINUTES", 20) * 60
 }
 
 # Fingerprint of the *versions* of everything a check installs, from CRAN


### PR DESCRIPTION
Prepared with Claude Code.

## No, there is no endless loop — there was an endless wait

Every loop in these scripts terminates. `install_chunks()` is a Kahn levelling that marks at least one package done per round or breaks; `install_in_chunks()` is a bounded `for`; the load test walks a fixed `split()`. What run 31276552027 hit was not a loop at all: `pak::pkg_install()` on chunk 21 of 45 never returned, and nothing around it had a time limit.

The diagnostics from #2830 are what make that readable. The sampler shows the machine flat and idle for the whole stall — `mem 7.9/15.6G used, load 1.1, / 105G free`, unchanged for over an hour — the OOM check comes back clean, and the chunk counter names the exact call that stopped:

```
21:08:28  Preflight: chunk 18/45 (100 packages) installed after 2.3 min
21:10:41  Preflight: chunk 19/45 (100 packages) installed after 2.2 min
21:11:32  Preflight: chunk 20 failed: ! error in pak subprocess
21:11:32  Preflight: chunk 20/45 (100 packages) failed after 0.9 min
             (nothing but sampler lines for the next 76 minutes)
22:27:24  ##[error]The operation was canceled.
```

Chunk 14 had failed the same way an hour earlier. The two R processes the runner reaped as orphans at cleanup are the driver and pak's stuck subprocess.

## Every call that leaves R now has a clock

- **Each pak install** runs in a `callr` child and is killed at `REVDEP2_INSTALL_TIMEOUT_MINUTES` (20). It is killed with `kill_tree()`, not `kill()`, because what wedges is pak's *own* subprocess — a grandchild, which outlives a plain kill of its parent. The child inherits stdout and stderr, so pak's progress still streams to the job log with nobody draining a pipe.
- **The load test** runs under a `processx` timeout (`REVDEP2_LOAD_TIMEOUT_MINUTES`, 10). `loadNamespace()` is not a thing that necessarily returns: a package whose `.onLoad` waits on a lock, a port or a display hangs the child for good. A batch that times out is retried package by package — already how a failing batch names its culprit — and a single package that then times out is a load failure with "timed out" as its reason.
- **The installs as a whole** stop at `REVDEP2_INSTALL_DEADLINE_MINUTES` (210), below the job's own 300. That is a different question from the per-call limit: one bounds a single call, the other stops 45 of them from adding up past what the job has. What it cuts off is named, and the packages that did install are still load-tested, packed and published instead of dying with the job. The shard passes its own deadline the same way, so an install that eats the whole budget leaves the checks to report what they can.

The per-package retry after a failed chunk gets the same treatment — it is the same call, one package at a time, and it was just as unbounded. That path is also why this mattered beyond one stall: with two chunks failed, the run was about to retry ~200 packages serially with no clock on any of them.

## A side effect worth having

A wedged pak subprocess used to poison every call after it, since all 45 chunks shared one R session and one pak. That is the likeliest reason chunk 21 hung where 14 and 20 had merely failed. Each chunk now starts a fresh R and a fresh pak, so a bad one is contained to itself.

## Dependencies

`callr` and the `processx` it brings come with `rcmdcheck` in the shard job. The preflight had only pak and jsonlite, so it now installs `callr` outright — pak vendors both and exports neither. Where they are somehow absent, `run_with_timeout()` makes the call inline exactly as before and says so, rather than failing.

## Testing

Against real `callr`, `processx` and `pak`:

- `run_with_timeout()` returns ok for a normal call; for a failing one it returns the child's own message (`boom`) rather than callr's three-line wrapper, which is what lands in `depfail.json`; for a call that sleeps 600 s under a 3 s limit it returns `timed_out` in 3 seconds.
- A child that spawns its own grandchild and hangs: after the timeout, zero grandchildren survive — the case that motivated `kill_tree()`.
- `install_in_chunks()` installing real packages into a scratch library through the new child path, with the chunk lines and pak's output still in the parent's log.
- The deadline path: with a deadline already past, no chunk is attempted and the loop reports how many it skipped.

R sources parse and are `air`-formatted; the workflow parses as YAML.

## Relationship to #2831

Independent, and based on current `main`. #2831 adds a second axis of parallelism inside the shard; this bounds the calls both it and the preflight make. They touch different parts of `shard.R` and should merge in either order.

<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->

<!-- The following text must be left intact and the box checked before the PR can be merged. -->

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1xpHRV7yVfgtJg4vp9P7z)_