### PR TITLE
fix(ci): A network port for each half, and say what the load test did

### DIFF
--- a/.github/workflows/revdep2.yaml
+++ b/.github/workflows/revdep2.yaml
@@ -496,6 +496,25 @@ jobs:
       # differences. `_R_CHECK_CRAN_INCOMING_: false` already suppresses it;
       # this says so out loud so `--as-cran` cannot turn it back on.
       _R_CHECK_CRAN_INCOMING_USE_ASPELL_: false
+      # No timings in the check output.
+      #
+      # `--as-cran` sets `_R_CHECK_TIMINGS_` to 10, which stamps every stage
+      # slower than that with its own `[user/elapsed]` pair and appends an
+      # "Examples with CPU ... > 5s" table. Both are pure noise here: they
+      # differ between the two halves by construction -- they are wall clock,
+      # measured on two checks racing each other for the same four cores --
+      # so every one of them is a line in the diff that says nothing about the
+      # package. `neutral_log()` strips them so the *comparison* is not fooled;
+      # this stops them being produced at all, so the diff a human reads is
+      # only what changed.
+      #
+      # Nothing is lost. What a stage cost is still recorded, per line and for
+      # every stage rather than only the slow ones, by the elapsed stamping in
+      # check-pair.sh -- which is on the driver log, not on the file the halves
+      # are compared through.
+      _R_CHECK_TIMINGS_: ""
+      _R_CHECK_EXAMPLE_TIMING_THRESHOLD_: 99999
+
       # 300 lines of a failed test transcript in the check log, not R's default
       # 13 -- thirteen routinely cuts off the failure itself, which is both
       # what a reader wants and the part the old/new diff has to see to be

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -1094,11 +1094,21 @@ Two things differ for reasons that have nothing to do with the package:
   `.../lib-old/...` against `.../lib-new/...` — and so do the two check
   directories, which the log names in its first line
   and quotes in every "see … for details".
-- **The stage timings.** `--as-cran` sets `_R_CHECK_TIMINGS_`,
-  so every stage slower than ten seconds
-  prints its own `[user/elapsed]` pair,
+- **The stage timings.** `--as-cran` used to set `_R_CHECK_TIMINGS_` to 10,
+  so every stage slower than that printed its own `[user/elapsed]` pair,
   and two checks racing each other for the same four cores
   never agree on those.
+  They are off now — `_R_CHECK_TIMINGS_=""` for the stamps,
+  `_R_CHECK_EXAMPLE_TIMING_THRESHOLD_=99999` for the
+  "Examples with CPU … > 5s" table, which is the same noise in table form.
+  `neutral_log()` still strips them, because a reused baseline
+  or an older artifact may carry them,
+  but nothing produces them any more, so the diff a human reads
+  is only what changed.
+  Nothing is lost: what a stage cost is still recorded, per line
+  and for *every* stage rather than only the slow ones,
+  by the elapsed stamping in `check-pair.sh` —
+  which is on the driver log, not on the file the halves are compared through.
 
 Both are removed before the log is parsed *and* before it is diffed.
 Measured, not assumed: rphylopic checked against the *same* igraph

--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -879,6 +879,51 @@ the next run's preflight timing is what settles it.
 the failures are re-run singly afterwards to keep their output,
 and there are few of them by construction.
 
+Every tested package gets a line, with what it cost,
+in a collapsed `::group::` sorted slowest first.
+That is ~500 lines the default view never shows,
+against a step that otherwise says nothing at all
+between "load-testing 498 packages" and the summary —
+and it is the only place a package that loads *slowly* appears,
+though every check of anything downstream of it pays that cost again.
+The slowest few are repeated outside the group, where they are read.
+
+### The two halves get a network port each
+
+`parallel` picks its default PSOCK port once, when its namespace loads:
+
+```r
+ran1 <- sample.int(.Machine$integer.max - 1L, 1L) / .Machine$integer.max
+port <- 11000 + 1000 * ((ran1 + unclass(Sys.time())/300) %% 1)
+```
+
+The random term is only random while the RNG stream is.
+Anything that calls `set.seed()` before `parallel` first loads —
+which examples, vignettes and testthat do constantly, for reproducibility —
+makes it deterministic, and both halves draw the same number.
+Measured: three sessions seeded with 42 gave 11181, 11183, 11183,
+against 11005, 11214, 11652 unseeded.
+
+The time term cannot separate them either.
+It sweeps 1000 ports over 300 seconds — 3.3 ports per second —
+so two halves that load `parallel`
+within a third of a second of each other
+land on the same integer port.
+They start together and run the same script, so they do.
+And the choice is made once per *session*, not per cluster,
+so from then on every cluster either half opens races for that one port.
+
+In run 31893156685 that cost `cia` (port 11477) and `TDApplied` (11058),
+both reported `newly_broken` with nothing wrong with them.
+Staggering the halves is not a fix:
+the separation would have to hold at the moment each loads `parallel`,
+the two drift apart by minutes over a check,
+and at 300 seconds the sweep wraps back onto itself.
+`R_PARALLEL_PORT`, 20000 for old and 30000 for new,
+costs nothing that was not already the case —
+R fixes one port per session and reuses it regardless —
+and both are far from R's own 11000–12000 band.
+
 ### A shard that cannot install still reports
 
 An install that overruns used to be given the shard's whole deadline,

--- a/.github/workflows/revdep2/check-pair.sh
+++ b/.github/workflows/revdep2/check-pair.sh
@@ -49,21 +49,54 @@ stamp() {
 check_one() {
   local phase=$1
   local lib=$2
+  local port=$3
   local out="${work}/${phase}"
   mkdir -p "${out}"
   # `timeout` sends TERM at the deadline and KILL a minute later, and R CMD
   # check's own children go with it because it runs in its own process group.
   # The status is PIPESTATUS[0] because the stamping is downstream of it.
   R_LIBS="${lib}:${lib_shared}" \
+    R_PARALLEL_PORT="${port}" \
     timeout --kill-after=60s "${seconds}s" \
     R CMD check --no-manual --as-cran --output="${out}" "${tarball}" 2>&1 |
     stamp > "${out}/driver.log"
   echo "${PIPESTATUS[0]}" > "${out}/status"
 }
 
-check_one old "${lib_old}" &
+# A port each, because the two halves would otherwise pick the same one.
+#
+# `parallel` chooses its default PSOCK port once, when its namespace loads:
+#
+#   ran1 <- sample.int(.Machine$integer.max - 1L, 1L) / .Machine$integer.max
+#   port <- 11000 + 1000 * ((ran1 + unclass(Sys.time())/300) %% 1)
+#
+# The random term is drawn from the session's RNG stream, so it is only random
+# while the stream is. Anything that calls `set.seed()` before `parallel` is
+# first loaded -- which examples, vignettes and testthat do constantly, for
+# reproducibility -- makes it deterministic, and both halves then draw the same
+# number. Measured: three sessions seeded with 42 gave 11181, 11183, 11183,
+# against 11005, 11214, 11652 unseeded.
+#
+# The time term cannot separate them either. It sweeps 1000 ports over 300
+# seconds -- 3.3 ports per second -- so two halves that load `parallel` within
+# a third of a second of each other land on the same integer port. They start
+# together and run the same script, so they do. And the choice is made once per
+# session, not per cluster, so from then on *every* cluster either half opens
+# races for that one port.
+#
+# In run 31893156685 that cost `cia` (port 11477) and `TDApplied` (11058),
+# both reported as newly broken having nothing wrong with them. Staggering the
+# halves is not a fix: the separation would have to hold at the moment each
+# loads `parallel`, the two drift apart by minutes over a check, and at 300
+# seconds the sweep wraps back onto itself.
+#
+# Setting the port explicitly costs nothing that was not already the case --
+# R fixes one port per session and reuses it regardless -- and the two ranges
+# are far from R's own 11000-12000 band, so a session that inherits neither
+# cannot wander into either.
+check_one old "${lib_old}" 20000 &
 old_pid=$!
-check_one new "${lib_new}" &
+check_one new "${lib_new}" 30000 &
 new_pid=$!
 
 wait "${old_pid}"

--- a/.github/workflows/revdep2/load-test.sh
+++ b/.github/workflows/revdep2/load-test.sh
@@ -5,10 +5,20 @@
 # Usage:
 #   load-test.sh <package-list-file> <library> <seconds> <jobs>
 #
-# Reads one package name per line. Prints one line per package that did not
-# load -- `FAIL <package> <timeout|error>` -- and nothing for the ones that
-# did. Always exits 0: which packages failed is the caller's business, not the
+# Reads one package name per line. Prints one line per package:
+#
+#   OK   <package> <seconds>
+#   FAIL <package> <timeout|error> <seconds>
+#
+# Always exits 0: which packages failed is the caller's business, not the
 # shell's.
+#
+# The `OK` lines are the whole log of a step that otherwise says nothing
+# between "load-testing 498 packages" and the summary. They are also the only
+# place a package that loads *slowly* -- half a minute of `.onLoad`, every
+# time anything downstream of it is checked -- ever shows up. The caller folds
+# them into a collapsed group, so the cost of the other 497 is a line nobody
+# has to scroll past.
 #
 # Why one session per package rather than batches:
 #
@@ -33,19 +43,19 @@ jobs=$4
 # One package, one session, one clock. `--vanilla` so nothing in a profile
 # loads anything this is supposed to be testing.
 load_one() {
-  local pkg=$1 status=0
+  local pkg=$1 status=0 start=${EPOCHSECONDS}
   timeout --kill-after=60s "${seconds}s" \
     Rscript --vanilla -e \
     ".libPaths(c('${lib}', .libPaths())); loadNamespace('${pkg}')" \
     > /dev/null 2>&1 || status=$?
+  local took=$((EPOCHSECONDS - start))
   if [ "${status}" -eq 0 ]; then
-    return 0
-  fi
+    echo "OK ${pkg} ${took}"
   # 124 is coreutils' timeout; anything else is R saying something.
-  if [ "${status}" -eq 124 ] || [ "${status}" -eq 137 ]; then
-    echo "FAIL ${pkg} timeout"
+  elif [ "${status}" -eq 124 ] || [ "${status}" -eq 137 ]; then
+    echo "FAIL ${pkg} timeout ${took}"
   else
-    echo "FAIL ${pkg} error"
+    echo "FAIL ${pkg} error ${took}"
   fi
 }
 export -f load_one

--- a/.github/workflows/revdep2/preflight.R
+++ b/.github/workflows/revdep2/preflight.R
@@ -319,6 +319,51 @@ if (!out_of_time("the load test") && length(roots) > 0) {
       "loading failed"
     }
   }
+
+  # Every package that was tested, and what it cost, folded away.
+  #
+  # Without this the step says "load-testing 498 packages" and then nothing at
+  # all until the summary -- and a package that loads *slowly* has nowhere to
+  # show up, though every check of anything downstream of it pays that cost
+  # again. 498 lines is a lot to scroll past, so they go in a collapsed group
+  # and the interesting ones are repeated outside it.
+  timed <- do.call(
+    rbind,
+    lapply(
+      strsplit(grep("^(OK|FAIL) ", out, value = TRUE), " ", fixed = TRUE),
+      function(p) {
+        data.frame(
+          package = p[[2]],
+          seconds = suppressWarnings(as.numeric(utils::tail(p, 1))),
+          ok = identical(p[[1]], "OK")
+        )
+      }
+    )
+  )
+  if (!is.null(timed) && nrow(timed) > 0) {
+    timed <- timed[order(-timed$seconds), ]
+    print_group(
+      sprintf("Load test: %d package(s), slowest first", nrow(timed)),
+      sprintf(
+        "%6.0fs  %-30s %s",
+        timed$seconds,
+        timed$package,
+        ifelse(timed$ok, "", "FAILED")
+      )
+    )
+    slow <- utils::head(timed[timed$ok, ], 5)
+    inform(sprintf(
+      "Load test: %d ok, %d failed, %s of CPU across %d job(s); slowest: %s",
+      sum(timed$ok),
+      sum(!timed$ok),
+      format_duration(sum(timed$seconds)),
+      load_jobs,
+      paste(
+        sprintf("%s (%.0fs)", slow$package, slow$seconds),
+        collapse = ", "
+      )
+    ))
+  }
   if (!run$ok) {
     inform("The load test did not finish: ", run$message)
   }


### PR DESCRIPTION
Prepared with Claude Code. Stacked on #2834, on top of the merged #2838.

## Why the two halves collided on the same port

`cia` and `TDApplied` were reported `newly_broken` in run 31893156685 with nothing wrong with them:

```
Error in serverSocket(port = port) :
  creation of server socket failed: port 11477 cannot be opened
Calls: SampleChains -> <Anonymous> -> makePSOCKcluster -> serverSocket
```

`parallel` picks its default PSOCK port **once, when its namespace loads** — in `initDefaultClusterOptions()`, not per `makeCluster()` call:

```r
ran1 <- sample.int(.Machine$integer.max - 1L, 1L) / .Machine$integer.max
port <- 11000 + 1000 * ((ran1 + unclass(Sys.time())/300) %% 1)
```

**The random term is the reason.** `sample.int` draws from the session's RNG stream, so it is only random while that stream is. Anything calling `set.seed()` *before* `parallel` first loads — which examples, vignettes and testthat do constantly, for reproducibility — makes it deterministic, and both halves draw the same number. Measured:

| | port |
| --- | --- |
| three sessions, `set.seed(42)` first | 11181, 11183, **11183** |
| three sessions, unseeded | 11005, 11214, 11652 |

**The time term cannot separate them.** It sweeps 1000 ports over 300 seconds — 3.3 ports per second, 0.3 s per port — so two halves that load `parallel` within a third of a second of each other land on the same integer port. They start together and run the same script, so they do.

**And it is not a one-shot risk.** The choice is per *session*, so once the halves agree, every cluster either of them opens races for that one port for the rest of the check. Verified: two clusters in one session, and the option two seconds later, all gave 11800.

## Why staggering is not the fix

You asked how long we would have to wait. From the 0.3 s/port sweep:

| stagger | port separation |
| --- | --- |
| 0.3 s | 1 |
| 1 s | 3 |
| 15 s | 50 |
| 150 s | 500 (maximal) |
| 300 s | **0 — wraps** |

Three problems with using that. The separation has to hold at the moment each half *loads `parallel`*, not at check start — and the halves drift apart by minutes over a check, so a start offset says nothing about the offset at load time. One port of separation is no margin. And the sweep wraps at 300 s, so a large stagger can land you back where you started.

## The fix

`R_PARALLEL_PORT`, 20000 for `old` and 30000 for `new`, set in `check-pair.sh`.

I flagged this last time as needing care, on the theory that a fixed port might break packages opening clusters back-to-back. **That was wrong**, and the session-fixity result above is why: R already fixes one port per session and reuses it for every cluster. Setting the variable changes nothing within a half — it only stops the two halves agreeing. It is strictly safer than the status quo, and both values are far from R's own 11000–12000 band, so a session inheriting neither cannot wander into either.

Verified end to end — the seeded pair that collided now separates:

```
before:  11978  11979
after:   20000  30000
```

## Should the load test log 500 more lines? Yes, folded

Your log is the argument for it:

```
Preflight: load-testing 498 of 1416 installed package(s) ... 4 at a time, 10 min each
[resources] 19:35:24 ... load 1.59
...
[resources] 19:38:25 ... load 5.37
Packed 1449 package(s) into library.tar (3 Gb)
```

Three minutes of a job people watch, and the only thing telling you it is alive is the resource sampler. (Which does confirm the parallelism is working — load climbs 1.6 → 6.4 → 5.4 for four jobs.) And there was nowhere for a package that loads *slowly* to appear, though every check of anything downstream of it pays that cost again.

So: every tested package gets a line with what it cost, in a **collapsed `::group::` sorted slowest first**, with the slowest few repeated outside it where they are actually read:

```
::group::Load test: 498 package(s), slowest first
    34s  slowpkg
     3s  curl
     2s  brokenpkg                      FAILED
     1s  jsonlite
::endgroup::
Load test: 497 ok, 1 failed, 6.2 min of CPU across 4 job(s); slowest: slowpkg (34s), curl (3s), ...
```

The 500 lines are ones the default view never shows — that is what makes the trade worth taking. Integration-tested on 24 real packages: 24 lines, 3.8 s at 4-way.

Incidentally your log confirms the roots projection: **498 of 1416**, against the 33% I measured on the full universe.

## Not in this PR

`cia` and `TDApplied` should not be reported upstream — nothing is wrong with them, and they are the only two `newly_broken` packages in that run absent from #2646. With this fix they should return to `ok`.

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1xpHRV7yVfgtJg4vp9P7z)_