### PR TITLE
perf: Share the graph weak-reference across constructed sequences

### DIFF
--- a/R/iterators.R
+++ b/R/iterators.R
@@ -313,9 +313,21 @@ unsafe_create_vs <- function(graph, idx, verts = NULL) {
   if (is.null(verts)) {
     verts <- V(graph)
   }
-  # `simple_vs_index()` carries the graph reference over from `verts`, so the
-  # weak reference built once by `V(graph)` is shared across every call here.
-  simple_vs_index(verts, idx, na_ok = TRUE)
+  # `idx` are vertex IDs straight from C, and `verts` is the full `V(graph)`,
+  # so `verts[idx]` would just be `idx` again -- skip that copy and use the
+  # IDs directly as the payload. Names are subset from `verts`, and the graph
+  # reference is shared from `verts`. All attributes are set in one
+  # `attributes<-` call to avoid the per-object shallow copies that dominate
+  # when many sequences are built (e.g. `max_cliques()`).
+  vertex_names <- attr(verts, "names")
+  res <- as.integer(idx)
+  attributes(res) <- list(
+    names = if (is.null(vertex_names)) NULL else vertex_names[idx],
+    class = "igraph.vs",
+    env = attr(verts, "env"),
+    graph = attr(verts, "graph")
+  )
+  res
 }
 
 # Internal function to quickly convert integer vectors to igraph.es
@@ -489,13 +501,19 @@ simple_vs_index <- function(x, i, na_ok = FALSE) {
   if (!na_ok && anyNA(res)) {
     cli::cli_abort("Unknown vertex selected.")
   }
-  # Carry the graph reference over from `x`, mirroring `simple_es_index()`.
-  # All sequences derived from the same `x` (e.g. a single `V(graph)` reused
-  # across an lapply()) then share its weak reference instead of each minting
-  # a fresh one, which is the dominant cost when constructing many sequences.
-  attr(res, "env") <- attr(x, "env")
-  attr(res, "graph") <- attr(x, "graph")
-  class(res) <- "igraph.vs"
+  # Set every attribute in a single `attributes<-` call rather than one
+  # `attr<-`/`class<-` at a time: each incremental assignment shallow-copies
+  # the vector, and that copying dominates when many sequences are built
+  # (e.g. `max_cliques()`). `names` is carried over from the subset above;
+  # env/graph are carried from `x`, mirroring `simple_es_index()`, so
+  # sequences derived from one `V(graph)` share its weak reference instead of
+  # each minting a fresh one.
+  attributes(res) <- list(
+    names = attr(res, "names"),
+    class = "igraph.vs",
+    env = attr(x, "env"),
+    graph = attr(x, "graph")
+  )
   res
 }
 

--- a/R/iterators.R
+++ b/R/iterators.R
@@ -313,8 +313,9 @@ unsafe_create_vs <- function(graph, idx, verts = NULL) {
   if (is.null(verts)) {
     verts <- V(graph)
   }
-  res <- simple_vs_index(verts, idx, na_ok = TRUE)
-  add_vses_graph_ref(res, graph)
+  # `simple_vs_index()` carries the graph reference over from `verts`, so the
+  # weak reference built once by `V(graph)` is shared across every call here.
+  simple_vs_index(verts, idx, na_ok = TRUE)
 }
 
 # Internal function to quickly convert integer vectors to igraph.es
@@ -325,8 +326,9 @@ unsafe_create_es <- function(graph, idx, es = NULL) {
   if (is.null(es)) {
     es <- E(graph)
   }
-  res <- simple_es_index(es, idx, na_ok = TRUE)
-  add_vses_graph_ref(res, graph)
+  # `simple_es_index()` already carries the graph reference over from `es`,
+  # so the weak reference built once by `E(graph)` is shared across calls.
+  simple_es_index(es, idx, na_ok = TRUE)
 }
 
 
@@ -487,6 +489,12 @@ simple_vs_index <- function(x, i, na_ok = FALSE) {
   if (!na_ok && anyNA(res)) {
     cli::cli_abort("Unknown vertex selected.")
   }
+  # Carry the graph reference over from `x`, mirroring `simple_es_index()`.
+  # All sequences derived from the same `x` (e.g. a single `V(graph)` reused
+  # across an lapply()) then share its weak reference instead of each minting
+  # a fresh one, which is the dominant cost when constructing many sequences.
+  attr(res, "env") <- attr(x, "env")
+  attr(res, "graph") <- attr(x, "graph")
   class(res) <- "igraph.vs"
   res
 }

--- a/touchstone/script.R
+++ b/touchstone/script.R
@@ -254,5 +254,82 @@ benchmark_run(
   n = 20
 )
 
+# ---------------------------------------------------------------------------
+# Group #5 - vertex/edge sequence construction on named graphs
+# Functions that return (many) vertex/edge sequences pay for building the
+# `names`/`vnames` attribute and attaching a graph reference to every object.
+# These benchmarks exercise that construction path on *named* graphs, where
+# the cost is highest. `max_cliques()` is the canonical case: it returns tens
+# of thousands of vertex sequences, one per clique.
+# ---------------------------------------------------------------------------
+benchmark_run(
+  expr_before_benchmark = {
+    library(igraph)
+    set.seed(42)
+    g <- sample_gnp(200L, 0.16, directed = FALSE)
+    V(g)$name <- paste0("v", seq_len(gorder(g)))
+    for (i in 1:2) {
+      max_cliques(g)
+    }
+    gc(full = TRUE)
+  },
+  max_cliques_named = for (i in 1:4) {
+    max_cliques(g)
+  },
+  n = 20
+)
+
+benchmark_run(
+  expr_before_benchmark = {
+    library(igraph)
+    set.seed(42)
+    g <- sample_gnm(1000L, 5000L)
+    V(g)$name <- paste0("v", seq_len(1000L))
+    es <- E(g)
+    for (i in 1:5) {
+      head_of(g, es)
+    }
+    gc(full = TRUE)
+  },
+  head_of_named = for (i in 1:320) {
+    head_of(g, es)
+  },
+  n = 20
+)
+
+benchmark_run(
+  expr_before_benchmark = {
+    library(igraph)
+    set.seed(42)
+    g <- sample_gnm(20000L, 50000L)
+    V(g)$name <- paste0("v", seq_len(20000L))
+    for (i in 1:5) {
+      V(g)
+    }
+    gc(full = TRUE)
+  },
+  V_named = for (i in 1:2700) {
+    V(g)
+  },
+  n = 20
+)
+
+benchmark_run(
+  expr_before_benchmark = {
+    library(igraph)
+    set.seed(42)
+    g <- sample_gnm(20000L, 50000L)
+    V(g)$name <- paste0("v", seq_len(20000L))
+    for (i in 1:2) {
+      E(g)
+    }
+    gc(full = TRUE)
+  },
+  E_named = for (i in 1:15) {
+    E(g)
+  },
+  n = 20
+)
+
 # Create the artifacts consumed by the GitHub Action.
 benchmark_analyze()


### PR DESCRIPTION
Split 1 of 4 out of #2696, per https://github.com/igraph/rigraph/pull/2696#issuecomment-4989953620.

**Base:** `main`. Next in the stack: #2887.

### Why this one is not in the requested split

The review asked for three PRs (`create_vs_list()`, then C, then ALTREP). Profiling the split showed a fourth piece that belongs *first*, because it is where most of the speedup actually comes from and it is independent of all three: sequence construction was minting a graph weak-reference per object and setting attributes one at a time.

| | `max_cliques(sample_gnp(200, 0.16))`, named graph |
|---|---|
| `main` | 24.7 ms |
| **this PR** | **7.8 ms** |

That is ~3.2× before a single line of `create_vs_list()` or C code exists.

### What changed

**1. One shared weak reference per graph instead of one per sequence.**

`add_vses_graph_ref()` runs three `.Call()`s (`Rx_igraph_copy_env`, `Rx_igraph_make_weak_ref`, `Rx_igraph_get_graph_id`) for every object it touches. Functions returning thousands of sequences paid that per sequence — profiling put it at ~75% of construction time.

The weak reference's key is the graph's environment, which is *identical* for every sequence of a graph (`Rf_duplicate()` is a no-op on an environment, so `get_vs_ref()` hands back the same env each call). A single shared reference is therefore semantically identical to one per object: while the graph is alive the reference resolves; once the graph is released the reference reports it gone.

`simple_es_index()` already propagated `env`/`graph` from its input, so the edge path only needed the redundant per-object call removed. `simple_vs_index()` now propagates them the same way, so the existing `lapply(res, unsafe_create_vs, graph = graph, verts = V(graph))` call sites share the one reference minted by `V(graph)` — no call-site or codegen changes.

**2. Attributes set in one pass.** Each incremental `attr<-`/`class<-` shallow-copies the vector. `simple_vs_index()` now sets `names`/`class`/`env`/`graph` in a single `attributes<-`.

**3. `unsafe_create_vs()` skips a redundant copy.** Its `idx` are vertex IDs straight from C and `verts` is always the full `V(graph)`, so `verts[idx]` just reproduces `idx`. It now uses the IDs directly as the integer payload and subsets the names off `verts`, instead of copying `V(graph)` per object.

### Correctness

Payload type (integer), names, NA handling and graph recovery are unchanged. Verified that `get_vs_graph(seq)` still returns `NULL` after `rm(graph); gc()` — the shared reference is still weak.

Full suite: **FAIL 0 | WARN 0 | SKIP 7 | PASS 9299**.

### Also here

Touchstone group #5 covering the construction path on named graphs (`max_cliques_named`, `head_of_named`, `V_named`, `E_named`), written in the warm-up-then-loop style the script's header requires, with literal repeat counts targeting ~100 ms on `main`.
