### PR TITLE
refactor: Purge legacy alias formals via the migration registry

### DIFF
--- a/R/community.R
+++ b/R/community.R
@@ -1758,7 +1758,6 @@ cluster_spinglass <- function(
 #' @param resolution The resolution parameter to use. Higher
 #'   resolutions lead to more smaller communities, while lower resolutions lead
 #'   to fewer larger communities.
-#' @param resolution_parameter  `r lifecycle::badge("superseded")` Use `resolution` instead.
 #' @param beta Parameter affecting the randomness in the Leiden algorithm.
 #'   This affects only the refinement step of the algorithm.
 #' @param initial_membership If provided, the Leiden algorithm
@@ -1809,22 +1808,57 @@ cluster_leiden <- function(
   ...,
   weights = NULL,
   resolution = 1,
-  resolution_parameter = deprecated(),
   beta = 0.01,
   initial_membership = NULL,
   n_iterations = 2,
   vertex_weights = NULL
 ) {
-  check_dots_empty()
-
-  if (lifecycle::is_present(resolution_parameter)) {
-    lifecycle::deprecate_warn(
-      "2.1.0",
-      "cluster_leiden(resolution_parameter)",
-      "cluster_leiden(resolution)"
-    )
-    resolution <- resolution_parameter
+  # BEGIN GENERATED ARG_HANDLE: cluster_leiden, do not edit, see tools/generate-migrations.R
+  # fmt: skip
+  if (...length() > 0L) {
+    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("r", "re", "res", "reso", "resol", "resolu", "resolut", "resoluti", "resolutio"))
+    if (base::length(.arg_ambiguous) > 0L) cli::cli_abort("Argument {.arg {(.arg_ambiguous[[1L]])}} matches multiple arguments of {.fn cluster_leiden}.")
+    # Pre-3.0.0 signature: cluster_leiden(graph, objective_function, weights, resolution_parameter, beta, initial_membership, n_iterations, vertex_weights)
+    .old_signature <- function(weights, resolution_parameter, beta, initial_membership, n_iterations, vertex_weights, ...) {
+      if (...length() > 0L) {
+        .arg_extra <- base::names(base::substitute(...()))
+        .arg_extra <- .arg_extra[base::nzchar(.arg_extra)]
+        if (base::length(.arg_extra) == 0L) cli::cli_abort("Too many arguments passed to {.fn cluster_leiden}.", call = base::parent.frame())
+        cli::cli_abort(base::c("Unexpected argument passed to {.fn cluster_leiden}: {.arg {(.arg_extra)}}.", i = "Arguments after {.arg ...} must be spelled out in full."), call = base::parent.frame())
+      }
+      base::c(
+        if (!base::missing(weights)) base::list(weights = weights),
+        if (!base::missing(resolution_parameter)) base::list(resolution = resolution_parameter),
+        if (!base::missing(beta)) base::list(beta = beta),
+        if (!base::missing(initial_membership)) base::list(initial_membership = initial_membership),
+        if (!base::missing(n_iterations)) base::list(n_iterations = n_iterations),
+        if (!base::missing(vertex_weights)) base::list(vertex_weights = vertex_weights)
+      )
+    }
+    .arg_handle <- .old_signature(...)
+    if (base::length(.arg_handle) > 0L) {
+      .arg_names <- base::names(.arg_handle)
+      .arg_conflict <- base::intersect(.arg_names, base::c(
+        if (!base::missing(weights)) "weights",
+        if (!base::missing(resolution)) "resolution",
+        if (!base::missing(beta)) "beta",
+        if (!base::missing(initial_membership)) "initial_membership",
+        if (!base::missing(n_iterations)) "n_iterations",
+        if (!base::missing(vertex_weights)) "vertex_weights"
+      ))
+      if (base::length(.arg_conflict) > 0L) cli::cli_abort(base::c("Argument {.arg {(.arg_conflict)}} of {.fn cluster_leiden} was supplied more than once.", i = "Pass it exactly once, by its new name {.arg {(.arg_conflict)}}."))
+      base::list2env(.arg_handle, base::environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = base::I("Calling `cluster_leiden()` with positional or abbreviated arguments"),
+        details = base::c(
+          i = base::paste0("Detected call:  cluster_leiden(", base::paste(base::c("graph", "objective_function", base::c(weights = "weights", resolution = "resolution_parameter", beta = "beta", initial_membership = "initial_membership", n_iterations = "n_iterations", vertex_weights = "vertex_weights")[.arg_names]), collapse = ", "), ")"),
+          i = base::paste0("Use instead:    cluster_leiden(", base::paste(base::c("graph", "objective_function", base::paste0(.arg_names, " = ")), collapse = ", "), ")")
+        )
+      )
+    }
   }
+  # END GENERATED ARG_HANDLE
 
   ensure_igraph(graph)
 

--- a/R/community.R
+++ b/R/community.R
@@ -1759,7 +1759,6 @@ cluster_spinglass <- function(
 #' @param resolution The resolution parameter to use. Higher
 #'   resolutions lead to more smaller communities, while lower resolutions lead
 #'   to fewer larger communities.
-#' @param resolution_parameter  `r lifecycle::badge("superseded")` Use `resolution` instead.
 #' @param beta Parameter affecting the randomness in the Leiden algorithm.
 #'   This affects only the refinement step of the algorithm.
 #' @param initial_membership If provided, the Leiden algorithm
@@ -1810,22 +1809,57 @@ cluster_leiden <- function(
   ...,
   weights = NULL,
   resolution = 1,
-  resolution_parameter = deprecated(),
   beta = 0.01,
   initial_membership = NULL,
   n_iterations = 2,
   vertex_weights = NULL
 ) {
-  check_dots_empty()
-
-  if (lifecycle::is_present(resolution_parameter)) {
-    lifecycle::deprecate_warn(
-      "2.1.0",
-      "cluster_leiden(resolution_parameter)",
-      "cluster_leiden(resolution)"
-    )
-    resolution <- resolution_parameter
+  # BEGIN GENERATED ARG_HANDLE: cluster_leiden, do not edit, see tools/generate-migrations.R
+  # fmt: skip
+  if (...length() > 0L) {
+    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("r", "re", "res", "reso", "resol", "resolu", "resolut", "resoluti", "resolutio"))
+    if (base::length(.arg_ambiguous) > 0L) cli::cli_abort("Argument {.arg {(.arg_ambiguous[[1L]])}} matches multiple arguments of {.fn cluster_leiden}.")
+    # Pre-3.0.0 signature: cluster_leiden(graph, objective_function, weights, resolution_parameter, beta, initial_membership, n_iterations, vertex_weights)
+    .old_signature <- function(weights, resolution_parameter, beta, initial_membership, n_iterations, vertex_weights, ...) {
+      if (...length() > 0L) {
+        .arg_extra <- base::names(base::substitute(...()))
+        .arg_extra <- .arg_extra[base::nzchar(.arg_extra)]
+        if (base::length(.arg_extra) == 0L) cli::cli_abort("Too many arguments passed to {.fn cluster_leiden}.", call = base::parent.frame())
+        cli::cli_abort(base::c("Unexpected argument passed to {.fn cluster_leiden}: {.arg {(.arg_extra)}}.", i = "Arguments after {.arg ...} must be spelled out in full."), call = base::parent.frame())
+      }
+      base::c(
+        if (!base::missing(weights)) base::list(weights = weights),
+        if (!base::missing(resolution_parameter)) base::list(resolution = resolution_parameter),
+        if (!base::missing(beta)) base::list(beta = beta),
+        if (!base::missing(initial_membership)) base::list(initial_membership = initial_membership),
+        if (!base::missing(n_iterations)) base::list(n_iterations = n_iterations),
+        if (!base::missing(vertex_weights)) base::list(vertex_weights = vertex_weights)
+      )
+    }
+    .arg_handle <- .old_signature(...)
+    if (base::length(.arg_handle) > 0L) {
+      .arg_names <- base::names(.arg_handle)
+      .arg_conflict <- base::intersect(.arg_names, base::c(
+        if (!base::missing(weights)) "weights",
+        if (!base::missing(resolution)) "resolution",
+        if (!base::missing(beta)) "beta",
+        if (!base::missing(initial_membership)) "initial_membership",
+        if (!base::missing(n_iterations)) "n_iterations",
+        if (!base::missing(vertex_weights)) "vertex_weights"
+      ))
+      if (base::length(.arg_conflict) > 0L) cli::cli_abort(base::c("Argument {.arg {(.arg_conflict)}} of {.fn cluster_leiden} was supplied more than once.", i = "Pass it exactly once, by its new name {.arg {(.arg_conflict)}}."))
+      base::list2env(.arg_handle, base::environment())
+      lifecycle::deprecate_soft(
+        "3.0.0",
+        what = base::I("Calling `cluster_leiden()` with positional or abbreviated arguments"),
+        details = base::c(
+          i = base::paste0("Detected call:  cluster_leiden(", base::paste(base::c("graph", "objective_function", base::c(weights = "weights", resolution = "resolution_parameter", beta = "beta", initial_membership = "initial_membership", n_iterations = "n_iterations", vertex_weights = "vertex_weights")[.arg_names]), collapse = ", "), ")"),
+          i = base::paste0("Use instead:    cluster_leiden(", base::paste(base::c("graph", "objective_function", base::paste0(.arg_names, " = ")), collapse = ", "), ")")
+        )
+      )
+    }
   }
+  # END GENERATED ARG_HANDLE
 
   ensure_igraph(graph)
 

--- a/R/layout.R
+++ b/R/layout.R
@@ -1766,7 +1766,6 @@ with_dh <- function(...) layout_spec(layout_with_dh, ...)
 #' @param coolexp,maxdelta,area,repulserad `r lifecycle::badge("deprecated")` These
 #'  arguments are not supported from igraph version 0.8.0 and are ignored
 #'  (with a warning).
-#' @param maxiter A deprecated synonym of `niter`, for compatibility.
 #' @return A two- or three-column matrix, each row giving the coordinates of a
 #'   vertex, according to the IDs of the vertex IDs.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
@@ -1817,15 +1816,14 @@ layout_with_fr <- function(
   coolexp = deprecated(),
   maxdelta = deprecated(),
   area = deprecated(),
-  repulserad = deprecated(),
-  maxiter = deprecated()
+  repulserad = deprecated()
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_with_fr, do not edit, see tools/generate-migrations.R
   # fmt: skip
   if (...length() > 0L) {
     .arg_forbidden <- base::intersect(base::names(base::sys.call()), base::c("g", "gr"))
     if (base::length(.arg_forbidden) > 0L) cli::cli_abort(base::c("Argument {.arg {(.arg_forbidden)}} matches multiple formal arguments of {.fn layout_with_fr}.", i = "Spell out the full argument name."))
-    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("c", "co", "coo", "m", "mi", "min", "ma", "max"))
+    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("m", "ma", "max", "c", "co", "coo", "mi", "min"))
     if (base::length(.arg_ambiguous) > 0L) cli::cli_abort("Argument {.arg {(.arg_ambiguous[[1L]])}} matches multiple arguments of {.fn layout_with_fr}.")
     # Pre-3.0.0 signature: layout_with_fr(graph, coords, dim, niter, start.temp, grid, weights, minx, maxx, miny, maxy, minz, maxz, coolexp, maxdelta, area, repulserad, maxiter)
     .old_signature <- function(coords, dim, niter, start.temp, grid, weights, minx, maxx, miny, maxy, minz, maxz, coolexp, maxdelta, area, repulserad, maxiter, ...) {
@@ -1852,7 +1850,7 @@ layout_with_fr <- function(
         if (!base::missing(maxdelta)) base::list(maxdelta = maxdelta),
         if (!base::missing(area)) base::list(area = area),
         if (!base::missing(repulserad)) base::list(repulserad = repulserad),
-        if (!base::missing(maxiter)) base::list(maxiter = maxiter)
+        if (!base::missing(maxiter)) base::list(niter = maxiter)
       )
     }
     .arg_handle <- .old_signature(...)
@@ -1875,7 +1873,7 @@ layout_with_fr <- function(
         if (!base::missing(maxdelta)) "maxdelta",
         if (!base::missing(area)) "area",
         if (!base::missing(repulserad)) "repulserad",
-        if (!base::missing(maxiter)) "maxiter"
+        if (!base::missing(niter)) "niter"
       ))
       if (base::length(.arg_conflict) > 0L) cli::cli_abort(base::c("Argument {.arg {(.arg_conflict)}} of {.fn layout_with_fr} was supplied more than once.", i = "Pass it exactly once, by its new name {.arg {(.arg_conflict)}}."))
       base::list2env(.arg_handle, base::environment())
@@ -1883,7 +1881,7 @@ layout_with_fr <- function(
         "3.0.0",
         what = base::I("Calling `layout_with_fr()` with positional or abbreviated arguments"),
         details = base::c(
-          i = base::paste0("Detected call:  layout_with_fr(", base::paste(base::c("graph", .arg_names), collapse = ", "), ")"),
+          i = base::paste0("Detected call:  layout_with_fr(", base::paste(base::c("graph", base::c(coords = "coords", dim = "dim", niter = "niter", start.temp = "start.temp", grid = "grid", weights = "weights", minx = "minx", maxx = "maxx", miny = "miny", maxy = "maxy", minz = "minz", maxz = "maxz", coolexp = "coolexp", maxdelta = "maxdelta", area = "area", repulserad = "repulserad", niter = "maxiter")[.arg_names]), collapse = ", "), ")"),
           i = base::paste0("Use instead:    layout_with_fr(", base::paste(base::c("graph", base::paste0(.arg_names, " = ")), collapse = ", "), ")")
         )
       )
@@ -1899,15 +1897,6 @@ layout_with_fr <- function(
 
   coords[] <- as.numeric(coords)
   dim <- igraph_match_arg(dim)
-  if (!missing(niter) && !missing(maxiter)) {
-    cli::cli_abort(c(
-      "{.arg niter} and {.arg maxiter} must not be specified at the same time.",
-      i = "Specify only {.arg niter}, {.arg maxiter} is deprecated."
-    ))
-  }
-  if (!missing(maxiter)) {
-    niter <- maxiter
-  }
   niter <- as.numeric(niter)
   start.temp <- as.numeric(start.temp)
 
@@ -2322,7 +2311,7 @@ with_graphopt <- function(...) layout_spec(layout_with_graphopt, ...)
 #'   \sQuote{z} coordinates.
 #' @param niter,sigma,initemp,coolexp `r lifecycle::badge("deprecated")` These
 #' arguments are not supported from igraph version 0.8.0 and are ignored (with a warning).
-#' @param start Deprecated synonym for `coords`, for compatibility.
+#' @param start `r lifecycle::badge("deprecated")` Use `coords` instead.
 #' @return A numeric matrix with two (dim=2) or three (dim=3) columns, and as
 #'   many rows as the number of vertices, the x, y and potentially z coordinates
 #'   of the vertices.
@@ -2445,6 +2434,11 @@ layout_with_kk <- function(
     ))
   }
   if (!missing(start)) {
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      "layout_with_kk(start = )",
+      "layout_with_kk(coords = )"
+    )
     coords <- start
   }
 

--- a/R/layout.R
+++ b/R/layout.R
@@ -1811,7 +1811,6 @@ with_dh <- function(...) layout_spec(layout_with_dh, ...)
 #' @param coolexp,maxdelta,area,repulserad `r lifecycle::badge("deprecated")` These
 #'  arguments are not supported from igraph version 0.8.0 and are ignored
 #'  (with a warning).
-#' @param maxiter A deprecated synonym of `niter`, for compatibility.
 #' @return A two- or three-column matrix, each row giving the coordinates of a
 #'   vertex, according to the IDs of the vertex IDs.
 #' @author Gabor Csardi \email{csardi.gabor@@gmail.com}
@@ -1863,15 +1862,14 @@ layout_with_fr <- function(
   coolexp = deprecated(),
   maxdelta = deprecated(),
   area = deprecated(),
-  repulserad = deprecated(),
-  maxiter = deprecated()
+  repulserad = deprecated()
 ) {
   # BEGIN GENERATED ARG_HANDLE: layout_with_fr, do not edit, see tools/generate-migrations.R
   # fmt: skip
   if (...length() > 0L) {
     .arg_forbidden <- base::intersect(base::names(base::sys.call()), base::c("g", "gr"))
     if (base::length(.arg_forbidden) > 0L) cli::cli_abort(base::c("Argument {.arg {(.arg_forbidden)}} matches multiple formal arguments of {.fn layout_with_fr}.", i = "Spell out the full argument name."))
-    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("c", "co", "coo", "m", "mi", "min", "ma", "max"))
+    .arg_ambiguous <- base::intersect(base::names(base::substitute(...())), base::c("m", "ma", "max", "c", "co", "coo", "mi", "min"))
     if (base::length(.arg_ambiguous) > 0L) cli::cli_abort("Argument {.arg {(.arg_ambiguous[[1L]])}} matches multiple arguments of {.fn layout_with_fr}.")
     # Pre-3.0.0 signature: layout_with_fr(graph, coords, dim, niter, start.temp, grid, weights, minx, maxx, miny, maxy, minz, maxz, coolexp, maxdelta, area, repulserad, maxiter)
     .old_signature <- function(coords, dim, niter, start.temp, grid, weights, minx, maxx, miny, maxy, minz, maxz, coolexp, maxdelta, area, repulserad, maxiter, ...) {
@@ -1898,7 +1896,7 @@ layout_with_fr <- function(
         if (!base::missing(maxdelta)) base::list(maxdelta = maxdelta),
         if (!base::missing(area)) base::list(area = area),
         if (!base::missing(repulserad)) base::list(repulserad = repulserad),
-        if (!base::missing(maxiter)) base::list(maxiter = maxiter)
+        if (!base::missing(maxiter)) base::list(niter = maxiter)
       )
     }
     .arg_handle <- .old_signature(...)
@@ -1921,7 +1919,7 @@ layout_with_fr <- function(
         if (!base::missing(maxdelta)) "maxdelta",
         if (!base::missing(area)) "area",
         if (!base::missing(repulserad)) "repulserad",
-        if (!base::missing(maxiter)) "maxiter"
+        if (!base::missing(niter)) "niter"
       ))
       if (base::length(.arg_conflict) > 0L) cli::cli_abort(base::c("Argument {.arg {(.arg_conflict)}} of {.fn layout_with_fr} was supplied more than once.", i = "Pass it exactly once, by its new name {.arg {(.arg_conflict)}}."))
       base::list2env(.arg_handle, base::environment())
@@ -1929,7 +1927,7 @@ layout_with_fr <- function(
         "3.0.0",
         what = base::I("Calling `layout_with_fr()` with positional or abbreviated arguments"),
         details = base::c(
-          i = base::paste0("Detected call:  layout_with_fr(", base::paste(base::c("graph", .arg_names), collapse = ", "), ")"),
+          i = base::paste0("Detected call:  layout_with_fr(", base::paste(base::c("graph", base::c(coords = "coords", dim = "dim", niter = "niter", start.temp = "start.temp", grid = "grid", weights = "weights", minx = "minx", maxx = "maxx", miny = "miny", maxy = "maxy", minz = "minz", maxz = "maxz", coolexp = "coolexp", maxdelta = "maxdelta", area = "area", repulserad = "repulserad", niter = "maxiter")[.arg_names]), collapse = ", "), ")"),
           i = base::paste0("Use instead:    layout_with_fr(", base::paste(base::c("graph", base::paste0(.arg_names, " = ")), collapse = ", "), ")")
         )
       )
@@ -1945,15 +1943,6 @@ layout_with_fr <- function(
 
   coords[] <- as.numeric(coords)
   dim <- igraph_match_arg(dim)
-  if (!missing(niter) && !missing(maxiter)) {
-    cli::cli_abort(c(
-      "{.arg niter} and {.arg maxiter} must not be specified at the same time.",
-      i = "Specify only {.arg niter}, {.arg maxiter} is deprecated."
-    ))
-  }
-  if (!missing(maxiter)) {
-    niter <- maxiter
-  }
   niter <- as.numeric(niter)
   start.temp <- as.numeric(start.temp)
 
@@ -2368,7 +2357,7 @@ with_graphopt <- function(...) layout_spec(layout_with_graphopt, ...)
 #'   \sQuote{z} coordinates.
 #' @param niter,sigma,initemp,coolexp `r lifecycle::badge("deprecated")` These
 #' arguments are not supported from igraph version 0.8.0 and are ignored (with a warning).
-#' @param start Deprecated synonym for `coords`, for compatibility.
+#' @param start `r lifecycle::badge("deprecated")` Use `coords` instead.
 #' @return A numeric matrix with two (dim=2) or three (dim=3) columns, and as
 #'   many rows as the number of vertices, the x, y and potentially z coordinates
 #'   of the vertices.
@@ -2492,6 +2481,11 @@ layout_with_kk <- function(
     ))
   }
   if (!missing(start)) {
+    lifecycle::deprecate_soft(
+      "3.0.0",
+      "layout_with_kk(start = )",
+      "layout_with_kk(coords = )"
+    )
     coords <- start
   }
 

--- a/R/structural-properties.R
+++ b/R/structural-properties.R
@@ -461,8 +461,7 @@ graph.dfs <- function(
   in.callback = NULL,
   out.callback = NULL,
   extra = NULL,
-  rho = parent.frame(),
-  neimode
+  rho = parent.frame()
 ) {
   # nocov start
   lifecycle::deprecate_warn("2.0.0", "graph.dfs()", "dfs()")
@@ -478,8 +477,7 @@ graph.dfs <- function(
     in.callback = in.callback,
     out.callback = out.callback,
     extra = extra,
-    rho = rho,
-    neimode = neimode
+    rho = rho
   )
 } # nocov end
 
@@ -540,8 +538,7 @@ graph.bfs <- function(
   dist = FALSE,
   callback = NULL,
   extra = NULL,
-  rho = parent.frame(),
-  neimode
+  rho = parent.frame()
 ) {
   # nocov start
   lifecycle::deprecate_warn("2.0.0", "graph.bfs()", "bfs()")
@@ -559,8 +556,7 @@ graph.bfs <- function(
     dist = dist,
     callback = callback,
     extra = extra,
-    rho = rho,
-    neimode = neimode
+    rho = rho
   )
 } # nocov end
 
@@ -3642,7 +3638,6 @@ count_loops <- function(graph) {
 #'   given vertices.
 #' @param order Logical, whether to return the ordering of the vertices.
 #' @param rank Logical, whether to return the rank of the vertices.
-#' @param father `r lifecycle::badge("deprecated")` Use `parent` instead.
 #' @param parent Logical, whether to return the parent of the vertices.
 #' @param pred Logical, whether to return the predecessors of the
 #'   vertices.
@@ -3657,8 +3652,6 @@ count_loops <- function(graph) {
 #' @param extra Additional argument to supply to the callback function.
 #' @param rho The environment in which the callback function is evaluated.
 #'   The default `NULL` uses the caller's environment.
-#' @param neimode `r lifecycle::badge("deprecated")` This argument is deprecated
-#'  from igraph 1.3.0; use `mode` instead.
 #' @inheritParams rlang::args_dots_empty
 #' @return A named list with the following entries:
 #'   \describe{
@@ -3666,7 +3659,7 @@ count_loops <- function(graph) {
 #'       Numeric vector. The root vertex (or vertices) that was used as the
 #'       starting point of the search, as supplied in the `root` argument.
 #'     }
-#'     \item{neimode}{
+#'     \item{mode}{
 #'       Character scalar. The `mode` argument of the function call.
 #'       Note that for undirected graphs this is always \sQuote{all}, irrespectively of the supplied value.
 #'     }
@@ -3682,9 +3675,6 @@ count_loops <- function(graph) {
 #'       The parent of each vertex, i.e. the vertex it was discovered from.
 #'       A vertex sequence (`igraph.vs`), or a numeric vector if the
 #'       `return.vs.es` option is `FALSE`.
-#'     }
-#'     \item{father}{
-#'       Like parent, kept for compatibility for now.
 #'     }
 #'     \item{pred}{
 #'       The previously visited vertex for each vertex, or 0 if there was no such vertex.
@@ -3751,9 +3741,7 @@ bfs <- function(
   dist = FALSE,
   callback = NULL,
   extra = NULL,
-  rho = NULL,
-  neimode = deprecated(),
-  father = deprecated()
+  rho = NULL
 ) {
   rlang::check_dots_empty()
 
@@ -3761,18 +3749,6 @@ bfs <- function(
 
   if (is.null(rho)) {
     rho <- parent.frame()
-  }
-
-  if (lifecycle::is_present(neimode)) {
-    lifecycle::deprecate_stop(
-      "1.3.0",
-      "bfs(neimode = )",
-      "bfs(mode = )"
-    )
-  }
-
-  if (lifecycle::is_present(father)) {
-    lifecycle::deprecate_stop("2.2.0", "bfs(father = )", "bfs(parent = )")
   }
 
   if (length(root) == 1) {
@@ -3826,9 +3802,6 @@ bfs <- function(
   # requested root vertices instead. See
   # https://github.com/igraph/rigraph/issues/1639
   res$root <- requested_roots
-
-  # Remove in 1.4.0
-  res$neimode <- res$mode
 
   if (order) {
     res$order <- res$order + 1
@@ -3885,9 +3858,6 @@ bfs <- function(
     res$dist[is.nan(res$dist)] <- -3
   }
 
-  # Remove this later? https://github.com/igraph/rigraph/issues/1576
-  res$father <- res$parent
-
   res
 }
 
@@ -3927,7 +3897,6 @@ bfs <- function(
 #'   vertices.
 #' @param order.out Logical, whether to return the ordering based on
 #'   leaving the subtree of the vertex.
-#' @param father `r lifecycle::badge("deprecated")`, use `parent` instead.
 #' @param parent Logical, whether to return the parent of the vertices.
 #' @param dist Logical, whether to return the distance from the root of
 #'   the search tree.
@@ -3941,15 +3910,13 @@ bfs <- function(
 #' @param extra Additional argument to supply to the callback function.
 #' @param rho The environment in which the callback function is evaluated.
 #'   The default `NULL` uses the caller's environment.
-#' @param neimode `r lifecycle::badge("deprecated")` This argument is deprecated from igraph 1.3.0; use
-#'   `mode` instead.
 #' @inheritParams rlang::args_dots_empty
 #' @return A named list with the following entries:
 #'   \describe{
 #'     \item{root}{
 #'       Numeric scalar. The root vertex that was used as the starting point of the search.
 #'     }
-#'     \item{neimode}{
+#'     \item{mode}{
 #'       Character scalar. The `mode` argument of the function call.
 #'       Note that for undirected graphs this is always \sQuote{all}, irrespectively of the supplied value.
 #'     }
@@ -3961,9 +3928,6 @@ bfs <- function(
 #'     }
 #'     \item{parent}{
 #'       Numeric vector. The parent of each vertex, i.e. the vertex it was discovered from.
-#'     }
-#'     \item{father}{
-#'       Like parent, kept for compatibility for now.
 #'     }
 #'     \item{dist}{
 #'       Numeric vector, for each vertex its distance from the root of the search tree.
@@ -4028,27 +3992,13 @@ dfs <- function(
   in.callback = NULL,
   out.callback = NULL,
   extra = NULL,
-  rho = NULL,
-  neimode = deprecated(),
-  father = deprecated()
+  rho = NULL
 ) {
   rlang::check_dots_empty()
 
   ensure_igraph(graph)
   if (is.null(rho)) {
     rho <- parent.frame()
-  }
-
-  if (lifecycle::is_present(neimode)) {
-    lifecycle::deprecate_stop(
-      "1.3.0",
-      "dfs(neimode = )",
-      "dfs(mode = )"
-    )
-  }
-
-  if (lifecycle::is_present(father)) {
-    lifecycle::deprecate_stop("2.2.0", "dfs(father = )", "dfs(parent = )")
   }
 
   root <- as_igraph_vs(graph, root) - 1
@@ -4084,9 +4034,6 @@ dfs <- function(
     rho
   )
 
-  # Remove in 1.4.0
-  res$neimode <- res$mode
-
   if (order) {
     res$order <- res$order + 1
   }
@@ -4118,9 +4065,6 @@ dfs <- function(
     }
     if (dist) names(res$dist) <- V(graph)$name
   }
-
-  # Remove this later? https://github.com/igraph/rigraph/issues/1576
-  res$father <- res$parent
 
   res
 }

--- a/R/structural-properties.R
+++ b/R/structural-properties.R
@@ -461,8 +461,7 @@ graph.dfs <- function(
   in.callback = NULL,
   out.callback = NULL,
   extra = NULL,
-  rho = parent.frame(),
-  neimode
+  rho = parent.frame()
 ) {
   # nocov start
   lifecycle::deprecate_warn("2.0.0", "graph.dfs()", "dfs()")
@@ -478,8 +477,7 @@ graph.dfs <- function(
     in.callback = in.callback,
     out.callback = out.callback,
     extra = extra,
-    rho = rho,
-    neimode = neimode
+    rho = rho
   )
 } # nocov end
 
@@ -540,8 +538,7 @@ graph.bfs <- function(
   dist = FALSE,
   callback = NULL,
   extra = NULL,
-  rho = parent.frame(),
-  neimode
+  rho = parent.frame()
 ) {
   # nocov start
   lifecycle::deprecate_warn("2.0.0", "graph.bfs()", "bfs()")
@@ -559,8 +556,7 @@ graph.bfs <- function(
     dist = dist,
     callback = callback,
     extra = extra,
-    rho = rho,
-    neimode = neimode
+    rho = rho
   )
 } # nocov end
 
@@ -3638,7 +3634,6 @@ count_loops <- function(graph) {
 #'   given vertices.
 #' @param order Logical, whether to return the ordering of the vertices.
 #' @param rank Logical, whether to return the rank of the vertices.
-#' @param father `r lifecycle::badge("deprecated")` Use `parent` instead.
 #' @param parent Logical, whether to return the parent of the vertices.
 #' @param pred Logical, whether to return the predecessors of the
 #'   vertices.
@@ -3653,8 +3648,6 @@ count_loops <- function(graph) {
 #' @param extra Additional argument to supply to the callback function.
 #' @param rho The environment in which the callback function is evaluated.
 #'   The default `NULL` uses the caller's environment.
-#' @param neimode `r lifecycle::badge("deprecated")` This argument is deprecated
-#'  from igraph 1.3.0; use `mode` instead.
 #' @inheritParams rlang::args_dots_empty
 #' @return A named list with the following entries:
 #'   \describe{
@@ -3662,7 +3655,7 @@ count_loops <- function(graph) {
 #'       Numeric vector. The root vertex (or vertices) that was used as the
 #'       starting point of the search, as supplied in the `root` argument.
 #'     }
-#'     \item{neimode}{
+#'     \item{mode}{
 #'       Character scalar. The `mode` argument of the function call.
 #'       Note that for undirected graphs this is always \sQuote{all}, irrespectively of the supplied value.
 #'     }
@@ -3678,9 +3671,6 @@ count_loops <- function(graph) {
 #'       The parent of each vertex, i.e. the vertex it was discovered from.
 #'       A vertex sequence (`igraph.vs`), or a numeric vector if the
 #'       `return.vs.es` option is `FALSE`.
-#'     }
-#'     \item{father}{
-#'       Like parent, kept for compatibility for now.
 #'     }
 #'     \item{pred}{
 #'       The previously visited vertex for each vertex, or 0 if there was no such vertex.
@@ -3747,9 +3737,7 @@ bfs <- function(
   dist = FALSE,
   callback = NULL,
   extra = NULL,
-  rho = NULL,
-  neimode = deprecated(),
-  father = deprecated()
+  rho = NULL
 ) {
   rlang::check_dots_empty()
 
@@ -3757,18 +3745,6 @@ bfs <- function(
 
   if (is.null(rho)) {
     rho <- parent.frame()
-  }
-
-  if (lifecycle::is_present(neimode)) {
-    lifecycle::deprecate_stop(
-      "1.3.0",
-      "bfs(neimode = )",
-      "bfs(mode = )"
-    )
-  }
-
-  if (lifecycle::is_present(father)) {
-    lifecycle::deprecate_stop("2.2.0", "bfs(father = )", "bfs(parent = )")
   }
 
   if (length(root) == 1) {
@@ -3822,9 +3798,6 @@ bfs <- function(
   # requested root vertices instead. See
   # https://github.com/igraph/rigraph/issues/1639
   res$root <- requested_roots
-
-  # Remove in 1.4.0
-  res$neimode <- res$mode
 
   if (order) {
     res$order <- res$order + 1
@@ -3881,9 +3854,6 @@ bfs <- function(
     res$dist[is.nan(res$dist)] <- -3
   }
 
-  # Remove this later? https://github.com/igraph/rigraph/issues/1576
-  res$father <- res$parent
-
   res
 }
 
@@ -3923,7 +3893,6 @@ bfs <- function(
 #'   vertices.
 #' @param order.out Logical, whether to return the ordering based on
 #'   leaving the subtree of the vertex.
-#' @param father `r lifecycle::badge("deprecated")`, use `parent` instead.
 #' @param parent Logical, whether to return the parent of the vertices.
 #' @param dist Logical, whether to return the distance from the root of
 #'   the search tree.
@@ -3937,15 +3906,13 @@ bfs <- function(
 #' @param extra Additional argument to supply to the callback function.
 #' @param rho The environment in which the callback function is evaluated.
 #'   The default `NULL` uses the caller's environment.
-#' @param neimode `r lifecycle::badge("deprecated")` This argument is deprecated from igraph 1.3.0; use
-#'   `mode` instead.
 #' @inheritParams rlang::args_dots_empty
 #' @return A named list with the following entries:
 #'   \describe{
 #'     \item{root}{
 #'       Numeric scalar. The root vertex that was used as the starting point of the search.
 #'     }
-#'     \item{neimode}{
+#'     \item{mode}{
 #'       Character scalar. The `mode` argument of the function call.
 #'       Note that for undirected graphs this is always \sQuote{all}, irrespectively of the supplied value.
 #'     }
@@ -3957,9 +3924,6 @@ bfs <- function(
 #'     }
 #'     \item{parent}{
 #'       Numeric vector. The parent of each vertex, i.e. the vertex it was discovered from.
-#'     }
-#'     \item{father}{
-#'       Like parent, kept for compatibility for now.
 #'     }
 #'     \item{dist}{
 #'       Numeric vector, for each vertex its distance from the root of the search tree.
@@ -4024,27 +3988,13 @@ dfs <- function(
   in.callback = NULL,
   out.callback = NULL,
   extra = NULL,
-  rho = NULL,
-  neimode = deprecated(),
-  father = deprecated()
+  rho = NULL
 ) {
   rlang::check_dots_empty()
 
   ensure_igraph(graph)
   if (is.null(rho)) {
     rho <- parent.frame()
-  }
-
-  if (lifecycle::is_present(neimode)) {
-    lifecycle::deprecate_stop(
-      "1.3.0",
-      "dfs(neimode = )",
-      "dfs(mode = )"
-    )
-  }
-
-  if (lifecycle::is_present(father)) {
-    lifecycle::deprecate_stop("2.2.0", "dfs(father = )", "dfs(parent = )")
   }
 
   root <- as_igraph_vs(graph, root) - 1
@@ -4080,9 +4030,6 @@ dfs <- function(
     rho
   )
 
-  # Remove in 1.4.0
-  res$neimode <- res$mode
-
   if (order) {
     res$order <- res$order + 1
   }
@@ -4114,9 +4061,6 @@ dfs <- function(
     }
     if (dist) names(res$dist) <- V(graph)$name
   }
-
-  # Remove this later? https://github.com/igraph/rigraph/issues/1576
-  res$father <- res$parent
 
   res
 }

--- a/man/bfs.Rd
+++ b/man/bfs.Rd
@@ -19,9 +19,7 @@ bfs(
   dist = FALSE,
   callback = NULL,
   extra = NULL,
-  rho = NULL,
-  neimode = deprecated(),
-  father = deprecated()
+  rho = NULL
 )
 }
 \arguments{
@@ -73,11 +71,6 @@ Default: \code{NULL}.}
 
 \item{rho}{The environment in which the callback function is evaluated.
 The default \code{NULL} uses the caller's environment.}
-
-\item{neimode}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This argument is deprecated
-from igraph 1.3.0; use \code{mode} instead.}
-
-\item{father}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{parent} instead.}
 }
 \value{
 A named list with the following entries:
@@ -86,7 +79,7 @@ A named list with the following entries:
 Numeric vector. The root vertex (or vertices) that was used as the
 starting point of the search, as supplied in the \code{root} argument.
 }
-\item{neimode}{
+\item{mode}{
 Character scalar. The \code{mode} argument of the function call.
 Note that for undirected graphs this is always \sQuote{all}, irrespectively of the supplied value.
 }
@@ -102,9 +95,6 @@ Numeric vector. The rank for each vertex, zero for unreachable vertices.
 The parent of each vertex, i.e. the vertex it was discovered from.
 A vertex sequence (\code{igraph.vs}), or a numeric vector if the
 \code{return.vs.es} option is \code{FALSE}.
-}
-\item{father}{
-Like parent, kept for compatibility for now.
 }
 \item{pred}{
 The previously visited vertex for each vertex, or 0 if there was no such vertex.

--- a/man/cluster_leiden.Rd
+++ b/man/cluster_leiden.Rd
@@ -11,7 +11,6 @@ cluster_leiden(
   ...,
   weights = NULL,
   resolution = 1,
-  resolution_parameter = deprecated(),
   beta = 0.01,
   initial_membership = NULL,
   n_iterations = 2,
@@ -37,8 +36,6 @@ edge weight means a stronger connection for this function.}
 \item{resolution}{The resolution parameter to use. Higher
 resolutions lead to more smaller communities, while lower resolutions lead
 to fewer larger communities.}
-
-\item{resolution_parameter}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}} Use \code{resolution} instead.}
 
 \item{beta}{Parameter affecting the randomness in the Leiden algorithm.
 This affects only the refinement step of the algorithm.}

--- a/man/dfs.Rd
+++ b/man/dfs.Rd
@@ -17,9 +17,7 @@ dfs(
   in.callback = NULL,
   out.callback = NULL,
   extra = NULL,
-  rho = NULL,
-  neimode = deprecated(),
-  father = deprecated()
+  rho = NULL
 )
 }
 \arguments{
@@ -63,11 +61,6 @@ Default: \code{NULL}.}
 
 \item{rho}{The environment in which the callback function is evaluated.
 The default \code{NULL} uses the caller's environment.}
-
-\item{neimode}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This argument is deprecated from igraph 1.3.0; use
-\code{mode} instead.}
-
-\item{father}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}, use \code{parent} instead.}
 }
 \value{
 A named list with the following entries:
@@ -75,7 +68,7 @@ A named list with the following entries:
 \item{root}{
 Numeric scalar. The root vertex that was used as the starting point of the search.
 }
-\item{neimode}{
+\item{mode}{
 Character scalar. The \code{mode} argument of the function call.
 Note that for undirected graphs this is always \sQuote{all}, irrespectively of the supplied value.
 }
@@ -87,9 +80,6 @@ Numeric vector, the vertex IDs, in the order of the completion of their subtree.
 }
 \item{parent}{
 Numeric vector. The parent of each vertex, i.e. the vertex it was discovered from.
-}
-\item{father}{
-Like parent, kept for compatibility for now.
 }
 \item{dist}{
 Numeric vector, for each vertex its distance from the root of the search tree.

--- a/man/graph.bfs.Rd
+++ b/man/graph.bfs.Rd
@@ -18,8 +18,7 @@ graph.bfs(
   dist = FALSE,
   callback = NULL,
   extra = NULL,
-  rho = parent.frame(),
-  neimode
+  rho = parent.frame()
 )
 }
 \arguments{
@@ -69,9 +68,6 @@ Default: \code{NULL}.}
 
 \item{rho}{The environment in which the callback function is evaluated.
 The default \code{NULL} uses the caller's environment.}
-
-\item{neimode}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This argument is deprecated
-from igraph 1.3.0; use \code{mode} instead.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/graph.dfs.Rd
+++ b/man/graph.dfs.Rd
@@ -16,8 +16,7 @@ graph.dfs(
   in.callback = NULL,
   out.callback = NULL,
   extra = NULL,
-  rho = parent.frame(),
-  neimode
+  rho = parent.frame()
 )
 }
 \arguments{
@@ -59,9 +58,6 @@ Default: \code{NULL}.}
 
 \item{rho}{The environment in which the callback function is evaluated.
 The default \code{NULL} uses the caller's environment.}
-
-\item{neimode}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This argument is deprecated from igraph 1.3.0; use
-\code{mode} instead.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/layout_with_fr.Rd
+++ b/man/layout_with_fr.Rd
@@ -23,8 +23,7 @@ layout_with_fr(
   coolexp = deprecated(),
   maxdelta = deprecated(),
   area = deprecated(),
-  repulserad = deprecated(),
-  maxiter = deprecated()
+  repulserad = deprecated()
 )
 
 with_fr(...)
@@ -82,8 +81,6 @@ Default: \code{NULL}.}
 \item{coolexp, maxdelta, area, repulserad}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} These
 arguments are not supported from igraph version 0.8.0 and are ignored
 (with a warning).}
-
-\item{maxiter}{A deprecated synonym of \code{niter}, for compatibility.}
 }
 \value{
 A two- or three-column matrix, each row giving the coordinates of a

--- a/man/layout_with_fr.Rd
+++ b/man/layout_with_fr.Rd
@@ -22,8 +22,7 @@ layout_with_fr(
   coolexp = deprecated(),
   maxdelta = deprecated(),
   area = deprecated(),
-  repulserad = deprecated(),
-  maxiter = deprecated()
+  repulserad = deprecated()
 )
 }
 \arguments{
@@ -79,8 +78,6 @@ Default: \code{NULL}.}
 \item{coolexp, maxdelta, area, repulserad}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} These
 arguments are not supported from igraph version 0.8.0 and are ignored
 (with a warning).}
-
-\item{maxiter}{A deprecated synonym of \code{niter}, for compatibility.}
 }
 \value{
 A two- or three-column matrix, each row giving the coordinates of a

--- a/man/layout_with_kk.Rd
+++ b/man/layout_with_kk.Rd
@@ -80,7 +80,7 @@ Default: \code{NULL}.}
 \item{niter, sigma, initemp, coolexp}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} These
 arguments are not supported from igraph version 0.8.0 and are ignored (with a warning).}
 
-\item{start}{Deprecated synonym for \code{coords}, for compatibility.}
+\item{start}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{coords} instead.}
 }
 \value{
 A numeric matrix with two (dim=2) or three (dim=3) columns, and as

--- a/man/layout_with_kk.Rd
+++ b/man/layout_with_kk.Rd
@@ -77,7 +77,7 @@ Default: \code{NULL}.}
 \item{niter, sigma, initemp, coolexp}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} These
 arguments are not supported from igraph version 0.8.0 and are ignored (with a warning).}
 
-\item{start}{Deprecated synonym for \code{coords}, for compatibility.}
+\item{start}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Use \code{coords} instead.}
 }
 \value{
 A numeric matrix with two (dim=2) or three (dim=3) columns, and as

--- a/tests/testthat/_snaps/community.md
+++ b/tests/testthat/_snaps/community.md
@@ -1,3 +1,13 @@
+# cluster_leiden() recovers the renamed resolution_parameter argument
+
+    Code
+      res <- cluster_leiden(g, "modularity", resolution_parameter = 1.5)
+    Condition
+      Warning:
+      Calling `cluster_leiden()` with positional or abbreviated arguments was deprecated in igraph 3.0.0.
+      i Detected call: cluster_leiden(graph, objective_function, resolution_parameter)
+      i Use instead: cluster_leiden(graph, objective_function, resolution = )
+
 # modularity_matrix no longer accepts a membership argument for compatibility
 
     Code

--- a/tests/testthat/_snaps/structural-properties.md
+++ b/tests/testthat/_snaps/structural-properties.md
@@ -3,9 +3,11 @@
     Code
       d <- dfs(g, root = 2, unreachable = FALSE, neimode = "out", father = TRUE)
     Condition
-      Error:
-      ! The `neimode` argument of `dfs()` was deprecated in igraph 1.3.0 and is now defunct.
-      i Please use the `mode` argument instead.
+      Error in `dfs()`:
+      ! `...` must be empty.
+      x Problematic arguments:
+      * neimode = "out"
+      * father = TRUE
 
 # bfs() works
 
@@ -47,14 +49,6 @@
        a  b  c  z  d 
       -1  0  1 -1 -1 
       
-      $neimode
-      [1] "out"
-      
-      $father
-      + 5/5 vertices, named:
-         a    b    c    z    d 
-      <NA> <NA>    b <NA> <NA> 
-      
 
 # bfs() deprecated arguments
 
@@ -62,9 +56,11 @@
       b <- bfs(g, root = 2, neimode = "out", unreachable = FALSE, order = TRUE, rank = TRUE,
         father = TRUE, pred = TRUE, succ = TRUE, dist = TRUE)
     Condition
-      Error:
-      ! The `neimode` argument of `bfs()` was deprecated in igraph 1.3.0 and is now defunct.
-      i Please use the `mode` argument instead.
+      Error in `bfs()`:
+      ! `...` must be empty.
+      x Problematic arguments:
+      * neimode = "out"
+      * father = TRUE
 
 # laplacian_matrix() works
 

--- a/tests/testthat/test-community.R
+++ b/tests/testthat/test-community.R
@@ -455,6 +455,21 @@ test_that("cluster_leiden works", {
   )
 })
 
+test_that("cluster_leiden() recovers the renamed resolution_parameter argument", {
+  g <- make_graph("Zachary")
+
+  rlang::local_options(lifecycle_verbosity = "warning")
+  igraph_with_seed(42, {
+    expect_snapshot(
+      res <- cluster_leiden(g, "modularity", resolution_parameter = 1.5)
+    )
+  })
+  igraph_with_seed(42, {
+    ref <- cluster_leiden(g, "modularity", resolution = 1.5)
+  })
+  expect_equal(res, ref)
+})
+
 test_that("modularity_matrix works", {
   karate <- make_graph("zachary")
 

--- a/tools/migrations/community.R
+++ b/tools/migrations/community.R
@@ -60,6 +60,31 @@ migrations <- list(
     when = "3.0.0"
   ),
 
+  cluster_leiden = list(
+    old = function(
+      graph,
+      objective_function,
+      weights,
+      resolution_parameter = resolution,
+      beta,
+      initial_membership,
+      n_iterations,
+      vertex_weights
+    ) {},
+    new = function(
+      graph,
+      objective_function = c("CPM", "modularity"),
+      ...,
+      weights = NULL,
+      resolution = 1,
+      beta = 0.01,
+      initial_membership = NULL,
+      n_iterations = 2,
+      vertex_weights = NULL
+    ) {},
+    when = "3.0.0"
+  ),
+
   cluster_louvain = list(
     old = function(graph, weights, resolution) {},
     new = function(

--- a/tools/migrations/layout.R
+++ b/tools/migrations/layout.R
@@ -125,7 +125,7 @@ migrations <- list(
       maxdelta,
       area,
       repulserad,
-      maxiter
+      maxiter = niter
     ) {},
     new = function(
       graph,
@@ -145,8 +145,7 @@ migrations <- list(
       coolexp = deprecated(),
       maxdelta = deprecated(),
       area = deprecated(),
-      repulserad = deprecated(),
-      maxiter = deprecated()
+      repulserad = deprecated()
     ) {},
     when = "3.0.0"
   ),


### PR DESCRIPTION
Part of #2788 (PR 5 of the stack, on top of #2862); answers the survey's "migrate the existing hand-rolled alias formals into the registry" question for the aliases that are ready, so the signatures shrink to canonical names.

## What this does

- **`layout_with_fr()`**: the trailing `maxiter = deprecated()` formal disappears; the registry now recovers `maxiter =` as a rename to `niter`. This alias was bridged **silently** before (no deprecation signal at all) — it now gets the standard 3.0.0 soft-deprecation.
- **`layout_with_kk()`**: `start` (alias of `coords`) cannot ride the registry because `coords` is a head formal, so the sentinel formal stays — but the bridge now emits the previously missing `deprecate_soft()` (it was a silent alias too), and the `@param` gains its deprecated badge.
- **`cluster_leiden()`**: gains its missing registry entry (it was the only `cluster_*()` without one, still on strict `check_dots_empty()`). The `resolution_parameter = deprecated()` formal and hand bridge are removed; the registry recovers it as a rename to `resolution`. The `old` entry reproduces the true v2.0.0 positional signature (verified against the `v2.0.0` tag, commit `8102f30`, where `resolution_parameter` was canonical slot 4), so both 2.0-era positional calls and 2.1-era keyword calls recover correctly.
- **`bfs()` / `dfs()`**: the `neimode`/`father` trailing formals — hard `deprecate_stop()` errors since 1.3.0/2.2.0 — are removed, together with the `res$neimode <- res$mode` and `res$father <- res$parent` return-value aliases (marked "Remove in 1.4.0" in the source). Calls using the dead names now fail `check_dots_empty()` (`` `...` must be empty ``) instead of the bespoke stop message. The `graph.bfs()`/`graph.dfs()` wrappers needed their unconditional `neimode` forwards dropped to keep working; their still-functional `father` → `parent` mapping is untouched.

## Deliberately left for a follow-up

- `make_lattice()`/`lattice()` `circular` → `periodic`: these functions have no ellipsis migration yet; the alias should ride that migration when it happens (note the known `dim`/`dimvector` prefix hazard documented in the generator fixture).
- `eigen_centrality()`/`centr_eigen()`/`centr_eigen_tmax()` `scale = deprecated()`: dropped functionality (normalization is always on), not aliases — nothing to recover; removal is a later deprecation-advancement step (#1121).
- `layout_with_fr()`/`layout_with_kk()` zombie formals (`coolexp`, `maxdelta`, `area`, `repulserad`, `sigma`, `initemp`, `niter`-on-kk) — hard-stopped since 0.8.0; same advancement track. The `niter`/`maxiter` role swap between fr and kk remains a naming wart for the iterations-family decision in #2788.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTPj4qNv2FWui6etixZeuR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RTPj4qNv2FWui6etixZeuR)_