### PR TITLE
fix(ci): Filter OS-restricted packages out of the revdep plan

### DIFF
--- a/.github/workflows/revdepx/util.R
+++ b/.github/workflows/revdepx/util.R
@@ -689,9 +689,16 @@ cran_db <- local({
   function() {
     if (is.null(db)) {
       inform("Fetching CRAN package metadata from ", cran_repo())
+      # No R_version filter on purpose (the containers may run a newer R
+      # than this script), but OS_type must apply: run 33777134786 planned
+      # hespdiv, an `OS_type: windows` package, three runs in a row -- the
+      # shard's download.packages(), which does filter by OS, then refused
+      # it each time ("no package 'hespdiv' at the repositories"), and the
+      # report carried a permanent phantom error for a package Linux can
+      # never check.
       db <<- utils::available.packages(
         repos = cran_repo(),
-        filters = c("CRAN", "duplicates")
+        filters = c("CRAN", "duplicates", "OS_type")
       )
     }
     db


### PR DESCRIPTION
Prepared with Claude Code (LLM-assisted).

`cran_db()` skips `available.packages()`'s default filters deliberately (no `R_version` filter — the check containers may run a newer R than the planner), but that also dropped the **`OS_type` filter**. The consequence has been visible in three consecutive runs: **hespdiv** declares `OS_type: windows`, the planner kept enumerating it as a reverse dependency, and every shard's `download.packages()` — which *does* filter by OS — refused it with "no package 'hespdiv' at the repositories", leaving a permanent "Source tarball could not be downloaded" error in the report for a package that can never be checked on Linux. One added filter; OS-restricted packages (41 on CRAN today) now drop out at planning time.

<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UB7YutLzVWU7xCTYUvF3kF

---
_Generated by [Claude Code](https://claude.ai/code/session_01UB7YutLzVWU7xCTYUvF3kF)_