### PR TITLE
chore!: rm unused argument in `layout_with_mds()`

### DIFF
--- a/R/layout.R
+++ b/R/layout.R
@@ -136,7 +136,7 @@ layout.mds <- function(
 ) {
   # nocov start
   lifecycle::deprecate_warn("2.0.0", "layout.mds()", "layout_with_mds()")
-  layout_with_mds(graph = graph, dist = dist, dim = dim, options = options)
+  layout_with_mds(graph = graph, dist = dist, dim = dim)
 } # nocov end
 
 #' Simple grid layout
@@ -2733,8 +2733,9 @@ layout.lgl <- function(..., params = list()) {
 #'   minus one, but only if the graph is connected; for unconnected graphs, the
 #'   only possible value is 2. This is because `merge_coords()` only works in
 #'   2D.
-#' @param options This is currently ignored, as ARPACK is not used any more for
-#'   solving the eigenproblem
+#' @param options `r lifecycle::badge("deprecated")` This argument is not
+#'   supported from igraph version 1.6.0, as ARPACK is not used any more for
+#'   solving the eigenproblem. Supplying it raises an error.
 #' @return A numeric matrix with `dim` columns.
 #' @author Tamas Nepusz \email{ntamas@@gmail.com} and Gabor Csardi
 #' \email{csardi.gabor@@gmail.com}
@@ -2753,21 +2754,13 @@ layout_with_mds <- function(
   graph,
   dist = NULL,
   dim = 2,
-  options = arpack_defaults()
+  options = deprecated()
 ) {
-  if (is.function(options)) {
-    lifecycle::deprecate_warn(
-      "1.6.0",
-      "layout_with_mds(options = 'must be a list')",
-      details = c(
-        "`arpack_defaults()` is now a function, use `options = arpack_defaults()` instead of `options = arpack_defaults`."
-      )
-    )
-    options <- options()
-  }
-
   # Argument checks
   ensure_igraph(graph)
+  if (lifecycle::is_present(options)) {
+    lifecycle::deprecate_stop("1.6.0", "layout_with_mds(options = )")
+  }
   dist[] <- as.numeric(dist)
   dim <- as.numeric(dim)
 

--- a/R/layout.R
+++ b/R/layout.R
@@ -2756,15 +2756,10 @@ layout_with_mds <- function(
   dim = 2,
   options = deprecated()
 ) {
-  # Argument checks
-  ensure_igraph(graph)
   if (lifecycle::is_present(options)) {
     lifecycle::deprecate_stop("1.6.0", "layout_with_mds(options = )")
   }
-  dist[] <- as.numeric(dist)
-  dim <- as.numeric(dim)
 
-  # Function call
   layout_mds_impl(
     graph = graph,
     dist = dist,

--- a/man/layout.mds.Rd
+++ b/man/layout.mds.Rd
@@ -17,8 +17,9 @@ minus one, but only if the graph is connected; for unconnected graphs, the
 only possible value is 2. This is because \code{merge_coords()} only works in
 2D.}
 
-\item{options}{This is currently ignored, as ARPACK is not used any more for
-solving the eigenproblem}
+\item{options}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This argument is not
+supported from igraph version 1.6.0, as ARPACK is not used any more for
+solving the eigenproblem. Supplying it raises an error.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}

--- a/man/layout_with_mds.Rd
+++ b/man/layout_with_mds.Rd
@@ -5,7 +5,7 @@
 \alias{with_mds}
 \title{Graph layout by multidimensional scaling}
 \usage{
-layout_with_mds(graph, dist = NULL, dim = 2, options = arpack_defaults())
+layout_with_mds(graph, dist = NULL, dim = 2, options = deprecated())
 
 with_mds(...)
 }
@@ -20,8 +20,9 @@ minus one, but only if the graph is connected; for unconnected graphs, the
 only possible value is 2. This is because \code{merge_coords()} only works in
 2D.}
 
-\item{options}{This is currently ignored, as ARPACK is not used any more for
-solving the eigenproblem}
+\item{options}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This argument is not
+supported from igraph version 1.6.0, as ARPACK is not used any more for
+solving the eigenproblem. Supplying it raises an error.}
 
 \item{...}{Passed to \code{layout_with_mds()}.}
 }

--- a/tests/testthat/_snaps/layout.md
+++ b/tests/testthat/_snaps/layout.md
@@ -16,6 +16,14 @@
       Error:
       ! The `niter` argument of `layout_with_kk()` was deprecated in igraph 0.8.0 and is now defunct.
 
+# layout_with_mds() deprecated argument
+
+    Code
+      l <- layout_with_mds(g, options = arpack_defaults())
+    Condition
+      Error:
+      ! The `options` argument of `layout_with_mds()` was deprecated in igraph 1.6.0 and is now defunct.
+
 # layout_randomly() errors well
 
     Code

--- a/tests/testthat/test-layout.R
+++ b/tests/testthat/test-layout.R
@@ -269,11 +269,14 @@ test_that("`layout_with_mds()` works", {
 
   out1 <- layout_with_mds(g)
   expect_equal(out1, mymds(g))
+})
 
+test_that("layout_with_mds() deprecated argument", {
   rlang::local_options(lifecycle_verbosity = "warning")
-
-  expect_warning(out2 <- layout_with_mds(g, options = arpack_defaults))
-  expect_equal(out2, out1)
+  g <- make_tree(10, 2, mode = "undirected")
+  expect_snapshot_igraph_error({
+    l <- layout_with_mds(g, options = arpack_defaults())
+  })
 })
 
 test_that("`layout_with_mds()` stress test, graph with multiple components", {


### PR DESCRIPTION
Fix #2730