### PR TITLE
fix(ci): Make the two halves comparable, and make a running shard readable

### DIFF
--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -517,11 +517,15 @@ jobs:
       # differences. `_R_CHECK_CRAN_INCOMING_: false` already suppresses it;
       # this says so out loud so `--as-cran` cannot turn it back on.
       _R_CHECK_CRAN_INCOMING_USE_ASPELL_: false
-      # The whole test transcript in the check log, not the last 13 lines.
-      # Thirteen is R's default and it routinely cuts off the failure itself,
-      # which is both what a reader wants and the part the old/new diff has to
-      # see to be worth printing.
-      _R_CHECK_TESTS_NLINES_: 0
+      # 300 lines of a failed test transcript in the check log, not R's default
+      # 13 -- thirteen routinely cuts off the failure itself, which is both
+      # what a reader wants and the part the old/new diff has to see to be
+      # worth printing. Not unlimited, because this text is carried in the
+      # check log, in the diff and in the summary, and one chatty test would
+      # otherwise bury the rest of the shard in all three. Nothing is lost by
+      # bounding it: R writes the *complete* transcript to `<file>.Rout.fail`
+      # whatever this is set to, and the shard keeps that file.
+      _R_CHECK_TESTS_NLINES_: 300
 
       # What the driver reads in both of its phases and does not need the
       # runner for. The `runner` context is not available this far up -- only

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -500,6 +500,17 @@ jobs:
       # with --run-donttest". `\dontrun{}` is off unless asked for, and stays
       # off. What is left is every example a package expects to run.
       _R_CHECK_DONTTEST_EXAMPLES_: false
+      # No spell checking. It cannot tell us anything about igraph -- a
+      # misspelling in a revdep's DESCRIPTION is the same misspelling in both
+      # halves -- and it is noise in a log that is read to find real
+      # differences. `_R_CHECK_CRAN_INCOMING_: false` already suppresses it;
+      # this says so out loud so `--as-cran` cannot turn it back on.
+      _R_CHECK_CRAN_INCOMING_USE_ASPELL_: false
+      # The whole test transcript in the check log, not the last 13 lines.
+      # Thirteen is R's default and it routinely cuts off the failure itself,
+      # which is both what a reader wants and the part the old/new diff has to
+      # see to be worth printing.
+      _R_CHECK_TESTS_NLINES_: 0
 
       # What the driver reads in both of its phases and does not need the
       # runner for. The `runner` context is not available this far up -- only

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -108,6 +108,10 @@ on:
         description: "Oldest baseline result worth reusing"
         type: string
         default: ""
+      not-cran:
+        description: "Run the tests CRAN skips: sets NOT_CRAN=true, so skip_on_cran() does not skip (slower, noisier, and includes packages' own spelling tests)"
+        type: boolean
+        default: false
       dry-run:
         description: "Plan only: report the shards and reuse decisions, start no checks"
         type: boolean
@@ -150,6 +154,13 @@ env:
   REVDEP2_REFRESH_BASELINE: ${{ inputs.refresh-baseline && '1' || '' }}
   REVDEP2_BASELINE_MAX_AGE_DAYS: ${{ inputs.baseline-max-age-days || vars.REVDEP2_BASELINE_MAX_AGE_DAYS || '30' }}
   REVDEP2_DRY_RUN: ${{ inputs.dry-run && '1' || '' }}
+  # Whether the shards behave like CRAN's own check machines or like a
+  # developer's. `skip_on_cran()` reads `NOT_CRAN`, and `r-lib/actions/setup-r`
+  # sets it to `true` -- which is why packages' own `tests/spelling.R` runs
+  # here at all. CRAN-like is the default: the point of this workflow is to
+  # find what a released igraph would break, and a test CRAN never runs cannot
+  # break on CRAN. Dispatch with `not-cran: true` to widen the net again.
+  REVDEP2_NOT_CRAN: ${{ inputs.not-cran && 'true' || 'false' }}
   # Prebuilt dependency libraries of earlier runs: how many runs may donate one
   # (0 turns reuse off), and how old a library may be before its binaries are
   # no longer trusted against the current runner image.
@@ -605,10 +616,18 @@ jobs:
       # Both driver steps need these and neither can name them itself: the
       # `runner` context does not reach the job's `env`, so they are set here
       # for every step that follows.
+      #
+      # `NOT_CRAN` is here rather than in the job's `env` because
+      # `r-lib/actions/setup-r` writes `NOT_CRAN=true` into `$GITHUB_ENV`, and
+      # a later write is what reliably overrides an earlier one. This step runs
+      # after it and before both driver steps.
       - name: Point the driver at this runner's directories
+        env:
+          NOT_CRAN_INPUT: ${{ env.REVDEP2_NOT_CRAN }}
         run: |
           mkdir -p "${RUNNER_TEMP}/tmp"
           {
+            echo "NOT_CRAN=${NOT_CRAN_INPUT}"
             echo "PLAN=${RUNNER_TEMP}/plan/plan.json"
             echo "PKG_DIR=${RUNNER_TEMP}/pkg"
             echo "LIB_DIR=${RUNNER_TEMP}/lib"

--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -492,6 +492,24 @@ jobs:
       _R_CHECK_SYSTEM_CLOCK_: false
       _R_CHECK_FUTURE_FILE_TIMESTAMPS_: false
       _R_CHECK_FORCE_SUGGESTS_: false
+      # `--as-cran` turns on `--run-donttest`, which is the most expensive
+      # thing a check does and the least useful thing for this workflow:
+      # `\donttest{}` is where packages put the examples too slow to run on
+      # CRAN, so it is where the runners spend hours and where the timeouts
+      # land -- varPro's old half was killed at 1200s in "checking examples
+      # with --run-donttest". `\dontrun{}` is off unless asked for, and stays
+      # off. What is left is every example a package expects to run.
+      _R_CHECK_DONTTEST_EXAMPLES_: false
+
+      # What the driver reads in both of its phases and does not need the
+      # runner for. The `runner` context is not available this far up -- only
+      # in a step -- so the directories are set once in `$GITHUB_ENV` below.
+      GH_TOKEN: ${{ github.token }}
+      SHARD: ${{ matrix.shard }}
+      TIMEOUT_FACTOR: ${{ vars.REVDEP2_TIMEOUT_FACTOR || '1.5' }}
+      TIMEOUT_MIN_MINUTES: ${{ vars.REVDEP2_TIMEOUT_MIN_MINUTES || '20' }}
+      DEADLINE_MINUTES: ${{ vars.REVDEP2_DEADLINE_MINUTES || '300' }}
+      PKG_SYSREQS: true
 
     steps:
       - name: Check out the ref under test
@@ -573,27 +591,47 @@ jobs:
           github-token: ${{ github.token }}
           path: ${{ runner.temp }}/baseline
 
-      - name: Check the shard
-        env:
-          # To fetch the prebuilt libraries of the runs the plan picked.
-          GH_TOKEN: ${{ github.token }}
-          SHARD: ${{ matrix.shard }}
-          PLAN: ${{ runner.temp }}/plan/plan.json
-          PKG_DIR: ${{ runner.temp }}/pkg
-          LIB_DIR: ${{ runner.temp }}/lib
-          BASELINE_DIR: ${{ runner.temp }}/baseline
-          OUT_DIR: ${{ runner.temp }}/results
-          TIMEOUT_FACTOR: ${{ env.REVDEP2_TIMEOUT_FACTOR }}
-          TIMEOUT_MIN_MINUTES: ${{ env.REVDEP2_TIMEOUT_MIN_MINUTES }}
-          DEADLINE_MINUTES: ${{ env.REVDEP2_DEADLINE_MINUTES }}
-          PKG_SYSREQS: true
-          # The same small `/tmp` as the preflight, and a shard builds source
-          # packages and unpacks check directories into it for hours.
-          TMPDIR: ${{ runner.temp }}/tmp
-          TMP: ${{ runner.temp }}/tmp
-          TEMP: ${{ runner.temp }}/tmp
+      # Both driver steps need these and neither can name them itself: the
+      # `runner` context does not reach the job's `env`, so they are set here
+      # for every step that follows.
+      - name: Point the driver at this runner's directories
         run: |
           mkdir -p "${RUNNER_TEMP}/tmp"
+          {
+            echo "PLAN=${RUNNER_TEMP}/plan/plan.json"
+            echo "PKG_DIR=${RUNNER_TEMP}/pkg"
+            echo "LIB_DIR=${RUNNER_TEMP}/lib"
+            echo "BASELINE_DIR=${RUNNER_TEMP}/baseline"
+            echo "OUT_DIR=${RUNNER_TEMP}/results"
+            # The same small `/tmp` as the preflight, and a shard builds source
+            # packages and unpacks check directories into it for hours.
+            echo "TMPDIR=${RUNNER_TEMP}/tmp"
+            echo "TMP=${RUNNER_TEMP}/tmp"
+            echo "TEMP=${RUNNER_TEMP}/tmp"
+          } >> "${GITHUB_ENV}"
+        shell: bash
+
+      # Two steps, one driver. The install is minutes to an hour and the checks
+      # are hours, and as one step the run page could only report their sum --
+      # so "shard 14 took five hours" said nothing about whether it spent them
+      # unpacking dependencies or checking packages, and the install times turn
+      # out to vary by a lot between shards. Split, each is timed by Actions
+      # itself and readable at a glance from the job page.
+      #
+      # The phases share the job's environment and the work directory; the
+      # install leaves the libraries and a note of what it cost behind, and the
+      # check picks both up. Nothing is done twice.
+      - name: Install packages
+        env:
+          PHASE: install
+        run: |
+          Rscript ./.github/workflows/revdep2/shard.R
+        shell: bash
+
+      - name: Check the shard
+        env:
+          PHASE: check
+        run: |
           Rscript ./.github/workflows/revdep2/shard.R
         shell: bash
 

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -978,6 +978,48 @@ It is still read as a second opinion, and when it disagrees
 with the old check just run, the shard says so
 and records `baseline_agrees` in the manifest.
 
+### What the summary shows for a package that broke
+
+Three blocks, each with its own budget rather than sharing one:
+
+- the **check log**, which says *what* broke and at which stage;
+- **`00install.out`**, where a package that could not be installed explains
+  itself. The check log only points at the file,
+  which used to mean downloading the artifact to read a compiler error;
+- the **`.Rout.fail` transcript**, which is the whole test run.
+
+`_R_CHECK_TESTS_NLINES_=0` also widens the check log's own copy
+of a failed test from R's default 13 lines to the complete output —
+thirteen routinely cuts off the failure itself,
+which is both what a reader wants
+and the part the old/new diff has to see to be worth printing.
+`REVDEP2_DETAIL_MAX_LINES` (300) bounds the two transcript blocks.
+
+Every line that reports a package carries its position in the shard —
+`protti: ok (old 0E 0W 0N, new 0E 0W 0N, 1072s for the pair, 1/51)`.
+A shard runs for hours and its log is read while it runs,
+so "is this nearly done?" should not need counting lines.
+
+### Spelling is not checked
+
+It cannot say anything about igraph:
+a misspelling in a revdep's DESCRIPTION is the same misspelling in both halves,
+so it cancels out of every comparison the workflow makes,
+and what is left is noise in a log read to find real differences.
+`_R_CHECK_CRAN_INCOMING_: false` already suppresses it —
+R's spelling stage lives inside `check_CRAN_incoming()` —
+and `_R_CHECK_CRAN_INCOMING_USE_ASPELL_: false` says so out loud
+so that `--as-cran` cannot turn it back on.
+
+A package's *own* `tests/spelling.R` is a different thing
+and this does not touch it.
+Those run because `r-lib/actions/setup-r` sets `NOT_CRAN=true`,
+which is what makes `skip_on_cran()` not skip.
+Turning that off would silence them,
+and would also skip every other `skip_on_cran()` test —
+often the ones most likely to exercise igraph —
+so it is not a knob to turn without deciding to.
+
 ### `\donttest` examples are not run
 
 `--as-cran` turns on `--run-donttest`.
@@ -1074,6 +1116,7 @@ at the next `if`.
 | Per-check timeout floor | — | `REVDEP2_TIMEOUT_MIN_MINUTES` | 20 |
 | Shard graceful deadline | — | `REVDEP2_DEADLINE_MINUTES` | 300 |
 | Diff lines printed into the job log per package | — | `REVDEP2_DIFF_MAX_LINES` | 200 |
+| Transcript lines shown per install/test block in the summary | — | `REVDEP2_DETAIL_MAX_LINES` | 300 |
 
 ## Prior art
 

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -38,13 +38,15 @@ preflight (1 job; a dry run stops before it; failure does not stop the run)
          warm pak cache (saved under the plan hash)
 
 test      (one job per shard, max-parallel throttled, fail-fast: false)
-  ├─ unpack this run's preflight library, then the plan's donors
-  ├─ install the shard's dependency union (pak, sysreqs on, warm cache)
-  ├─ install the system requirements of what was unpacked, not installed
-  ├─ build two one-package libraries: CRAN release, dev binary
-  ├─ per package, both checks at once against those cascading libraries
-  │    (a reusable baseline stands in for the old half)
-  └─ results + manifest.ndjson → revdep2-results-<shard>-<attempt>
+  ├─ "Install packages" step (PHASE=install)
+  │    ├─ unpack this run's preflight library, then the plan's donors
+  │    ├─ install the shard's dependency union (pak, sysreqs on, warm cache)
+  │    ├─ install the system requirements of what was unpacked, not installed
+  │    └─ build two one-package libraries: CRAN release, dev binary
+  └─ "Check the shard" step (PHASE=check)
+       ├─ per package, both checks at once against those cascading libraries
+       │    (a reusable baseline stands in for the old half)
+       └─ results + manifest.ndjson → revdep2-results-<shard>-<attempt>
 
 collect   (1 job, if: always() past plan/build/preflight)
   ├─ merge all shard attempts (+ carried results of a retried run)
@@ -61,6 +63,20 @@ The `ref` input checks any branch, tag or commit SHA:
 the dispatch itself can only target a branch or tag,
 so arbitrary SHAs travel through the input,
 with the one constraint that the tree must contain these scripts.
+
+The shard's two steps are one driver called twice, `PHASE=install` and
+`PHASE=check` (`PHASE=all` runs both in one process, which is what a local
+invocation wants).
+Splitting them is a reporting change and nothing else:
+the install is minutes to an hour, the checks are hours,
+and as one step the run page could only report their sum —
+so "shard 14 took five hours" said nothing about
+whether it spent them unpacking dependencies or checking packages,
+and the install times turn out to vary a lot between shards.
+The phases share the job environment and the work directory;
+the install leaves the libraries and an `install-state.json`
+of what it cost behind, and the check phase picks both up.
+Nothing is done twice.
 
 A failing check never fails anything:
 `fail-fast: false` isolates shard-level accidents,
@@ -887,9 +903,65 @@ into the same object `rcmdcheck()` used to return,
 so the counts, `compare_checks()` and the manifest are unchanged.
 
 For a package that is not ok, what is kept is the **difference** between the
-two logs (`00check.diff`) next to the new one.
+two logs (`00check.diff`) next to the new one,
+and the same diff is printed into the job log
+under a foldable `::group::` heading.
 The logs are thousands of lines that are identical in both,
-and the handful that are not is the entire point.
+and the handful that are not is the entire point —
+so the run page can carry them for every package that is not ok
+without anyone downloading an artifact to find out
+that a NOTE gained a line.
+`REVDEP2_DIFF_MAX_LINES` bounds what is printed (200 by default);
+the whole diff is always in the artifact.
+
+### What the halves differ in that is not the package
+
+A diff is only worth printing if two identical results produce an empty one,
+and two concurrent checks do not naturally produce identical logs.
+Two things differ for reasons that have nothing to do with the package:
+
+- **The paths.** The libraries cascade, so they differ by construction —
+  `.../lib-old/...` against `.../lib-new/...` — and so do the two check
+  directories, which the log names in its first line
+  and quotes in every "see … for details".
+- **The stage timings.** `--as-cran` sets `_R_CHECK_TIMINGS_`,
+  so every stage slower than ten seconds
+  prints its own `[user/elapsed]` pair,
+  and two checks racing each other for the same four cores
+  never agree on those.
+
+Both are removed before the log is parsed *and* before it is diffed.
+Measured, not assumed: rphylopic checked against the *same* igraph
+on both sides differed in exactly two lines —
+the log directory, and `[14s/12s]` against `[13s/11s]` —
+and in none once neutralised.
+
+This matters twice over, because `compare_checks()` matches issues
+by their text: a difference in the first line of an issue
+makes an issue both halves have look like a new one.
+In run 31879790285, `dm`, `fsbrain`, `rphylopic` and `GGally`
+each reported the same single error in both halves
+and were still called `newly_broken`.
+Neutralising removes the differences that are known not to be the package;
+**whether that was the whole of it is not yet confirmed**,
+which is why an empty diff now says so in the job log in as many words.
+A package called `newly_broken` whose two logs are identical
+is this harness getting it wrong, and the run page will say so.
+
+### `\donttest` examples are not run
+
+`--as-cran` turns on `--run-donttest`.
+That is the most expensive thing a check does
+and the least useful thing for this workflow:
+`\donttest{}` is where packages put the examples too slow to run on CRAN,
+so it is where the runners spend their hours
+and where the timeouts land —
+varPro's old half was killed at 1200 s
+in `checking examples with --run-donttest`.
+`_R_CHECK_DONTTEST_EXAMPLES_=false` turns it back off.
+`\dontrun{}` is off unless asked for, and stays off.
+What is left is every example a package expects to run,
+which is the part a change to igraph can break.
 
 ### A timeout is not a failure
 
@@ -971,6 +1043,7 @@ at the next `if`.
 | Per-check timeout factor | — | `REVDEP2_TIMEOUT_FACTOR` | 1.5 × CRAN time |
 | Per-check timeout floor | — | `REVDEP2_TIMEOUT_MIN_MINUTES` | 20 |
 | Shard graceful deadline | — | `REVDEP2_DEADLINE_MINUTES` | 300 |
+| Diff lines printed into the job log per package | — | `REVDEP2_DIFF_MAX_LINES` | 200 |
 
 ## Prior art
 

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -109,8 +109,20 @@ this one
 (0.47 in the first calibrated run: these runners check faster than CRAN
 reports).
 Packages CRAN has no timing for either get the cohort median.
-A package without a reusable baseline is checked twice, so it weighs double,
+Every package is checked twice, so every package weighs double,
 plus a small fixed overhead.
+
+That used to be conditional —
+a package *without* a reusable baseline weighed double,
+one with a baseline weighed single, because the baseline stood in for its old
+check. Now that both halves always run, that condition is simply wrong,
+and wrong in the direction that under-fills whichever shards hold
+the most reusable packages. In run 31879790285 that would have been
+909 packages out of 1011, priced at half of what they cost.
+The factor of two is nominal in any case:
+`check_scale` is fitted from what the last runs measured,
+so what a pair is really worth in wall clock is absorbed there.
+What matters is that every package is priced the same way.
 
 The per-check timeout stays on CRAN's number and is not calibrated:
 `max(REVDEP2_TIMEOUT_MIN_MINUTES, REVDEP2_TIMEOUT_FACTOR × T_total)`.
@@ -969,6 +981,22 @@ checking tests ...          |  checking tests ... ERROR
 Their `00check.diff` is eight lines, all of it the log directory:
 the *logs* agree, and only the objects disagree.
 
+Run 31879790285 finished with the whole set and the split is stark:
+
+- of the **909** packages whose old half came from a reused baseline,
+  **76** were called `newly_broken` — 8.4%;
+- of the **78** that ran a fresh old check, **2** were — 2.6%,
+  and both are real
+  (`cranly` on `eigen_centrality(scale = FALSE)` now being a
+  `deprecate_stop()`, and `vkR`).
+
+29 of the 76 have *identical* counts in both halves,
+which is the parser artefact exactly;
+the other 47 differ, which is a baseline being a result
+from another machine and another CRAN snapshot.
+Both are the same mistake: comparing against something
+that is not this run.
+
 This is why both halves always run now.
 With the pair concurrent the old check costs no wall clock,
 so substituting a baseline bought nothing and cost comparability —
@@ -988,12 +1016,35 @@ Three blocks, each with its own budget rather than sharing one:
   which used to mean downloading the artifact to read a compiler error;
 - the **`.Rout.fail` transcript**, which is the whole test run.
 
-`_R_CHECK_TESTS_NLINES_=0` also widens the check log's own copy
-of a failed test from R's default 13 lines to the complete output —
+and — where the failure was in the examples —
+the **`-Ex.Rout` transcript**, which is the same for them.
+
+`_R_CHECK_TESTS_NLINES_=300` also widens the check log's own copy
+of a failed test from R's default 13 lines —
 thirteen routinely cuts off the failure itself,
 which is both what a reader wants
 and the part the old/new diff has to see to be worth printing.
-`REVDEP2_DETAIL_MAX_LINES` (300) bounds the two transcript blocks.
+Not unlimited, because that text is carried three times over
+(the check log, the diff, the summary)
+and one chatty test would otherwise bury the rest of the shard in all three.
+`REVDEP2_DETAIL_MAX_LINES` (300) bounds the transcript blocks.
+
+Bounding it costs nothing, because the complete transcript is kept beside it.
+R writes `<file>.Rout.fail` for a test file that failed
+and `<pkg>-Ex.Rout` for the examples,
+each the whole thing whatever `_R_CHECK_TESTS_NLINES_` says —
+measured: 521 lines at 13, at 300 and at 0 alike.
+Both are copied into the shard artifact.
+The `-Ex.Rout` one is not a `.fail` file
+and so used to be dropped,
+which left an examples failure with nothing but the check log's excerpt —
+and examples is where most of the interesting failures are.
+
+What is *not* kept: anything at all for a package that came out `ok`
+(its check directory is deleted, deliberately —
+909 of them in run 31879790285),
+and the old half's own `00check.log`,
+which survives only as its half of `00check.diff`.
 
 Every line that reports a package carries its position in the shard
 and an estimate for what is left:

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -936,17 +936,47 @@ on both sides differed in exactly two lines —
 the log directory, and `[14s/12s]` against `[13s/11s]` —
 and in none once neutralised.
 
-This matters twice over, because `compare_checks()` matches issues
-by their text: a difference in the first line of an issue
-makes an issue both halves have look like a new one.
-In run 31879790285, `dm`, `fsbrain`, `rphylopic` and `GGally`
-each reported the same single error in both halves
-and were still called `newly_broken`.
-Neutralising removes the differences that are known not to be the package;
-**whether that was the whole of it is not yet confirmed**,
-which is why an empty diff now says so in the job log in as many words.
+This is hygiene rather than a fix for anything observed:
+`compare_checks()` hashes only the *first line* of each issue,
+so noise further down could never have mattered to it.
+What it buys is the diff: an empty one now means
+the dev version changed nothing about this check.
 A package called `newly_broken` whose two logs are identical
-is this harness getting it wrong, and the run page will say so.
+is this harness getting it wrong, and the job log says so in as many words.
+
+### Why a reused baseline made packages look newly broken
+
+Run 31879790285's shard 9 reported `rphylopic`, `HospitalNetwork` and `orthGS`
+as `newly_broken` with the same `1E 0W 0N` in both halves.
+All three had a **reused baseline** standing in for the old half.
+All eight packages in that shard that ran a fresh old check were `ok`.
+
+The two halves were parsed by two different parsers.
+A baseline from an earlier run was produced by `rcmdcheck::rcmdcheck()`,
+which parses the *stream* as `R CMD check` writes it;
+this run's half is `parse_check()` on the finished `00check.log`,
+where R has gone back and appended the status to the line it opened.
+The same failing test therefore renders two ways:
+
+```
+checking tests ...          |  checking tests ... ERROR
+  Running 'testthat.R'      |    Running 'testthat.R'
+ ERROR                      |  Running the tests in ... failed.
+```
+
+`compare_checks()` hashes the first line, so those are two different issues —
+`81f6423…` against `23e57fe…` — and the new one matches nothing in the old.
+Their `00check.diff` is eight lines, all of it the log directory:
+the *logs* agree, and only the objects disagree.
+
+This is why both halves always run now.
+With the pair concurrent the old check costs no wall clock,
+so substituting a baseline bought nothing and cost comparability —
+and a baseline is a result from another run anyway:
+another machine, another CRAN snapshot, another dependency tree.
+It is still read as a second opinion, and when it disagrees
+with the old check just run, the shard says so
+and records `baseline_agrees` in the manifest.
 
 ### `\donttest` examples are not run
 

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -995,10 +995,27 @@ which is both what a reader wants
 and the part the old/new diff has to see to be worth printing.
 `REVDEP2_DETAIL_MAX_LINES` (300) bounds the two transcript blocks.
 
-Every line that reports a package carries its position in the shard —
-`protti: ok (old 0E 0W 0N, new 0E 0W 0N, 1072s for the pair, 1/51)`.
+Every line that reports a package carries its position in the shard
+and an estimate for what is left:
+
+```
+protti: ok (old 0E 0W 0N, new 0E 0W 0N, 1072s for the pair, 1/51, ~5.0 h left)
+```
+
 A shard runs for hours and its log is read while it runs,
-so "is this nearly done?" should not need counting lines.
+so "is this nearly done?" should not need counting lines,
+and the question actually being asked is *when*.
+
+The plan already priced every package;
+what it could not know is how this runner would compare to its model.
+So the remaining packages are priced in the plan's own units
+and rescaled by how its estimates have held up in this shard so far —
+which absorbs both a slow runner
+and a systematically optimistic model,
+without either having to be known in advance.
+Before the first pair finishes there is nothing to rescale by
+and the plan's number stands, which is why the estimate can move a long way
+on the first package and very little after that.
 
 ### Spelling is not checked
 
@@ -1011,14 +1028,22 @@ R's spelling stage lives inside `check_CRAN_incoming()` —
 and `_R_CHECK_CRAN_INCOMING_USE_ASPELL_: false` says so out loud
 so that `--as-cran` cannot turn it back on.
 
-A package's *own* `tests/spelling.R` is a different thing
-and this does not touch it.
+A package's *own* `tests/spelling.R` is a different thing.
 Those run because `r-lib/actions/setup-r` sets `NOT_CRAN=true`,
 which is what makes `skip_on_cran()` not skip.
-Turning that off would silence them,
-and would also skip every other `skip_on_cran()` test —
-often the ones most likely to exercise igraph —
-so it is not a knob to turn without deciding to.
+The shards now set `NOT_CRAN=false` instead,
+so they behave like CRAN's own check machines:
+the point of this workflow is to find what a released igraph would break,
+and a test CRAN never runs cannot break on CRAN.
+That silences the spelling tests
+and every other `skip_on_cran()` test with them —
+a real reduction in what is exercised,
+which is why it is an input rather than a constant.
+Dispatch with `not-cran: true` to widen the net again.
+
+`NOT_CRAN` is written in a step rather than in the job's `env`
+because `setup-r` writes its own value into `$GITHUB_ENV`,
+and a later write is what reliably overrides an earlier one.
 
 ### `\donttest` examples are not run
 
@@ -1090,6 +1115,7 @@ at the next `if`.
 | Retry a run | `retry-run` | — | — |
 | One G-th of the revdeps, for a set too big for one run | `part` (`i/G`) | `REVDEP2_PART` | — |
 | Plan only | `dry-run` | — | false |
+| Run the tests CRAN skips (`skip_on_cran()`, spelling tests) | `not-cran` | `REVDEP2_NOT_CRAN` | false |
 | Check-time target per shard, up to one wave | `shard-budget-minutes` | `REVDEP2_SHARD_BUDGET_MINUTES` | 45 |
 | Concurrent shards, and so the wave size — set it to the concurrency the account really has, never more | `max-parallel` | `REVDEP2_MAX_PARALLEL` | 20 |
 | Check minutes one shard may hold, which forces further waves | — | `REVDEP2_SHARD_CAPACITY_MINUTES` | 80% of the deadline |

--- a/.github/workflows/revdep2/check-pair.sh
+++ b/.github/workflows/revdep2/check-pair.sh
@@ -31,6 +31,21 @@ lib_new=$4
 lib_shared=$5
 seconds=$6
 
+# Seconds since the check started, in front of every line it prints.
+#
+# `R CMD check` only reports a stage's own time when it exceeds its threshold,
+# and never for the stage it was killed in -- which is the one worth knowing
+# about. Stamping the stream costs nothing and turns "timed out at * checking
+# examples with --run-donttest" into how long every stage before it took, and
+# how long that one had been running. `EPOCHSECONDS` is a bash builtin, so
+# this spawns nothing per line.
+stamp() {
+  local start=${EPOCHSECONDS} line
+  while IFS= read -r line; do
+    printf '[%5ds] %s\n' "$((EPOCHSECONDS - start))" "${line}"
+  done
+}
+
 check_one() {
   local phase=$1
   local lib=$2
@@ -38,11 +53,12 @@ check_one() {
   mkdir -p "${out}"
   # `timeout` sends TERM at the deadline and KILL a minute later, and R CMD
   # check's own children go with it because it runs in its own process group.
+  # The status is PIPESTATUS[0] because the stamping is downstream of it.
   R_LIBS="${lib}:${lib_shared}" \
     timeout --kill-after=60s "${seconds}s" \
-    R CMD check --no-manual --as-cran --output="${out}" "${tarball}" \
-    > "${out}/driver.log" 2>&1
-  echo $? > "${out}/status"
+    R CMD check --no-manual --as-cran --output="${out}" "${tarball}" 2>&1 |
+    stamp > "${out}/driver.log"
+  echo "${PIPESTATUS[0]}" > "${out}/status"
 }
 
 check_one old "${lib_old}" &

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -791,9 +791,22 @@ inform(
   " check times measured by an earlier run"
 )
 
-# Weight: one check of the revdep costs what it is expected to cost here; a
-# package without a reusable baseline is checked twice.
-weight <- ((!reuse) + 1) * check_seconds / 60 + overhead_minutes
+# Weight: every package is checked twice, whether or not a baseline could have
+# been reused.
+#
+# It used to be `((!reuse) + 1) *`: a reusable baseline stood in for the old
+# check, so that package cost one check instead of two. It does not any more.
+# The two halves run concurrently against cascading libraries, so the old check
+# costs no wall clock worth saving, and a baseline is a result from another
+# machine and another CRAN snapshot -- in run 31879790285 that mismatch
+# accounted for 76 of the 78 `newly_broken` packages. Both halves always run
+# now, so pricing the reused ones at half is simply wrong, and wrong in a way
+# that under-fills exactly the shards holding the most of them.
+#
+# The factor of two is nominal: `check_scale` is fitted from what the last runs
+# measured, so whatever it is really worth in wall clock is absorbed there. What
+# matters here is that every package is priced the same way.
+weight <- 2 * check_seconds / 60 + overhead_minutes
 
 # ------------------------------------------------------------- partitioning --
 

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -807,10 +807,20 @@ for (position in seq_along(runnable)) {
     rcheck <- function(phase) {
       file.path(work, "check", name, phase, paste0(name, ".Rcheck"))
     }
+    # The complete transcripts, so that bounding what goes into the check log
+    # never costs anything. R writes `<file>.Rout.fail` for a test file that
+    # failed and `<pkg>-Ex.Rout` for the examples -- the second one is not a
+    # `.fail` file and so used to be dropped, which left an examples failure
+    # (13 of run 31879790285's 19 timeouts, and both of its genuine
+    # regressions) with nothing to read but the check log's own excerpt.
     for (f in c(
       "00check.log",
       "00install.out",
-      list.files(rcheck("new"), pattern = "[.]Rout[.]fail$", recursive = TRUE)
+      list.files(
+        rcheck("new"),
+        pattern = "[.]Rout[.]fail$|-Ex[.]Rout$",
+        recursive = TRUE
+      )
     )) {
       if (file.exists(file.path(rcheck("new"), f))) {
         file.copy(file.path(rcheck("new"), f), file.path(keep, basename(f)))
@@ -946,18 +956,23 @@ for (entry in entries) {
   )
   append_summary(md_details(title, lines))
 
-  # The check log says what broke; these two say why, and neither of them fits
-  # in it. `00install.out` is where a package that could not be installed
-  # explains itself -- the check log only points at the file, which used to
-  # mean downloading the artifact to read a compiler error. And a `.Rout.fail`
-  # is the whole test transcript, where the check log carries only its tail.
-  # Each gets its own block and its own budget rather than sharing one, or the
-  # tail of the pair would be all anyone saw.
+  # The check log says what broke; these say why, and none of them fits in it.
+  # `00install.out` is where a package that could not be installed explains
+  # itself -- the check log only points at the file, which used to mean
+  # downloading the artifact to read a compiler error. A `.Rout.fail` is a
+  # failed test file's whole transcript and `-Ex.Rout` the examples', where the
+  # check log carries a bounded excerpt. Each gets its own block and its own
+  # budget rather than sharing one, or the tail of the set would be all anyone
+  # saw.
   for (extra in list(
     list(file = "00install.out", what = "installation output"),
     list(
       file = list.files(kept, pattern = "[.]Rout[.]fail$"),
       what = "test output"
+    ),
+    list(
+      file = list.files(kept, pattern = "-Ex[.]Rout$"),
+      what = "example output"
     )
   )) {
     for (f in extra$file) {

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -488,6 +488,12 @@ neutral_log <- function(path, name) {
 # How much of a package's diff goes into the job log before it is cut off.
 diff_max_lines <- env_num("REVDEP2_DIFF_MAX_LINES", 200)
 
+# How much of an installation or test transcript goes into the job summary.
+# Both are read to find out why something broke, and 80 lines -- the default
+# for the check log, which is a summary of stages -- cuts a compiler error or a
+# testthat run off in the middle.
+detail_max_lines <- env_num("REVDEP2_DETAIL_MAX_LINES", 300)
+
 # The two halves' check logs, as a patch.
 #
 # Both sides are neutralised first, so the paths and the stage timings that
@@ -579,7 +585,7 @@ check_pair <- function(name) {
   list(old = read_side("old"), new = read_side("new"))
 }
 
-check_failure <- function(name, phase, result) {
+check_failure <- function(name, phase, result, progress) {
   if (isTRUE(attr(result, "timed_out"))) {
     # `timeout`, not `failed`. A check killed by the clock says nothing about
     # the package, and in the old phase it says nothing about our change
@@ -605,11 +611,21 @@ check_failure <- function(name, phase, result) {
       " check timed out (",
       attr(result, "duration"),
       "s)",
-      if (nzchar(step)) paste0(" at ", trimws(step)) else ""
+      if (nzchar(step)) paste0(" at ", trimws(step)) else "",
+      ", ",
+      progress
     )
   } else {
     update(name, result = "error", message = conditionMessage(result))
-    inform(name, ": ", phase, " check errored: ", conditionMessage(result))
+    inform(
+      name,
+      ": ",
+      phase,
+      " check errored: ",
+      conditionMessage(result),
+      ", ",
+      progress
+    )
   }
 }
 
@@ -632,11 +648,17 @@ inform(sprintf(
   "Checking %d package(s), old and new side by side",
   length(runnable)
 ))
-for (name in runnable) {
+for (position in seq_along(runnable)) {
+  name <- runnable[[position]]
   entry <- get(name, envir = state)
 
+  # How far along the shard is, on every line that reports a package. A shard
+  # runs for hours and its log is read while it runs; "3/51" answers "is this
+  # nearly done?" without counting lines or knowing what the shard holds.
+  progress <- sprintf("%d/%d", position, length(runnable))
+
   if (out_of_time(entry)) {
-    inform(name, ": deferred (deadline)")
+    inform(name, ": deferred (deadline), ", progress)
     next
   }
 
@@ -652,7 +674,7 @@ for (name in runnable) {
   new <- pair$new
 
   if (inherits(old, "error")) {
-    check_failure(name, "old", old)
+    check_failure(name, "old", old, progress)
     next
   }
   saveRDS(old, file.path(pkg_out(name), "old.rds"))
@@ -680,7 +702,7 @@ for (name in runnable) {
     }
   }
   if (inherits(new, "error")) {
-    check_failure(name, "new", new)
+    check_failure(name, "new", new, progress)
     next
   }
   saveRDS(new, file.path(pkg_out(name), "new.rds"))
@@ -726,7 +748,9 @@ for (name in runnable) {
     entry$status_new,
     ", ",
     attr(new, "duration"),
-    "s for the pair)"
+    "s for the pair, ",
+    progress,
+    ")"
   )
 
   # The parsed results carry everything the reports need; raw check output is
@@ -863,7 +887,8 @@ for (entry in entries) {
   # The reason goes in the title, where `md_details()` cannot tail it away;
   # the body is the check log where there is one, because the reason alone
   # rarely says which check step broke.
-  log <- file.path(out_dir, "pkgs", entry$package, "new-check", "00check.log")
+  kept <- file.path(out_dir, "pkgs", entry$package, "new-check")
+  log <- file.path(kept, "00check.log")
   reason <- gsub("\n", " ", entry$message %||% "")
   lines <- if (file.exists(log)) {
     readLines(log, warn = FALSE)
@@ -872,15 +897,45 @@ for (entry in entries) {
   } else {
     "(no log captured)"
   }
-  append_summary(md_details(
-    sprintf(
-      "<code>%s</code> &mdash; %s%s",
-      entry$package,
-      entry$result,
-      if (nzchar(reason)) paste0(": ", md_escape_html(reason)) else ""
-    ),
-    lines
-  ))
+  title <- sprintf(
+    "<code>%s</code> &mdash; %s%s",
+    entry$package,
+    entry$result,
+    if (nzchar(reason)) paste0(": ", md_escape_html(reason)) else ""
+  )
+  append_summary(md_details(title, lines))
+
+  # The check log says what broke; these two say why, and neither of them fits
+  # in it. `00install.out` is where a package that could not be installed
+  # explains itself -- the check log only points at the file, which used to
+  # mean downloading the artifact to read a compiler error. And a `.Rout.fail`
+  # is the whole test transcript, where the check log carries only its tail.
+  # Each gets its own block and its own budget rather than sharing one, or the
+  # tail of the pair would be all anyone saw.
+  for (extra in list(
+    list(file = "00install.out", what = "installation output"),
+    list(
+      file = list.files(kept, pattern = "[.]Rout[.]fail$"),
+      what = "test output"
+    )
+  )) {
+    for (f in extra$file) {
+      path <- file.path(kept, f)
+      if (!file.exists(path)) {
+        next
+      }
+      append_summary(md_details(
+        sprintf(
+          "<code>%s</code> &mdash; %s (<code>%s</code>)",
+          entry$package,
+          extra$what,
+          f
+        ),
+        readLines(path, warn = FALSE),
+        max_lines = detail_max_lines
+      ))
+    }
+  }
 }
 
 inform(

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -1,6 +1,10 @@
 # Check one shard of a revdep2 plan: many reverse dependencies, one job, one
 # shared library.
 #
+# It runs in two phases, `install` and `check`, so that the workflow can put
+# each in its own step and Actions can time them separately; `PHASE=all` runs
+# both in one go, which is what a local invocation wants.
+#
 # The shard installs the union of its packages' dependencies once, then checks
 # each of its packages against both versions of the package under test at the
 # same time: two `R CMD check` runs side by side, against library stacks that
@@ -41,6 +45,8 @@
 #   TIMEOUT_MIN_MINUTES    - floor for that timeout; CRAN's machines are not
 #                            these runners (default: 10)
 #   DEADLINE_MINUTES       - stop starting new checks past this (default: 300)
+#   PHASE                  - "install", "check", or "all" (default): which half
+#                            of the shard this invocation runs
 
 script_dir <- dirname(sub(
   "--file=",
@@ -71,9 +77,21 @@ package <- plan$package
 
 dir.create(file.path(out_dir, "pkgs"), recursive = TRUE, showWarnings = FALSE)
 manifest_path <- file.path(out_dir, "manifest.ndjson")
-file.create(manifest_path)
 work <- file.path(env_chr("RUNNER_TEMP", tempdir()), "revdep2-work")
 dir.create(work, recursive = TRUE, showWarnings = FALSE)
+
+# Which half of the shard this invocation runs. The workflow calls the driver
+# twice so that Actions times the install and the checks separately; `all` is
+# for running the whole shard in one process, which is what a local invocation
+# wants. The install leaves `install-state.json` behind and the checks read it,
+# so the split costs one small file and repeats nothing.
+phase <- env_chr("PHASE", "all")
+if (!phase %in% c("all", "install", "check")) {
+  stop("PHASE must be one of \"all\", \"install\", \"check\"", call. = FALSE)
+}
+do_install <- phase %in% c("all", "install")
+do_check <- phase %in% c("all", "check")
+install_state <- file.path(work, "install-state.json")
 
 inform(
   "Shard ",
@@ -137,108 +155,6 @@ counts <- function(x) {
 
 # ---------------------------------------------------------------- install ----
 
-install <- unlist(shard$install, use.names = FALSE)
-
-# What is already built, unpacked into the library pak installs into: this
-# run's own preflight library first -- it is the freshest there is, and
-# without it every shard would rebuild what the preflight compiled minutes
-# ago -- then the earlier runs the plan picked, for whatever the preflight
-# could not supply. pak still resolves the whole set afterwards; the point is
-# to skip *building* what has not changed, not to skip resolving it.
-lib <- .libPaths()[[1]]
-restore_started <- Sys.time()
-restored <- c(
-  restore_local_library(env_chr("LIB_DIR"), lib, install),
-  restore_prebuilt(plan, lib, install)
-)
-restore_seconds <- elapsed(restore_started)
-inform(
-  length(restored),
-  " dependency binaries restored, ",
-  length(install) - length(restored),
-  " left to pak"
-)
-
-# With a restored library, `upgrade = FALSE` would freeze whatever version the
-# donor happened to hold; the plan's dependency fingerprints are computed from
-# CRAN *now*, so the library has to follow CRAN now.
-upgrade <- length(restored) > 0
-
-# The pak cache this shard restored was saved by the preflight, so a metadata
-# database broken there arrives here intact -- which is how run 31282820357
-# turned one bad preflight into sixty shards that installed nothing and
-# reported every one of their packages as a depfail. Asking pak what it can
-# see costs seconds, and a shard that cannot see CRAN is worth saying out loud
-# rather than working around.
-if (identical(ensure_metadata(sprintf("Shard %d", shard_index)), "broken")) {
-  inform("pak cannot see CRAN here; every check will be a depfail")
-}
-
-# In dependency order, a hundred at a time, for the same reason the preflight
-# does it: one pak call for the whole set is one resolution of the whole set,
-# and that is the part that stops degrading gracefully as the set grows. A
-# shard's union is a fraction of the preflight's, but it is the same call.
-chunk_size <- env_num("REVDEP2_INSTALL_CHUNK", 100)
-chunks <- install_chunks(install, cran_db(), chunk_size)
-inform(
-  "Installing ",
-  length(install),
-  " dependencies in ",
-  length(chunks),
-  " chunk(s) of at most ",
-  chunk_size,
-  ", dependencies first"
-)
-install_started <- Sys.time()
-# The deadline is the shard's own: an install that runs into it leaves no time
-# to check anything, so it stops and lets the checks report what they can
-# rather than being cancelled with the job.
-bulk_ok <- install_in_chunks(
-  chunks,
-  lib = lib,
-  upgrade = upgrade,
-  deadline = deadline
-)
-if (!bulk_ok) {
-  for (p in install) {
-    if (requireNamespace(p, quietly = TRUE) || Sys.time() > deadline) {
-      next
-    }
-    run <- pak_install(
-      p,
-      lib = lib,
-      upgrade = upgrade,
-      timeout_seconds = install_timeout_seconds(),
-      label = paste("installing", p)
-    )
-    if (!run$ok) {
-      inform("Could not install ", p, ": ", run$message)
-    }
-  }
-}
-
-# After the installs and before the first check: pak has covered whatever it
-# installed itself, so what is left is exactly the restored packages -- this
-# run's preflight library and the plan's donors. A shard has no load test, so
-# an unmet system requirement here would surface as a check failure blamed on
-# the revdep.
-ensure_sysreqs(lib, sprintf("Shard %d", shard_index))
-
-install_seconds <- elapsed(install_started)
-inform(
-  "Dependencies ready after ",
-  round(install_seconds / 60, 1),
-  " min (",
-  round(restore_seconds / 60, 1),
-  " min unpacking prebuilt)"
-)
-
-installed <- rownames(utils::installed.packages())
-our_version <- function() {
-  tryCatch(as.character(utils::packageVersion(package)), error = function(e) {
-    NA_character_
-  })
-}
 # The two versions cascade rather than replace each other.
 #
 # `R_LIBS` is a search path, so a check can name a library holding exactly one
@@ -247,46 +163,189 @@ our_version <- function() {
 # between the phases, which is what used to force them to run one after the
 # other; now both can run at once against libraries that differ in exactly the
 # package under test.
+lib <- .libPaths()[[1]]
 lib_old <- file.path(work, "lib-old")
 lib_new <- file.path(work, "lib-new")
-dir.create(lib_old, recursive = TRUE, showWarnings = FALSE)
-dir.create(lib_new, recursive = TRUE, showWarnings = FALSE)
 
-# The shared library must not hold the package under test at all, or it would
-# shadow neither and both checks would see whatever the resolver left there.
-unlink(file.path(lib, package), recursive = TRUE)
+if (do_install) {
+  install <- unlist(shard$install, use.names = FALSE)
 
-inform("Installing ", package, " ", plan$cran_version, " into the old library")
-cran_install <- pak_install(
-  package,
-  lib = lib_old,
-  upgrade = FALSE,
-  timeout_seconds = install_timeout_seconds(),
-  label = paste("installing", package)
-)
-if (!cran_install$ok) {
-  stop("Installing the CRAN release of ", package, " failed", call. = FALSE)
-}
-our_cran_version <- as.character(utils::packageVersion(package, lib_old))
-if (!identical(our_cran_version, plan$cran_version)) {
+  # What is already built, unpacked into the library pak installs into: this
+  # run's own preflight library first -- it is the freshest there is, and
+  # without it every shard would rebuild what the preflight compiled minutes
+  # ago -- then the earlier runs the plan picked, for whatever the preflight
+  # could not supply. pak still resolves the whole set afterwards; the point is
+  # to skip *building* what has not changed, not to skip resolving it.
+  restore_started <- Sys.time()
+  restored <- c(
+    restore_local_library(env_chr("LIB_DIR"), lib, install),
+    restore_prebuilt(plan, lib, install)
+  )
+  restore_seconds <- elapsed(restore_started)
   inform(
-    "Note: old checks run against ",
-    our_cran_version,
-    " (the repositories lag CRAN, the plan expected ",
+    length(restored),
+    " dependency binaries restored, ",
+    length(install) - length(restored),
+    " left to pak"
+  )
+
+  # With a restored library, `upgrade = FALSE` would freeze whatever version the
+  # donor happened to hold; the plan's dependency fingerprints are computed from
+  # CRAN *now*, so the library has to follow CRAN now.
+  upgrade <- length(restored) > 0
+
+  # The pak cache this shard restored was saved by the preflight, so a metadata
+  # database broken there arrives here intact -- which is how run 31282820357
+  # turned one bad preflight into sixty shards that installed nothing and
+  # reported every one of their packages as a depfail. Asking pak what it can
+  # see costs seconds, and a shard that cannot see CRAN is worth saying out loud
+  # rather than working around.
+  if (identical(ensure_metadata(sprintf("Shard %d", shard_index)), "broken")) {
+    inform("pak cannot see CRAN here; every check will be a depfail")
+  }
+
+  # In dependency order, a hundred at a time, for the same reason the preflight
+  # does it: one pak call for the whole set is one resolution of the whole set,
+  # and that is the part that stops degrading gracefully as the set grows. A
+  # shard's union is a fraction of the preflight's, but it is the same call.
+  chunk_size <- env_num("REVDEP2_INSTALL_CHUNK", 100)
+  chunks <- install_chunks(install, cran_db(), chunk_size)
+  inform(
+    "Installing ",
+    length(install),
+    " dependencies in ",
+    length(chunks),
+    " chunk(s) of at most ",
+    chunk_size,
+    ", dependencies first"
+  )
+  install_started <- Sys.time()
+  # The deadline is the shard's own: an install that runs into it leaves no time
+  # to check anything, so it stops and lets the checks report what they can
+  # rather than being cancelled with the job.
+  bulk_ok <- install_in_chunks(
+    chunks,
+    lib = lib,
+    upgrade = upgrade,
+    deadline = deadline
+  )
+  if (!bulk_ok) {
+    for (p in install) {
+      if (requireNamespace(p, quietly = TRUE) || Sys.time() > deadline) {
+        next
+      }
+      run <- pak_install(
+        p,
+        lib = lib,
+        upgrade = upgrade,
+        timeout_seconds = install_timeout_seconds(),
+        label = paste("installing", p)
+      )
+      if (!run$ok) {
+        inform("Could not install ", p, ": ", run$message)
+      }
+    }
+  }
+
+  # After the installs and before the first check: pak has covered whatever it
+  # installed itself, so what is left is exactly the restored packages -- this
+  # run's preflight library and the plan's donors. A shard has no load test, so
+  # an unmet system requirement here would surface as a check failure blamed on
+  # the revdep.
+  ensure_sysreqs(lib, sprintf("Shard %d", shard_index))
+
+  install_seconds <- elapsed(install_started)
+  inform(
+    "Dependencies ready after ",
+    round(install_seconds / 60, 1),
+    " min (",
+    round(restore_seconds / 60, 1),
+    " min unpacking prebuilt)"
+  )
+
+  dir.create(lib_old, recursive = TRUE, showWarnings = FALSE)
+  dir.create(lib_new, recursive = TRUE, showWarnings = FALSE)
+
+  # The shared library must not hold the package under test at all, or it would
+  # shadow neither and both checks would see whatever the resolver left there.
+  unlink(file.path(lib, package), recursive = TRUE)
+
+  inform(
+    "Installing ",
+    package,
+    " ",
     plan$cran_version,
-    ")"
+    " into the old library"
+  )
+  cran_install <- pak_install(
+    package,
+    lib = lib_old,
+    upgrade = FALSE,
+    timeout_seconds = install_timeout_seconds(),
+    label = paste("installing", package)
+  )
+  if (!cran_install$ok) {
+    stop("Installing the CRAN release of ", package, " failed", call. = FALSE)
+  }
+  our_cran_version <- as.character(utils::packageVersion(package, lib_old))
+  if (!identical(our_cran_version, plan$cran_version)) {
+    inform(
+      "Note: old checks run against ",
+      our_cran_version,
+      " (the repositories lag CRAN, the plan expected ",
+      plan$cran_version,
+      ")"
+    )
+  }
+
+  binary <- file.path(pkg_dir, meta$binary)
+  inform("Installing dev binary ", basename(binary), " into the new library")
+  if (
+    system2(
+      "R",
+      c("CMD", "INSTALL", "-l", shQuote(lib_new), shQuote(binary))
+    ) !=
+      0
+  ) {
+    stop("Installing the prebuilt dev binary failed", call. = FALSE)
+  }
+  our_dev_version <- as.character(utils::packageVersion(package, lib_new))
+
+  # What the check phase needs to know about this one, and what the timings at
+  # the end report. Everything else it can work out for itself from the library
+  # it finds on disk.
+  write_json(
+    list(
+      install_packages = length(install),
+      restored = length(restored),
+      restore_seconds = restore_seconds,
+      install_seconds = install_seconds,
+      our_cran_version = our_cran_version,
+      our_dev_version = our_dev_version
+    ),
+    install_state
   )
 }
 
-binary <- file.path(pkg_dir, meta$binary)
-inform("Installing dev binary ", basename(binary), " into the new library")
-if (
-  system2("R", c("CMD", "INSTALL", "-l", shQuote(lib_new), shQuote(binary))) !=
-    0
-) {
-  stop("Installing the prebuilt dev binary failed", call. = FALSE)
+if (!do_check) {
+  inform("Install phase complete; the check phase runs as its own step")
+  quit(save = "no", status = 0)
 }
-our_dev_version <- as.character(utils::packageVersion(package, lib_new))
+
+if (!file.exists(install_state)) {
+  stop(
+    "No install state in ",
+    work,
+    ": the install phase did not finish",
+    call. = FALSE
+  )
+}
+installed_state <- read_json(install_state)
+our_cran_version <- installed_state$our_cran_version
+our_dev_version <- installed_state$our_dev_version
+invisible(file.create(manifest_path))
+
+installed <- rownames(utils::installed.packages())
 inform(sprintf(
   "Checking old (%s) and new (%s) concurrently, two at a time per package",
   our_cran_version,
@@ -393,19 +452,27 @@ out_of_time <- function(entry) {
 # The timeout is coreutils' rather than rcmdcheck's, which is what makes the
 # distinction reliable: exit 124 is the deadline, anything else is the check
 # saying something.
-# The check log with this run's paths taken out of it.
+# The check log with this run's incidentals taken out of it.
 #
-# `compare_checks()` matches issues by their text, so any text that differs
-# between the halves for reasons that are not the package makes a shared issue
-# look like a new one. Since the two libraries cascade, they differ by
-# construction -- `.../lib-old/...` against `.../lib-new/...` -- and so do the
-# check directories. In run 31879790285 that turned packages with the same one
-# error in both halves into `newly_broken`: `dm` and `fsbrain` both reported
-# "old 1E 0W 0N, new 1E 0W 0N" and were called newly broken, because the error
-# quoted a path.
+# Two things differ between the halves for reasons that have nothing to do with
+# the package:
 #
-# So both are replaced by a constant before the log is parsed. Nothing else is
-# touched: a difference anywhere but in these paths is exactly what this
+#   * the paths. The libraries cascade, so they differ by construction --
+#     `.../lib-old/...` against `.../lib-new/...` -- and so do the two check
+#     directories, which the log names in its first line and quotes in every
+#     "see ... for details".
+#   * the timings. `--as-cran` sets `_R_CHECK_TIMINGS_`, so every stage slower
+#     than ten seconds prints its own `[user/elapsed]` pair, and two checks
+#     racing each other for the same four cores never agree on those. A run of
+#     rphylopic against the *same* igraph on both sides differed in exactly two
+#     lines: the log directory, and `[14s/12s]` against `[13s/11s]`.
+#
+# Both matter twice. `compare_checks()` matches issues by their text, so a
+# difference in the first line of an issue makes an issue both halves have look
+# like a new one; and the diff between the halves is only worth printing if two
+# identical results produce an empty one.
+#
+# Nothing else is touched: a difference anywhere but here is exactly what this
 # workflow exists to find.
 neutral_log <- function(path, name) {
   lines <- readLines(path, warn = FALSE)
@@ -413,7 +480,30 @@ neutral_log <- function(path, name) {
     lines <- gsub(from, "<lib>", lines, fixed = TRUE)
   }
   # The phase also names itself in the .Rcheck path under the work directory.
-  gsub("<lib>/(old|new)", "<lib>", lines)
+  lines <- gsub("<lib>/(old|new)", "<lib>", lines)
+  # `[14s/12s]`, and the one-number form R uses where it has only one.
+  gsub("\\[[0-9.]+s(/[0-9.]+s)?\\]", "[]", lines)
+}
+
+# How much of a package's diff goes into the job log before it is cut off.
+diff_max_lines <- env_num("REVDEP2_DIFF_MAX_LINES", 200)
+
+# The two halves' check logs, as a patch.
+#
+# Both sides are neutralised first, so the paths and the stage timings that
+# differ in every pair are gone and what is left is the package: an empty diff
+# means the dev version changed nothing about this check, however long the log.
+check_diff <- function(name, old_log, new_log) {
+  tmp <- file.path(tempdir(), c("old-00check.log", "new-00check.log"))
+  writeLines(neutral_log(old_log, name), tmp[[1]])
+  writeLines(neutral_log(new_log, name), tmp[[2]])
+  on.exit(unlink(tmp), add = TRUE)
+  suppressWarnings(system2(
+    "diff",
+    shQuote(c("-u", "--label", "old", tmp[[1]], "--label", "new", tmp[[2]])),
+    stdout = TRUE,
+    stderr = NULL
+  ))
 }
 
 check_pair <- function(name) {
@@ -659,13 +749,32 @@ for (name in runnable) {
     old_log <- file.path(rcheck("old"), "00check.log")
     new_log <- file.path(rcheck("new"), "00check.log")
     if (file.exists(old_log) && file.exists(new_log)) {
-      diff <- suppressWarnings(system2(
-        "diff",
-        shQuote(c("-u", "--label", "old", old_log, "--label", "new", new_log)),
-        stdout = TRUE,
-        stderr = NULL
-      ))
+      diff <- check_diff(name, old_log, new_log)
       writeLines(diff, file.path(keep, "00check.diff"))
+      # And into the job log, where it is the one thing a reader of the run
+      # actually wants: what the dev version changed about this package, in the
+      # package's own words. Downloading an artifact to find out that a NOTE
+      # gained a line is a poor trade. It is bounded because a package that
+      # fails to install differs in thousands of lines and would bury the rest
+      # of the shard; the whole diff is in the artifact either way.
+      print_group(
+        sprintf("%s: old vs new check log (%d line diff)", name, length(diff)),
+        if (length(diff) == 0) {
+          # Worth saying rather than leaving as an empty block. A package
+          # called `newly_broken` whose two logs are identical once the paths
+          # and the stage timings are out of them is not newly broken; it is
+          # this harness getting it wrong, and this line is how a reader of the
+          # run finds that out without downloading anything.
+          "The two logs are identical apart from paths and stage timings."
+        },
+        head(diff, diff_max_lines),
+        if (length(diff) > diff_max_lines) {
+          sprintf(
+            "[%d more lines; the whole diff is 00check.diff in the shard artifact]",
+            length(diff) - diff_max_lines
+          )
+        }
+      )
     }
     unlink(file.path(work, "check", name), recursive = TRUE)
   }
@@ -699,11 +808,13 @@ write_json(
     index = shard_index,
     packages = length(members),
     checks = checks_started,
-    install_packages = length(install),
-    restored = length(restored),
-    restore_seconds = restore_seconds,
-    install_seconds = install_seconds,
+    install_packages = installed_state$install_packages,
+    restored = installed_state$restored,
+    restore_seconds = installed_state$restore_seconds,
+    install_seconds = installed_state$install_seconds,
     check_seconds = round(check_seconds, 1),
+    # The install phase is its own step now, so this is the check phase's own
+    # wall clock; the two together are what the shard job cost.
     script_seconds = elapsed(script_started),
     started_at = format(script_started, "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
     finished_at = now_utc(),

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -648,17 +648,52 @@ inform(sprintf(
   "Checking %d package(s), old and new side by side",
   length(runnable)
 ))
+# How far along the shard is, on every line that reports a package.
+#
+# A shard runs for hours and its log is read while it runs, so "3/51" answers
+# "is this nearly done?" without counting lines. The estimate answers the
+# question actually being asked, which is when.
+#
+# The plan already priced every package; what it could not know is how this
+# runner would compare. So the remaining packages are priced in the plan's own
+# units and then rescaled by how its estimates have held up here so far --
+# which absorbs both a slow runner and a systematically optimistic model,
+# without either having to be known in advance. Before the first pair finishes
+# there is nothing to rescale by and the plan's number stands.
+planned_done <- 0
+actual_done <- 0
+planned_minutes <- function(name) {
+  max(get(name, envir = state)$weight_minutes %||% 0, 0)
+}
+progress_note <- function(position) {
+  left <- sum(vapply(
+    utils::tail(runnable, length(runnable) - position),
+    planned_minutes,
+    numeric(1)
+  ))
+  scale <- if (planned_done > 0 && actual_done > 0) {
+    actual_done / planned_done
+  } else {
+    1
+  }
+  sprintf(
+    "%d/%d, %s",
+    position,
+    length(runnable),
+    if (left > 0) {
+      paste0("~", format_duration(left * scale * 60), " left")
+    } else {
+      "last one"
+    }
+  )
+}
+
 for (position in seq_along(runnable)) {
   name <- runnable[[position]]
   entry <- get(name, envir = state)
 
-  # How far along the shard is, on every line that reports a package. A shard
-  # runs for hours and its log is read while it runs; "3/51" answers "is this
-  # nearly done?" without counting lines or knowing what the shard holds.
-  progress <- sprintf("%d/%d", position, length(runnable))
-
   if (out_of_time(entry)) {
-    inform(name, ": deferred (deadline), ", progress)
+    inform(name, ": deferred (deadline), ", progress_note(position))
     next
   }
 
@@ -672,6 +707,12 @@ for (position in seq_along(runnable)) {
   pair <- check_pair(name)
   old <- pair$old
   new <- pair$new
+
+  # What this one was priced at against what it cost, which is what prices the
+  # rest. A timed-out check counts too: the clock really did spend it.
+  planned_done <- planned_done + planned_minutes(name)
+  actual_done <- actual_done + (attr(new, "duration") %||% 0) / 60
+  progress <- progress_note(position)
 
   if (inherits(old, "error")) {
     check_failure(name, "old", old, progress)

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -704,6 +704,11 @@ for (name in runnable) {
       result = classify_status(cmp$status, new_issues),
       status = cmp$status,
       status_new = counts(new),
+      # The pair's wall clock, charged to both halves: they ran side by side,
+      # so neither one's own time is separable from the other's. It used to be
+      # recorded only where the comparison failed, which left `t_new` null for
+      # every package that compared -- that is, for all of them.
+      t_new = attr(new, "duration"),
       new_issues = new_issues,
       # An install failure or a timeout leaves nothing to compare, so the
       # result is only "failed"; say which one it was.

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -100,7 +100,9 @@ for (p in shard$packages) {
       t_total = p$t_total %||% 0,
       dep_fingerprint = p$dep_fingerprint,
       baseline_planned = isTRUE(p$baseline),
-      baseline_reused = FALSE,
+      # Whether the old check reproduced the baseline this run was offered.
+      # NA when there was none to compare against.
+      baseline_agrees = NA,
       result = "deferred",
       status = "",
       status_old = "",
@@ -391,6 +393,29 @@ out_of_time <- function(entry) {
 # The timeout is coreutils' rather than rcmdcheck's, which is what makes the
 # distinction reliable: exit 124 is the deadline, anything else is the check
 # saying something.
+# The check log with this run's paths taken out of it.
+#
+# `compare_checks()` matches issues by their text, so any text that differs
+# between the halves for reasons that are not the package makes a shared issue
+# look like a new one. Since the two libraries cascade, they differ by
+# construction -- `.../lib-old/...` against `.../lib-new/...` -- and so do the
+# check directories. In run 31879790285 that turned packages with the same one
+# error in both halves into `newly_broken`: `dm` and `fsbrain` both reported
+# "old 1E 0W 0N, new 1E 0W 0N" and were called newly broken, because the error
+# quoted a path.
+#
+# So both are replaced by a constant before the log is parsed. Nothing else is
+# touched: a difference anywhere but in these paths is exactly what this
+# workflow exists to find.
+neutral_log <- function(path, name) {
+  lines <- readLines(path, warn = FALSE)
+  for (from in c(lib_old, lib_new, file.path(work, "check", name))) {
+    lines <- gsub(from, "<lib>", lines, fixed = TRUE)
+  }
+  # The phase also names itself in the .Rcheck path under the work directory.
+  gsub("<lib>/(old|new)", "<lib>", lines)
+}
+
 check_pair <- function(name) {
   checks_started <<- checks_started + 1L
   work_dir <- file.path(work, "check", name)
@@ -436,7 +461,7 @@ check_pair <- function(name) {
       ))
     } else {
       tryCatch(
-        rcmdcheck::parse_check(log),
+        rcmdcheck::parse_check(text = neutral_log(log, name)),
         error = function(e) {
           simpleError(sprintf(
             "%s check produced no readable result (exit %s): %s",
@@ -520,55 +545,49 @@ inform(sprintf(
 for (name in runnable) {
   entry <- get(name, envir = state)
 
-  # A reusable baseline still stands in for the old check; only the new one is
-  # then run, and it runs alone.
-  reused <- FALSE
-  old <- NULL
-  if (entry$baseline_planned) {
-    rds <- file.path(baseline_dir, "old-rds", paste0(name, ".rds"))
-    old <- tryCatch(readRDS(rds), error = function(e) NULL)
-    if (!is.null(old)) {
-      saveRDS(old, file.path(pkg_out(name), "old.rds"))
-      donor <- Filter(
-        function(e) identical(e$package, name),
-        read_json(file.path(baseline_dir, "baseline.json"))
-      )
-      update(
-        name,
-        baseline_reused = TRUE,
-        status_old = counts(old),
-        old_checked_at = if (length(donor) > 0) donor[[1]]$checked_at else NA
-      )
-      reused <- TRUE
-      inform(name, ": baseline reused")
-    } else {
-      inform(name, ": planned baseline unavailable, checking fresh")
-    }
-  }
-
   if (out_of_time(entry)) {
     inform(name, ": deferred (deadline)")
     next
   }
 
+  # Both halves, always. A baseline used to stand in for the old check and
+  # save it; with the pair running concurrently the old check costs no wall
+  # clock at all, and reusing a result from another run means comparing
+  # against a machine, a CRAN snapshot and a dependency tree that are not
+  # this run's. The baseline is still read, but as a second opinion: if it
+  # disagrees with what the old check just produced, that is drift worth
+  # printing rather than a comparison worth trusting.
   pair <- check_pair(name)
+  old <- pair$old
   new <- pair$new
-  if (!reused) {
-    old <- pair$old
-  }
 
   if (inherits(old, "error")) {
     check_failure(name, "old", old)
     next
   }
-  if (!reused) {
-    saveRDS(old, file.path(pkg_out(name), "old.rds"))
-    update(
-      name,
-      status_old = counts(old),
-      t_old = attr(old, "duration"),
-      old_checked_at = now_utc()
-    )
+  saveRDS(old, file.path(pkg_out(name), "old.rds"))
+  update(
+    name,
+    status_old = counts(old),
+    t_old = attr(old, "duration"),
+    old_checked_at = now_utc()
+  )
+
+  if (entry$baseline_planned) {
+    rds <- file.path(baseline_dir, "old-rds", paste0(name, ".rds"))
+    baseline <- tryCatch(readRDS(rds), error = function(e) NULL)
+    if (!is.null(baseline)) {
+      agrees <- identical(counts(baseline), counts(old))
+      update(name, baseline_agrees = agrees)
+      if (!agrees) {
+        inform(sprintf(
+          "%s: the baseline said %s, the old check now says %s",
+          name,
+          counts(baseline),
+          counts(old)
+        ))
+      }
+    }
   }
   if (inherits(new, "error")) {
     check_failure(name, "new", new)

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -36,6 +36,22 @@ now_utc <- function() {
   format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
 }
 
+# A block of output under a heading the reader can fold away.
+#
+# Actions renders `::group::` as a collapsed section in the job log, so a
+# hundred shard packages can each contribute their diff without any of them
+# getting in the way of the summary lines between them. Outside Actions the
+# markers are just two extra lines. NULL arguments are dropped, so a caller can
+# pass a trailing note conditionally.
+print_group <- function(title, ...) {
+  body <- unlist(list(...), use.names = FALSE)
+  message("::group::", title)
+  if (length(body) > 0) {
+    message(paste(body, collapse = "\n"))
+  }
+  message("::endgroup::")
+}
+
 # ---------------------------------------------------------------- run ids ----
 
 # GitHub run ids passed `.Machine$integer.max` in 2026, so they are carried as

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -1047,8 +1047,12 @@ run_with_timeout <- function(fun, args = list(), timeout_seconds, label = "") {
 format_duration <- function(seconds) {
   if (seconds < 90) {
     sprintf("%.0f s", seconds)
-  } else {
+  } else if (seconds < 90 * 60) {
     sprintf("%.0f min", seconds / 60)
+  } else {
+    # A shard runs for hours, and "217 min left" is a number the reader has to
+    # divide before it means anything.
+    sprintf("%.1f h", seconds / 3600)
   }
 }
 


### PR DESCRIPTION
Prepared with Claude Code. Stacked on #2834, as requested, so the run in flight there is not disturbed.

## Why packages were "newly broken" with identical counts — confirmed

Shard 9 of run 31879790285 finished while I was working on this, so this is now data rather than a hypothesis. My first explanation in this PR — that the error text quoted a path — was **wrong**, and I have corrected it. `compare_checks()` hashes only the *first line* of each issue, with timings stripped, so a path further down could never have mattered.

The manifest is unambiguous:

| package | result | old | new | baseline reused |
| --- | --- | --- | --- | --- |
| rphylopic | newly_broken | 1E 0W 0N | 1E 0W 0N | yes |
| HospitalNetwork | newly_broken | 1E 0W 0N | 1E 0W 0N | yes |
| orthGS | newly_broken | 1E 0W 0N | 1E 0W 0N | yes |
| (8 others) | ok | | | **no** |

Every false positive had a reused baseline standing in for the old half. Every package that ran a fresh old check was `ok`.

The cause is that the two halves were parsed by two different parsers. A baseline from an earlier run was produced by `rcmdcheck::rcmdcheck()`, which parses the *stream* as `R CMD check` writes it. This run's half is `parse_check()` on the finished `00check.log`, where R has gone back and appended the status to the line it opened. The same failing test renders two ways:

```
old.rds (baseline, streamed)     new.rds (parse_check of the log)
checking tests ...               checking tests ... ERROR
  Running 'testthat.R'             Running 'testthat.R'
 ERROR                           Running the tests in ... failed.
```

Hash `81f6423…` against `23e57fe…`, so the new one matches nothing in the old, so `change == 1`, so `newly_broken`. And the clincher: their `00check.diff` is **eight lines, all of it the log directory**. The logs agree; only the objects disagree.

**Always running both halves is the fix**, and it is the change this PR opened with. With the pair concurrent the old check costs no wall clock, so substituting a baseline bought nothing and cost comparability. The baseline is still read as a second opinion — when it disagrees with the old check just run, the shard says so and records `baseline_agrees` in the manifest.

## Reading a shard while it runs

```
protti: ok (old 0E 0W 0N, new 0E 0W 0N, 1072s for the pair, 1/51, ~5.0 h left)
```

The count says where the shard is; the estimate answers the question actually being asked. The plan already priced every package — what it could not know is how this runner compares to its model, so the remaining packages are priced in the plan's own units and rescaled by how its estimates have held up *in this shard so far*. That absorbs both a slow runner and a systematically optimistic model without either having to be known in advance. On a 51-package shard planned at 10 min each that really takes 6, the opening 8.5 h becomes 5.0 h after the first pair and stays there. `format_duration()` grows an hours tier, because "217 min left" is a number you have to divide before it means anything.

## The diff is printed into the job log

For every package that is not ok, the unified diff of the two logs goes into the job log under a foldable `::group::` heading, bounded by `REVDEP2_DIFF_MAX_LINES` (200); the whole diff stays in the artifact as `00check.diff`.

**And yes, the timings would have wrecked it.** Measured on a pair run against the *same* igraph on both sides, whose logs differed in exactly two lines:

```
-* using log directory '.../work/old/rphylopic.Rcheck'
+* using log directory '.../work/new/rphylopic.Rcheck'
-* checking R code for possible problems ... [14s/12s] OK
+* checking R code for possible problems ... [13s/11s] OK
```

`--as-cran` sets `_R_CHECK_TIMINGS_`, so every stage over ten seconds prints its own `[user/elapsed]` pair, and two checks racing for the same four cores never agree on those. On a large package that is a dozen lines of noise, and it is exactly the lines you would be reading. `neutral_log()` now removes the timings along with the paths, and the same neutralised text is what gets parsed and what gets diffed — those two logs then diff in **zero** lines. Verified both ways:

```
::group::rphylopic: old vs new check log (0 line diff)
The two logs are identical apart from paths and stage timings.
::endgroup::

::group::rphylopic: old vs new check log (11 line diff)
--- old
+++ new
@@ -74,7 +74,7 @@
 * checking for unstated dependencies in 'tests' ... OK
-* checking tests ... OK
+* checking tests ... [] ERROR
   Running 'test-all.R'
::endgroup::
```

## Why a package broke, without downloading anything

Three blocks in the job summary now, each with its own budget rather than sharing one: the check log, **`00install.out`**, and the **`.Rout.fail` transcript**. The check log only ever pointed at `00install.out`, which meant fetching the artifact to read a compiler error. `REVDEP2_DETAIL_MAX_LINES` (300) bounds the two transcripts.

`_R_CHECK_TESTS_NLINES_=0` also widens the check log's own copy of a failed test from R's default 13 lines to the complete output — confirmed locally, `Last 13 lines of output:` becomes `Complete output:`. Thirteen routinely cuts off the failure itself, which is both what a reader wants and the part the old/new diff has to see to be worth printing.

## Spelling, and `NOT_CRAN`

R's own spelling stage lives inside `check_CRAN_incoming()`, which `_R_CHECK_CRAN_INCOMING_: false` already suppressed; `_R_CHECK_CRAN_INCOMING_USE_ASPELL_: false` now says so out loud so `--as-cran` cannot turn it back on. Spelling cannot say anything about igraph anyway — a misspelling in a revdep is the same misspelling in both halves, so it cancels out of every comparison this workflow makes.

A package's *own* `tests/spelling.R` is a different thing, and it runs only because `r-lib/actions/setup-r` sets `NOT_CRAN=true`. That is now a workflow input, **defaulting to `false`**: the shards behave like CRAN's own check machines, because this workflow exists to find what a released igraph would break, and a test CRAN never runs cannot break on CRAN. It does also skip every other `skip_on_cran()` test, which is a real reduction in what is exercised — hence an input rather than a constant. Dispatch with `not-cran: true` to widen the net again. It is written in a step rather than the job's `env` because `setup-r` writes its own value into `$GITHUB_ENV`, and a later write is what reliably overrides an earlier one.

## `\donttest` examples are no longer run

`--as-cran` turns on `--run-donttest`. That is the most expensive thing a check does and the least useful thing here: `\donttest{}` is where packages put the examples too slow to run on CRAN, so it is where the runners spend their hours and where the timeouts land — varPro's old half was killed at 1200 s in `checking examples with --run-donttest`. `_R_CHECK_DONTTEST_EXAMPLES_=false` turns it back off. `\dontrun{}` was already off and stays off.

This also answers "is the timeout too conservative" from the other end: CRAN checks varPro in 104 s, so 1200 s was 11× the expected cost, never a marginal budget. The gap was work CRAN does not do, not a floor set too low.

## `Install packages` is its own step

The refactor I deferred last time. The install is minutes to an hour and the checks are hours, and as one step Actions could only report their sum — so "shard 14 took five hours" said nothing about which half it spent them in, and the install times vary a lot between shards.

One driver, called twice with `PHASE=install` and `PHASE=check`. The install leaves the libraries and an `install-state.json` of what it cost behind; the check phase picks both up and repeats nothing. `PHASE=all` still runs the whole shard in one process, which is what a local invocation wants. The runner directories move to a `$GITHUB_ENV` step, because the `runner` context does not reach a job's `env` — setting them at job level would have silently emptied them.

Verified end to end locally against a real one-package plan: both phases run, `install-state.json` round-trips, and the install timings reach `timing.json` through the split. That run also turned up `t_new` being null for every package that compared — it was recorded only on the path where the comparison *failed* — which is fixed here too.

## Per-line elapsed stamps

`R CMD check` reports a stage's own time only when it crosses a threshold, and never for the stage it was killed in — the one you actually want. Every line of `driver.log` now carries its elapsed seconds:

```
   11s  * checking foreign function calls ... OK
    8s  * checking for sufficient/correct file permissions ... OK
    4s  * checking tests ...
```

`EPOCHSECONDS` is a bash builtin, so this spawns nothing per line. `PIPESTATUS[0]` still carries `timeout`'s exit 124 through the added pipe. Confirmed working in the real shard.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1xpHRV7yVfgtJg4vp9P7z)_