### PR TITLE
fix(ci): Repair what the phase split broke, and what a full review found

### DIFF
--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -24,9 +24,10 @@
 # still runs over the whole set afterwards, because CRAN moves between runs
 # and what changed has to be built after all.
 #
-# Each test shard installs its dependency union, checks every one of its
-# packages against the CRAN version (or reuses a baseline), swaps in the dev
-# binary, checks again, and compares -- revdepcheck-style, one manifest line
+# Each test shard installs its dependency union, then checks every one of its
+# packages against the CRAN version and the dev version at the same time --
+# two `R CMD check` runs side by side against library stacks differing in that
+# one package -- and compares the pair, revdepcheck-style, one manifest line
 # and a pair of rcmdcheck results per package. A broken package is a result,
 # never a job failure; the shard defers what its deadline cannot fit and says
 # so.
@@ -766,6 +767,7 @@ jobs:
           path: ${{ runner.temp }}/retry-report
 
       - name: Collect results
+        id: collect
         env:
           # To read how long the shard *jobs* took -- the minutes before their
           # driver starts, which is what an extra shard really costs.
@@ -806,8 +808,17 @@ jobs:
       # results, so its report is every package `missing`. Run 31303054725 was
       # cancelled and pushed 104k lines of that onto the branch it was testing.
       # A run with red shards is a different thing and still reports.
+      #
+      # `compared > 0` covers the rest of that family: a run in which *no*
+      # package produced a comparison learnt nothing, and the committed report
+      # is the repository's record and what `packages: broken` reads back. The
+      # report is still built and uploaded; only overwriting the good one is
+      # skipped.
       - name: Commit the report to the checked ref
-        if: '!cancelled() && vars.REVDEP2_COMMIT_REPORT != ''false'''
+        if: >-
+          !cancelled()
+          && vars.REVDEP2_COMMIT_REPORT != 'false'
+          && steps.collect.outputs.compared != '0'
         continue-on-error: true
         env:
           REF_INPUT: ${{ inputs.ref }}

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -45,7 +45,6 @@ test      (one job per shard, max-parallel throttled, fail-fast: false)
   │    └─ build two one-package libraries: CRAN release, dev binary
   └─ "Check the shard" step (PHASE=check)
        ├─ per package, both checks at once against those cascading libraries
-       │    (a reusable baseline stands in for the old half)
        └─ results + manifest.ndjson → revdep2-results-<shard>-<attempt>
 
 collect   (1 job, if: always() past plan/build/preflight)
@@ -109,20 +108,24 @@ this one
 (0.47 in the first calibrated run: these runners check faster than CRAN
 reports).
 Packages CRAN has no timing for either get the cohort median.
-Every package is checked twice, so every package weighs double,
-plus a small fixed overhead.
+Every package is checked twice, but the two run at once,
+so a package weighs one pair of checks plus a small fixed overhead.
 
 That used to be conditional —
 a package *without* a reusable baseline weighed double,
 one with a baseline weighed single, because the baseline stood in for its old
-check. Now that both halves always run, that condition is simply wrong,
-and wrong in the direction that under-fills whichever shards hold
-the most reusable packages. In run 31879790285 that would have been
-909 packages out of 1011, priced at half of what they cost.
-The factor of two is nominal in any case:
-`check_scale` is fitted from what the last runs measured,
-so what a pair is really worth in wall clock is absorbed there.
-What matters is that every package is priced the same way.
+check. Now that both halves always run, the condition is gone.
+So is the doubling, and that part is easy to get backwards:
+the two halves run *concurrently*,
+so a package costs the shard the wall clock of the slower one,
+not the sum of both.
+`check_scale` is fitted from exactly that quantity —
+`t_old` and `t_new` are both recorded as the pair's wall clock,
+and the calibration fits `median(seconds / T_total)` from them —
+so the weight already *is* the pair.
+Multiplying by two would price every shard at twice its wall clock,
+which buys twice the shards, each paying its own setup,
+and defers packages at the deadline that would have fit.
 
 The per-check timeout stays on CRAN's number and is not calibrated:
 `max(REVDEP2_TIMEOUT_MIN_MINUTES, REVDEP2_TIMEOUT_FACTOR × T_total)`.
@@ -635,7 +638,8 @@ the report is about *results*, a retry is about *coverage*.
 | A revdep breaks under the dev version | `newly_broken` in manifest and report; the run stays green |
 | The checked ref is a tag or a SHA | the report is not committed; a `::notice::` says so and the artifact still has it |
 | The report cannot be pushed (protection, fork, race) | the step is `continue-on-error`; the run keeps its result |
-| A revdep fails under both versions | `ok` (no *new* problems), visible in the report's tables |
+| A revdep fails the same way under both versions | `ok` (no *new* problems), visible in the report's tables |
+| A revdep fails to *install* under both versions | `failed` — there is nothing to compare |
 | A check times out | `timeout` kills it at `max(floor, factor × its CRAN time)`; reported `timeout`, not `failed`, with the check step it died at |
 | A revdep's strong dependencies cannot install | `depfail`, check not attempted, named in the shard summary |
 | A dependency fails the preflight | reported in the preflight summary and `depfail.json`; shards still try their own subset |
@@ -905,7 +909,9 @@ That is worth two things.
 A package's wall clock halves, on a four-core runner
 where one check keeps about one core busy.
 And a package whose old check hangs still gets its new answer,
-where before the old timeout meant the run learnt nothing about it at all.
+where before the old timeout meant the run learnt nothing about it at all —
+the half that finished is saved, with its own check output,
+even though there is no verdict to draw from one side.
 
 The timeout is coreutils' `timeout` rather than rcmdcheck's,
 which makes the distinction reliable:

--- a/.github/workflows/revdep2/collect.R
+++ b/.github/workflows/revdep2/collect.R
@@ -145,7 +145,9 @@ for (shard in plan$shards %||% list()) {
       t_total = p$t_total %||% 0,
       dep_fingerprint = p$dep_fingerprint,
       baseline_planned = isTRUE(p$baseline),
-      baseline_reused = FALSE,
+      # Matches the shard's own entry shape; `baseline_reused` was dropped when
+      # both halves became mandatory, and nothing sets it any more.
+      baseline_agrees = NA,
       result = "missing",
       status = "",
       status_old = "",
@@ -431,6 +433,25 @@ if (has_revdepcheck) {
 tally <- function(what) sum(results_tbl == what)
 not_ok <- sum(results_tbl != "ok")
 
+# Whether this report is worth writing over the committed one.
+#
+# The report in `revdep/` is the repository's record, and `packages: broken`
+# reads it back to decide what to re-check. A run in which nothing produced a
+# comparison -- every shard dead, every package `missing`, a bad plan, a driver
+# bug that turned the whole set into `depfail` -- would replace that record with
+# a list of things it never learnt anything about, and there is no way back to
+# it. So the run says out loud whether it compared anything at all, and the
+# workflow gates the commit on that; the artifact is uploaded either way, so
+# nothing is hidden, only the destructive step is skipped.
+compared <- tally("ok") + tally("newly_broken")
+set_output("compared", compared)
+if (compared == 0) {
+  inform(
+    "No package produced a comparison; the report is written and uploaded, ",
+    "but the committed one is left alone"
+  )
+}
+
 # The one sentence a reader needs, before any table.
 headline <- if (tally("newly_broken") > 0) {
   sprintf(
@@ -521,8 +542,11 @@ readme <- drop_section(readme, "^## Failed to check")
 # own URL, where `problems.md#pkg` resolves to /actions/runs/problems.md and
 # 404s. The package's CRAN page is the reachable equivalent; where the details
 # actually live is said once, below.
+# Only where the link text is a package name -- the anchor form revdepcheck
+# emits for a package. A bare `[failures.md](failures.md)` is a link to the
+# report's own file, and rewriting it to `package=failures.md` was nonsense.
 readme <- gsub(
-  "\\[([^][]+)\\]\\([^)]*[.]md(#[^)]*)?\\)",
+  "\\[([a-zA-Z][a-zA-Z0-9.]*)\\]\\([^)]*[.]md(#[^)]*)?\\)",
   "[\\1](https://cran.r-project.org/package=\\1)",
   readme
 )
@@ -581,9 +605,11 @@ append_summary(c(
     # From the package rows, not the shard rows: a shard whose job died leaves
     # no timing of its own, but the checks it did finish are still in the
     # manifest the collector just merged.
+    # `seconds` is the pair's wall clock, not one half's, so it is not
+    # multiplied by `checks` -- the two ran at the same time.
     check_minutes <- sum(vapply(
       package_rows,
-      function(p) p$seconds * p$checks / 60,
+      function(p) p$seconds / 60,
       numeric(1)
     ))
     job <- vapply(

--- a/.github/workflows/revdep2/plan.R
+++ b/.github/workflows/revdep2/plan.R
@@ -791,22 +791,22 @@ inform(
   " check times measured by an earlier run"
 )
 
-# Weight: every package is checked twice, whether or not a baseline could have
-# been reused.
+# Weight: what one package costs the shard in wall clock, which is one *pair*
+# of checks.
 #
-# It used to be `((!reuse) + 1) *`: a reusable baseline stood in for the old
-# check, so that package cost one check instead of two. It does not any more.
-# The two halves run concurrently against cascading libraries, so the old check
-# costs no wall clock worth saving, and a baseline is a result from another
-# machine and another CRAN snapshot -- in run 31879790285 that mismatch
-# accounted for 76 of the 78 `newly_broken` packages. Both halves always run
-# now, so pricing the reused ones at half is simply wrong, and wrong in a way
-# that under-fills exactly the shards holding the most of them.
-#
-# The factor of two is nominal: `check_scale` is fitted from what the last runs
-# measured, so whatever it is really worth in wall clock is absorbed there. What
-# matters here is that every package is priced the same way.
-weight <- 2 * check_seconds / 60 + overhead_minutes
+# This used to be `((!reuse) + 1) *`: a reusable baseline stood in for the old
+# check, so such a package cost one check and everything else cost two. Both
+# halves always run now, so the condition is gone -- but so is the factor of
+# two, and that part is easy to get backwards. The two halves run
+# *concurrently*, so a package costs the shard the wall clock of the slower
+# one, not the sum. And `check_scale` is fitted from exactly that quantity:
+# `collect.R` records `t_old` and `t_new` as the pair's wall clock and
+# `calibration()` fits `median(seconds / T_total)` from it, so
+# `check_seconds` already *is* the pair. Multiplying by two here would price
+# every shard at twice its wall clock -- which buys twice the shards, each
+# paying its own setup, and defers packages at the deadline that would have
+# fit.
+weight <- check_seconds / 60 + overhead_minutes
 
 # ------------------------------------------------------------- partitioning --
 

--- a/.github/workflows/revdep2/preflight.R
+++ b/.github/workflows/revdep2/preflight.R
@@ -80,6 +80,27 @@ chunk_size <- env_num("REVDEP2_INSTALL_CHUNK", 100)
 # instead of dying with the job.
 install_deadline <- Sys.time() +
   env_num("REVDEP2_INSTALL_DEADLINE_MINUTES", 210) * 60
+# And a deadline for the whole job, because stopping the *installs* early only
+# helps if what follows them is bounded too. After `install_deadline` come the
+# sysreqs survey, some seventy load batches at up to `REVDEP2_LOAD_TIMEOUT_
+# MINUTES` each, a per-package retry of every failure, and a rebuild loop of
+# up to `REVDEP2_INSTALL_TIMEOUT_MINUTES` per stale binary -- whose worst case
+# is far past the job's own `timeout-minutes: 300`. Reaching that means the
+# library is never packed and `revdep2-lib` is never uploaded, so every shard
+# rebuilds from scratch: the one outcome this job exists to prevent.
+job_deadline <- Sys.time() +
+  env_num("REVDEP2_JOB_DEADLINE_MINUTES", 270) * 60
+out_of_time <- function(what) {
+  if (Sys.time() <= job_deadline) {
+    return(FALSE)
+  }
+  inform(
+    "Past the job deadline; ",
+    what,
+    " stops here so the library is packed"
+  )
+  TRUE
+}
 chunks <- install_chunks(install_union, cran_db(), chunk_size)
 inform(
   "Preflight: installing ",
@@ -218,11 +239,17 @@ load_batch <- function(pkgs) {
 load_failures <- list()
 chunks <- split(installed, ceiling(seq_along(installed) / 40))
 for (chunk in chunks) {
+  if (out_of_time("the load test")) {
+    break
+  }
   first <- load_batch(chunk)
   if (length(first$failed) == 0) {
     next
   }
   for (p in first$failed) {
+    if (out_of_time("the load test")) {
+      break
+    }
     single <- load_batch(p)
     if (length(single$failed) > 0) {
       load_failures[[p]] <- if (isTRUE(single$timed_out)) {

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -8,8 +8,11 @@
 # The shard installs the union of its packages' dependencies once, then checks
 # each of its packages against both versions of the package under test at the
 # same time: two `R CMD check` runs side by side, against library stacks that
-# differ in exactly that one package (a reusable baseline stands in for the
-# old half). The two results are compared per package, revdepcheck-style.
+# differ in exactly that one package. Both halves always run -- a reusable
+# baseline used to stand in for the old one, and comparing against another
+# run's machine and CRAN snapshot is what made 76 of run 31879790285's 78
+# `newly_broken` verdicts false. The two results are compared per package,
+# revdepcheck-style.
 #
 # Failure is data here, never a job failure: a package that breaks, times out,
 # or cannot even install its dependencies gets a manifest entry saying so, and
@@ -43,7 +46,7 @@
 #   TIMEOUT_FACTOR         - per-check timeout as a multiple of the package's
 #                            CRAN check time (default: 1.5)
 #   TIMEOUT_MIN_MINUTES    - floor for that timeout; CRAN's machines are not
-#                            these runners (default: 10)
+#                            these runners (default: 20 in the workflow)
 #   DEADLINE_MINUTES       - stop starting new checks past this (default: 300)
 #   PHASE                  - "install", "check", or "all" (default): which half
 #                            of the shard this invocation runs
@@ -70,7 +73,18 @@ timeout_factor <- env_num("TIMEOUT_FACTOR", 1.5)
 timeout_min_sec <- env_num("TIMEOUT_MIN_MINUTES", 10) * 60
 deadline <- Sys.time() + env_num("DEADLINE_MINUTES", 300) * 60
 
-shard <- Filter(function(s) s$index == shard_index, plan$shards)[[1]]
+mine <- Filter(function(s) s$index == shard_index, plan$shards)
+if (length(mine) == 0) {
+  stop(
+    "Plan has no shard ",
+    shard_index,
+    " (it has ",
+    length(plan$shards),
+    "); the plan and the matrix disagree",
+    call. = FALSE
+  )
+}
+shard <- mine[[1]]
 members <- vapply(shard$packages, function(p) p$name, character(1))
 meta <- read_json(file.path(pkg_dir, "meta.json"))
 package <- plan$package
@@ -321,7 +335,12 @@ if (do_install) {
       restore_seconds = restore_seconds,
       install_seconds = install_seconds,
       our_cran_version = our_cran_version,
-      our_dev_version = our_dev_version
+      our_dev_version = our_dev_version,
+      # When the shard's clock started, and what the install phase spent of it.
+      # Both matter to the phase that follows: it has to finish inside the same
+      # job, and its own `script_seconds` is no longer the whole driver.
+      started_at = format(script_started, "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+      phase_seconds = elapsed(script_started)
     ),
     install_state
   )
@@ -343,9 +362,63 @@ if (!file.exists(install_state)) {
 installed_state <- read_json(install_state)
 our_cran_version <- installed_state$our_cran_version
 our_dev_version <- installed_state$our_dev_version
+
+# The deadline belongs to the *shard*, not to this process.
+#
+# `deadline` was computed at the top of the script, so the check phase gave
+# itself a fresh 300 minutes on top of whatever the install phase had already
+# spent -- and the job's own `timeout-minutes: 350` covers their sum. A shard
+# with a 50-minute install could then be killed mid-check by Actions instead of
+# stopping itself and deferring, which is the one thing the deadline exists to
+# prevent. Rebased on when the install phase started.
+shard_started <- tryCatch(
+  as.POSIXct(
+    installed_state$started_at,
+    format = "%Y-%m-%dT%H:%M:%SZ",
+    tz = "UTC"
+  ),
+  error = function(e) NA
+)
+if (!is.na(shard_started)) {
+  deadline <- shard_started + env_num("DEADLINE_MINUTES", 300) * 60
+  inform(sprintf(
+    "Install phase took %s; %s of the shard's deadline left for checks",
+    format_duration(installed_state$phase_seconds %||% 0),
+    format_duration(max(0, as.numeric(deadline - Sys.time(), units = "secs")))
+  ))
+}
 invisible(file.create(manifest_path))
 
-installed <- rownames(utils::installed.packages())
+# What a check will be able to load, which is not the same as what is in the
+# shared library: the package under test is deliberately *not* there. It is
+# unlinked at the end of the install phase so that neither half's cascading
+# library is shadowed by it, and it lives in `lib-old` and `lib-new` instead --
+# neither of which is on this process's `.libPaths()`, because only
+# `check-pair.sh` puts them on `R_LIBS`.
+#
+# Asking the bare `installed.packages()` therefore reports the package under
+# test as missing, and `strong_missing()` below then reports it missing for
+# every revdep that depends on it strongly -- which is every revdep, under
+# `which: strong`. The whole shard would come back `depfail` having checked
+# nothing. Before the install and check phases were split this line ran while
+# the package was still in the shared library, so the question never arose.
+installed <- rownames(utils::installed.packages(
+  lib.loc = c(.libPaths(), lib_old)
+))
+
+# One manifest line, appended as soon as the package has one.
+reported <- character()
+write_manifest_line <- function(entry) {
+  entry$our_cran_version <- our_cran_version
+  entry$our_dev_version <- our_dev_version
+  cat(
+    jsonlite::toJSON(entry, auto_unbox = TRUE, null = "null"),
+    "\n",
+    sep = "",
+    file = manifest_path,
+    append = TRUE
+  )
+}
 inform(sprintf(
   "Checking old (%s) and new (%s) concurrently, two at a time per package",
   our_cran_version,
@@ -537,17 +610,24 @@ check_pair <- function(name) {
     ))
   )
   duration <- round(as.numeric(Sys.time() - started, units = "secs"))
-  # Both checks ran side by side, so the pair cost what the slower one cost --
-  # but each half is still charged, because that is the work the cost model
-  # measures and the shard's own deadline spends.
-  check_seconds <<- check_seconds + 2 * duration
+  # Both checks ran side by side, so the pair cost what the slower one cost,
+  # and that -- not the sum of the two -- is what the shard's deadline spends
+  # and what the cost model is fitted against.
+  check_seconds <<- check_seconds + duration
 
   read_side <- function(phase) {
     dir <- file.path(work_dir, phase)
-    status <- suppressWarnings(as.integer(readLines(
-      file.path(dir, "status"),
-      warn = FALSE
-    )[[1]]))
+    # A pair that never wrote its status -- an unwritable work directory, a
+    # full disk, `check-pair.sh` dying before its last line -- used to throw
+    # "subscript out of bounds" out of the whole loop. It is one package's
+    # problem, so it reads as one.
+    status <- tryCatch(
+      suppressWarnings(as.integer(readLines(
+        file.path(dir, "status"),
+        warn = FALSE
+      )[[1]])),
+      error = function(e) NA_integer_
+    )
     log <- file.path(dir, paste0(name, ".Rcheck"), "00check.log")
     result <- if (identical(status, 124L)) {
       simpleError(sprintf(
@@ -557,7 +637,24 @@ check_pair <- function(name) {
       ))
     } else {
       tryCatch(
-        rcmdcheck::parse_check(text = neutral_log(log, name)),
+        {
+          # Parsed twice, on purpose. `parse_check()` reads `00install.out`
+          # and the test transcripts off the check directory it finds named in
+          # the log's first line -- so parsing the *neutralised* text alone,
+          # where that path has been replaced by a constant, silently leaves
+          # `install_out` at "<00install.out file does not exist>" and
+          # `test_fail` empty, and revdepcheck's failures.md loses exactly the
+          # output a reader opens it for. So the real file gives the object,
+          # and the neutralised text gives only the three fields that are
+          # compared and diffed, where the paths and stage timings would
+          # otherwise make two identical halves look different.
+          res <- rcmdcheck::parse_check(log)
+          neutral <- rcmdcheck::parse_check(text = neutral_log(log, name))
+          res$errors <- neutral$errors
+          res$warnings <- neutral$warnings
+          res$notes <- neutral$notes
+          res
+        },
         error = function(e) {
           simpleError(sprintf(
             "%s check produced no readable result (exit %s): %s",
@@ -583,6 +680,57 @@ check_pair <- function(name) {
   }
 
   list(old = read_side("old"), new = read_side("new"))
+}
+
+# Record the half that did produce a result, when its partner did not.
+#
+# There is nothing to compare, so there is no verdict -- but the check ran, and
+# what it found is the only thing anyone will have to go on when they come back
+# to the package. Kept where the comparison path keeps it, so `retry-run` and a
+# human reading the artifact find it in the usual place.
+keep_side <- function(name, phase, result) {
+  saveRDS(result, file.path(pkg_out(name), paste0(phase, ".rds")))
+  if (identical(phase, "old")) {
+    update(
+      name,
+      status_old = counts(result),
+      t_old = attr(result, "duration"),
+      old_checked_at = now_utc()
+    )
+  } else {
+    update(
+      name,
+      status_new = counts(result),
+      t_new = attr(result, "duration")
+    )
+  }
+  copy_check_output(
+    file.path(work, "check", name, phase, paste0(name, ".Rcheck")),
+    file.path(out_dir, "pkgs", name, paste0(phase, "-check"))
+  )
+}
+
+# The files worth carrying out of a check directory: what broke, and the
+# complete transcripts of the two stages that explain why.
+copy_check_output <- function(rcheck, keep) {
+  dir.create(keep, recursive = TRUE, showWarnings = FALSE)
+  for (f in c(
+    "00check.log",
+    "00install.out",
+    list.files(
+      rcheck,
+      pattern = "[.]Rout[.]fail$|-Ex[.]Rout$",
+      recursive = TRUE
+    )
+  )) {
+    if (file.exists(file.path(rcheck, f))) {
+      file.copy(
+        file.path(rcheck, f),
+        file.path(keep, basename(f)),
+        overwrite = TRUE
+      )
+    }
+  }
 }
 
 check_failure <- function(name, phase, result, progress) {
@@ -688,13 +836,14 @@ progress_note <- function(position) {
   )
 }
 
-for (position in seq_along(runnable)) {
-  name <- runnable[[position]]
+# One package: both halves, compared, recorded. Returns nothing; everything it
+# learns goes into `state`, and the caller writes that out however this ends.
+check_package <- function(name, position) {
   entry <- get(name, envir = state)
 
   if (out_of_time(entry)) {
     inform(name, ": deferred (deadline), ", progress_note(position))
-    next
+    return(invisible(NULL))
   }
 
   # Both halves, always. A baseline used to stand in for the old check and
@@ -710,13 +859,28 @@ for (position in seq_along(runnable)) {
 
   # What this one was priced at against what it cost, which is what prices the
   # rest. A timed-out check counts too: the clock really did spend it.
-  planned_done <- planned_done + planned_minutes(name)
-  actual_done <- actual_done + (attr(new, "duration") %||% 0) / 60
+  planned_done <<- planned_done + planned_minutes(name)
+  actual_done <<- actual_done + (attr(new, "duration") %||% 0) / 60
   progress <- progress_note(position)
 
+  # A half that produced a result is kept even when its partner did not.
+  #
+  # Running the pair concurrently was supposed to mean that "a package whose
+  # old check hangs still gets its new answer" -- but the old half's error used
+  # to `next` straight past the code that saves the new one, so the answer was
+  # produced and then thrown away, and the artifact held nothing at all for
+  # that package. 19 packages in run 31879790285 lost a half this way.
+  if (inherits(new, "error")) {
+    if (!inherits(old, "error")) {
+      keep_side(name, "old", old)
+    }
+    check_failure(name, "new", new, progress)
+    return(invisible(NULL))
+  }
   if (inherits(old, "error")) {
+    keep_side(name, "new", new)
     check_failure(name, "old", old, progress)
-    next
+    return(invisible(NULL))
   }
   saveRDS(old, file.path(pkg_out(name), "old.rds"))
   update(
@@ -741,10 +905,6 @@ for (position in seq_along(runnable)) {
         ))
       }
     }
-  }
-  if (inherits(new, "error")) {
-    check_failure(name, "new", new, progress)
-    next
   }
   saveRDS(new, file.path(pkg_out(name), "new.rds"))
 
@@ -803,29 +963,10 @@ for (position in seq_along(runnable)) {
     unlink(file.path(work, "check", name), recursive = TRUE)
   } else {
     keep <- file.path(out_dir, "pkgs", name, "new-check")
-    dir.create(keep, recursive = TRUE, showWarnings = FALSE)
     rcheck <- function(phase) {
       file.path(work, "check", name, phase, paste0(name, ".Rcheck"))
     }
-    # The complete transcripts, so that bounding what goes into the check log
-    # never costs anything. R writes `<file>.Rout.fail` for a test file that
-    # failed and `<pkg>-Ex.Rout` for the examples -- the second one is not a
-    # `.fail` file and so used to be dropped, which left an examples failure
-    # (13 of run 31879790285's 19 timeouts, and both of its genuine
-    # regressions) with nothing to read but the check log's own excerpt.
-    for (f in c(
-      "00check.log",
-      "00install.out",
-      list.files(
-        rcheck("new"),
-        pattern = "[.]Rout[.]fail$|-Ex[.]Rout$",
-        recursive = TRUE
-      )
-    )) {
-      if (file.exists(file.path(rcheck("new"), f))) {
-        file.copy(file.path(rcheck("new"), f), file.path(keep, basename(f)))
-      }
-    }
+    copy_check_output(rcheck("new"), keep)
     old_log <- file.path(rcheck("old"), "00check.log")
     new_log <- file.path(rcheck("new"), "00check.log")
     if (file.exists(old_log) && file.exists(new_log)) {
@@ -858,23 +999,50 @@ for (position in seq_along(runnable)) {
     }
     unlink(file.path(work, "check", name), recursive = TRUE)
   }
+  invisible(NULL)
+}
+
+for (position in seq_along(runnable)) {
+  name <- runnable[[position]]
+  # A driver error is this package's problem, not the shard's. Before, an
+  # unguarded `readLines(.../status)[[1]]` on a check-pair that never wrote its
+  # status file -- a full disk, an unwritable work directory -- threw out of
+  # the loop and took every remaining package with it.
+  tryCatch(
+    check_package(name, position),
+    error = function(e) {
+      update(
+        name,
+        result = "error",
+        message = paste("driver error:", conditionMessage(e))
+      )
+      inform(name, ": driver error: ", conditionMessage(e))
+    }
+  )
+
+  # This package's line, now rather than at the end of the shard.
+  #
+  # The file is newline-delimited JSON precisely so that it can be appended to,
+  # but it used to be written in one pass after the loop -- so a shard killed
+  # by the job timeout, or thrown out of the loop by an unhandled error, left
+  # an *empty* manifest next to a full set of results, and `collect.R` skips a
+  # directory whose manifest has no lines. Hours of finished checks were one
+  # kill away from being reported as `missing`. Deferred and unreached packages
+  # are appended at the end, and the collector reconciles the rest against the
+  # plan.
+  write_manifest_line(get(name, envir = state))
+  reported <- c(reported, name)
 }
 
 
 # ---------------------------------------------------------------- manifest ---
 
-entries <- lapply(members, function(name) get(name, envir = state))
-for (entry in entries) {
-  entry$our_cran_version <- our_cran_version
-  entry$our_dev_version <- our_dev_version
-  cat(
-    jsonlite::toJSON(entry, auto_unbox = TRUE, null = "null"),
-    "\n",
-    sep = "",
-    file = manifest_path,
-    append = TRUE
-  )
+# Whatever the loop never reached: deferred packages, and the ones a depfail or
+# a missing source knocked out before it started.
+for (name in setdiff(members, reported)) {
+  write_manifest_line(get(name, envir = state))
 }
+entries <- lapply(members, function(name) get(name, envir = state))
 
 # ----------------------------------------------------------------- timings ---
 
@@ -893,10 +1061,18 @@ write_json(
     restore_seconds = installed_state$restore_seconds,
     install_seconds = installed_state$install_seconds,
     check_seconds = round(check_seconds, 1),
-    # The install phase is its own step now, so this is the check phase's own
-    # wall clock; the two together are what the shard job cost.
-    script_seconds = elapsed(script_started),
-    started_at = format(script_started, "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
+    # Both phases, because the collector fits `setup_minutes` as
+    # `job_minutes - script_minutes` -- the minutes before the driver starts.
+    # Reporting only this process would have charged the whole install phase to
+    # "setup", which the plan then seeds every shard's load with *and* prices
+    # again per dependency, and a setup of tens of minutes instead of six is
+    # what tips a plan into extra waves.
+    script_seconds = round(
+      (installed_state$phase_seconds %||% 0) + elapsed(script_started),
+      1
+    ),
+    started_at = installed_state$started_at %||%
+      format(script_started, "%Y-%m-%dT%H:%M:%SZ", tz = "UTC"),
     finished_at = now_utc(),
     planned_minutes = shard$estimate_minutes,
     planned_check_minutes = shard$check_minutes
@@ -913,10 +1089,22 @@ df <- data.frame(
   Result = results,
   Old = vapply(entries, function(e) e$status_old, character(1)),
   New = vapply(entries, function(e) e$status_new, character(1)),
-  Baseline = ifelse(
-    vapply(entries, function(e) isTRUE(e$baseline_reused), logical(1)),
-    "reused",
-    ""
+  # `baseline_reused` stopped being set when both halves became mandatory, so
+  # this column was empty in every row. What the baseline is still good for is
+  # the drift check -- whether a result from an earlier run still reproduces --
+  # and that is what it says now.
+  Baseline = vapply(
+    entries,
+    function(e) {
+      if (isTRUE(e$baseline_agrees)) {
+        "agrees"
+      } else if (isFALSE(e$baseline_agrees)) {
+        "disagrees"
+      } else {
+        ""
+      }
+    },
+    character(1)
   )
 )
 append_summary(c(

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -245,14 +245,22 @@ gh_lines <- function(...) {
 }
 
 # The unexpired artifacts of one run, as a named character vector of ids;
-# empty when the run has none or when gh cannot say. One API call per run, so
-# a walk over the run history calls this once per run and asks it everything.
+# empty when the run has none or when gh cannot say.
+#
+# Paginated, because a single page is not enough and the ones that fall off it
+# are exactly the ones that matter. A run publishes one
+# `revdep2-results-<shard>-<attempt>` per shard -- up to 250 -- and uploads
+# `revdep2-baseline`, `revdep2-timings` and `revdep2-report` last of all. Ask
+# for one page of 100 and a run with a hundred shards hides its baseline behind
+# its results: reuse would silently stop and `retry-run` would fail outright,
+# both for a reason no log would name.
 run_artifacts <- function(run_id) {
   if (!gh_ok() || !nzchar(gh_repo())) {
     return(character())
   }
   out <- gh_lines(
     "api",
+    "--paginate",
     sprintf(
       "repos/%s/actions/runs/%s/artifacts?per_page=100",
       gh_repo(),


### PR DESCRIPTION
Prepared with Claude Code. Stacked on #2834, on top of the merged #2836.

A clean-context review of the whole of `revdep2` — the workflow, all six R scripts, both shell scripts and the README. **Run 31891439702 was dispatched against the merged code and I have cancelled it**: the install/check split that merged in #2836 had never actually run in CI, and it was broken in a way that would have reported every package in every shard as `depfail` having checked nothing.

## Critical: the shard deleted the package under test, then declared everything a depfail

The install phase unlinks igraph from the shared library so that neither half's cascading library is shadowed by it. `installed <- rownames(installed.packages())` used to run *before* that unlink. The phase split moved it into the check phase — i.e. after — and `lib-old`/`lib-new` are never on the driver's own `.libPaths()`, since only `check-pair.sh` puts them on `R_LIBS`.

So igraph read as not installed, and `strong_missing()` then reported it missing for every revdep that depends on it strongly — which, under `which: strong`, is all of them. `runnable` would have been empty, no check would have run, and the collector would have committed 1011 × `depfail` over the good report in `revdep/`.

Reproduced directly:

```
shared library holds 0 packages after the unlink
shard.R:348 as written  -> igraph in installed: FALSE
with lib_old on lib.loc -> igraph in installed: TRUE
```

Fixed by asking the question against the library stack the checks actually get. A local end-to-end against `roughnet` — a genuine strong revdep of igraph — now comes back `ok`, where before the fix it reported igraph missing.

## High

**A timed-out old half threw the good new half away.** The whole justification for running the pair concurrently is that "a package whose old check hangs still gets its new answer" — but the old half's error `next`ed straight past the code that saves the new one, so the artifact held nothing at all for that package. 19 packages in run 31879790285 lost a half this way. Whichever half produced a result is now kept, with its own check output.

**The manifest was written in one pass after the loop**, though the format is newline-delimited JSON precisely so it can be appended to. A shard killed by the job timeout left an *empty* manifest beside a full set of results, and `collect.R` skips a directory whose manifest has no lines — hours of finished checks reported as `missing`. Each package now writes its line as soon as it has one, and the per-package body runs under a `tryCatch`, so an unguarded `readLines(.../status)[[1]]` on a check-pair that died before writing its status is that package's problem rather than the rest of the shard's.

**The check phase restarted the shard's deadline**, giving itself a fresh 300 minutes on top of whatever the install had already spent — while the job's own `timeout-minutes: 350` covers their sum. A shard with a long install could be killed mid-check by Actions instead of stopping itself and deferring, which is the one thing the deadline exists to prevent. Rebased on when the install phase started, and it now says how much is left:

```
Install phase took 34 s; 59 min of the shard's deadline left for checks
```

**The install fallback loaded the entire dependency union into the driver.** `requireNamespace()` on 400–500 packages attaches hundreds of namespaces and DLLs, and past `R_MAX_NUM_DLLS` it starts returning `FALSE` for packages that *are* installed, so the loop reinstalls them. It is a filesystem question, and `missing_from()` already answers it — which is what the preflight uses.

## Medium

**`setup_minutes` absorbed the entire install phase.** `script_seconds` became the check phase only, while the collector fits setup as `job − script`. That constant seeds every shard's load in the next plan *and* is already double-counted against the per-dependency install price, so a setup of tens of minutes instead of six is what tips a plan into extra waves. Both phases are reported now.

**The cost model double-counted a concurrent pair** — my error in the previous PR. I removed the `reuse` conditionality but kept a factor of two; `check_scale` is fitted from `t_old` and `t_new`, *both of which are the pair's wall clock*, so the weight already was the pair. Doubling it buys twice the shards, each paying its own setup, and defers packages at the deadline that would have fit. One pair per package now, and `check_seconds` and the summary's check minutes stop doubling with it. Verified the three consumers agree: 110 s measured against 200 s on CRAN gives `check_scale` 0.55 and a weight of 2.33 min = 110 s + overhead.

**`neutral_log()` blinded `parse_check()`.** It reads `00install.out` and the test transcripts off the check directory named in the log's first line — which neutralisation replaces with a constant. So every `old.rds`/`new.rds` carried `install_out = "<00install.out file does not exist>"` and no test transcript, and revdepcheck's `failures.md` lost exactly what a reader opens it for. The real file gives the object; the neutralised text gives only the three fields that are compared and diffed. Measured: `install_out` kept, `test_fail` kept, error text still neutralised, hashes still stable.

**Artifact listing was one page of 100.** A run publishes one results artifact per shard (up to 250) and uploads `revdep2-baseline`, `revdep2-timings` and `revdep2-report` *last* — so past ~95 shards the baseline hides behind the results, reuse silently stops and `retry-run` fails outright, for a reason no log would name. Paginated.

**The preflight had no job deadline.** `install_deadline` stops the installs, but after it come the sysreqs survey, ~70 load batches at up to 10 minutes each, a per-package retry of every failure, and a rebuild loop — whose worst case is far past the job's own 300 minutes, at which point the library is never packed and `revdep2-lib` never uploaded, so every shard rebuilds from scratch.

**A run where every shard died still overwrote the committed report.** The commit is now gated on the run having compared at least one package. The report is still built and uploaded; only the destructive step is skipped.

**The `Baseline` column was dead** — `baseline_reused` stopped being set when both halves became mandatory, so it was empty in every row, while `baseline_agrees` (the signal that replaced it) was never surfaced. It reports that now.

## Low

`-Ex.Rout` copies could collide under `basename()` without `overwrite`; a missing shard index gave "subscript out of bounds" rather than a diagnosis; the README's claims about baseline substitution, the factor of two, and "a revdep fails under both versions → ok" (false for install failures, which are `failed`) are corrected; the `.md` link rewrite in the report no longer turns `[failures.md](failures.md)` into `package=failures.md`.

## Checked and found correct

Worth recording, since these are where a reviewer would reasonably look: no `runner` context in any job-level `env:`; the `$GITHUB_ENV` step runs after `setup-r` so its `NOT_CRAN` write wins; run ids are strings everywhere and never pass through `as.integer()`; no variable defined only under `if (do_install)` is read in the check phase; `check-pair.sh`'s `PIPESTATUS[0]`, process-group kill and `--kill-after` are all right; `collect.R`'s attempt precedence relies on `order()` being stable, which it is; the empty-vector paths (`progress_note()` at the last position, `install_chunks(character(0))`, `vapply(list(), …)`) all behave.

## Validation

Local end-to-end against a one-package plan with a real strong revdep, both phases, on the fully patched driver: `roughnet: ok (old 0E 0W 0N, new 0E 0W 0N, 10s for the pair, 1/1, last one)`, manifest written, `check_seconds` no longer doubled, `script_seconds` spanning both phases.

I have not dispatched a new run — worth reviewing this first, given what the last one would have done.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1xpHRV7yVfgtJg4vp9P7z)_