### PR TITLE
fix(ci): Install the system requirements of the packages being checked

### DIFF
--- a/.github/workflows/revdep2/README.md
+++ b/.github/workflows/revdep2/README.md
@@ -731,6 +731,7 @@ the report is about *results*, a retry is about *coverage*.
 | pak's metadata database is empty or unreadable | detected by probe before the first install, cleared and rebuilt once; the preflight stops if that does not fix it |
 | `/tmp` fills and R can no longer start | `TMPDIR` is on the big disk, so it does not; the sampler still reports `/tmp` if it ever does |
 | A restored package's system library is absent | `sysreqs_check_installed()` names it and `sysreqs_fix_installed()` installs it, in both the preflight and every shard |
+| A *checked* package needs a system library | the revdep is never in the library -- `R CMD check` builds it from its tarball -- so the shard resolves the members' own `SystemRequirements` with `pkg_sysreqs()` and installs what is missing before the first check |
 | The preflight job itself dies | the shards run anyway and install their own unions, the collector still reports; only the free rebuild and the early diagnosis are lost |
 | A shard hits its deadline | remaining packages `deferred`; finished old-halves still uploaded and baseline-fed |
 | A shard job dies hard | the collector reconciles against the plan: its packages are reported `missing`, naming the shard, and `retry-run` re-checks exactly them |

--- a/.github/workflows/revdep2/shard.R
+++ b/.github/workflows/revdep2/shard.R
@@ -308,6 +308,11 @@ if (do_install) {
   # the revdep.
   ensure_sysreqs(lib, sprintf("Shard %d", shard_index))
 
+  # And the requirements of the packages this shard will *check*, which the
+  # survey above cannot see: they are never installed into the library, `R CMD
+  # check` builds each one from its tarball.
+  ensure_check_sysreqs(members, sprintf("Shard %d", shard_index))
+
   install_seconds <- elapsed(install_started)
   inform(
     "Dependencies ready after ",

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -1336,6 +1336,110 @@ ensure_sysreqs <- function(lib = NULL, label = "") {
   invisible(still)
 }
 
+# The system requirements of the packages the shard is about to *check*.
+#
+# `ensure_sysreqs()` above reads the installed library, which is the right
+# question for dependencies and the wrong one for the revdeps themselves: a
+# shard installs each package's dependency closure and never the package, so
+# the revdep under test is never in that library. `R CMD check` builds it from
+# its tarball, and nothing has resolved its `SystemRequirements` -- not
+# `PKG_SYSREQS`, which covers what pak installs, and not
+# `sysreqs_fix_installed()`, which covers what is on disk.
+#
+# Libra is the case that found this. It declares `SystemRequirements: gsl`,
+# `pak::pkg_sysreqs("Libra")` resolves it to `libgsl0-dev` without difficulty,
+# and nobody asked: the check failed to compile `LBLasso.c` under both versions
+# with `fatal error: gsl/gsl_vector.h: No such file or directory`, which the
+# report then recorded as a package that fails to install rather than as a
+# runner that could not build it.
+#
+# Only the missing ones are installed. `sysreqs_list_system_packages()` says
+# what is already there, including what other packages *provide* -- a virtual
+# package satisfies a dependency just as a real one does -- so a shard whose
+# requirements the image already carries runs no apt at all.
+ensure_check_sysreqs <- function(packages, label = "") {
+  prefix <- if (nzchar(label)) paste0(label, ": ") else ""
+  if (length(packages) == 0) {
+    return(invisible(character()))
+  }
+
+  run <- run_with_timeout(
+    function(repos, packages) {
+      options(repos = repos)
+      wanted <- unique(unlist(
+        pak::pkg_sysreqs(packages)$packages$system_packages,
+        use.names = FALSE
+      ))
+      have <- pak::sysreqs_list_system_packages()
+      present <- unique(c(
+        have$package,
+        unlist(have$provides, use.names = FALSE)
+      ))
+      list(wanted = wanted, missing = setdiff(wanted, present))
+    },
+    args = list(repos = pinned_repos(), packages = packages),
+    timeout_seconds = sysreqs_timeout_seconds(),
+    label = paste0(prefix, "check system requirements survey")
+  )
+  if (!isTRUE(run$ok)) {
+    inform(
+      prefix,
+      "could not resolve the checked packages' system requirements: ",
+      run$message
+    )
+    return(invisible(NULL))
+  }
+
+  if (length(run$value$missing) == 0) {
+    inform(sprintf(
+      "%sall %d system requirement(s) of the %d package(s) to check are present",
+      prefix,
+      length(run$value$wanted),
+      length(packages)
+    ))
+    return(invisible(character()))
+  }
+  inform(sprintf(
+    "%s%d of %d system requirement(s) of the packages to check are missing: %s",
+    prefix,
+    length(run$value$missing),
+    length(run$value$wanted),
+    paste(run$value$missing, collapse = ", ")
+  ))
+
+  # apt directly rather than through pak: `sysreqs_fix_installed()` reads the
+  # library, and these packages are not in it. Failure is reported and not
+  # fatal -- the check will fail either way, and it will say why more clearly
+  # than this can.
+  sudo <- if (identical(Sys.info()[["effective_user"]], "root")) {
+    character()
+  } else {
+    "sudo"
+  }
+  status <- suppressWarnings(system2(
+    if (length(sudo)) "sudo" else "apt-get",
+    c(
+      if (length(sudo)) "apt-get",
+      "-o",
+      "DPkg::Lock::Timeout=300",
+      "install",
+      "-y",
+      "--no-install-recommends",
+      run$value$missing
+    )
+  ))
+  if (!identical(status, 0L)) {
+    inform(prefix, "apt-get exited ", status, "; the checks run anyway")
+    return(invisible(run$value$missing))
+  }
+  inform(sprintf(
+    "%sinstalled %d system package(s) for the packages to check",
+    prefix,
+    length(run$value$missing)
+  ))
+  invisible(character())
+}
+
 # One pak install, bounded. Separate from install_in_chunks() because the
 # per-package retry after a failed chunk needs exactly the same treatment: it
 # is the same call, one package at a time, and it used to be just as


### PR DESCRIPTION
Libra fails both halves of its check with

```
LBLasso.c:8:10: fatal error: gsl/gsl_vector.h: No such file or directory
```

and the report records it under "failed to check — installation failed". It is not a Libra problem: nothing ever installed `libgsl-dev` on the runner.

## Why nothing did

`install_closure()` returns each revdep's *dependencies*, never the revdep itself, so the package under test is never in the shard's library. `R CMD check` builds it from its tarball. Neither of the two things that resolve system requirements can see it:

- `PKG_SYSREQS` covers what pak installs — and pak never installs Libra.
- `sysreqs_fix_installed(library =)` covers what is on disk — and Libra is not.

Libra declares `SystemRequirements: gsl`, and `pak::pkg_sysreqs("Libra")` resolves it to `libgsl0-dev` without difficulty. Nobody asked.

## The change

`ensure_check_sysreqs(members)`, called from the shard after the installs and before the first check, alongside the existing library survey.

Only what is missing gets installed. `sysreqs_list_system_packages()` says what is already there, including what other packages **provide** — a virtual package satisfies a dependency as a real one does — so a shard whose requirements the image already carries runs no apt at all.

apt directly rather than through pak, because `sysreqs_fix_installed()` reads the library and these packages are not in it. A failure is reported and not fatal: the check will fail either way, and it will say why more clearly than this can.

## Verified on a runner without gsl

```
Test: 1 of 1 system requirement(s) of the packages to check are missing: libgsl0-dev
...
Setting up libgsl-dev (2.7.1+dfsg-6ubuntu2) ...
Test: installed 1 system package(s) for the packages to check
```

A second call is a no-op — `all 1 system requirement(s) of the 1 package(s) to check are present`. A package with no unmet requirements installs nothing. An empty member list returns without resolving anything.

Note apt resolved `libgsl0-dev` to `libgsl-dev`; the mapping pak returns and the package apt installs need not be the same name, which is why the check is `setdiff` against installed-plus-provided rather than an equality test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1xpHRV7yVfgtJg4vp9P7z

---
_Generated by [Claude Code](https://claude.ai/code/session_01D1xpHRV7yVfgtJg4vp9P7z)_