### PR TITLE
perf(touchstone): Measure warm, repeated calls instead of one cold call

### DIFF
--- a/touchstone/script.R
+++ b/touchstone/script.R
@@ -9,12 +9,38 @@
 # vendored C core. The CI workflow only triggers on `R/**` changes, so the C
 # library performance is intentionally out of scope here.
 #
-# Each benchmark is fully self-contained: touchstone evaluates every iteration
-# in a fresh subprocess that only sees its own `expr_before_benchmark` and the
-# benchmarked expression -- top-level variables defined in this script are NOT
-# visible there. So each setup block rebuilds its input graph from scratch
-# (~1000 vertices / ~5000 edges). A fixed seed makes the inputs identical on the
-# base and head branches, and the setup cost is excluded from the measured time.
+# ---------------------------------------------------------------------------
+# How touchstone measures, and what that forces on us
+# ---------------------------------------------------------------------------
+# touchstone runs *every* data point in a fresh `callr::r()` subprocess and
+# hard-codes `bench::mark(..., iterations = 1)`. One data point is therefore a
+# single, completely cold call. Two consequences drive the shape of this file:
+#
+# 1. WARM UP IN THE SETUP BLOCK. A cold call pays for R's JIT compiling the
+#    whole call path, for the igraph lazy-load database being faulted in, for
+#    Matrix's S4 method tables being built on first dispatch (~300 ms!), and for
+#    lifecycle's first `deprecate_warn()` (~11 ms). Those costs are one to three
+#    orders of magnitude larger than the R code we want to measure, and they do
+#    not respond to changes under `R/`, so leaving them in the measurement both
+#    hides real regressions and invents fake ones. Every setup block below runs
+#    the benchmarked expression a few times and then calls `gc()`, so the
+#    measured region starts warm and from a comparable heap.
+#
+# 2. REPEAT INSIDE THE MEASURED EXPRESSION. A single warm call here takes
+#    0.07-1.5 ms, far too short to time reliably across processes. Each measured
+#    expression is a `for` loop with a fixed repeat count chosen so the measured
+#    region lands around 100 ms.
+#
+#    The repeat counts MUST stay literal constants. Calibrating them at runtime
+#    would let base and head measure a different number of calls, which biases
+#    the comparison outright.
+#
+# Each benchmark is fully self-contained: the subprocess only sees its own
+# `expr_before_benchmark` and the benchmarked expression -- top-level variables
+# defined in this script are NOT visible there. So each setup block rebuilds its
+# input graph from scratch (~1000 vertices / ~5000 edges). A fixed seed makes
+# the inputs identical on the base and head branches, and the setup cost is
+# excluded from the measured time.
 
 library(touchstone)
 
@@ -44,8 +70,14 @@ benchmark_run(
       value = runif(1000L),
       stringsAsFactors = FALSE
     )
+    for (i in 1:5) {
+      graph_from_data_frame(edges, vertices = verts)
+    }
+    gc(full = TRUE)
   },
-  graph_from_data_frame = graph_from_data_frame(edges, vertices = verts),
+  graph_from_data_frame = for (i in 1:150) {
+    graph_from_data_frame(edges, vertices = verts)
+  },
   n = 20
 )
 
@@ -63,8 +95,14 @@ benchmark_run(
     V(g)$color <- sample(c("red", "blue"), 1000L, replace = TRUE)
     E(g)$weight <- runif(5000L)
     E(g)$type <- sample(letters[1:5], 5000L, replace = TRUE)
+    for (i in 1:5) {
+      as_long_data_frame(g)
+    }
+    gc(full = TRUE)
   },
-  as_long_data_frame = as_long_data_frame(g),
+  as_long_data_frame = for (i in 1:70) {
+    as_long_data_frame(g)
+  },
   n = 20
 )
 
@@ -77,8 +115,14 @@ benchmark_run(
     V(g)$color <- sample(c("red", "blue"), 1000L, replace = TRUE)
     E(g)$weight <- runif(5000L)
     E(g)$type <- sample(letters[1:5], 5000L, replace = TRUE)
+    for (i in 1:5) {
+      as_data_frame(g, what = "both")
+    }
+    gc(full = TRUE)
   },
-  as_data_frame_both = as_data_frame(g, what = "both"),
+  as_data_frame_both = for (i in 1:370) {
+    as_data_frame(g, what = "both")
+  },
   n = 20
 )
 
@@ -86,6 +130,11 @@ benchmark_run(
 # Group #3 - adjacency matrix round-trip
 # as_adjacency_matrix() / graph_from_adjacency_matrix(): Matrix tril/triu/t/
 # drop0, summary(), and edge-count expansion via rep().
+#
+# These pass `weights=`, not the deprecated `attr=`. `attr=` routes through
+# lifecycle::deprecate_warn(), which costs ~11 ms the first time it fires in a
+# process -- i.e. more than 10x the work being benchmarked, on every single
+# data point, since every data point is a fresh process.
 # ---------------------------------------------------------------------------
 benchmark_run(
   expr_before_benchmark = {
@@ -93,8 +142,14 @@ benchmark_run(
     set.seed(42)
     g <- sample_gnm(1000L, 5000L)
     E(g)$weight <- runif(5000L)
+    for (i in 1:5) {
+      as_adjacency_matrix(g, weights = "weight")
+    }
+    gc(full = TRUE)
   },
-  as_adjacency_matrix = as_adjacency_matrix(g, attr = "weight"),
+  as_adjacency_matrix = for (i in 1:180) {
+    as_adjacency_matrix(g, weights = "weight")
+  },
   n = 20
 )
 
@@ -104,13 +159,15 @@ benchmark_run(
     set.seed(42)
     g <- sample_gnm(1000L, 5000L)
     E(g)$weight <- runif(5000L)
-    m <- as_adjacency_matrix(g, attr = "weight")
+    m <- as_adjacency_matrix(g, weights = "weight")
+    for (i in 1:5) {
+      graph_from_adjacency_matrix(m, mode = "undirected", weighted = TRUE)
+    }
+    gc(full = TRUE)
   },
-  graph_from_adjacency_matrix = graph_from_adjacency_matrix(
-    m,
-    mode = "undirected",
-    weighted = TRUE
-  ),
+  graph_from_adjacency_matrix = for (i in 1:160) {
+    graph_from_adjacency_matrix(m, mode = "undirected", weighted = TRUE)
+  },
   n = 20
 )
 
@@ -123,12 +180,14 @@ benchmark_run(
     set.seed(42)
     g <- sample_bipartite_gnm(500L, 500L, m = 5000L)
     E(g)$weight <- runif(5000L)
+    for (i in 1:5) {
+      as_biadjacency_matrix(g, weights = "weight", sparse = TRUE)
+    }
+    gc(full = TRUE)
   },
-  as_biadjacency_matrix = as_biadjacency_matrix(
-    g,
-    attr = "weight",
-    sparse = TRUE
-  ),
+  as_biadjacency_matrix = for (i in 1:230) {
+    as_biadjacency_matrix(g, weights = "weight", sparse = TRUE)
+  },
   n = 20
 )
 
@@ -145,8 +204,14 @@ benchmark_run(
     V(g)$name <- paste0("v", seq_len(1000L))
     V(g)$color <- sample(c("red", "blue", "green"), 1000L, replace = TRUE)
     E(g)$weight <- runif(5000L)
+    for (i in 1:5) {
+      V(g)[color == "red"]
+    }
+    gc(full = TRUE)
   },
-  vs_attr_filter = V(g)[color == "red"],
+  vs_attr_filter = for (i in 1:750) {
+    V(g)[color == "red"]
+  },
   n = 20
 )
 
@@ -158,8 +223,14 @@ benchmark_run(
     V(g)$name <- paste0("v", seq_len(1000L))
     V(g)$color <- sample(c("red", "blue", "green"), 1000L, replace = TRUE)
     E(g)$weight <- runif(5000L)
+    for (i in 1:5) {
+      E(g)[weight > 0.5]
+    }
+    gc(full = TRUE)
   },
-  es_attr_filter = E(g)[weight > 0.5],
+  es_attr_filter = for (i in 1:120) {
+    E(g)[weight > 0.5]
+  },
   n = 20
 )
 
@@ -172,8 +243,14 @@ benchmark_run(
     V(g)$color <- sample(c("red", "blue", "green"), 1000L, replace = TRUE)
     E(g)$weight <- runif(5000L)
     pick <- sample(V(g)$name, 200)
+    for (i in 1:5) {
+      V(g)[pick]
+    }
+    gc(full = TRUE)
   },
-  vs_by_name = V(g)[pick],
+  vs_by_name = for (i in 1:1410) {
+    V(g)[pick]
+  },
   n = 20
 )
 


### PR DESCRIPTION
We sometimes see touchstone report a runtime change on PRs that cannot possibly have affected the benchmarked code. This is why.

## Root cause: the benchmarks barely measure igraph

touchstone runs **every data point in a fresh `callr::r()` subprocess** and hard-codes `bench::mark(..., iterations = 1)` — `benchmark_write()` even aborts if `n_itr > 1`. So one data point is a *single completely cold call*. Timing each expression cold in a fresh process vs. warm:

| benchmark | cold (what CI measured) | warm | warm-up share |
|---|---|---|---|
| `as_biadjacency_matrix` | 305 ms | 0.44 ms | **99.9%** |
| `as_adjacency_matrix` | 306 ms | 0.62 ms | **99.8%** |
| `graph_from_adjacency_matrix` | 12.4 ms | 0.62 ms | 95% |
| `vs_by_name` | 0.51 ms | 0.07 ms | 86% |
| `vs_attr_filter` | 0.80 ms | 0.13 ms | 84% |
| `as_data_frame_both` | 0.52 ms | 0.27 ms | 50% |
| `graph_from_data_frame` | 1.29 ms | 0.65 ms | 47% |
| `es_attr_filter` | 1.56 ms | 0.86 ms | 45% |
| `as_long_data_frame` | 2.02 ms | 1.48 ms | 27% |

Every benchmark measured more warm-up than signal. The two Matrix ones were ~300 ms of **Matrix S4 method-table construction on first dispatch** wrapped around ~0.5 ms of igraph R code. A 2x regression in `as_biadjacency_matrix` would have moved that number by 0.15% — invisible — while runner-side variation in the 300 ms showed up at full scale.

Two further contributors, also measured:

- **The deprecated `attr=` argument.** `as_adjacency_matrix(g, attr=)` and `as_biadjacency_matrix(g, attr=)` route through `lifecycle::deprecate_warn()`, which costs **11.2 ms** the first time it fires vs 0.7 ms for the actual work. It's once-per-session, and every data point is a new session, so *every* measurement paid it. Switched to `weights=`.
- **Sub-millisecond durations.** Even the clean benchmarks ran 0.07–1.5 ms, single-sampled across process boundaries.

## The change

Since `iterations = 1` is enforced upstream, the only lever is inside the expressions. Each benchmark now:

1. runs the expression 5x in `expr_before_benchmark` plus `gc(full = TRUE)`, so JIT, lazy-load, Matrix dispatch and lifecycle are all paid before the clock starts;
2. measures a `for` loop with a fixed repeat count sized to ~100 ms.

The repeat counts are deliberately **literal constants**. Calibrating them at runtime would let base and head measure a different number of calls, which biases the comparison outright. That rationale is written into the file header so it survives future edits.

Verified across 10 fresh processes per benchmark: mean 105–119 ms, CV 2.6–5.4%. With `n = 20` that's roughly a ±2–3% CI, and it is now sensitivity to igraph's R code rather than to Matrix's loader. Costs about a minute of extra CI wall-clock, negligible next to the two branch compiles.

This PR touches `touchstone/**`, so the benchmark workflow runs on it — the reported numbers will shift wholesale, since base and head measure different things here. That is expected once; subsequent PRs compare like with like.

## Not addressed here (upstream)

`touchstone:::confint_relative_get()` builds `block` as a factor and then fits `aov(elapsed ~ branch)` — the block term is never used, so all block-to-block runner drift lands in the residual. `branches_upsample()` already randomizes branch order within each block, so the design exists and just isn't analyzed. Simulating drift (sd 3 ms/block, true effect 0): `~ branch` gives a median CI width of 6.15%, `~ branch + block` gives 1.30% — **4.7x tighter**, same 5% false-positive rate. This doesn't cause false regressions (the unblocked model is conservative, not biased), it just costs sensitivity. Worth a PR to lorenzwalthert/touchstone; we already pin the action to a SHA, so picking up a fix is easy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)