### PR TITLE
chore(ci): Retire the pair engine from the revdepx core

### DIFF
--- a/.github/workflows/revdep4.yaml
+++ b/.github/workflows/revdep4.yaml
@@ -23,7 +23,7 @@
 # Sequential halves make per-half durations real measurements -- revdep2
 # could only ever record the pair's shared wall clock. Both halves always
 # run fresh: where the plan finds a valid old-version result from an earlier
-# run -- of this workflow or of revdep3 -- it rides along as a *second
+# run it rides along as a *second
 # opinion* (`baseline_agrees` records whether the fresh old check reproduced
 # it, and disagreement is reported as drift), never as a substitute for the
 # check itself.
@@ -52,15 +52,11 @@
 #             the manifest, the baseline for later runs, and the timings the
 #             next plan calibrates from.
 #
-# Compatibility with revdep3 (the concurrent-pair sibling): the two
-# workflows share the `.github/workflows/revdepx/` scripts, the artifact
-# family (revdepx-plan/-pkg/-baseline/-timings/-report/-results-*), the
-# manifest schema and result vocabulary, the universe image on GHCR, and the
-# check platform. A revdep3 run reuses this workflow's baselines, timings,
-# universe image and reports -- and vice versa. `retry-run` accepts a run id
-# of either workflow. The shared concurrency group serializes the two
-# workflows against each other on the same ref, because they also share the
-# committed report and the baseline lineage.
+# The scripts live in `.github/workflows/revdepx/` (once shared with the
+# retired concurrent-pair sibling, revdep3, whose PR was closed unmerged);
+# artifacts, manifest schema and the universe image lineage are unchanged,
+# so history from the sibling's live runs still serves as baselines and
+# timings.
 #
 # Results land in artifacts:
 #   revdepx-report          the merged report -- fetch with
@@ -107,7 +103,7 @@ on:
         type: string
         default: "1"
       retry-run:
-        description: "Run id of an earlier revdep4 or revdep3 run; re-check only its not-ok packages"
+        description: "Run id of an earlier revdep4 run; re-check only its not-ok packages"
         type: string
         default: ""
       part:
@@ -157,11 +153,11 @@ run-name: "revdep4 ${{ inputs.packages && format('({0})', inputs.packages) || fo
 permissions:
   contents: read
 
-# One revdepx run per checked ref at a time -- across BOTH workflows, which
-# is why the group is not named after this file. revdep3 and revdep4 share
-# the committed report, the baseline lineage and the universe image's
-# `latest` tag; letting them interleave on the same ref would race all three.
-# A queued run waits rather than killing shards mid-check.
+# One revdepx run per checked ref at a time -- the group is named revdepx,
+# not after this file, a relic of the retired sibling workflow that shared
+# it. Two runs interleaving on one ref would race the committed report, the
+# baseline lineage and the universe image's `latest` tag. A queued run waits
+# rather than killing shards mid-check.
 #
 # `github.ref_name`, not `github.ref`: the input holds a bare name ("main")
 # while `github.ref` is fully qualified ("refs/heads/main"), and a group

--- a/.github/workflows/revdep4/README.md
+++ b/.github/workflows/revdep4/README.md
@@ -1,17 +1,17 @@
 # `revdep4` — the sequential-halves queue engine
 
-`.github/workflows/revdep4.yaml` is one of two sibling workflows
-built on the shared core in [`../revdepx/`](../revdepx/README.md);
-the other is `revdep3.yaml`.
-Both check every reverse dependency of igraph twice —
+`.github/workflows/revdep4.yaml` is built on the core in
+[`../revdepx/`](../revdepx/README.md).
+It checks every reverse dependency of igraph twice —
 once against the CRAN release, once against the dev version —
-inside the same prebuilt universe image,
-and publish the same artifact family under the same schemas,
-so either workflow's runs feed the other's baselines, timings and retries.
-They differ in exactly one thing, the check engine:
-`revdep3` runs a package's two halves simultaneously, one container each;
-`revdep4` runs them one after the other,
-and wins the lost parallelism back *across* packages with a bash work queue.
+inside a prebuilt universe image,
+running a package's two halves one after the other
+and winning the lost parallelism back *across* packages
+with a bash work queue.
+(A sibling *pair* engine, `revdep3`,
+ran the halves simultaneously, one container each;
+it was retired with its unmerged PR,
+and its runs remain valid baseline and timing history.)
 The shared core is documented in `../revdepx/README.md`;
 this file covers only what `REVDEPX_ENGINE=queue` changes.
 
@@ -35,7 +35,7 @@ is simply not a mode anything in the R toolchain promises to support.
 This engine removes the class instead of its members:
 at no moment do two checks of the same package coexist.
 The old half runs, finishes, and then the new half runs.
-What the pair bought — parallel hardware use — is bought back one level up:
+What simultaneity bought — parallel hardware use — is bought back one level up:
 with `W` workers, `W` *different* packages are in flight at once,
 which no shared assumption anywhere touches.
 
@@ -100,7 +100,7 @@ that reconciles `claimed.log` against the manifest.
 
 The queue's order key is **expected check seconds** —
 measured on this infrastructure in prior `revdepx` runs
-(either workflow's, youngest first),
+(youngest first),
 else CRAN's reported `T_total` scaled by the self-calibrating factor
 the collector fits from measured runs,
 else the cohort median.
@@ -117,10 +117,9 @@ at both halves' seconds — twice the per-half estimate.
 
 ## The stored old result: always a second opinion, never a substitute
 
-Both halves always run fresh, in this engine as in `revdep3`.
+Both halves always run fresh.
 Sequential halves would make skipping the old check tempting —
-unlike the pair engine's free concurrent old half,
-it costs real wall clock here —
+it costs real wall clock —
 and the pinned container platform would even make the substitution
 far safer than when `revdep2` tried and abandoned it
 (76 of one run's 78 `newly_broken` verdicts were false,
@@ -155,7 +154,7 @@ since their checks ran on a different platform entirely.
   exported to `check-half.sh` as `REVDEPX_MEMORY`.
   A hungry check OOM-kills its own container, not the runner,
   and the 2 GiB headroom keeps docker and the runner agent responsive —
-  the sequential engine has no need for the pair engine's `nice`.
+  the sequential engine has no need for revdep2's `nice`.
 - Before claiming, a worker prices the candidate
   at `weight_minutes × 60 × 1.3`
   (the plan's estimate plus the shard driver's usual trailing margin)
@@ -183,20 +182,19 @@ since their checks ran on a different platform entirely.
   and appends the manifest line under the manifest lock.
   All shared logic comes from `../revdepx/util.R` and `../revdepx/compare.R`.
 
-## Shared with `revdep3`
+## Continuity with the retired `revdep3`
 
-Everything but the engine:
+The retired pair engine shared everything but the engine:
 the `revdepx-*` artifact family and names,
 `plan.json`, manifest and `timings.json` schemas
 (the queue's `t_old`/`t_new` are true per-half seconds,
-where the pair engine records the pair's shared wall clock —
+where the pair engine recorded the pair's shared wall clock —
 `timings.json` carries an `engine` field
 so calibration never mixes the two setups' overheads),
 the baseline artifact,
 the universe image on GHCR and the base image under it,
 the comparison code,
 and the report committed to the `revdep` directory.
-Both workflows scan both workflows' histories
-(`REVDEPX_WORKFLOWS`),
-so a `revdep3` run's measured timings price a `revdep4` plan and vice versa,
-and either can be retried from the other's report.
+`REVDEPX_WORKFLOWS` says whose histories the plan scans,
+so old `revdep3` runs still feed baselines and timings
+while they remain within the age bounds.

--- a/.github/workflows/revdep4/queue.sh
+++ b/.github/workflows/revdep4/queue.sh
@@ -315,8 +315,7 @@ process_claim() {
   # The halves, one after the other: this engine's whole point. Timed here,
   # around each call, because the halves are separate processes now and their
   # true per-half seconds are what the manifest and the next plan's cost
-  # model get -- the pair engine can only ever record the pair's shared wall
-  # clock. check-half.sh always exits 0 by contract; a nonzero exit means
+  # model get. check-half.sh always exits 0 by contract; a nonzero exit means
   # the harness around the container broke, and compare-one.R reading the
   # half's absent status file turns that into this one package's error line.
   local t_old='' t_new='' started status

--- a/.github/workflows/revdepx/README.md
+++ b/.github/workflows/revdepx/README.md
@@ -1,17 +1,12 @@
-# revdepx: the shared core of revdep3 and revdep4
+# revdepx: the core of the revdep4 workflow
 
-This directory is the engine-agnostic core
-of two sibling reverse-dependency-check workflows:
+This directory is the core of the reverse-dependency-check workflow
+`revdep4.yaml` (the *queue* engine):
+a package's CRAN half and dev half run **sequentially**,
+each in its own Docker container,
+and a bash work queue checks several packages at once.
 
-- **revdep3** (`revdep3.yaml`, the *pair* engine):
-  a package's CRAN half and dev half run **concurrently**,
-  each in its own Docker container.
-- **revdep4** (`revdep4.yaml`, the *queue* engine):
-  the two halves run **sequentially**,
-  and a bash work queue checks several packages at once,
-  one container per package.
-
-Both exist because of the same diagnosis:
+It exists because of a diagnosis:
 revdep2 ran the two halves as two simultaneous `R CMD check` processes
 on one host,
 and simultaneously checking the same package against two libraries
@@ -20,8 +15,13 @@ The PSOCK port collision that needed the `R_PARALLEL_PORT` split
 was one member of an open-ended class —
 shared TMPDIR, shared caches, shared locks,
 any singleton a check believes it owns.
-revdep3 dissolves the class by isolation;
-revdep4 dissolves it by never being simultaneous.
+revdep4 dissolves the class by never being simultaneous,
+and by containers.
+(A sibling *pair* engine, revdep3,
+dissolved it by isolation alone —
+both halves concurrently, one container each;
+it was validated live and retired with its unmerged PR,
+and its runs remain valid history.)
 Everything that was *not* about that flaw —
 the planner, the cost model, the baseline lineage,
 the manifest and report machinery,
@@ -45,10 +45,10 @@ from "an earlier run of this one":
   `revdepx-timings`, `revdepx-report`,
   `revdepx-results-<shard>-<attempt>`,
   `revdepx-universe-report`.
-  `plan.R` walks the completed runs of *both* workflow files
-  (`REVDEPX_WORKFLOWS`), youngest first across the union.
-- **Baselines** (old-version check results) are valid for either engine
-  because both check inside the *same* container platform:
+  `plan.R` walks the completed runs of the files in `REVDEPX_WORKFLOWS`,
+  youngest first across the union.
+- **Baselines** (old-version check results) are valid across runs
+  because every run checks inside the *same* container platform:
   a baseline row records the revdep's version,
   our CRAN version, the container R series,
   the base-image tag, the dependency fingerprint,
@@ -62,19 +62,16 @@ from "an earlier run of this one":
   which were measured on the runner's own toolchain
   and carry no tag.
 - **Timings** record one canonical per-package number:
-  `seconds` = the mean of the per-half durations that exist.
-  For the pair engine that *is* the pair's wall clock
-  (both halves record the same number, the slower one);
-  for the queue engine it is the mean of two real halves.
-  Either plan converts it to its own bill:
-  the pair plan uses it as-is,
-  the queue plan doubles it.
-  Shard-level rows (setup, install minutes) are engine-shaped,
-  so `calibration()` takes them only from same-engine runs;
+  `seconds` = the mean of the per-half durations that exist —
+  what one half costs, which the plan doubles into a package's bill.
+  (Retired pair-engine rows carry the pair's shared wall clock
+  in both fields; the unit still holds.)
+  Shard-level rows (setup, install minutes) are engine-tagged,
+  so `calibration()` takes them only from queue runs;
   the per-package pool is shared.
 - **Reports and `retry-run`**: `manifest.json` and the report files
   have one schema and one result vocabulary,
-  so `retry-run: <id>` accepts a run of either workflow
+  so `retry-run: <id>` accepts any earlier revdepx run
   and carries its good results into the new report.
 - **The universe image** on GHCR is one lineage (`revdepx-universe`),
   updated by whichever workflow ran last
@@ -129,7 +126,7 @@ One half = one container (`check-half.sh`):
 the tarball, the half's library and the work directory bind-mounted,
 `R_LIBS=<half lib>:<universe lib>`,
 `timeout` inside the container,
-the same `_R_CHECK_*` environment both engines forward,
+the same `_R_CHECK_*` environment the workflow forwards,
 a per-container `/tmp` on the big disk,
 a memory cap so a hungry check kills its container
 and not the runner,
@@ -141,11 +138,9 @@ revdep2 produced,
 so parsing, comparison, salvage and reporting
 carry over unchanged (`compare.R`).
 
-The pair engine runs two such containers side by side
-(`../revdep3/check-pair.sh`);
-the queue engine runs them back to back per package,
+The queue runs two such containers back to back per package,
 several packages at once (`../revdep4/queue.sh`).
-Both halves are always fresh checks, in both engines.
+Both halves are always fresh checks.
 
 ## Dropped from revdep2, deliberately
 
@@ -178,8 +173,7 @@ so a floor sized for uncontended times kills healthy checks),
 `REVDEPX_DEADLINE_MINUTES`,
 `REVDEPX_COMMIT_REPORT`,
 `REVDEPX_MEMORY_PER_CHECK` (per-check container memory cap, default 6g;
-both engines honor it, and each derives a machine-sized cap when it is
-cleared),
+a machine-sized cap is derived when it is cleared),
 `REVDEPX_CHECK_FLAGS` (compiler flags appended for the check's own compile
 of the package under test, default `-g0` — template-heavy Stan/TMB
 translation units spend most of their compiler memory on debug info;

--- a/.github/workflows/revdepx/collect.R
+++ b/.github/workflows/revdepx/collect.R
@@ -1,4 +1,4 @@
-# Fan-in for the revdepx workflows (revdep3 and revdep4): merge every shard's results into one report, one
+# Fan-in for the revdepx workflow: merge every shard's results into one report, one
 # manifest, and one baseline for future runs to reuse.
 #
 # Reads all revdepx-results-* artifacts (every attempt; on a re-run the later
@@ -303,13 +303,12 @@ inform("Baseline carries ", length(baseline), " old-version result(s)")
 # the shard count honest: a model that overestimates the work cuts it into more
 # shards than the parallel capacity can run, and each extra shard is another
 # setup paid for nothing.
-# The canonical per-package number both engines share: the mean of the
-# per-half durations that exist. The pair engine records the pair's wall
-# clock for both halves, so the mean IS that wall clock (the slower half);
-# the queue engine records two real durations, and the mean is their honest
-# middle. Either way "seconds" answers "what does one half cost here", which
-# is the unit the cost model prices engines from (the queue plan doubles it,
-# the pair plan does not).
+# The canonical per-package number: the mean of the per-half durations that
+# exist -- two real measurements, their honest middle. "seconds" answers
+# "what does one half cost here", the unit the cost model doubles into a
+# package's bill. (Rows from the retired pair engine carried the pair's
+# shared wall clock in both fields, so their mean is that wall clock, and
+# the unit still holds.)
 seconds_of <- function(entry) {
   both <- suppressWarnings(as.numeric(c(entry$t_old, entry$t_new)))
   both <- both[!is.na(both) & both > 0]
@@ -885,11 +884,9 @@ append_summary(c(
     # no timing of its own, but the checks it did finish are still in the
     # manifest the collector just merged.
     # `seconds` is the canonical per-half number; `checks` says how many
-    # halves it stands for. Under the pair engine the halves overlapped, so
-    # summing seconds alone (never seconds x checks) is the wall clock; under
-    # the queue engine the same sum is half the check wall clock, which the
-    # planned-vs-actual shard table already reports exactly. Close enough for
-    # a cost headline either way.
+    # halves it stands for. Summing seconds is half the check wall clock,
+    # which the planned-vs-actual shard table already reports exactly. Close
+    # enough for a cost headline.
     check_minutes <- sum(vapply(
       package_rows,
       function(p) p$seconds / 60,
@@ -960,7 +957,7 @@ append_summary(c(
     local({
       ref <- env_chr("GITHUB_WORKFLOW_REF")
       file <- basename(sub("@.*$", "", ref))
-      if (nzchar(file) && grepl("[.]ya?ml$", file)) file else "revdep3.yaml"
+      if (nzchar(file) && grepl("[.]ya?ml$", file)) file else "revdep4.yaml"
     }),
     run_id
   ),

--- a/.github/workflows/revdepx/compare.R
+++ b/.github/workflows/revdepx/compare.R
@@ -1,9 +1,7 @@
 # The comparison layer: from two `R CMD check` halves to one manifest line.
 #
-# Extracted from revdep2's shard.R so that both engines share it. The pair
-# engine (revdep3) sources it into the shard driver and compares in-process,
-# one package after another; the queue engine (revdep4) sources it into
-# compare-one.R, one short-lived process per package, run by a worker the
+# Extracted from revdep2's shard.R. The queue engine (revdep4) sources it
+# into compare-one.R, one short-lived process per package, run by a worker the
 # moment that package's halves are done. Everything here is a plain function
 # of its arguments -- no shard state, no globals -- and what a function learns
 # comes back as a named list of manifest-field updates for the caller to apply
@@ -92,10 +90,9 @@ check_diff <- function(name, old_log, new_log, work_dir) {
 # inside the container, which is what makes the distinction reliable: exit 124
 # is the deadline, anything else is the check saying something.
 #
-# `duration` is this half's cost in seconds as the engine measured it: the
-# pair engine cannot separate its two concurrent halves and passes the pair's
-# wall clock for both, while the queue engine runs them one after the other
-# and passes each half's own clock.
+# `duration` is this half's own clock in seconds: the queue runs the two
+# halves one after the other, so each is a real measurement. (Rows written by
+# the retired pair engine carried the pair's shared wall clock instead.)
 read_side <- function(work_dir, phase, name, timeout_sec, duration) {
   dir <- file.path(work_dir, phase)
   # A half that never wrote its status -- an unwritable work directory, a
@@ -293,9 +290,8 @@ keep_side <- function(work_dir, pkgs_dir, name, phase, result) {
 }
 
 # A half that errored or timed out, turned into this package's verdict.
-# Returns the manifest-field updates; the log line is printed here so both
-# engines say it the same way (`progress` is the pair engine's position note,
-# empty elsewhere).
+# Returns the manifest-field updates; the log line is printed here so every
+# caller says it the same way (`progress` is an optional position note).
 check_failure <- function(name, phase, result, progress = "") {
   note <- if (nzchar(progress)) paste0(", ", progress) else ""
   if (isTRUE(attr(result, "timed_out"))) {
@@ -426,12 +422,10 @@ compare_halves <- function(
     updates$result <- classify_status(cmp$status, new_issues)
     updates$status <- cmp$status
     updates$status_new <- counts(new)
-    # This half's measured seconds, whatever the engine means by that: the
-    # pair engine charges the pair's wall clock to both halves -- they ran
-    # side by side, so neither one's own time is separable from the other's
-    # -- and the queue engine records each half's true clock. It used to be
-    # recorded only where the comparison failed, which left `t_new` null for
-    # every package that compared -- that is, for all of them.
+    # This half's measured seconds -- each half's true clock under the
+    # queue. It used to be recorded only where the comparison failed, which
+    # left `t_new` null for every package that compared -- that is, for all
+    # of them.
     updates$t_new <- attr(new, "duration")
     updates$new_issues <- new_issues
     # An install failure or a timeout leaves nothing to compare, so the
@@ -490,10 +484,9 @@ manifest_entry_defaults <- function(name, plan_pkg, shard_index) {
 #
 # The versions are stamped at write time, so even a line written on an error
 # path names the versions it would have compared. Appended under `flock` when
-# there is one: the pair engine has a single writer -- the shard driver, one
-# line per package as it finishes -- but the queue engine has many, every
-# worker's compare-one.R appending its package's line the moment it is done
-# and the driver appending the deferred tail after the queue drains. One
+# there is one: the queue has many writers, every worker's compare-one.R
+# appending its package's line the moment it is done and the driver
+# appending the deferred tail after the queue drains. One
 # short O_APPEND write per line would probably never tear; the lock costs
 # nothing and turns probably into does not. Where flock does not exist (it is
 # util-linux, so everywhere this runs in CI, but a local macOS invocation

--- a/.github/workflows/revdepx/fetch.sh
+++ b/.github/workflows/revdepx/fetch.sh
@@ -4,9 +4,7 @@
 # Usage:
 #   .github/workflows/revdepx/fetch.sh [<run-id>] [<dir>]
 #
-# Without a run id, the newest completed run of either engine -- revdep3.yaml
-# or revdep4.yaml, which publish interchangeable revdepx-* artifacts -- is
-# used. Needs the `gh` CLI, authenticated for the repository.
+# Without a run id, the newest completed revdep4.yaml run is used. Needs the `gh` CLI, authenticated for the repository.
 
 set -eu
 
@@ -18,7 +16,7 @@ if [ -z "${run}" ]; then
   # two workflows is the normal case while the other PR is unmerged, so a
   # workflow that gh cannot list is skipped, not fatal.
   run="$(
-    for wf in revdep3.yaml revdep4.yaml; do
+    for wf in revdep4.yaml; do
       gh run list --workflow "${wf}" --limit 20 \
         --json databaseId,status,createdAt --jq \
         '.[] | select(.status == "completed") | [.createdAt, .databaseId] | @tsv' \
@@ -26,7 +24,7 @@ if [ -z "${run}" ]; then
     done | sort -r | head -n 1 | cut -f 2
   )"
   if [ -z "${run}" ] || [ "${run}" = "null" ]; then
-    echo "No completed revdep3/revdep4 run found; pass a run id." >&2
+    echo "No completed revdep4 run found; pass a run id." >&2
     exit 1
   fi
   echo "Using newest completed run: ${run}"
@@ -49,6 +47,6 @@ if [ -f "${dir}/README.md" ]; then
   cat "${dir}/README.md"
 fi
 echo
-echo "To re-check everything that is not ok (either engine can retry the other's run):"
-echo "  gh workflow run revdep3.yaml -f retry-run=${run}"
+echo "To re-check everything that is not ok:"
+
 echo "  gh workflow run revdep4.yaml -f retry-run=${run}"

--- a/.github/workflows/revdepx/plan.R
+++ b/.github/workflows/revdepx/plan.R
@@ -4,23 +4,13 @@
 # weighs each one by what its check is expected to cost on these runners,
 # decides which stored old-version results may stand beside this run's fresh
 # checks as second opinions, and partitions the packages into cost-balanced
-# shards. One shard becomes one
-# matrix leg of revdep3.yaml or revdep4.yaml -- the same plan serves both, and
-# the history it mines is shared: baselines, timings and reports of *either*
-# workflow feed the next run of either.
+# shards. One shard becomes one matrix leg of revdep4.yaml.
 #
-# The two engines spend a shard's minutes differently, and REVDEPX_ENGINE is
-# how the plan knows which bill to price:
+# The bill the plan prices: a package's two halves run sequentially, so the
+# package costs both of them end to end, and REVDEPX_WORKERS packages run at
+# once, so a shard's wall clock is its check load divided by the workers.
 #
-#   pair   (revdep3) - the two halves of a package run concurrently, one
-#            container each; a package costs the wall clock of its slower
-#            half, and a shard works through its packages one at a time.
-#   queue  (revdep4) - the halves run sequentially, so a package costs both
-#            of them end to end, and REVDEPX_WORKERS packages run at once,
-#            so a shard's wall clock is its check load divided by the
-#            workers.
-#
-# Both engines always check both halves fresh. A stored old result from an
+# Both halves are always checked fresh. A stored old result from an
 # earlier run (the baseline) rides along as a *second opinion* -- the shard
 # records whether the fresh old check reproduced it (`baseline_agrees`) --
 # and never substitutes for the check itself.
@@ -56,19 +46,16 @@
 #                             `broken` to take them from the committed report
 #   REVDEPX_WHICH           - "strong" (default) or "most" (adds Suggests/
 #                             Enhances dependents)
-#   REVDEPX_ENGINE          - "pair" (revdep3) or "queue" (revdep4); prices
-#                             the checks as described above (default: pair)
-#   REVDEPX_WORKERS         - queue engine only: packages checked concurrently
-#                             per shard (default: 4)
+#   REVDEPX_WORKERS         - packages checked concurrently per shard
+#                             (default: 4)
 #   REVDEPX_R_VERSION       - the full R version the *containers* check under,
 #                             e.g. "4.5.3", resolved by the workflow; required,
 #                             because the baseline key must name the R that ran
 #                             the checks, not the R running this script
 #   REVDEPX_WORKFLOWS       - workflow files whose completed runs the history
 #                             walk mines for baselines and timings (default:
-#                             "revdep3.yaml revdep4.yaml" -- the two engines
-#                             feed each other)
-#   REVDEPX_RETRY_RUN       - run id of an earlier revdep3/revdep4 run; check
+#                             "revdep4.yaml")
+#   REVDEPX_RETRY_RUN       - run id of an earlier revdepx run; check
 #                             only the packages that run could not declare ok
 #   REVDEPX_PART            - "i/G": check one G-th of the batch, for a revdep
 #                             set too big for a single run (the plan refuses
@@ -158,24 +145,26 @@ repo <- env_chr("GITHUB_REPOSITORY")
 # release flavor is the closest Linux number there is -- check_scale absorbs
 # the difference like any other speed gap.
 timing_flavor <- env_chr("REVDEPX_TIMING_FLAVOR", "r-release-linux-x86_64")
-engine <- match.arg(env_chr("REVDEPX_ENGINE", "pair"), c("pair", "queue"))
+# The queue engine is the only one -- the pair engine (revdep3) was retired
+# with its unmerged PR -- and the constant keeps the engine-tagged plan,
+# manifest and timings schema unchanged.
+engine <- "queue"
 workers <- max(1, env_num("REVDEPX_WORKERS", 4))
-# How many packages a shard works on at once. The pair engine runs one package
-# at a time (its two halves fill the runner); the queue engine runs one per
-# worker. This is the divisor that turns a shard's check load into wall clock.
-parallelism <- if (engine == "queue") workers else 1
+# How many packages a shard works on at once: one per worker. This is the
+# divisor that turns a shard's check load into wall clock.
+parallelism <- workers
 workflow_files <- strsplit(
-  env_chr("REVDEPX_WORKFLOWS", "revdep3.yaml revdep4.yaml"),
+  env_chr("REVDEPX_WORKFLOWS", "revdep4.yaml"),
   "[,[:space:]]+"
 )[[1]]
 workflow_files <- workflow_files[nzchar(workflow_files)]
-# Which of the two workflow files dispatched *this* run, for messages that
-# print a re-dispatch command. GITHUB_WORKFLOW_REF looks like
-# "owner/repo/.github/workflows/revdep3.yaml@refs/heads/main".
+# Which workflow file dispatched *this* run, for messages that print a
+# re-dispatch command. GITHUB_WORKFLOW_REF looks like
+# "owner/repo/.github/workflows/revdep4.yaml@refs/heads/main".
 this_workflow_file <- local({
   ref <- env_chr("GITHUB_WORKFLOW_REF")
   file <- basename(sub("@.*$", "", ref))
-  if (nzchar(file) && grepl("[.]ya?ml$", file)) file else "revdep3.yaml"
+  if (nzchar(file) && grepl("[.]ya?ml$", file)) file else "revdep4.yaml"
 })
 
 # The R the *checks* run under -- the container's, resolved by the workflow --
@@ -233,11 +222,11 @@ plan_nothing <- function(reason) {
 # The gh plumbing itself lives in util.R, because the shards fetch artifacts
 # too; what is planned here is *which* earlier runs to take them from.
 #
-# One walk over the completed runs of every revdepx workflow -- both engines
-# publish the same artifacts under the same names, so a revdep3 run's history
-# serves a revdep4 plan and the other way around -- youngest first across all
-# of them, answers every question this plan asks of its history, and asks the
-# API for a run's artifacts at most once:
+# One walk over the completed runs of every workflow in REVDEPX_WORKFLOWS --
+# runs of the retired pair engine published the same artifacts under the same
+# names, so old history still serves -- youngest first across all of them,
+# answers every question this plan asks of its history, and asks the API for
+# a run's artifacts at most once:
 #
 #   * which run donates the CRAN baseline -- the newest one that still has it;
 #   * which runs donate measured timings -- the youngest few, whose numbers
@@ -841,33 +830,22 @@ inform(
   " check times measured by an earlier run"
 )
 
-# Weight: what one package costs a worker in wall clock, and it depends on the
-# engine.
+# Weight: what one package costs a worker in wall clock.
 #
 # `check_seconds` is calibrated to mean *one half*: `collect.R` records the
-# mean of the positive per-half durations (for the pair engine the two are the
-# same number, the pair's wall clock, which is the slower half; for the queue
-# engine they are real and the mean is the honest middle), and
-# `calibration()` fits `median(seconds / T_total)` from that. So:
-#
-#   pair  - the halves run concurrently and the package costs the slower one:
-#           one `check_seconds`, exactly as revdep2 priced it. Multiplying by
-#           two here would price every shard at twice its wall clock -- twice
-#           the shards, each paying its own setup, and packages deferred at
-#           the deadline that would have fit.
-#   queue - the halves run back to back, so the package always costs both.
-#           Both halves run fresh in every engine: a stored old result is a
-#           second opinion (`baseline_agrees`), never a substitute, so a
-#           baseline changes no weight. This is where revdep2's
-#           `((!reuse) + 1) *` factor would otherwise come back; it stays
-#           retired on purpose.
-halves <- if (engine == "queue") 2 else 1
+# mean of the positive per-half durations and `calibration()` fits
+# `median(seconds / T_total)` from that. The halves run back to back, so the
+# package always costs both. Both halves run fresh: a stored old result is a
+# second opinion (`baseline_agrees`), never a substitute, so a baseline
+# changes no weight -- this is where revdep2's `((!reuse) + 1) *` factor
+# would otherwise come back, and it stays retired on purpose.
+halves <- 2
 weight <- halves * check_seconds / 60 + overhead_minutes
 
 # ------------------------------------------------------------- partitioning --
 
 n <- length(packages)
-# What the whole batch costs in *wall clock*: the queue engine works
+# What the whole batch costs in *wall clock*: the queue works
 # `parallelism` packages at once, so a shard's check minutes are its check
 # load divided by the workers -- a lower bound the per-shard model below
 # tightens for shards dominated by one giant.
@@ -930,8 +908,7 @@ ord <- order(-weight)
 #
 #   overhead + max(heaviest member, check sum / parallelism)
 #
-# For the pair engine (parallelism 1) the max() collapses and this is exactly
-# revdep2's model. For the queue engine the division alone would flatter a
+# The division alone would flatter a
 # shard dominated by one giant -- workers cannot share a package, so a shard
 # whose heaviest member outweighs everything else runs exactly as long as
 # that member, however many workers idle beside it. max(heaviest, mean work
@@ -1210,7 +1187,7 @@ plan <- list(
   r_full_version = r_full_version,
   base_image = base_image_tag,
   engine = engine,
-  workers = if (engine == "queue") workers else 1,
+  workers = workers,
   sha = head_sha,
   ref = env_chr("GITHUB_REF_NAME"),
   which = which_input,
@@ -1382,11 +1359,7 @@ append_summary(c(
   sprintf(
     "| Engine | `%s`%s |",
     engine,
-    if (engine == "queue") {
-      sprintf(" (%d workers per shard)", workers)
-    } else {
-      " (both halves concurrently, a container each)"
-    }
+    sprintf(" (%d workers per shard)", workers)
   ),
   sprintf(
     "| Check platform | R %s in containers on base `%s` |",

--- a/.github/workflows/revdepx/shard.R
+++ b/.github/workflows/revdepx/shard.R
@@ -12,11 +12,8 @@
 # can time them separately; `PHASE=all` runs both in one go, which is what a
 # local invocation wants.
 #
-# The check phase is dispatched on REVDEPX_ENGINE:
+# The check phase:
 #
-#   pair  -- one package's two halves at once: revdep3/check-pair.sh runs two
-#            check containers side by side, and this process compares them
-#            and appends the manifest line. Exactly revdep2's flow.
 #   queue -- one line per runnable package into a queue file, heaviest first;
 #            revdep4/queue.sh drains it with a pool of workers, each running
 #            a package's two halves in turn and then a per-package
@@ -50,8 +47,6 @@
 #                            may be missing or empty, then everything is fresh
 #   OUT_DIR                - results directory, uploaded as the shard artifact
 #                            (default: results)
-#   REVDEPX_ENGINE         - "pair" or "queue": who drives the checks
-#                            (default: pair)
 #   REVDEPX_IMAGE_FILE     - file holding the universe image reference,
 #                            written by shard-prep.sh
 #                            (default: $RUNNER_TEMP/revdepx-image-ref)
@@ -92,17 +87,10 @@ timeout_factor <- env_num("TIMEOUT_FACTOR", 1.5)
 timeout_min_sec <- env_num("TIMEOUT_MIN_MINUTES", 10) * 60
 deadline <- Sys.time() + env_num("DEADLINE_MINUTES", 300) * 60
 
-# Which engine will execute the checks. Validated here, before any work is
-# spent, so a typo in the workflow fails the prepare phase and not the first
-# check three quarters of an hour later.
-engine <- env_chr("REVDEPX_ENGINE", "pair")
-if (!engine %in% c("pair", "queue")) {
-  stop(
-    "REVDEPX_ENGINE must be \"pair\" or \"queue\", not ",
-    engine,
-    call. = FALSE
-  )
-}
+# The queue engine is the only one: the pair engine (revdep3) was retired
+# with its unmerged PR. The constant keeps the manifest, plan and timings
+# schema -- whose rows are engine-tagged -- unchanged.
+engine <- "queue"
 
 mine <- Filter(function(s) s$index == shard_index, plan$shards)
 if (length(mine) == 0) {
@@ -655,9 +643,8 @@ runnable <- names(sources)
 # The check containers must run the exact image the half libraries were
 # prepared against, so the ref recorded by the prepare phase wins; the ref
 # file is the fallback for a hand-driven PHASE=check over an existing work
-# directory. Exported because both engines hand it down the same way:
-# check-pair.sh and queue.sh pass it to check-half.sh, which passes it to
-# `docker run`.
+# directory. Exported because queue.sh passes it to check-half.sh, which
+# passes it to `docker run`.
 image_ref <- installed_state$image %||% read_image_ref()
 Sys.setenv(REVDEPX_IMAGE = image_ref)
 inform(sprintf(
@@ -670,10 +657,8 @@ inform(sprintf(
 
 # The timeout scales with what the check costs CRAN, floored because these
 # runners are slower than CRAN's machines and a tiny package must not be
-# killed over the difference. It is a *per-half* clock under both engines:
-# the pair engine hands the full budget to each of its two concurrent
-# containers, as it always did, and the queue engine hands it to the old and
-# the new half in turn.
+# killed over the difference. It is a *per-half* clock: the queue hands it
+# to the old and the new half in turn.
 package_timeout_sec <- function(name) {
   max(
     timeout_min_sec,
@@ -694,383 +679,88 @@ checks_started <- 0L
 check_seconds <- 0
 reported <- character()
 
-if (engine == "pair") {
-  # One package, both versions, at once.
-  #
-  # revdep3/check-pair.sh runs the two check containers concurrently -- each
-  # one a check-half.sh invocation against the universe image, with the right
-  # half library bind-mounted in front of the baked dependency library -- and
-  # writes each half's log and exit status; `read_side()` (compare.R) reads
-  # them back.
-  check_pair_sh <- file.path(dirname(script_dir), "revdep3", "check-pair.sh")
-  if (!file.exists(check_pair_sh)) {
-    stop(
-      "REVDEPX_ENGINE=pair needs ",
-      check_pair_sh,
-      ", which does not exist; is the revdep3 directory checked out?",
-      call. = FALSE
-    )
-  }
+# The queue engine: this driver writes the work list and hands it to
+# revdep4/queue.sh, whose workers run the two halves of a package one after
+# the other and then a per-package compare-one.R -- sourcing the same
+# compare.R as this script -- which appends the manifest line itself, under
+# flock, as each package finishes. Write-as-you-go, so a killed shard still
+# accounts for what it finished. This process only writes the deferred tail afterwards.
+queue_sh <- file.path(dirname(script_dir), "revdep4", "queue.sh")
+if (!file.exists(queue_sh)) {
+  stop(
+    "REVDEPX_ENGINE=queue needs ",
+    queue_sh,
+    ", which does not exist; is the revdep4 directory checked out?",
+    call. = FALSE
+  )
+}
 
-  # Stop before a check the trailing estimate says will not finish -- but
-  # always attempt the first check of a phase, or a mis-budgeted shard would
-  # make no progress at all and a retry would repeat the mistake. (The queue
-  # engine's workers apply the same rule per claim, inside queue.sh.)
-  out_of_time <- function(entry) {
-    if (checks_started == 0L) {
-      return(FALSE)
-    }
-    budget_sec <- max(entry$weight_minutes, 1) * 60 * 1.3
-    Sys.time() + budget_sec > deadline
-  }
-
-  check_pair <- function(name) {
-    checks_started <<- checks_started + 1L
-    work_dir <- file.path(work, "check", name)
-    unlink(work_dir, recursive = TRUE)
-    dir.create(work_dir, recursive = TRUE, showWarnings = FALSE)
-    timeout_sec <- package_timeout_sec(name)
-    started <- Sys.time()
-    system2(
-      check_pair_sh,
-      shQuote(c(
-        sources[[name]],
-        work_dir,
-        lib_old,
-        lib_new,
-        format(round(timeout_sec), scientific = FALSE)
-      ))
-    )
-    duration <- round(as.numeric(Sys.time() - started, units = "secs"))
-    # Both checks ran side by side, so the pair cost what the slower one
-    # cost, and that -- not the sum of the two -- is what the shard's
-    # deadline spends and what the cost model is fitted against. It is also
-    # the only per-half duration there is: simultaneous halves are
-    # inseparable, so `read_side()` records it for both.
-    check_seconds <<- check_seconds + duration
-    list(
-      old = read_side(work_dir, "old", name, timeout_sec, duration),
-      new = read_side(work_dir, "new", name, timeout_sec, duration)
-    )
-  }
-
-  # The checks: one pass, both versions of every package at once.
-  #
-  # There used to be two passes -- every old check, then the dev binary
-  # installed over the CRAN one, then every new check -- because the library
-  # could only hold one version at a time. With the two cascading libraries it
-  # can hold both, so a package's pair runs together and the shard makes one
-  # pass. That halves a package's wall clock, and it means a package whose old
-  # check hangs still gets its new answer instead of the run learning nothing
-  # about it.
-  inform(sprintf(
-    "Checking %d package(s), old and new side by side",
-    length(runnable)
-  ))
-  # How far along the shard is, on every line that reports a package.
-  #
-  # A shard runs for hours and its log is read while it runs, so "3/51" answers
-  # "is this nearly done?" without counting lines. The estimate answers the
-  # question actually being asked, which is when.
-  #
-  # The plan already priced every package; what it could not know is how this
-  # runner would compare. So the remaining packages are priced in the plan's
-  # own units and then rescaled by how its estimates have held up here so far
-  # -- which absorbs both a slow runner and a systematically optimistic model,
-  # without either having to be known in advance. Before the first pair
-  # finishes there is nothing to rescale by and the plan's number stands.
-  planned_done <- 0
-  actual_done <- 0
-  planned_minutes <- function(name) {
-    max(get(name, envir = state)$weight_minutes %||% 0, 0)
-  }
-  progress_note <- function(position) {
-    left <- sum(vapply(
-      utils::tail(runnable, length(runnable) - position),
-      planned_minutes,
-      numeric(1)
-    ))
-    scale <- if (planned_done > 0 && actual_done > 0) {
-      actual_done / planned_done
-    } else {
-      1
-    }
-    sprintf(
-      "%d/%d, %s",
-      position,
-      length(runnable),
-      if (left > 0) {
-        paste0("~", format_duration(left * scale * 60), " left")
-      } else {
-        "last one"
-      }
-    )
-  }
-
-  # One package: both halves, compared, recorded. Returns nothing; everything
-  # it learns goes into `state`, and the caller writes that out however this
-  # ends.
-  check_package <- function(name, position) {
-    entry <- get(name, envir = state)
-
-    if (out_of_time(entry)) {
-      inform(name, ": deferred (deadline), ", progress_note(position))
-      return(invisible(NULL))
-    }
-
-    # Both halves, always. A baseline used to stand in for the old check and
-    # save it; with the pair running concurrently the old check costs no wall
-    # clock at all, and reusing a result from another run meant comparing
-    # against a machine, a CRAN snapshot and a dependency tree that were not
-    # this run's. The baseline is still read, but as a second opinion: if it
-    # disagrees with what the old check just produced, that is drift worth
-    # printing rather than a comparison worth trusting. (The queue engine,
-    # whose halves cost real wall clock, reuses it under the far stricter
-    # image-era conditions -- see compare.R.)
-    pair <- check_pair(name)
-    old <- pair$old
-    new <- pair$new
-
-    # What this one was priced at against what it cost, which is what prices
-    # the rest. A timed-out check counts too: the clock really did spend it.
-    planned_done <<- planned_done + planned_minutes(name)
-    actual_done <<- actual_done + (attr(new, "duration") %||% 0) / 60
-    progress <- progress_note(position)
-
-    work_dir <- file.path(work, "check", name)
-    pkgs_dir <- file.path(out_dir, "pkgs")
-
-    # A half that produced a result is kept even when its partner did not.
-    #
-    # Running the pair concurrently was supposed to mean that "a package whose
-    # old check hangs still gets its new answer" -- but the old half's error
-    # used to `next` straight past the code that saves the new one, so the
-    # answer was produced and then thrown away, and the artifact held nothing
-    # at all for that package. 19 packages in run 31879790285 lost a half this
-    # way.
-    if (inherits(new, "error")) {
-      if (!inherits(old, "error")) {
-        do.call(
-          update,
-          c(list(name), keep_side(work_dir, pkgs_dir, name, "old", old))
-        )
-      }
-      do.call(update, c(list(name), check_failure(name, "new", new, progress)))
-      return(invisible(NULL))
-    }
-    if (inherits(old, "error")) {
-      do.call(
-        update,
-        c(list(name), keep_side(work_dir, pkgs_dir, name, "new", new))
-      )
-      do.call(update, c(list(name), check_failure(name, "old", old, progress)))
-      return(invisible(NULL))
-    }
-
-    # Compared in-process; the queue engine runs the same function from
-    # compare-one.R. Everything learnt comes back as manifest-field updates.
-    entry <- do.call(
-      update,
-      c(
-        list(name),
-        compare_halves(
-          name,
-          old,
-          new,
-          pkgs_dir,
-          baseline_dir,
-          baseline_planned = entry$baseline_planned
-        )
-      )
-    )
-    inform(
-      name,
-      ": ",
-      entry$result,
-      " (old ",
-      entry$status_old,
-      ", new ",
-      entry$status_new,
-      ", ",
-      attr(new, "duration"),
-      "s for the pair, ",
-      progress,
-      ")"
-    )
-
-    # The parsed results carry everything the reports need; raw check output
-    # is kept only where a human will want to dig, and then as the
-    # *difference* between the two logs rather than the whole of the new one.
-    # The whole log is thousands of lines that are identical in both, and what
-    # a reader wants is the handful that are not.
-    if (entry$result == "ok") {
-      unlink(work_dir, recursive = TRUE)
-    } else {
-      keep <- file.path(out_dir, "pkgs", name, "new-check")
-      rcheck <- function(phase) {
-        file.path(work_dir, phase, paste0(name, ".Rcheck"))
-      }
-      copy_check_output(rcheck("new"), keep)
-      old_log <- file.path(rcheck("old"), "00check.log")
-      new_log <- file.path(rcheck("new"), "00check.log")
-      if (file.exists(old_log) && file.exists(new_log)) {
-        diff <- check_diff(name, old_log, new_log, work_dir)
-        writeLines(diff, file.path(keep, "00check.diff"))
-        # And into the job log, where it is the one thing a reader of the run
-        # actually wants: what the dev version changed about this package, in
-        # the package's own words. Downloading an artifact to find out that a
-        # NOTE gained a line is a poor trade. It is bounded because a package
-        # that fails to install differs in thousands of lines and would bury
-        # the rest of the shard; the whole diff is in the artifact either way.
-        print_group(
-          sprintf(
-            "%s: old vs new check log (%d line diff)",
-            name,
-            length(diff)
-          ),
-          if (length(diff) == 0) {
-            # Worth saying rather than leaving as an empty block. A package
-            # called `newly_broken` whose two logs are identical once the
-            # paths and the stage timings are out of them is not newly broken;
-            # it is this harness getting it wrong, and this line is how a
-            # reader of the run finds that out without downloading anything.
-            "The two logs are identical apart from paths and stage timings."
-          },
-          head(diff, diff_max_lines),
-          if (length(diff) > diff_max_lines) {
-            sprintf(
-              "[%d more lines; the whole diff is 00check.diff in the shard artifact]",
-              length(diff) - diff_max_lines
-            )
-          }
-        )
-      }
-      unlink(work_dir, recursive = TRUE)
-    }
-    invisible(NULL)
-  }
-
-  for (position in seq_along(runnable)) {
-    name <- runnable[[position]]
-    # A driver error is this package's problem, not the shard's. Before, an
-    # unguarded `readLines(.../status)[[1]]` on a check-pair that never wrote
-    # its status file -- a full disk, an unwritable work directory -- threw
-    # out of the loop and took every remaining package with it.
-    tryCatch(
-      check_package(name, position),
-      error = function(e) {
-        update(
-          name,
-          result = "error",
-          message = paste("driver error:", conditionMessage(e))
-        )
-        inform(name, ": driver error: ", conditionMessage(e))
-      }
-    )
-
-    # This package's line, now rather than at the end of the shard.
-    #
-    # The file is newline-delimited JSON precisely so that it can be appended
-    # to, but it used to be written in one pass after the loop -- so a shard
-    # killed by the job timeout, or thrown out of the loop by an unhandled
-    # error, left an *empty* manifest next to a full set of results, and
-    # `collect.R` skips a directory whose manifest has no lines. Hours of
-    # finished checks were one kill away from being reported as `missing`.
-    # Deferred and unreached packages are appended at the end, and the
-    # collector reconciles the rest against the plan.
-    write_manifest_line(
-      get(name, envir = state),
-      manifest_path,
-      our_cran_version,
-      our_dev_version
-    )
-    reported <- c(reported, name)
-  }
-} else {
-  # The queue engine: this driver writes the work list and hands it to
-  # revdep4/queue.sh, whose workers run the two halves of a package one after
-  # the other and then a per-package compare-one.R -- sourcing the same
-  # compare.R as this script -- which appends the manifest line itself, under
-  # flock, as each package finishes. Write-as-you-go for the same reason the
-  # pair loop appends per package: a killed shard still accounts for what it
-  # finished. This process only writes the deferred tail afterwards.
-  queue_sh <- file.path(dirname(script_dir), "revdep4", "queue.sh")
-  if (!file.exists(queue_sh)) {
-    stop(
-      "REVDEPX_ENGINE=queue needs ",
-      queue_sh,
-      ", which does not exist; is the revdep4 directory checked out?",
-      call. = FALSE
-    )
-  }
-
-  # One line per runnable package: name, tarball, per-half timeout seconds,
-  # and the plan's weight in minutes (queue.sh defers on it near the
-  # deadline). `runnable` is already heaviest first -- the plan deals shard
-  # members that way and nothing above reorders them -- which is what
-  # queue.sh's two cursors rely on: one worker eats from the heavy end, the
-  # rest from the light end, so a giant cannot strand a tail of cheap
-  # packages behind it.
-  #
-  # Both halves always run fresh, in this engine as in the pair engine. A
-  # stored old result the plan certified as comparable is read back by
-  # compare-one.R purely as a second opinion (`baseline_agrees`) -- never as
-  # a substitute for the old check, however tempting the saved wall clock: a
-  # fresh old is the only result whose provenance this run controls, and the
-  # second opinion is exactly how a discrepancy in the stored one gets
-  # noticed rather than trusted.
-  second_opinions <- sum(vapply(
+# One line per runnable package: name, tarball, per-half timeout seconds,
+# and the plan's weight in minutes (queue.sh defers on it near the
+# deadline). `runnable` is already heaviest first -- the plan deals shard
+# members that way and nothing above reorders them -- which is what
+# queue.sh's two cursors rely on: one worker eats from the heavy end, the
+# rest from the light end, so a giant cannot strand a tail of cheap
+# packages behind it.
+#
+# Both halves always run fresh. A
+# stored old result the plan certified as comparable is read back by
+# compare-one.R purely as a second opinion (`baseline_agrees`) -- never as
+# a substitute for the old check, however tempting the saved wall clock: a
+# fresh old is the only result whose provenance this run controls, and the
+# second opinion is exactly how a discrepancy in the stored one gets
+# noticed rather than trusted.
+second_opinions <- sum(vapply(
+  runnable,
+  function(name) {
+    isTRUE(get(name, envir = state)$baseline_planned) &&
+      file.exists(file.path(baseline_dir, "old-rds", paste0(name, ".rds")))
+  },
+  logical(1)
+))
+queue_file <- file.path(
+  work,
+  sprintf("queue-slice-%d.tsv", check_slice$index)
+)
+writeLines(
+  vapply(
     runnable,
     function(name) {
-      isTRUE(get(name, envir = state)$baseline_planned) &&
-        file.exists(file.path(baseline_dir, "old-rds", paste0(name, ".rds")))
+      entry <- get(name, envir = state)
+      paste(
+        name,
+        sources[[name]],
+        format(round(package_timeout_sec(name)), scientific = FALSE),
+        format(
+          max(entry$weight_minutes %||% 0, 0),
+          scientific = FALSE,
+          trim = TRUE
+        ),
+        sep = "\t"
+      )
     },
-    logical(1)
-  ))
-  queue_file <- file.path(
-    work,
-    sprintf("queue-slice-%d.tsv", check_slice$index)
-  )
-  writeLines(
-    vapply(
-      runnable,
-      function(name) {
-        entry <- get(name, envir = state)
-        paste(
-          name,
-          sources[[name]],
-          format(round(package_timeout_sec(name)), scientific = FALSE),
-          format(
-            max(entry$weight_minutes %||% 0, 0),
-            scientific = FALSE,
-            trim = TRUE
-          ),
-          sep = "\t"
-        )
-      },
-      character(1)
-    ),
-    queue_file
-  )
-  inform(sprintf(
-    "Queue: %d package(s), %d with a stored old result as a second opinion",
-    length(runnable),
-    second_opinions
-  ))
+    character(1)
+  ),
+  queue_file
+)
+inform(sprintf(
+  "Queue: %d package(s), %d with a stored old result as a second opinion",
+  length(runnable),
+  second_opinions
+))
 
-  queue_work <- file.path(work, "check")
-  dir.create(queue_work, recursive = TRUE, showWarnings = FALSE)
-  # What the prepare phase installed into the two half libraries; queue.sh
-  # forwards these to compare-one.R (and stamps its last-resort fallback
-  # lines with them), so every queue-engine manifest line carries the same
-  # versions the pair engine writes.
-  Sys.setenv(
-    REVDEPX_OUR_CRAN_VERSION = our_cran_version,
-    REVDEPX_OUR_DEV_VERSION = our_dev_version
-  )
-  status <- system2(
-    queue_sh,
-    shQuote(c(
+queue_work <- file.path(work, "check")
+dir.create(queue_work, recursive = TRUE, showWarnings = FALSE)
+# What the prepare phase installed into the two half libraries; queue.sh
+# forwards these to compare-one.R (and stamps its last-resort fallback
+# lines with them), so every manifest line carries the versions.
+Sys.setenv(
+  REVDEPX_OUR_CRAN_VERSION = our_cran_version,
+  REVDEPX_OUR_DEV_VERSION = our_dev_version
+)
+status <- system2(
+  queue_sh,
+  shQuote(c(
       queue_file,
       queue_work,
       lib_old,
@@ -1078,34 +768,33 @@ if (engine == "pair") {
       manifest_path,
       format(round(as.numeric(deadline)), scientific = FALSE)
     ))
+)
+if (!identical(status, 0L)) {
+  # queue.sh promises to always exit 0, so anything else means it never
+  # reached its own last line. Whatever the workers did write is on disk
+  # and is read back below; the packages without lines become deferred.
+  inform(
+    "queue.sh exited with status ",
+    status,
+    "; reading back what it left"
   )
-  if (!identical(status, 0L)) {
-    # queue.sh promises to always exit 0, so anything else means it never
-    # reached its own last line. Whatever the workers did write is on disk
-    # and is read back below; the packages without lines become deferred.
-    inform(
-      "queue.sh exited with status ",
-      status,
-      "; reading back what it left"
-    )
-  }
+}
 
-  # The queue's forensics -- who claimed what, and the closing tallies -- go
-  # into the results artifact, named per slice so later slices do not
-  # overwrite them. Left in the work directory alone they die with the
-  # runner, which is exactly when they are wanted.
-  for (record in c("claimed.log", "queue-state.json")) {
-    from <- file.path(queue_work, record)
-    if (file.exists(from)) {
-      file.copy(
-        from,
-        file.path(
-          out_dir,
-          sprintf("queue-slice-%d-%s", check_slice$index, record)
-        ),
-        overwrite = TRUE
-      )
-    }
+# The queue's forensics -- who claimed what, and the closing tallies -- go
+# into the results artifact, named per slice so later slices do not
+# overwrite them. Left in the work directory alone they die with the
+# runner, which is exactly when they are wanted.
+for (record in c("claimed.log", "queue-state.json")) {
+  from <- file.path(queue_work, record)
+  if (file.exists(from)) {
+    file.copy(
+      from,
+      file.path(
+        out_dir,
+        sprintf("queue-slice-%d-%s", check_slice$index, record)
+      ),
+      overwrite = TRUE
+    )
   }
 }
 
@@ -1142,44 +831,36 @@ for (name in setdiff(members, c(reported, already))) {
 # The summary below is this slice's, not the shard's: the other slices'
 # packages are still at their initial `deferred` in this process and would pad
 # every table with rows that say nothing.
-if (engine == "pair") {
-  entries <- lapply(
-    if (check_slice$of > 1L) reported else members,
-    function(name) get(name, envir = state)
-  )
-} else {
-  # The queue's results were written by compare-one.R in other processes, so
-  # this driver's `state` never saw them; the manifest on disk is the source
-  # of truth. Later lines win per package, matching the collector.
-  by_package <- list()
-  for (e in read_manifest()) {
-    by_package[[e$package]] <- e
-  }
-  slice_names <- if (check_slice$of > 1L) runnable else members
-  entries <- lapply(
-    intersect(slice_names, names(by_package)),
-    function(name) by_package[[name]]
-  )
-  # What this slice's checks cost, read back the same way rather than
-  # accumulated in-process. `check_seconds` sums true per-half seconds
-  # (t_old + t_new) over the lines this slice produced, and `checks_started`
-  # counts halves run -- one for each positive t -- where the pair engine
-  # counts pairs and pair wall clocks.
-  ran <- lapply(
-    intersect(runnable, names(by_package)),
-    function(name) by_package[[name]]
-  )
-  check_seconds <- sum(vapply(
-    ran,
-    function(e) (e$t_old %||% 0) + (e$t_new %||% 0),
-    numeric(1)
-  ))
-  checks_started <- as.integer(sum(vapply(
-    ran,
-    function(e) ((e$t_old %||% 0) > 0) + ((e$t_new %||% 0) > 0),
-    numeric(1)
-  )))
+# The queue's results were written by compare-one.R in other processes, so
+# this driver's `state` never saw them; the manifest on disk is the source
+# of truth. Later lines win per package, matching the collector.
+by_package <- list()
+for (e in read_manifest()) {
+  by_package[[e$package]] <- e
 }
+slice_names <- if (check_slice$of > 1L) runnable else members
+entries <- lapply(
+  intersect(slice_names, names(by_package)),
+  function(name) by_package[[name]]
+)
+# What this slice's checks cost, read back the same way rather than
+# accumulated in-process. `check_seconds` sums true per-half seconds
+# (t_old + t_new) over the lines this slice produced, and `checks_started`
+# counts halves run -- one for each positive t.
+ran <- lapply(
+  intersect(runnable, names(by_package)),
+  function(name) by_package[[name]]
+)
+check_seconds <- sum(vapply(
+  ran,
+  function(e) (e$t_old %||% 0) + (e$t_new %||% 0),
+  numeric(1)
+))
+checks_started <- as.integer(sum(vapply(
+  ran,
+  function(e) ((e$t_old %||% 0) > 0) + ((e$t_new %||% 0) > 0),
+  numeric(1)
+)))
 
 # ----------------------------------------------------------------- timings ---
 
@@ -1188,9 +869,9 @@ if (engine == "pair") {
 # cost model from them. The job's own minutes -- the runner image, the image
 # pull, the artifact downloads before this script even starts -- are not
 # visible from here; the collector reads those off the API and adds them.
-# `checks` and `check_seconds` mean what the engine measured: pairs and pair
-# wall clocks under the pair engine, halves and summed per-half seconds under
-# the queue engine.
+# `checks` and `check_seconds` mean halves run and summed per-half seconds.
+# Historical rows from the retired pair engine tallied pairs and pair wall
+# clocks instead; calibration() keys on the engine tag, so they never mix.
 # Across slices, not per slice: the collector fits the cost model from these,
 # and a `check_seconds` covering a third of the shard next to a `script_seconds`
 # covering the job would make every shard look three times cheaper than it is.

--- a/.github/workflows/revdepx/util.R
+++ b/.github/workflows/revdepx/util.R
@@ -1,4 +1,4 @@
-# Shared helpers for the revdepx workflow scripts (the revdep3 and revdep4
+# Shared helpers for the revdepx workflow scripts (the revdep4
 # engines).
 # Sourced by plan.R, build.R, shard.R and collect.R; base R plus jsonlite only,
 # so every job can use it before any heavyweight dependency is installed.


### PR DESCRIPTION
Prepared with Claude Code (LLM-assisted).

With the pair engine's PR (#2856, revdep3) closed unmerged, its half of the shared core sat dead on `main` — and not inertly so: the default `REVDEPX_ENGINE` was still `"pair"`, `shard.R`'s default dispatch pointed at `revdep3/check-pair.sh` (a directory that doesn't exist here), and every plan walked the run history of `revdep3.yaml`, a workflow that was never registered.

This removes the pair branches of the shard driver (~370 lines), the engine knob and its validation, the `revdep3.yaml` entries in workflow lists and dispatch fallbacks, and the two-engine framing across comments and READMEs — each replaced by a short retirement note where history still matters. `engine` stays as a constant `"queue"` because the plan, manifest and timings schemas tag rows with it, and the retired engine's live runs remain valid, mineable history for baselines and per-package timings (their `t_old`/`t_new` carried the pair's shared wall clock; the calibration keys on the engine tag and never mixes shard-level overheads).

No behavior change for dispatched runs — the yaml always set `REVDEPX_ENGINE=queue`, so every deleted path was unreachable from CI. Net −371 lines. Validated with full parses of every script, `bash -n` on every shell file, `air` formatting, and actionlint (no new findings).

<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UB7YutLzVWU7xCTYUvF3kF

---
_Generated by [Claude Code](https://claude.ai/code/session_01UB7YutLzVWU7xCTYUvF3kF)_