### PR TITLE
feat(ci): Make the revdep driver log's timing record durable and visible

### DIFF
--- a/.github/workflows/revdep4.yaml
+++ b/.github/workflows/revdep4.yaml
@@ -937,8 +937,10 @@ jobs:
       # No timings in the check output. The two halves run at different
       # times next to different queue neighbours, so per-stage
       # `[user/elapsed]` stamps differ by construction and would be pure
-      # diff noise; what a stage cost is still recorded by the elapsed
-      # stamping on the driver log.
+      # diff noise. What a stage cost is recorded by the elapsed stamping
+      # on the driver log instead -- which the salvage now carries into the
+      # results artifact for every failed half, and check-half.sh prints as
+      # a stage timeline in the job log when a half dies.
       _R_CHECK_TIMINGS_: ""
       _R_CHECK_EXAMPLE_TIMING_THRESHOLD_: 99999
       # 300 lines of a failed test transcript in the check log, not R's

--- a/.github/workflows/revdep4/compare-one.R
+++ b/.github/workflows/revdep4/compare-one.R
@@ -196,16 +196,20 @@ old <- read_side(work_dir, "old", name, timeout_sec, t_old)
 # A half that produced a result is kept even when its partner did not --
 # the same dance as the pair engine, through the same functions.
 if (inherits(new, "error")) {
+  salvage_side(work_dir, pkgs_dir, name, "new")
   if (!inherits(old, "error")) {
     entry <- apply_updates(
       entry,
       keep_side(work_dir, pkgs_dir, name, "old", old)
     )
+  } else {
+    salvage_side(work_dir, pkgs_dir, name, "old")
   }
   entry <- apply_updates(entry, check_failure(name, "new", new))
   finish(entry)
 }
 if (inherits(old, "error")) {
+  salvage_side(work_dir, pkgs_dir, name, "old")
   entry <- apply_updates(
     entry,
     keep_side(work_dir, pkgs_dir, name, "new", new)

--- a/.github/workflows/revdepx/README.md
+++ b/.github/workflows/revdepx/README.md
@@ -137,6 +137,15 @@ and the `status` file land in the same relative layout
 revdep2 produced,
 so parsing, comparison, salvage and reporting
 carry over unchanged (`compare.R`).
+The driver log doubles as the per-stage timing record
+(`_R_CHECK_TIMINGS_` stays off
+to keep the compared check logs free of timing noise):
+the salvage copies it into the results artifact
+for every half that failed —
+including a killed half's partial `.Rcheck`,
+whose check log lists every stage it completed —
+and `check-half.sh` prints a failed half's stage timeline
+into the job log.
 
 The queue runs two such containers back to back per package,
 several packages at once (`../revdep4/queue.sh`).

--- a/.github/workflows/revdepx/check-half.sh
+++ b/.github/workflows/revdepx/check-half.sh
@@ -267,4 +267,15 @@ if [ -s "${cidfile}" ]; then
   fi
 fi
 
+# A failed half's timing record, into the job log while it is cheap to read:
+# every driver.log line carries the elapsed stamp, so its stage lines are a
+# complete where-did-the-time-go trace up to the kill, and GitHub adds
+# wall-clock timestamps on top. Successful halves stay quiet; the salvage
+# keeps every failed half's full driver.log in the results artifact besides.
+if [ "${status}" -ne 0 ] && [ -f "${out}/driver.log" ]; then
+  echo "::group::${half} half of ${src_name%_*} exited ${status}: stage timeline"
+  grep -E '^\[ *[0-9]+s\] \* ' "${out}/driver.log" | tail -n 60
+  echo "::endgroup::"
+fi
+
 exit 0

--- a/.github/workflows/revdepx/compare.R
+++ b/.github/workflows/revdepx/compare.R
@@ -240,7 +240,13 @@ pkg_out <- function(pkgs_dir, name) {
 }
 
 # The files worth carrying out of a check directory: what broke, and the
-# complete transcripts of the two stages that explain why.
+# complete transcripts of the two stages that explain why. The half's
+# `driver.log` and `status` ride along from next to the .Rcheck directory:
+# the driver log is the per-stage timing record -- check-half.sh stamps
+# every line with elapsed seconds, precisely because `_R_CHECK_TIMINGS_`
+# stays off to keep the compared check logs stable -- and before this it
+# died with the runner's work directory, which made the yaml's "nothing is
+# lost" claim quietly false.
 copy_check_output <- function(rcheck, keep) {
   dir.create(keep, recursive = TRUE, showWarnings = FALSE)
   for (f in c(
@@ -260,6 +266,31 @@ copy_check_output <- function(rcheck, keep) {
       )
     }
   }
+  for (f in c("driver.log", "status")) {
+    if (file.exists(file.path(dirname(rcheck), f))) {
+      file.copy(
+        file.path(dirname(rcheck), f),
+        file.path(keep, f),
+        overwrite = TRUE
+      )
+    }
+  }
+}
+
+# Salvage a half that produced no readable result -- a timeout, an OOM kill,
+# a container that never started. What survives varies: a killed check
+# leaves a partial .Rcheck whose 00check.log lists every stage it finished,
+# a container that never ran leaves only the driver log -- and
+# copy_check_output() copies whatever of that exists, including the stamped
+# driver log, so the post-mortem of exactly these packages stops depending
+# on a work directory that dies with the runner. Run 33777134786's
+# both-halves timeouts (ctmm, E2E, PortfolioTesteR) salvaged nothing at
+# all; "where did the 1800 seconds go" had no answer in any artifact.
+salvage_side <- function(work_dir, pkgs_dir, name, phase) {
+  copy_check_output(
+    file.path(work_dir, phase, paste0(name, ".Rcheck")),
+    file.path(pkg_out(pkgs_dir, name), paste0(phase, "-check"))
+  )
 }
 
 # Record the half that did produce a result, when its partner did not.


### PR DESCRIPTION
Prepared with Claude Code (LLM-assisted).

**Why `_R_CHECK_TIMINGS_` is off, and stays off.** The setting is inherited from revdep2 with a rationale that still holds: the two halves of a package run at different times next to different queue neighbours, so per-stage `[user/elapsed]` stamps differ *by construction* and would be pure noise in the very log the halves are compared through. The design compensated with `check-half.sh`'s `stamp()` filter — every container line prefixed with elapsed seconds in `driver.log` — and the comment promised "nothing is lost".

**That promise went quietly false in the container era**: the driver log only ever lived in the runner's ephemeral work directory. The timeout analysis of run [33777134786](https://github.com/igraph/rigraph/actions/runs/33777134786) hit the wall this creates — for both-halves timeouts (ctmm, E2E, PortfolioTesteR) *nothing* was salvaged, and "where did the 1800 seconds go" had no answer in any artifact or log.

Three changes make the record real again, at a cost confined to the handful of failures per run:

- **`copy_check_output()` now carries `driver.log` and `status`** alongside every kept check directory, so anything salvaged brings its per-stage timeline with it.
- **The failed side is salvaged too** (`salvage_side()` in `compare.R`, wired into `compare-one.R`'s failure branches — both sides when both fail). A killed check leaves a partial `.Rcheck` whose `00check.log` lists every stage it completed; even a container that never ran leaves its driver log. Verified locally with simulated timeout work directories in both shapes.
- **`check-half.sh` prints a failed half's stage timeline** (the stamped `* checking …` lines, last 60) into the job log under a collapsible group, where GitHub's wall-clock timestamps stack on the elapsed stamps. Successful halves stay quiet.

After this, the next timeout's post-mortem is one grep — over the job log or the salvaged `driver.log` in the `revdepx-report` artifact — instead of an archaeology expedition.

<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->

- [x] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UB7YutLzVWU7xCTYUvF3kF

---
_Generated by [Claude Code](https://claude.ai/code/session_01UB7YutLzVWU7xCTYUvF3kF)_