### PR TITLE
refactor: snake_case weights arguments in clique functions and `cluster_infomap()`

### DIFF
--- a/R/cliques.R
+++ b/R/cliques.R
@@ -475,12 +475,12 @@ clique_num <- function(graph) {
 #'
 #' @param graph The input graph, directed graphs will be considered as
 #'   undirected ones, multiple edges and loops are ignored.
-#' @param min.weight Numeric constant, lower limit on the weight of the cliques to find.
+#' @param min_weight Numeric constant, lower limit on the weight of the cliques to find.
 #'   `NULL` means no limit, i.e. it is the same as 0.
-#' @param max.weight Numeric constant, upper limit on the weight of the cliques to find.
+#' @param max_weight Numeric constant, upper limit on the weight of the cliques to find.
 #'   `NULL` means no limit.
 #' @inheritParams rlang::args_dots_empty
-#' @param vertex.weights Vertex weight vector. If the graph has a `weight`
+#' @param vertex_weights Vertex weight vector. If the graph has a `weight`
 #'   vertex attribute, then this is used by default. If the graph does not have a
 #'   `weight` vertex attribute and this argument is `NULL`, then every
 #'   vertex is assumed to have a weight of 1. Note that the current implementation
@@ -510,15 +510,15 @@ clique_num <- function(graph) {
 weighted_cliques <- function(
   graph,
   ...,
-  vertex.weights = NULL,
-  min.weight = 0,
-  max.weight = 0,
+  vertex_weights = NULL,
+  min_weight = 0,
+  max_weight = 0,
   maximal = FALSE
 ) {
   # BEGIN GENERATED ARG_HANDLE: weighted_cliques, do not edit, see tools/generate-migrations.R
   # fmt: skip
   if (...length() > 0L) {
-    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("m", "ma", "max"))
+    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("v", "ve", "ver", "vert", "verte", "vertex", "m", "mi", "min", "ma", "max"))
     if (base::length(.arg_ambiguous) > 0L) cli::cli_abort("Argument {.arg {(.arg_ambiguous[[1L]])}} matches multiple arguments of {.fn weighted_cliques}.")
     # Pre-3.0.0 signature: weighted_cliques(graph, vertex.weights, min.weight, max.weight, maximal)
     .old_signature <- function(vertex.weights, min.weight, max.weight, maximal, ...) {
@@ -529,9 +529,9 @@ weighted_cliques <- function(
         cli::cli_abort(base::c("Unexpected argument passed to {.fn weighted_cliques}: {.arg {(.arg_extra)}}.", i = "Arguments after {.arg ...} must be spelled out in full."), call = base::parent.frame())
       }
       base::c(
-        if (!base::missing(vertex.weights)) base::list(vertex.weights = vertex.weights),
-        if (!base::missing(min.weight)) base::list(min.weight = min.weight),
-        if (!base::missing(max.weight)) base::list(max.weight = max.weight),
+        if (!base::missing(vertex.weights)) base::list(vertex_weights = vertex.weights),
+        if (!base::missing(min.weight)) base::list(min_weight = min.weight),
+        if (!base::missing(max.weight)) base::list(max_weight = max.weight),
         if (!base::missing(maximal)) base::list(maximal = maximal)
       )
     }
@@ -539,9 +539,9 @@ weighted_cliques <- function(
     if (base::length(.arg_handle) > 0L) {
       .arg_names <- base::names(.arg_handle)
       .arg_conflict <- base::intersect(.arg_names, base::c(
-        if (!base::missing(vertex.weights)) "vertex.weights",
-        if (!base::missing(min.weight)) "min.weight",
-        if (!base::missing(max.weight)) "max.weight",
+        if (!base::missing(vertex_weights)) "vertex_weights",
+        if (!base::missing(min_weight)) "min_weight",
+        if (!base::missing(max_weight)) "max_weight",
         if (!base::missing(maximal)) "maximal"
       ))
       if (base::length(.arg_conflict) > 0L) cli::cli_abort(base::c("Argument {.arg {(.arg_conflict)}} of {.fn weighted_cliques} was supplied more than once.", i = "Pass it exactly once, by its new name {.arg {(.arg_conflict)}}."))
@@ -550,7 +550,7 @@ weighted_cliques <- function(
         "3.0.0",
         what = base::I("Calling `weighted_cliques()` with positional or abbreviated arguments"),
         details = base::c(
-          i = base::paste0("Detected call:  weighted_cliques(", base::paste(base::c("graph", .arg_names), collapse = ", "), ")"),
+          i = base::paste0("Detected call:  weighted_cliques(", base::paste(base::c("graph", base::c(vertex_weights = "vertex.weights", min_weight = "min.weight", max_weight = "max.weight", maximal = "maximal")[.arg_names]), collapse = ", "), ")"),
           i = base::paste0("Use instead:    weighted_cliques(", base::paste(base::c("graph", base::paste0(.arg_names, " = ")), collapse = ", "), ")")
         )
       )
@@ -560,9 +560,9 @@ weighted_cliques <- function(
 
   weighted_cliques_impl(
     graph = graph,
-    vertex_weights = vertex.weights,
-    min_weight = min.weight,
-    max_weight = max.weight,
+    vertex_weights = vertex_weights,
+    min_weight = min_weight,
+    max_weight = max_weight,
     maximal = maximal
   )
 }
@@ -572,11 +572,13 @@ weighted_cliques <- function(
 largest_weighted_cliques <- function(
   graph,
   ...,
-  vertex.weights = NULL
+  vertex_weights = NULL
 ) {
   # BEGIN GENERATED ARG_HANDLE: largest_weighted_cliques, do not edit, see tools/generate-migrations.R
   # fmt: skip
   if (...length() > 0L) {
+    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("v", "ve", "ver", "vert", "verte", "vertex"))
+    if (base::length(.arg_ambiguous) > 0L) cli::cli_abort("Argument {.arg {(.arg_ambiguous[[1L]])}} matches multiple arguments of {.fn largest_weighted_cliques}.")
     # Pre-3.0.0 signature: largest_weighted_cliques(graph, vertex.weights)
     .old_signature <- function(vertex.weights, ...) {
       if (...length() > 0L) {
@@ -586,14 +588,14 @@ largest_weighted_cliques <- function(
         cli::cli_abort(base::c("Unexpected argument passed to {.fn largest_weighted_cliques}: {.arg {(.arg_extra)}}.", i = "Arguments after {.arg ...} must be spelled out in full."), call = base::parent.frame())
       }
       base::c(
-        if (!base::missing(vertex.weights)) base::list(vertex.weights = vertex.weights)
+        if (!base::missing(vertex.weights)) base::list(vertex_weights = vertex.weights)
       )
     }
     .arg_handle <- .old_signature(...)
     if (base::length(.arg_handle) > 0L) {
       .arg_names <- base::names(.arg_handle)
       .arg_conflict <- base::intersect(.arg_names, base::c(
-        if (!base::missing(vertex.weights)) "vertex.weights"
+        if (!base::missing(vertex_weights)) "vertex_weights"
       ))
       if (base::length(.arg_conflict) > 0L) cli::cli_abort(base::c("Argument {.arg {(.arg_conflict)}} of {.fn largest_weighted_cliques} was supplied more than once.", i = "Pass it exactly once, by its new name {.arg {(.arg_conflict)}}."))
       base::list2env(.arg_handle, base::environment())
@@ -601,7 +603,7 @@ largest_weighted_cliques <- function(
         "3.0.0",
         what = base::I("Calling `largest_weighted_cliques()` with positional or abbreviated arguments"),
         details = base::c(
-          i = base::paste0("Detected call:  largest_weighted_cliques(", base::paste(base::c("graph", .arg_names), collapse = ", "), ")"),
+          i = base::paste0("Detected call:  largest_weighted_cliques(", base::paste(base::c("graph", base::c(vertex_weights = "vertex.weights")[.arg_names]), collapse = ", "), ")"),
           i = base::paste0("Use instead:    largest_weighted_cliques(", base::paste(base::c("graph", base::paste0(.arg_names, " = ")), collapse = ", "), ")")
         )
       )
@@ -611,7 +613,7 @@ largest_weighted_cliques <- function(
 
   largest_weighted_cliques_impl(
     graph = graph,
-    vertex_weights = vertex.weights
+    vertex_weights = vertex_weights
   )
 }
 #' @inheritParams rlang::args_dots_empty
@@ -620,11 +622,13 @@ largest_weighted_cliques <- function(
 weighted_clique_num <- function(
   graph,
   ...,
-  vertex.weights = NULL
+  vertex_weights = NULL
 ) {
   # BEGIN GENERATED ARG_HANDLE: weighted_clique_num, do not edit, see tools/generate-migrations.R
   # fmt: skip
   if (...length() > 0L) {
+    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("v", "ve", "ver", "vert", "verte", "vertex"))
+    if (base::length(.arg_ambiguous) > 0L) cli::cli_abort("Argument {.arg {(.arg_ambiguous[[1L]])}} matches multiple arguments of {.fn weighted_clique_num}.")
     # Pre-3.0.0 signature: weighted_clique_num(graph, vertex.weights)
     .old_signature <- function(vertex.weights, ...) {
       if (...length() > 0L) {
@@ -634,14 +638,14 @@ weighted_clique_num <- function(
         cli::cli_abort(base::c("Unexpected argument passed to {.fn weighted_clique_num}: {.arg {(.arg_extra)}}.", i = "Arguments after {.arg ...} must be spelled out in full."), call = base::parent.frame())
       }
       base::c(
-        if (!base::missing(vertex.weights)) base::list(vertex.weights = vertex.weights)
+        if (!base::missing(vertex.weights)) base::list(vertex_weights = vertex.weights)
       )
     }
     .arg_handle <- .old_signature(...)
     if (base::length(.arg_handle) > 0L) {
       .arg_names <- base::names(.arg_handle)
       .arg_conflict <- base::intersect(.arg_names, base::c(
-        if (!base::missing(vertex.weights)) "vertex.weights"
+        if (!base::missing(vertex_weights)) "vertex_weights"
       ))
       if (base::length(.arg_conflict) > 0L) cli::cli_abort(base::c("Argument {.arg {(.arg_conflict)}} of {.fn weighted_clique_num} was supplied more than once.", i = "Pass it exactly once, by its new name {.arg {(.arg_conflict)}}."))
       base::list2env(.arg_handle, base::environment())
@@ -649,7 +653,7 @@ weighted_clique_num <- function(
         "3.0.0",
         what = base::I("Calling `weighted_clique_num()` with positional or abbreviated arguments"),
         details = base::c(
-          i = base::paste0("Detected call:  weighted_clique_num(", base::paste(base::c("graph", .arg_names), collapse = ", "), ")"),
+          i = base::paste0("Detected call:  weighted_clique_num(", base::paste(base::c("graph", base::c(vertex_weights = "vertex.weights")[.arg_names]), collapse = ", "), ")"),
           i = base::paste0("Use instead:    weighted_clique_num(", base::paste(base::c("graph", base::paste0(.arg_names, " = ")), collapse = ", "), ")")
         )
       )
@@ -659,7 +663,7 @@ weighted_clique_num <- function(
 
   weighted_clique_number_impl(
     graph = graph,
-    vertex_weights = vertex.weights
+    vertex_weights = vertex_weights
   )
 }
 

--- a/R/cliques.R
+++ b/R/cliques.R
@@ -474,12 +474,12 @@ clique_num <- function(graph) {
 #'
 #' @param graph The input graph, directed graphs will be considered as
 #'   undirected ones, multiple edges and loops are ignored.
-#' @param min.weight Numeric constant, lower limit on the weight of the cliques to find.
+#' @param min_weight Numeric constant, lower limit on the weight of the cliques to find.
 #'   `NULL` means no limit, i.e. it is the same as 0.
-#' @param max.weight Numeric constant, upper limit on the weight of the cliques to find.
+#' @param max_weight Numeric constant, upper limit on the weight of the cliques to find.
 #'   `NULL` means no limit.
 #' @inheritParams rlang::args_dots_empty
-#' @param vertex.weights Vertex weight vector. If the graph has a `weight`
+#' @param vertex_weights Vertex weight vector. If the graph has a `weight`
 #'   vertex attribute, then this is used by default. If the graph does not have a
 #'   `weight` vertex attribute and this argument is `NULL`, then every
 #'   vertex is assumed to have a weight of 1. Note that the current implementation
@@ -509,15 +509,15 @@ clique_num <- function(graph) {
 weighted_cliques <- function(
   graph,
   ...,
-  vertex.weights = NULL,
-  min.weight = 0,
-  max.weight = 0,
+  vertex_weights = NULL,
+  min_weight = 0,
+  max_weight = 0,
   maximal = FALSE
 ) {
   # BEGIN GENERATED ARG_HANDLE: weighted_cliques, do not edit, see tools/generate-migrations.R
   # fmt: skip
   if (...length() > 0L) {
-    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("m", "ma", "max"))
+    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("v", "ve", "ver", "vert", "verte", "vertex", "m", "mi", "min", "ma", "max"))
     if (base::length(.arg_ambiguous) > 0L) cli::cli_abort("Argument {.arg {(.arg_ambiguous[[1L]])}} matches multiple arguments of {.fn weighted_cliques}.")
     # Pre-3.0.0 signature: weighted_cliques(graph, vertex.weights, min.weight, max.weight, maximal)
     .old_signature <- function(vertex.weights, min.weight, max.weight, maximal, ...) {
@@ -528,9 +528,9 @@ weighted_cliques <- function(
         cli::cli_abort(base::c("Unexpected argument passed to {.fn weighted_cliques}: {.arg {(.arg_extra)}}.", i = "Arguments after {.arg ...} must be spelled out in full."), call = base::parent.frame())
       }
       base::c(
-        if (!base::missing(vertex.weights)) base::list(vertex.weights = vertex.weights),
-        if (!base::missing(min.weight)) base::list(min.weight = min.weight),
-        if (!base::missing(max.weight)) base::list(max.weight = max.weight),
+        if (!base::missing(vertex.weights)) base::list(vertex_weights = vertex.weights),
+        if (!base::missing(min.weight)) base::list(min_weight = min.weight),
+        if (!base::missing(max.weight)) base::list(max_weight = max.weight),
         if (!base::missing(maximal)) base::list(maximal = maximal)
       )
     }
@@ -538,9 +538,9 @@ weighted_cliques <- function(
     if (base::length(.arg_handle) > 0L) {
       .arg_names <- base::names(.arg_handle)
       .arg_conflict <- base::intersect(.arg_names, base::c(
-        if (!base::missing(vertex.weights)) "vertex.weights",
-        if (!base::missing(min.weight)) "min.weight",
-        if (!base::missing(max.weight)) "max.weight",
+        if (!base::missing(vertex_weights)) "vertex_weights",
+        if (!base::missing(min_weight)) "min_weight",
+        if (!base::missing(max_weight)) "max_weight",
         if (!base::missing(maximal)) "maximal"
       ))
       if (base::length(.arg_conflict) > 0L) cli::cli_abort(base::c("Argument {.arg {(.arg_conflict)}} of {.fn weighted_cliques} was supplied more than once.", i = "Pass it exactly once, by its new name {.arg {(.arg_conflict)}}."))
@@ -549,7 +549,7 @@ weighted_cliques <- function(
         "3.0.0",
         what = base::I("Calling `weighted_cliques()` with positional or abbreviated arguments"),
         details = base::c(
-          i = base::paste0("Detected call:  weighted_cliques(", base::paste(base::c("graph", .arg_names), collapse = ", "), ")"),
+          i = base::paste0("Detected call:  weighted_cliques(", base::paste(base::c("graph", base::c(vertex_weights = "vertex.weights", min_weight = "min.weight", max_weight = "max.weight", maximal = "maximal")[.arg_names]), collapse = ", "), ")"),
           i = base::paste0("Use instead:    weighted_cliques(", base::paste(base::c("graph", base::paste0(.arg_names, " = ")), collapse = ", "), ")")
         )
       )
@@ -559,9 +559,9 @@ weighted_cliques <- function(
 
   weighted_cliques_impl(
     graph = graph,
-    vertex_weights = vertex.weights,
-    min_weight = min.weight,
-    max_weight = max.weight,
+    vertex_weights = vertex_weights,
+    min_weight = min_weight,
+    max_weight = max_weight,
     maximal = maximal
   )
 }
@@ -570,11 +570,13 @@ weighted_cliques <- function(
 largest_weighted_cliques <- function(
   graph,
   ...,
-  vertex.weights = NULL
+  vertex_weights = NULL
 ) {
   # BEGIN GENERATED ARG_HANDLE: largest_weighted_cliques, do not edit, see tools/generate-migrations.R
   # fmt: skip
   if (...length() > 0L) {
+    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("v", "ve", "ver", "vert", "verte", "vertex"))
+    if (base::length(.arg_ambiguous) > 0L) cli::cli_abort("Argument {.arg {(.arg_ambiguous[[1L]])}} matches multiple arguments of {.fn largest_weighted_cliques}.")
     # Pre-3.0.0 signature: largest_weighted_cliques(graph, vertex.weights)
     .old_signature <- function(vertex.weights, ...) {
       if (...length() > 0L) {
@@ -584,14 +586,14 @@ largest_weighted_cliques <- function(
         cli::cli_abort(base::c("Unexpected argument passed to {.fn largest_weighted_cliques}: {.arg {(.arg_extra)}}.", i = "Arguments after {.arg ...} must be spelled out in full."), call = base::parent.frame())
       }
       base::c(
-        if (!base::missing(vertex.weights)) base::list(vertex.weights = vertex.weights)
+        if (!base::missing(vertex.weights)) base::list(vertex_weights = vertex.weights)
       )
     }
     .arg_handle <- .old_signature(...)
     if (base::length(.arg_handle) > 0L) {
       .arg_names <- base::names(.arg_handle)
       .arg_conflict <- base::intersect(.arg_names, base::c(
-        if (!base::missing(vertex.weights)) "vertex.weights"
+        if (!base::missing(vertex_weights)) "vertex_weights"
       ))
       if (base::length(.arg_conflict) > 0L) cli::cli_abort(base::c("Argument {.arg {(.arg_conflict)}} of {.fn largest_weighted_cliques} was supplied more than once.", i = "Pass it exactly once, by its new name {.arg {(.arg_conflict)}}."))
       base::list2env(.arg_handle, base::environment())
@@ -599,7 +601,7 @@ largest_weighted_cliques <- function(
         "3.0.0",
         what = base::I("Calling `largest_weighted_cliques()` with positional or abbreviated arguments"),
         details = base::c(
-          i = base::paste0("Detected call:  largest_weighted_cliques(", base::paste(base::c("graph", .arg_names), collapse = ", "), ")"),
+          i = base::paste0("Detected call:  largest_weighted_cliques(", base::paste(base::c("graph", base::c(vertex_weights = "vertex.weights")[.arg_names]), collapse = ", "), ")"),
           i = base::paste0("Use instead:    largest_weighted_cliques(", base::paste(base::c("graph", base::paste0(.arg_names, " = ")), collapse = ", "), ")")
         )
       )
@@ -609,7 +611,7 @@ largest_weighted_cliques <- function(
 
   largest_weighted_cliques_impl(
     graph = graph,
-    vertex_weights = vertex.weights
+    vertex_weights = vertex_weights
   )
 }
 #' @export
@@ -617,11 +619,13 @@ largest_weighted_cliques <- function(
 weighted_clique_num <- function(
   graph,
   ...,
-  vertex.weights = NULL
+  vertex_weights = NULL
 ) {
   # BEGIN GENERATED ARG_HANDLE: weighted_clique_num, do not edit, see tools/generate-migrations.R
   # fmt: skip
   if (...length() > 0L) {
+    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("v", "ve", "ver", "vert", "verte", "vertex"))
+    if (base::length(.arg_ambiguous) > 0L) cli::cli_abort("Argument {.arg {(.arg_ambiguous[[1L]])}} matches multiple arguments of {.fn weighted_clique_num}.")
     # Pre-3.0.0 signature: weighted_clique_num(graph, vertex.weights)
     .old_signature <- function(vertex.weights, ...) {
       if (...length() > 0L) {
@@ -631,14 +635,14 @@ weighted_clique_num <- function(
         cli::cli_abort(base::c("Unexpected argument passed to {.fn weighted_clique_num}: {.arg {(.arg_extra)}}.", i = "Arguments after {.arg ...} must be spelled out in full."), call = base::parent.frame())
       }
       base::c(
-        if (!base::missing(vertex.weights)) base::list(vertex.weights = vertex.weights)
+        if (!base::missing(vertex.weights)) base::list(vertex_weights = vertex.weights)
       )
     }
     .arg_handle <- .old_signature(...)
     if (base::length(.arg_handle) > 0L) {
       .arg_names <- base::names(.arg_handle)
       .arg_conflict <- base::intersect(.arg_names, base::c(
-        if (!base::missing(vertex.weights)) "vertex.weights"
+        if (!base::missing(vertex_weights)) "vertex_weights"
       ))
       if (base::length(.arg_conflict) > 0L) cli::cli_abort(base::c("Argument {.arg {(.arg_conflict)}} of {.fn weighted_clique_num} was supplied more than once.", i = "Pass it exactly once, by its new name {.arg {(.arg_conflict)}}."))
       base::list2env(.arg_handle, base::environment())
@@ -646,7 +650,7 @@ weighted_clique_num <- function(
         "3.0.0",
         what = base::I("Calling `weighted_clique_num()` with positional or abbreviated arguments"),
         details = base::c(
-          i = base::paste0("Detected call:  weighted_clique_num(", base::paste(base::c("graph", .arg_names), collapse = ", "), ")"),
+          i = base::paste0("Detected call:  weighted_clique_num(", base::paste(base::c("graph", base::c(vertex_weights = "vertex.weights")[.arg_names]), collapse = ", "), ")"),
           i = base::paste0("Use instead:    weighted_clique_num(", base::paste(base::c("graph", base::paste0(.arg_names, " = ")), collapse = ", "), ")")
         )
       )
@@ -656,7 +660,7 @@ weighted_clique_num <- function(
 
   weighted_clique_number_impl(
     graph = graph,
-    vertex_weights = vertex.weights
+    vertex_weights = vertex_weights
   )
 }
 

--- a/R/community.R
+++ b/R/community.R
@@ -282,6 +282,10 @@ is.hierarchical <- function(communities) {
 #' `infomap.community()` was renamed to [cluster_infomap()] to create a more
 #' consistent API.
 #' @inheritParams cluster_infomap
+#' @param e.weights `r lifecycle::badge("deprecated")` Use `weights` in
+#'   [cluster_infomap()] instead.
+#' @param v.weights `r lifecycle::badge("deprecated")` Use `vertex_weights` in
+#'   [cluster_infomap()] instead.
 #' @keywords internal
 #' @export
 infomap.community <- function(
@@ -295,8 +299,8 @@ infomap.community <- function(
   lifecycle::deprecate_warn("2.0.0", "infomap.community()", "cluster_infomap()")
   cluster_infomap(
     graph = graph,
-    e.weights = e.weights,
-    v.weights = v.weights,
+    weights = e.weights,
+    vertex_weights = v.weights,
     nb.trials = nb.trials,
     modularity = modularity
   )
@@ -3020,12 +3024,12 @@ cluster_optimal <- function(
 #'
 #' @param graph The input graph. Edge directions will be taken into account.
 #' @inheritParams rlang::args_dots_empty
-#' @param e.weights Numeric vector of edge weights.
+#' @param weights Numeric vector of edge weights.
 #'   The length must match the number of edges in the graph.  By default (`NULL`) the
 #'   \sQuote{`weight`} edge attribute is used as weights. If it is not
 #'   present, then all edges are considered to have the same weight.
 #'   Larger edge weights correspond to stronger connections.
-#' @param v.weights Numeric vector of vertex
+#' @param vertex_weights Numeric vector of vertex
 #'   weights. The length must match the number of vertices in the graph.  By
 #'   default (`NULL`) the \sQuote{`weight`} vertex attribute is used as weights. If
 #'   it is not present, then all vertices are considered to have the same weight.
@@ -3063,14 +3067,16 @@ cluster_optimal <- function(
 cluster_infomap <- function(
   graph,
   ...,
-  e.weights = NULL,
-  v.weights = NULL,
+  weights = NULL,
+  vertex_weights = NULL,
   nb.trials = 10,
   modularity = TRUE
 ) {
   # BEGIN GENERATED ARG_HANDLE: cluster_infomap, do not edit, see tools/generate-migrations.R
   # fmt: skip
   if (...length() > 0L) {
+    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("v"))
+    if (base::length(.arg_ambiguous) > 0L) cli::cli_abort("Argument {.arg {(.arg_ambiguous[[1L]])}} matches multiple arguments of {.fn cluster_infomap}.")
     # Pre-3.0.0 signature: cluster_infomap(graph, e.weights, v.weights, nb.trials, modularity)
     .old_signature <- function(e.weights, v.weights, nb.trials, modularity, ...) {
       if (...length() > 0L) {
@@ -3080,8 +3086,8 @@ cluster_infomap <- function(
         cli::cli_abort(base::c("Unexpected argument passed to {.fn cluster_infomap}: {.arg {(.arg_extra)}}.", i = "Arguments after {.arg ...} must be spelled out in full."), call = base::parent.frame())
       }
       base::c(
-        if (!base::missing(e.weights)) base::list(e.weights = e.weights),
-        if (!base::missing(v.weights)) base::list(v.weights = v.weights),
+        if (!base::missing(e.weights)) base::list(weights = e.weights),
+        if (!base::missing(v.weights)) base::list(vertex_weights = v.weights),
         if (!base::missing(nb.trials)) base::list(nb.trials = nb.trials),
         if (!base::missing(modularity)) base::list(modularity = modularity)
       )
@@ -3090,8 +3096,8 @@ cluster_infomap <- function(
     if (base::length(.arg_handle) > 0L) {
       .arg_names <- base::names(.arg_handle)
       .arg_conflict <- base::intersect(.arg_names, base::c(
-        if (!base::missing(e.weights)) "e.weights",
-        if (!base::missing(v.weights)) "v.weights",
+        if (!base::missing(weights)) "weights",
+        if (!base::missing(vertex_weights)) "vertex_weights",
         if (!base::missing(nb.trials)) "nb.trials",
         if (!base::missing(modularity)) "modularity"
       ))
@@ -3101,7 +3107,7 @@ cluster_infomap <- function(
         "3.0.0",
         what = base::I("Calling `cluster_infomap()` with positional or abbreviated arguments"),
         details = base::c(
-          i = base::paste0("Detected call:  cluster_infomap(", base::paste(base::c("graph", .arg_names), collapse = ", "), ")"),
+          i = base::paste0("Detected call:  cluster_infomap(", base::paste(base::c("graph", base::c(weights = "e.weights", vertex_weights = "v.weights", nb.trials = "nb.trials", modularity = "modularity")[.arg_names]), collapse = ", "), ")"),
           i = base::paste0("Use instead:    cluster_infomap(", base::paste(base::c("graph", base::paste0(.arg_names, " = ")), collapse = ", "), ")")
         )
       )
@@ -3111,8 +3117,8 @@ cluster_infomap <- function(
 
   res <- community_infomap_impl(
     graph = graph,
-    e_weights = e.weights,
-    v_weights = v.weights,
+    e_weights = weights,
+    v_weights = vertex_weights,
     nb_trials = nb.trials
   )
 
@@ -3123,7 +3129,7 @@ cluster_infomap <- function(
   res$algorithm <- "infomap"
   res$membership <- res$membership + 1
   if (modularity) {
-    res$modularity <- modularity(graph, res$membership, weights = e.weights)
+    res$modularity <- modularity(graph, res$membership, weights = weights)
   }
   class(res) <- "communities"
   res

--- a/R/community.R
+++ b/R/community.R
@@ -282,6 +282,10 @@ is.hierarchical <- function(communities) {
 #' `infomap.community()` was renamed to [cluster_infomap()] to create a more
 #' consistent API.
 #' @inheritParams cluster_infomap
+#' @param e.weights `r lifecycle::badge("deprecated")` Use `weights` in
+#'   [cluster_infomap()] instead.
+#' @param v.weights `r lifecycle::badge("deprecated")` Use `vertex_weights` in
+#'   [cluster_infomap()] instead.
 #' @keywords internal
 #' @export
 infomap.community <- function(
@@ -295,8 +299,8 @@ infomap.community <- function(
   lifecycle::deprecate_warn("2.0.0", "infomap.community()", "cluster_infomap()")
   cluster_infomap(
     graph = graph,
-    e.weights = e.weights,
-    v.weights = v.weights,
+    weights = e.weights,
+    vertex_weights = v.weights,
     nb.trials = nb.trials,
     modularity = modularity
   )
@@ -3021,12 +3025,12 @@ cluster_optimal <- function(
 #'
 #' @param graph The input graph. Edge directions will be taken into account.
 #' @inheritParams rlang::args_dots_empty
-#' @param e.weights Numeric vector of edge weights.
+#' @param weights Numeric vector of edge weights.
 #'   The length must match the number of edges in the graph.  By default (`NULL`) the
 #'   \sQuote{`weight`} edge attribute is used as weights. If it is not
 #'   present, then all edges are considered to have the same weight.
 #'   Larger edge weights correspond to stronger connections.
-#' @param v.weights Numeric vector of vertex
+#' @param vertex_weights Numeric vector of vertex
 #'   weights. The length must match the number of vertices in the graph.  By
 #'   default (`NULL`) the \sQuote{`weight`} vertex attribute is used as weights. If
 #'   it is not present, then all vertices are considered to have the same weight.
@@ -3064,14 +3068,16 @@ cluster_optimal <- function(
 cluster_infomap <- function(
   graph,
   ...,
-  e.weights = NULL,
-  v.weights = NULL,
+  weights = NULL,
+  vertex_weights = NULL,
   nb.trials = 10,
   modularity = TRUE
 ) {
   # BEGIN GENERATED ARG_HANDLE: cluster_infomap, do not edit, see tools/generate-migrations.R
   # fmt: skip
   if (...length() > 0L) {
+    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("v"))
+    if (base::length(.arg_ambiguous) > 0L) cli::cli_abort("Argument {.arg {(.arg_ambiguous[[1L]])}} matches multiple arguments of {.fn cluster_infomap}.")
     # Pre-3.0.0 signature: cluster_infomap(graph, e.weights, v.weights, nb.trials, modularity)
     .old_signature <- function(e.weights, v.weights, nb.trials, modularity, ...) {
       if (...length() > 0L) {
@@ -3081,8 +3087,8 @@ cluster_infomap <- function(
         cli::cli_abort(base::c("Unexpected argument passed to {.fn cluster_infomap}: {.arg {(.arg_extra)}}.", i = "Arguments after {.arg ...} must be spelled out in full."), call = base::parent.frame())
       }
       base::c(
-        if (!base::missing(e.weights)) base::list(e.weights = e.weights),
-        if (!base::missing(v.weights)) base::list(v.weights = v.weights),
+        if (!base::missing(e.weights)) base::list(weights = e.weights),
+        if (!base::missing(v.weights)) base::list(vertex_weights = v.weights),
         if (!base::missing(nb.trials)) base::list(nb.trials = nb.trials),
         if (!base::missing(modularity)) base::list(modularity = modularity)
       )
@@ -3091,8 +3097,8 @@ cluster_infomap <- function(
     if (base::length(.arg_handle) > 0L) {
       .arg_names <- base::names(.arg_handle)
       .arg_conflict <- base::intersect(.arg_names, base::c(
-        if (!base::missing(e.weights)) "e.weights",
-        if (!base::missing(v.weights)) "v.weights",
+        if (!base::missing(weights)) "weights",
+        if (!base::missing(vertex_weights)) "vertex_weights",
         if (!base::missing(nb.trials)) "nb.trials",
         if (!base::missing(modularity)) "modularity"
       ))
@@ -3102,7 +3108,7 @@ cluster_infomap <- function(
         "3.0.0",
         what = base::I("Calling `cluster_infomap()` with positional or abbreviated arguments"),
         details = base::c(
-          i = base::paste0("Detected call:  cluster_infomap(", base::paste(base::c("graph", .arg_names), collapse = ", "), ")"),
+          i = base::paste0("Detected call:  cluster_infomap(", base::paste(base::c("graph", base::c(weights = "e.weights", vertex_weights = "v.weights", nb.trials = "nb.trials", modularity = "modularity")[.arg_names]), collapse = ", "), ")"),
           i = base::paste0("Use instead:    cluster_infomap(", base::paste(base::c("graph", base::paste0(.arg_names, " = ")), collapse = ", "), ")")
         )
       )
@@ -3112,8 +3118,8 @@ cluster_infomap <- function(
 
   res <- community_infomap_impl(
     graph = graph,
-    e_weights = e.weights,
-    v_weights = v.weights,
+    e_weights = weights,
+    v_weights = vertex_weights,
     nb_trials = nb.trials
   )
 
@@ -3124,7 +3130,7 @@ cluster_infomap <- function(
   res$algorithm <- "infomap"
   res$membership <- res$membership + 1
   if (modularity) {
-    res$modularity <- modularity(graph, res$membership, weights = e.weights)
+    res$modularity <- modularity(graph, res$membership, weights = weights)
   }
   class(res) <- "communities"
   res

--- a/man/cliques.Rd
+++ b/man/cliques.Rd
@@ -30,9 +30,9 @@ count_max_cliques(graph, min = NULL, max = NULL, ..., subset = NULL)
 
 clique_num(graph)
 
-largest_weighted_cliques(graph, ..., vertex.weights = NULL)
+largest_weighted_cliques(graph, ..., vertex_weights = NULL)
 
-weighted_clique_num(graph, ..., vertex.weights = NULL)
+weighted_clique_num(graph, ..., vertex_weights = NULL)
 
 clique_size_counts(graph, ..., min = 0, max = 0, maximal = FALSE)
 
@@ -73,7 +73,7 @@ it exists, then it will be overwritten.) Each clique will be a separate line
 in the file, given with the numeric IDs of its vertices, separated by
 whitespace.}
 
-\item{vertex.weights}{Vertex weight vector. If the graph has a \code{weight}
+\item{vertex_weights}{Vertex weight vector. If the graph has a \code{weight}
 vertex attribute, then this is used by default. If the graph does not have a
 \code{weight} vertex attribute and this argument is \code{NULL}, then every
 vertex is assumed to have a weight of 1. Note that the current implementation

--- a/man/cluster_infomap.Rd
+++ b/man/cluster_infomap.Rd
@@ -7,8 +7,8 @@
 cluster_infomap(
   graph,
   ...,
-  e.weights = NULL,
-  v.weights = NULL,
+  weights = NULL,
+  vertex_weights = NULL,
   nb.trials = 10,
   modularity = TRUE
 )
@@ -18,13 +18,13 @@ cluster_infomap(
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{e.weights}{Numeric vector of edge weights.
+\item{weights}{Numeric vector of edge weights.
 The length must match the number of edges in the graph.  By default (\code{NULL}) the
 \sQuote{\code{weight}} edge attribute is used as weights. If it is not
 present, then all edges are considered to have the same weight.
 Larger edge weights correspond to stronger connections.}
 
-\item{v.weights}{Numeric vector of vertex
+\item{vertex_weights}{Numeric vector of vertex
 weights. The length must match the number of vertices in the graph.  By
 default (\code{NULL}) the \sQuote{\code{weight}} vertex attribute is used as weights. If
 it is not present, then all vertices are considered to have the same weight.

--- a/man/infomap.community.Rd
+++ b/man/infomap.community.Rd
@@ -15,18 +15,11 @@ infomap.community(
 \arguments{
 \item{graph}{The input graph. Edge directions will be taken into account.}
 
-\item{e.weights}{Numeric vector of edge weights.
-The length must match the number of edges in the graph.  By default (\code{NULL}) the
-\sQuote{\code{weight}} edge attribute is used as weights. If it is not
-present, then all edges are considered to have the same weight.
-Larger edge weights correspond to stronger connections.}
+\item{e.weights}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{weights} in
+\code{\link[=cluster_infomap]{cluster_infomap()}} instead.}
 
-\item{v.weights}{Numeric vector of vertex
-weights. The length must match the number of vertices in the graph.  By
-default (\code{NULL}) the \sQuote{\code{weight}} vertex attribute is used as weights. If
-it is not present, then all vertices are considered to have the same weight.
-A larger vertex weight means a larger probability that the random surfer
-jumps to that vertex.}
+\item{v.weights}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{vertex_weights} in
+\code{\link[=cluster_infomap]{cluster_infomap()}} instead.}
 
 \item{nb.trials}{The number of attempts to partition the network (can be any
 integer value equal or larger than 1).}

--- a/man/weighted_cliques.Rd
+++ b/man/weighted_cliques.Rd
@@ -7,9 +7,9 @@
 weighted_cliques(
   graph,
   ...,
-  vertex.weights = NULL,
-  min.weight = 0,
-  max.weight = 0,
+  vertex_weights = NULL,
+  min_weight = 0,
+  max_weight = 0,
   maximal = FALSE
 )
 }
@@ -19,16 +19,16 @@ undirected ones, multiple edges and loops are ignored.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
-\item{vertex.weights}{Vertex weight vector. If the graph has a \code{weight}
+\item{vertex_weights}{Vertex weight vector. If the graph has a \code{weight}
 vertex attribute, then this is used by default. If the graph does not have a
 \code{weight} vertex attribute and this argument is \code{NULL}, then every
 vertex is assumed to have a weight of 1. Note that the current implementation
 of the weighted clique finder supports positive integer weights only.}
 
-\item{min.weight}{Numeric constant, lower limit on the weight of the cliques to find.
+\item{min_weight}{Numeric constant, lower limit on the weight of the cliques to find.
 \code{NULL} means no limit, i.e. it is the same as 0.}
 
-\item{max.weight}{Numeric constant, upper limit on the weight of the cliques to find.
+\item{max_weight}{Numeric constant, upper limit on the weight of the cliques to find.
 \code{NULL} means no limit.}
 
 \item{maximal}{Specifies whether to look for all weighted cliques (\code{FALSE})

--- a/tests/testthat/_snaps/cliques.md
+++ b/tests/testthat/_snaps/cliques.md
@@ -1,0 +1,10 @@
+# weighted_cliques(vertex.weights = ) is deprecated but still works
+
+    Code
+      res <- weighted_cliques(g, vertex.weights = w, min.weight = 6)
+    Condition
+      Warning:
+      Calling `weighted_cliques()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
+      i Detected call: weighted_cliques(graph, vertex.weights, min.weight)
+      i Use instead: weighted_cliques(graph, vertex_weights = , min_weight = )
+

--- a/tests/testthat/test-cliques.R
+++ b/tests/testthat/test-cliques.R
@@ -48,13 +48,13 @@ test_that("weighted_cliques works", {
   }
 
   expect_equal(
-    lapply(largest_weighted_cliques(g, vertex.weights = weights), as.numeric),
+    lapply(largest_weighted_cliques(g, vertex_weights = weights), as.numeric),
     list(c(1, 2, 3))
   )
 
   V(g)$weight <- weights
   cl <- sapply(
-    weighted_cliques(g, min.weight = 9),
+    weighted_cliques(g, min_weight = 9),
     is_clique_weight,
     graph = g,
     min_weight = 9
@@ -64,7 +64,7 @@ test_that("weighted_cliques works", {
   karate <- make_graph("zachary")
   weights <- rep(1, vcount(karate))
   weights[c(1, 2, 3, 4, 14)] <- 3
-  expect_equal(weighted_clique_num(karate, vertex.weights = weights), 15)
+  expect_equal(weighted_clique_num(karate, vertex_weights = weights), 15)
 
   V(karate)$weight <- weights * 2
   expect_equal(weighted_clique_num(karate), 30)
@@ -522,19 +522,19 @@ test_that("weighted_cliques() covers all tail arguments", {
   # Under the attribute weights only the edge satisfies the weight bounds.
   res_attr <- weighted_cliques(
     g,
-    min.weight = 6,
-    max.weight = 9,
+    min_weight = 6,
+    max_weight = 9,
     maximal = TRUE
   )
   expect_identical(lapply(res_attr, as.numeric), list(c(4, 5)))
 
-  # An explicit `vertex.weights` overrides the attribute,
+  # An explicit `vertex_weights` overrides the attribute,
   # flipping the selection to the triangle.
   res <- weighted_cliques(
     g,
-    vertex.weights = w,
-    min.weight = 6,
-    max.weight = 9,
+    vertex_weights = w,
+    min_weight = 6,
+    max_weight = 9,
     maximal = TRUE
   )
   expect_identical(lapply(res, as.numeric), list(c(1, 2, 3)))
@@ -543,21 +543,42 @@ test_that("weighted_cliques() covers all tail arguments", {
   lifecycle::expect_deprecated(
     res <- weighted_cliques(g, w, 6)
   )
-  expect_identical(res, weighted_cliques(g, vertex.weights = w, min.weight = 6))
+  expect_identical(res, weighted_cliques(g, vertex_weights = w, min_weight = 6))
 })
 
-test_that("largest_weighted_cliques() covers vertex.weights", {
+test_that("weighted_cliques(vertex.weights = ) is deprecated but still works", {
+  rlang::local_options(lifecycle_verbosity = "warning")
+  g <- make_weighted_clique_graph()
+  w <- c(3, 3, 3, 1, 1)
+
+  expect_snapshot(
+    res <- weighted_cliques(g, vertex.weights = w, min.weight = 6)
+  )
+  expect_identical(res, weighted_cliques(g, vertex_weights = w, min_weight = 6))
+
+  lifecycle::expect_deprecated(
+    res_num <- weighted_clique_num(g, vertex.weights = w)
+  )
+  expect_identical(res_num, weighted_clique_num(g, vertex_weights = w))
+
+  lifecycle::expect_deprecated(
+    res_largest <- largest_weighted_cliques(g, vertex.weights = w)
+  )
+  expect_identical(res_largest, largest_weighted_cliques(g, vertex_weights = w))
+})
+
+test_that("largest_weighted_cliques() covers vertex_weights", {
   g <- make_weighted_clique_graph()
   w <- c(3, 3, 3, 1, 1)
 
   # Attribute weights favor the edge,
-  # the explicit `vertex.weights` vector overrides them.
+  # the explicit `vertex_weights` vector overrides them.
   expect_identical(
     lapply(largest_weighted_cliques(g), as.numeric),
     list(c(4, 5))
   )
   expect_identical(
-    lapply(largest_weighted_cliques(g, vertex.weights = w), as.numeric),
+    lapply(largest_weighted_cliques(g, vertex_weights = w), as.numeric),
     list(c(1, 2, 3))
   )
 
@@ -565,21 +586,21 @@ test_that("largest_weighted_cliques() covers vertex.weights", {
   lifecycle::expect_deprecated(
     res <- largest_weighted_cliques(g, w)
   )
-  expect_identical(res, largest_weighted_cliques(g, vertex.weights = w))
+  expect_identical(res, largest_weighted_cliques(g, vertex_weights = w))
 })
 
-test_that("weighted_clique_num() covers vertex.weights", {
+test_that("weighted_clique_num() covers vertex_weights", {
   g <- make_weighted_clique_graph()
   w <- c(3, 3, 3, 1, 1)
 
   # Attribute weights favor the edge,
-  # the explicit `vertex.weights` vector overrides them.
+  # the explicit `vertex_weights` vector overrides them.
   expect_equal(weighted_clique_num(g), 8)
-  expect_equal(weighted_clique_num(g, vertex.weights = w), 9)
+  expect_equal(weighted_clique_num(g, vertex_weights = w), 9)
 
   # Legacy positional `vertex.weights` is recovered with a deprecation warning.
   lifecycle::expect_deprecated(
     res <- weighted_clique_num(g, w)
   )
-  expect_identical(res, weighted_clique_num(g, vertex.weights = w))
+  expect_identical(res, weighted_clique_num(g, vertex_weights = w))
 })

--- a/tests/testthat/test-community.R
+++ b/tests/testthat/test-community.R
@@ -787,8 +787,8 @@ test_that("cluster_infomap() covers migrated tail args and positional recovery",
 
   res <- cluster_infomap(
     karate,
-    e.weights = rep(1, ecount(karate)),
-    v.weights = rep(1, vcount(karate)),
+    weights = rep(1, ecount(karate)),
+    vertex_weights = rep(1, vcount(karate)),
     nb.trials = 3,
     modularity = FALSE
   )
@@ -804,7 +804,23 @@ test_that("cluster_infomap() covers migrated tail args and positional recovery",
     res_legacy <- cluster_infomap(karate, ew)
   )
   set.seed(1)
-  expect_identical(res_legacy, cluster_infomap(karate, e.weights = ew))
+  expect_identical(res_legacy, cluster_infomap(karate, weights = ew))
+
+  # The legacy `e.weights` and `v.weights` names are recovered.
+  set.seed(1)
+  lifecycle::expect_deprecated(
+    res_enamed <- cluster_infomap(karate, e.weights = ew)
+  )
+  expect_identical(res_enamed, res_legacy)
+  set.seed(1)
+  lifecycle::expect_deprecated(
+    res_vnamed <- cluster_infomap(karate, v.weights = rep(1, vcount(karate)))
+  )
+  set.seed(1)
+  expect_identical(
+    res_vnamed,
+    cluster_infomap(karate, vertex_weights = rep(1, vcount(karate)))
+  )
 })
 
 test_that("cluster_louvain() covers migrated tail args and positional recovery", {

--- a/tools/migrations/cliques.R
+++ b/tools/migrations/cliques.R
@@ -39,33 +39,39 @@ migrations <- list(
   ),
 
   largest_weighted_cliques = list(
-    old = function(graph, vertex.weights) {},
+    old = function(graph, vertex.weights = vertex_weights) {},
     new = function(
       graph,
       ...,
-      vertex.weights = NULL
+      vertex_weights = NULL
     ) {},
     when = "3.0.0"
   ),
 
   weighted_clique_num = list(
-    old = function(graph, vertex.weights) {},
+    old = function(graph, vertex.weights = vertex_weights) {},
     new = function(
       graph,
       ...,
-      vertex.weights = NULL
+      vertex_weights = NULL
     ) {},
     when = "3.0.0"
   ),
 
   weighted_cliques = list(
-    old = function(graph, vertex.weights, min.weight, max.weight, maximal) {},
+    old = function(
+      graph,
+      vertex.weights = vertex_weights,
+      min.weight = min_weight,
+      max.weight = max_weight,
+      maximal
+    ) {},
     new = function(
       graph,
       ...,
-      vertex.weights = NULL,
-      min.weight = 0,
-      max.weight = 0,
+      vertex_weights = NULL,
+      min_weight = 0,
+      max_weight = 0,
       maximal = FALSE
     ) {},
     when = "3.0.0"

--- a/tools/migrations/community.R
+++ b/tools/migrations/community.R
@@ -42,12 +42,18 @@ migrations <- list(
   ),
 
   cluster_infomap = list(
-    old = function(graph, e.weights, v.weights, nb.trials, modularity) {},
+    old = function(
+      graph,
+      e.weights = weights,
+      v.weights = vertex_weights,
+      nb.trials,
+      modularity
+    ) {},
     new = function(
       graph,
       ...,
-      e.weights = NULL,
-      v.weights = NULL,
+      weights = NULL,
+      vertex_weights = NULL,
       nb.trials = 10,
       modularity = TRUE
     ) {},


### PR DESCRIPTION
Part of #2788 (PR 3 of the stack, on top of #2860); executes the weights-spelling row of the survey plus the `vertex.weights`/`min.weight`/`max.weight` names called out in the issue comments.

## What this does

Pure registry renames (all arguments already sit after `...` with 3.0.0 entries); legacy spellings are recovered under the standard single soft-deprecation:

- `weighted_cliques()`: `vertex.weights` → `vertex_weights`, `min.weight` → `min_weight`, `max.weight` → `max_weight`
- `largest_weighted_cliques()`, `weighted_clique_num()`: `vertex.weights` → `vertex_weights`
- `cluster_infomap()`: `e.weights` → **`weights`** and `v.weights` → **`vertex_weights`** — this pair was *missing from the #2788 survey table*; `e.weights` has exactly the standard `weights` semantics (`NULL` picks up the `weight` edge attribute), and `v.weights` matches `cluster_leiden()`'s existing `vertex_weights`. The `infomap.community()` wrapper keeps its frozen dotted formals (now documented locally with deprecated badges) and forwards to the new names.

This aligns the whole package on exactly two vertex-weight spellings (`vertex_weights`) and one edge-weight spelling (`weights`) among non-deprecated functions.

## Deliberately out of scope (survey corrections)

The issue's weights row lists two functions this PR does **not** touch, because renaming them to `weights` would be semantically wrong:

- `make_chordal_ring(w)` — `w` is the **shift matrix** defining the extended chordal ring, not edge weights. A rename should go to something like `shifts` (follow-up decision).
- `graph_from_graphnel(weight)` — a **logical toggle** ("import graphNEL edge weights?"), not a weights vector. A rename should go to something like `use_weights` (follow-up decision).

Other weight-adjacent spellings left alone on semantic grounds: `out.weights`/`in.weights` in `sample_chung_lu()` (fitness vectors), `weight.*` in `layout_with_dh()` (objective-function coefficients). These belong to the dotted-name case sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTPj4qNv2FWui6etixZeuR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTPj4qNv2FWui6etixZeuR)_