### PR TITLE
fix(ci): Stop reporting a check that never ran as `ok`

### DIFF
--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -723,6 +723,7 @@ the report is about *results*, a retry is about *coverage*.
 | A revdep fails to *install* under both versions | `failed` — there is nothing to compare |
 | A check times out | `timeout` kills it at `max(floor, factor × its CRAN time)`; reported `timeout`, not `failed`, with the check step it died at |
 | A revdep's strong dependencies cannot install | `depfail`, check not attempted, named in the shard summary |
+| A revdep needs a package that is not on CRAN | both halves stop at `checking package dependencies ... ERROR` in seconds and agree, so the pair compares clean; reported `depmissing`, not `ok`, with the missing packages named |
 | A dependency fails the preflight | reported in the preflight summary and `depfail.json`; shards still try their own subset |
 | A pak install chunk fails | the chunk is reported and the rest still run; what is still missing is retried one package at a time |
 | A pak install chunk never returns | killed at `REVDEP2_INSTALL_TIMEOUT_MINUTES`, tree and all; the next chunk starts a fresh pak |

--- a/.github/workflows/revdep2/collect.R
+++ b/.github/workflows/revdep2/collect.R
@@ -483,7 +483,7 @@ if (has_revdepcheck) {
   # protect, so it is written from the comparison like any other.
   keeps_committed <- function(entry, dir) {
     (isTRUE(entry$carried) ||
-      entry$result %in% c("missing", "deferred") ||
+      entry$result %in% c("missing", "deferred", "depmissing") ||
       still_broken(entry)) &&
       file.exists(file.path(out_dir, dir, paste0(entry$package, ".md")))
   }
@@ -618,13 +618,18 @@ counts_df <- data.frame(
     # by the clock says nothing about the package, and in the old half it says
     # nothing about our change either.
     "timed out, not checked",
-    "dependencies not installable", "shard error", "deferred",
+    "dependencies not installable",
+    # `R CMD check` refused to start, in both halves, because something the
+    # package needs is not installed. Its own row rather than a failure: the
+    # package is not broken, it is unknown.
+    "dependencies unavailable to R CMD check",
+    "shard error", "deferred",
     "no result from its shard"
   ),
   Packages = c(
     tally("ok"), tally("newly_broken"), tally("failed"),
     tally("timeout"),
-    tally("depfail"), tally("error"), tally("deferred"),
+    tally("depfail"), tally("depmissing"), tally("error"), tally("deferred"),
     tally("missing")
   )
 )
@@ -652,6 +657,7 @@ reason_of <- function(e) {
     e$result,
     deferred = "the shard hit its deadline before this package was checked",
     depfail = "dependencies could not be installed",
+    depmissing = "R CMD check stopped at `checking package dependencies` under both versions",
     missing = "its shard uploaded no results; the job did not finish",
     sprintf("no reason recorded (result `%s`)", e$result)
   )

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -1004,6 +1004,27 @@ check_package <- function(name, position) {
       t_new = attr(new, "duration"),
       message = "both checks ran, but their results could not be compared"
     )
+  } else if (aborted_on_dependencies(new) && aborted_on_dependencies(old)) {
+    # Neither half ran. `compare_checks()` still says `+` -- the two agree, and
+    # they agree on having done nothing -- so without this the package is
+    # reported `ok`. It is not ok, it is unknown, and `needs_recheck()` picks
+    # `depmissing` up so a retry with those repositories enabled re-checks it.
+    absent <- missing_dependencies(new)
+    update(
+      name,
+      result = "depmissing",
+      status = cmp$status,
+      status_new = counts(new),
+      t_new = attr(new, "duration"),
+      new_issues = 0L,
+      message = paste0(
+        "R CMD check stopped at `checking package dependencies` under both ",
+        "versions; nothing was checked",
+        if (length(absent) > 0) {
+          paste0(" (not installed: ", paste(absent, collapse = ", "), ")")
+        }
+      )
+    )
   } else {
     new_issues <- sum(cmp$cmp$change == 1)
     update(
@@ -1195,10 +1216,11 @@ append_summary(c(
   sprintf("### Shard %d", shard_index),
   "",
   sprintf(
-    "%d ok, %d newly broken, %d failed, %d timed out, %d depfail, %d error, %d deferred.",
+    "%d ok, %d newly broken, %d failed, %d timed out, %d depfail, %d depmissing, %d error, %d deferred.",
     sum(results == "ok"), sum(results == "newly_broken"), sum(results == "failed"),
     sum(results == "timeout"),
-    sum(results == "depfail"), sum(results == "error"), sum(results == "deferred")
+    sum(results == "depfail"), sum(results == "depmissing"),
+    sum(results == "error"), sum(results == "deferred")
   ),
   "",
   md_table(df)

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -1484,6 +1484,62 @@ classify_status <- function(status, new_issues) {
   }
 }
 
+# Did `R CMD check` refuse to start because a package this one needs is not
+# installed?
+#
+# That stage is fatal: check reports the one error and stops, in two or three
+# seconds, having looked at nothing. When it happens to *both* halves -- and it
+# always does, since the two libraries differ only in igraph -- the pair
+# compares clean, `compare_checks()` returns `+`, and the verdict is `ok`.
+#
+# 55 of run 31930350338's 984 `ok` results were that: every one of them a
+# package whose Bioconductor dependencies are not on CRAN and so were never
+# installed. `SEMgraph` is the clearest -- `1E 0W 0N` on both sides in three
+# seconds, reported `ok`, while being genuinely broken by a dev change nobody
+# saw because the check never ran.
+#
+# The check log is the only place this is visible; the status is `+` like any
+# other agreeing pair.
+aborted_on_dependencies <- function(check) {
+  errors <- check$errors %||% character()
+  length(errors) > 0 &&
+    any(grepl("^checking package dependencies [.]{3} ERROR", errors))
+}
+
+# The packages the aborted check named, for the manifest message: the whole
+# point of the class is that a reader can see *what* was missing without
+# opening the artifact.
+missing_dependencies <- function(check) {
+  errors <- check$errors %||% character()
+  hit <- grep(
+    "^checking package dependencies [.]{3} ERROR",
+    errors,
+    value = TRUE
+  )
+  if (length(hit) == 0) {
+    return(character())
+  }
+  lines <- strsplit(hit[[1]], "\n", fixed = TRUE)[[1]]
+  # `Packages required but not available:` puts them on the next line, quoted;
+  # `Package required but not available: 'x'` puts one on the same line.
+  named <- grep("required but not available", lines)
+  if (length(named) == 0) {
+    return(character())
+  }
+  block <- paste(
+    lines[seq(named[[1]], min(named[[1]] + 1L, length(lines)))],
+    collapse = " "
+  )
+  unique(gsub(
+    "[‘’']",
+    "",
+    regmatches(
+      block,
+      gregexpr("[‘'][^’']+[’']", block)
+    )[[1]]
+  ))
+}
+
 # What a status that `classify_status()` can only call "failed" actually means,
 # in words. A reader of the summary has to tell "broken under the dev version"
 # apart from "broken everywhere" without opening the artifact, and the one word


### PR DESCRIPTION
`R CMD check` stops at `checking package dependencies` when something the package needs is not installed: one error, two or three seconds, nothing else looked at. It happens to **both** halves — the two libraries differ only in igraph — so the pair compares clean, `compare_checks()` returns `+`, and the verdict is `ok`.

**55 of run 31930350338's 984 `ok` results were exactly that.** Every one a package with Bioconductor dependencies that are not on CRAN and so were never installed. `SEMgraph` gives the game away:

```
SEMgraph: result "ok", status_old "1E 0W 0N", status_new "1E 0W 0N", t_old 3, t_new 3
```

and its `new.rds`:

```
checking package dependencies ... ERROR
Packages required but not available:
  'RBGL', 'Rgraphviz', 'graphite', 'AnnotationDbi'
```

Reported `ok`, while being genuinely broken by a dev change that nobody saw because the check never ran.

## The change

Those results are now `depmissing`, with the packages `R CMD check` named written into the manifest message, so a reader can see *what* was missing without opening the artifact. `needs_recheck()` covers it without changing, so `retry-run` picks them up once those repositories are available.

## Why not `depfail` or `install_failure`

`depfail` sits next to it in the summary and means something different: there the shard could not install the strong dependencies and never attempted a check. Here the check *was* attempted and refused to start. Keeping them apart is diagnostically useful — it says whether our installer fell short or whether the package needs something we never try to provide.

`install_failure` would be actively wrong: the package itself installs fine. It is the dependencies `R CMD check` cannot find.

## Collector

`keeps_committed()` treats `depmissing` the way it treats `missing` and `deferred` — a run that learnt nothing about a package does not get to delete that package's report section. Without this, the `SEMgraph`, `scistreer` and `MiscMetabar` sections restored in #2834 would be deleted by the next run that reproduces the same abort.

## Validation

The detector was run against run 31903576720's stored `old.rds`/`new.rds` for all 1011 packages: **55 hits, the same 55**, with the right names — `pwalign` for AntibodyForests, `Rgraphviz` and `graph` for CePa, `qvalue` for cancerGI, `bluster` for Canek, `limma` for Cascade. No false positives among the 956 others.

All five scripts parse and are `air`-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1xpHRV7yVfgtJg4vp9P7z

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1xpHRV7yVfgtJg4vp9P7z)_