### PR TITLE
fix: `as_adjacency_matrix(attr = NULL)` is unweighted again

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -243,9 +243,24 @@ resolve_edge_weights <- function(
       "3.0.0",
       sprintf("%s(attr = )", fn),
       sprintf("%s(weights = )", fn),
+      details = if (is.null(attr)) {
+        "`attr = NULL` becomes `weights = NA`, not `weights = NULL`."
+      },
       user_env = user_env
     )
-    weights <- attr
+    # `attr` and `weights` spell "unweighted" differently, so the two cannot
+    # simply be assigned across. `attr = NULL` was the documented way to ask
+    # for a plain 0/1 matrix -- "If `NULL` a traditional adjacency matrix is
+    # returned" -- while `weights = NULL` means the opposite: use the `weight`
+    # edge attribute if the graph has one. Passing it straight through
+    # therefore inverts what the caller asked for, silently and without a
+    # warning, for every call that spelled it out. `NA` is how the new
+    # vocabulary says "unweighted".
+    #
+    # `lifecycle::is_present()` is true for an explicit `NULL` -- only the
+    # `deprecated()` sentinel counts as absent -- so this branch really does
+    # see `attr = NULL` and has to translate it.
+    weights <- if (is.null(attr)) NA else attr
   }
 
   if (is.null(weights)) {
@@ -412,9 +427,10 @@ get.adjacency.sparse <- function(
 #'   }
 #'   If multiple edges share endpoints, the value of an arbitrarily chosen edge
 #'   is included in the matrix.
-#' @param attr `r lifecycle::badge("deprecated")` Use `weights` instead. If
-#'   supplied, the value is forwarded to `weights` as a character edge
-#'   attribute name.
+#' @param attr `r lifecycle::badge("deprecated")` Use `weights` instead. A
+#'   character edge attribute name is forwarded to `weights` unchanged; `NULL`
+#'   becomes `weights = NA`, since `attr = NULL` asked for a traditional
+#'   unweighted matrix while `weights = NULL` picks the `weight` attribute up.
 #' @param edges `r lifecycle::badge("deprecated")` Logical, whether to return the edge IDs in the matrix.
 #'   For non-existant edges zero is returned.
 #' @param names Logical, whether to assign row and column names

--- a/man/as_adj.Rd
+++ b/man/as_adj.Rd
@@ -36,9 +36,10 @@ used as weights. The attribute must be numeric or logical.
 If multiple edges share endpoints, the value of an arbitrarily chosen edge
 is included in the matrix.}
 
-\item{attr}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} instead. If
-supplied, the value is forwarded to \code{weights} as a character edge
-attribute name.}
+\item{attr}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} instead. A
+character edge attribute name is forwarded to \code{weights} unchanged; \code{NULL}
+becomes \code{weights = NA}, since \code{attr = NULL} asked for a traditional
+unweighted matrix while \code{weights = NULL} picks the \code{weight} attribute up.}
 
 \item{edges}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Logical, whether to return the edge IDs in the matrix.
 For non-existant edges zero is returned.}

--- a/man/as_adjacency_matrix.Rd
+++ b/man/as_adjacency_matrix.Rd
@@ -50,9 +50,10 @@ matrices. The default \code{NULL} uses the \code{sparsematrices} igraph option.}
 \item{edges}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Logical, whether to return the edge IDs in the matrix.
 For non-existant edges zero is returned.}
 
-\item{attr}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} instead. If
-supplied, the value is forwarded to \code{weights} as a character edge
-attribute name.}
+\item{attr}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} instead. A
+character edge attribute name is forwarded to \code{weights} unchanged; \code{NULL}
+becomes \code{weights = NA}, since \code{attr = NULL} asked for a traditional
+unweighted matrix while \code{weights = NULL} picks the \code{weight} attribute up.}
 }
 \value{
 A \code{vcount(graph)} by \code{vcount(graph)} (usually) numeric

--- a/man/as_biadjacency_matrix.Rd
+++ b/man/as_biadjacency_matrix.Rd
@@ -45,9 +45,10 @@ the IDs of the vertices are used as row and column names.}
 \item{sparse}{Logical, if it is \code{TRUE} then a sparse matrix is
 created, you will need the \code{Matrix} package for this.}
 
-\item{attr}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} instead. If
-supplied, the value is forwarded to \code{weights} as a character edge
-attribute name.}
+\item{attr}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} instead. A
+character edge attribute name is forwarded to \code{weights} unchanged; \code{NULL}
+becomes \code{weights = NA}, since \code{attr = NULL} asked for a traditional
+unweighted matrix while \code{weights = NULL} picks the \code{weight} attribute up.}
 }
 \value{
 A sparse or dense matrix.

--- a/man/get.adjacency.Rd
+++ b/man/get.adjacency.Rd
@@ -22,9 +22,10 @@ right triangle of the matrix is used, \code{lower}: the lower left triangle
 of the matrix is used. \code{both}: the whole matrix is used, a symmetric
 matrix is returned.}
 
-\item{attr}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} instead. If
-supplied, the value is forwarded to \code{weights} as a character edge
-attribute name.}
+\item{attr}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} instead. A
+character edge attribute name is forwarded to \code{weights} unchanged; \code{NULL}
+becomes \code{weights = NA}, since \code{attr = NULL} asked for a traditional
+unweighted matrix while \code{weights = NULL} picks the \code{weight} attribute up.}
 
 \item{edges}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Logical, whether to return the edge IDs in the matrix.
 For non-existant edges zero is returned.}

--- a/man/get.incidence.Rd
+++ b/man/get.incidence.Rd
@@ -14,9 +14,10 @@ directed graphs.}
 \code{type} vertex attribute. You must supply this argument if the graph has
 no \code{type} vertex attribute.}
 
-\item{attr}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} instead. If
-supplied, the value is forwarded to \code{weights} as a character edge
-attribute name.}
+\item{attr}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} instead. A
+character edge attribute name is forwarded to \code{weights} unchanged; \code{NULL}
+becomes \code{weights = NA}, since \code{attr = NULL} asked for a traditional
+unweighted matrix while \code{weights = NULL} picks the \code{weight} attribute up.}
 
 \item{names}{Logical, if \code{TRUE} and the vertices in the graph
 are named (i.e. the graph has a vertex attribute called \code{name}), then

--- a/tests/testthat/_snaps/conversion.md
+++ b/tests/testthat/_snaps/conversion.md
@@ -89,6 +89,25 @@
       The `attr` argument of `as_adjacency_matrix()` is deprecated as of igraph 3.0.0.
       i Please use the `weights` argument instead.
 
+# the `attr` deprecation warning spells out the NULL translation
+
+    Code
+      A <- as_adjacency_matrix(g, attr = NULL, sparse = FALSE)
+    Condition
+      Warning:
+      The `attr` argument of `as_adjacency_matrix()` is deprecated as of igraph 3.0.0.
+      i Please use the `weights` argument instead.
+      i `attr = NULL` becomes `weights = NA`, not `weights = NULL`.
+
+---
+
+    Code
+      B <- as_adjacency_matrix(g, attr = "weight", sparse = FALSE)
+    Condition
+      Warning:
+      The `attr` argument of `as_adjacency_matrix()` is deprecated as of igraph 3.0.0.
+      i Please use the `weights` argument instead.
+
 # as_biadjacency_matrix(attr =) is deprecated but still works
 
     Code

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -380,6 +380,63 @@ test_that("as_adjacency_matrix(attr =) is deprecated but still works", {
   expect_equal(A, expected)
 })
 
+test_that("as_adjacency_matrix(attr = NULL) still means unweighted", {
+  # `attr = NULL` was the documented spelling of "give me a plain 0/1 matrix";
+  # `weights = NULL` means the opposite, "use the weight attribute if there is
+  # one". Translating one into the other inverted every call that spelled it
+  # out -- silently, since the graph having a `weight` attribute is exactly the
+  # case where the caller bothers to ask for an unweighted matrix.
+  rlang::local_options(lifecycle_verbosity = "quiet")
+  g <- make_graph(c(1, 2, 2, 3), directed = FALSE)
+  E(g)$weight <- c(0.5, 0.7)
+
+  expect_equal(
+    as_adjacency_matrix(g, attr = NULL, sparse = FALSE),
+    as_adjacency_matrix(g, weights = NA, sparse = FALSE)
+  )
+  expect_true(all(as_adjacency_matrix(g, attr = NULL, sparse = FALSE) %in% 0:1))
+
+  # And the other spellings keep their meanings.
+  expect_equal(
+    as_adjacency_matrix(g, attr = "weight", sparse = FALSE),
+    as_adjacency_matrix(g, weights = "weight", sparse = FALSE)
+  )
+})
+
+test_that("as_biadjacency_matrix(attr = NULL) still means unweighted", {
+  # Same translation, same shared helper -- the second caller of it.
+  rlang::local_options(lifecycle_verbosity = "quiet")
+  g <- make_bipartite_graph(c(0, 1, 0, 1), c(1, 2, 3, 4))
+  E(g)$weight <- c(0.5, 0.7)
+
+  expect_equal(
+    as_biadjacency_matrix(g, attr = NULL, sparse = FALSE),
+    as_biadjacency_matrix(g, weights = NA, sparse = FALSE)
+  )
+  expect_true(
+    all(as_biadjacency_matrix(g, attr = NULL, sparse = FALSE) %in% 0:1)
+  )
+})
+
+test_that("the `attr` deprecation warning spells out the NULL translation", {
+  # Following the bare "use `weights` instead" advice literally would turn
+  # `attr = NULL` into `weights = NULL`, which means the opposite thing.
+  rlang::local_options(lifecycle_verbosity = "warning")
+  g <- make_graph(c(1, 2, 2, 3), directed = FALSE)
+  E(g)$weight <- c(0.5, 0.7)
+
+  expect_warning(
+    as_adjacency_matrix(g, attr = NULL, sparse = FALSE),
+    "weights = NA",
+    fixed = TRUE
+  )
+  expect_warning(
+    as_adjacency_matrix(g, attr = "weight", sparse = FALSE),
+    "weights",
+    fixed = TRUE
+  )
+})
+
 test_that("as_adjacency_matrix() wires up legacy `attr` recovery", {
   # The generic recovery machinery (messages, errors, abbreviations) is tested
   # exhaustively in test-migration-fixture.R; here we only confirm the block is

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -420,21 +420,14 @@ test_that("as_biadjacency_matrix(attr = NULL) still means unweighted", {
 
 test_that("the `attr` deprecation warning spells out the NULL translation", {
   # Following the bare "use `weights` instead" advice literally would turn
-  # `attr = NULL` into `weights = NULL`, which means the opposite thing.
+  # `attr = NULL` into `weights = NULL`, which means the opposite thing. The
+  # extra line is only there for the `NULL` case, so both are snapshotted.
   rlang::local_options(lifecycle_verbosity = "warning")
   g <- make_graph(c(1, 2, 2, 3), directed = FALSE)
   E(g)$weight <- c(0.5, 0.7)
 
-  expect_warning(
-    as_adjacency_matrix(g, attr = NULL, sparse = FALSE),
-    "weights = NA",
-    fixed = TRUE
-  )
-  expect_warning(
-    as_adjacency_matrix(g, attr = "weight", sparse = FALSE),
-    "weights",
-    fixed = TRUE
-  )
+  expect_snapshot(A <- as_adjacency_matrix(g, attr = NULL, sparse = FALSE))
+  expect_snapshot(B <- as_adjacency_matrix(g, attr = "weight", sparse = FALSE))
 })
 
 test_that("as_adjacency_matrix() wires up legacy `attr` recovery", {


### PR DESCRIPTION
`attr` and `weights` spell "unweighted" differently, and the deprecation shim forwards one to the other unchanged.

- `attr = NULL` was the documented way to ask for a plain 0/1 matrix. CRAN 2.3.3's `?as_adjacency_matrix` says: *"attr: Either `NULL` or a character string ... If `NULL` a traditional adjacency matrix is returned."*
- `weights = NULL` means the opposite: use the `weight` edge attribute if the graph has one.

`resolve_edge_weights()` did `weights <- attr`, so every call that spelled out `attr = NULL` started returning a **weighted** matrix — silently, with no warning beyond the generic "use `weights` instead". A graph having a `weight` attribute is exactly the case where a caller bothers to ask for an unweighted matrix, so the inversion hits precisely the calls that meant it.

`lifecycle::is_present(NULL)` is `TRUE` — only the `deprecated()` sentinel counts as absent — so the branch really does see an explicit `attr = NULL` and has to translate it.

### What changed

- `attr = NULL` now maps to `weights = NA` (the new vocabulary for "explicitly unweighted"). A character attribute name is still forwarded unchanged.
- The deprecation warning gains a detail line for the `NULL` case: `` `attr = NULL` becomes `weights = NA`, not `weights = NULL`. `` Following the bare advice literally would reintroduce the same inversion in user code.
- `@param attr` documents the translation instead of claiming the value is always "a character edge attribute name".
- Tests for both callers of `resolve_edge_weights()` — `as_adjacency_matrix()` and `as_biadjacency_matrix()` — plus one for the warning text.

### Reproducer

```r
g <- make_graph(c(1, 2, 2, 3), directed = FALSE)
E(g)$weight <- c(0.5, 0.7)
as_adjacency_matrix(g, attr = NULL, sparse = FALSE)
```

CRAN 2.3.3 and this branch return a 0/1 matrix; `main` returns the 0.5/0.7 one.

### Where this came from

Found while triaging the reverse-dependency failures in #2646. `bnstruct` calls `as_adjacency_matrix(ig.mst, type = "both", attr = NULL)` in `buildJunctionTree-methods.R`, on a minimum spanning tree that carries weights — the whole point of the call is to get the topology without them. Introduced by a6ace1515c (#2677).

### What this does *not* fix

The `attr = NULL` spelling is unambiguously a bug: the shim inverts an explicit request. The **default** is a separate, deliberate-looking question that this PR leaves alone.

`as_adjacency_matrix(g)` with no weight argument at all also changed meaning — `weights = NULL` picks up `weight`, where `attr`'s default `NULL` did not. That is the item #2646 raises for `sfclust`, and it is also what breaks `MetaNet`: `within_module_deg_z_score()` and `part_coeff()` call `as_adj(g, sparse = FALSE)` in their `weighted = FALSE` branch and `as_adj(g, sparse = FALSE, attr = "weight")` in the other, so the unweighted branch now returns the weighted matrix and the Zi/Pi values land outside every role band.

Whether the new default is the intended 3.0.0 behaviour is a maintainer call — it is the same shape as the `modularity()` item in #2646, and it needs a NEWS entry either way. Flagging it here rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1xpHRV7yVfgtJg4vp9P7z