### PR TITLE
fix(ci): Align the workflow kit with `cynkratemplate`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -221,7 +221,8 @@ jobs:
           echo -n "${{ steps.commit.outputs.sha }}" > rcc-smoke-sha.txt
         shell: bash
 
-      - uses: actions/upload-artifact@v6
+      - name: Upload the commit SHA reached by the smoke test
+        uses: actions/upload-artifact@v6
         with:
           name: rcc-smoke-sha
           path: rcc-smoke-sha.txt

--- a/.github/workflows/revdep2/util.R
+++ b/.github/workflows/revdep2/util.R
@@ -28,15 +28,6 @@ env_flag <- function(name) {
   tolower(env_chr(name)) %in% c("1", "true", "yes")
 }
 
-# GitHub run ids passed `.Machine$integer.max` in 2026, so they are carried as
-# strings everywhere here: `as.integer("31048405399")` is a silent NA, and an
-# NA reaching `if (run > 0)` takes the whole planning job down.
-# "0" is the "no such run" sentinel, which is also what the workflow's job
-# outputs and plan.json already use.
-run_id_chr <- function(x) {
-  if (is.null(x) || length(x) != 1 || is.na(x)) "0" else trimws(as.character(x))
-}
-
 inform <- function(...) {
   message(paste0(...))
 }

--- a/.github/workflows/revdepx/base-image.sh
+++ b/.github/workflows/revdepx/base-image.sh
@@ -130,7 +130,7 @@ RUN Rscript -e 'lines <- readLines("/etc/os-release"); \\
     options(repos = c(CRAN = sprintf("https://p3m.dev/cran/__linux__/%s/latest", codename))); \\
     install.packages(c("pak", "jsonlite", "callr")); \\
     stopifnot(requireNamespace("pak"), requireNamespace("jsonlite"), requireNamespace("callr"))'
-LABEL org.opencontainers.image.source=https://github.com/igraph/rigraph
+LABEL org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}
 EOF
 
 if [ "${REVDEPX_PUSH:-0}" = "1" ]; then

--- a/.github/workflows/revdepx/image.R
+++ b/.github/workflows/revdepx/image.R
@@ -94,7 +94,12 @@ options(
 plan <- read_json(env_chr("PLAN", "plan.json"))
 out_dir <- env_chr("OUT_DIR", "universe")
 dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
-package <- plan$package %||% "igraph"
+# `plan$package` normally names it. The fallback reads this repository's own
+# DESCRIPTION rather than a hardcoded name, so the kit is correct in every
+# repository it is broadcast to; the repository name is not a safe source,
+# since igraph/rigraph ships the `igraph` package.
+package <- plan$package %||%
+  unname(read.dcf("DESCRIPTION", fields = "Package")[1, 1])
 
 # The install set is the whole universe: everything any shard's checks need
 # installed anywhere. plan$universe is the sorted union plan.R writes; a


### PR DESCRIPTION
<!-- LLM disclosure, per this template's request: this PR was prepared with Claude Code. The change set was derived by diffing this repository's `.github/workflows/` against cynkratemplate's, and every claim below was checked against the files rather than assumed. -->

The kit under `.github/workflows/` is shared across 26 repositories and broadcast from `cynkra/cynkratemplate`. This repository is where most of it actually gets developed, so it runs ahead of the template. cynkratemplate has now taken the `revdep2`, `revdep4` and `revdepx` subsystems from here wholesale (cynkra/cynkratemplate#110).

Four files came back changed. This brings them home, so the next broadcast into this repository is a no-op rather than a conflict.

All four are behaviour-preserving here.

## `revdep2/util.R` — `run_id_chr()` was defined twice

The earlier broadcast that carried the run-id fix *out* from here inserted a copy after `env_flag()`, while ours already sat in the `run ids` section next to `has_run()`. The insertion points differed, so the merge was clean and nothing conflicted:

```
22:env_num_opt <- function(name) {
36:run_id_chr <- function(x) {     # inserted by the broadcast
70:run_id_chr <- function(x) {     # ours
74:has_run <- function(x) {
```

The two bodies are byte-identical, so R takes the second and behaviour is unaffected — but it is dead code, and it would ship to 26 repositories. Kept ours next to `has_run()`, dropped the inserted one.

## `revdepx/image.R` — hardcoded package name

It fell back to the literal `"igraph"` when the plan did not name the package. It now reads `Package` from the repository's own DESCRIPTION, which resolves to `igraph` here — identical behaviour, and correct in the other 25 repositories.

Worth noting the repository name would *not* have worked as a source: igraph/rigraph ships the `igraph` package, which is presumably why the name was hardcoded in the first place.

## `revdepx/base-image.sh` — hardcoded image label

Every built image was stamped with `org.opencontainers.image.source=https://github.com/igraph/rigraph`. It now uses `${GITHUB_REPOSITORY}`, which expands to the same string in this repository's CI. The surrounding Dockerfile heredoc is `<<EOF`, unquoted, so the expansion happens in the shell as intended.

## `R-CMD-check.yaml` — restored step name

The smoke-test upload step regains its `name:`, so it reads as "Upload the commit SHA reached by the smoke test" in the job log instead of a bare `Run actions/upload-artifact@v6`. This is the one cosmetic change of the four.

## Validation

Both changed R files parse; `base-image.sh` passes `bash -n`; `R-CMD-check.yaml` parses as YAML. `revdep2/util.R` sources cleanly with `run_id_chr()` and `has_run()` behaving correctly on a 2026-shaped run id (`31048405399`). The DESCRIPTION fallback was executed here and returns `igraph`.

Formatted with air per this repository's `air.toml`; the wrapped fallback line is byte-identical to the copy in the companion cynkratemplate PR, so the two do not drift apart the moment they land.

After this, `.github/workflows/` is identical between the two repositories for every file they share. This repository keeps its own additions — `each.yaml`, `rhub.yaml`, `vendor.yaml`, `touchstone-*`, `update-citation-cff.yaml`, `build-and-check.yml`, and the `custom/*-install` hooks — which the template does not carry.

<!-- Please disclose any use of LLMs (ChatGPT, Copilot, Gemini, etc.) during the preparation of this PR. -->

<!-- The following text must be left intact and the box checked before the PR can be merged. -->

- [ ] By submitting this pull request, I assign the copyright of my contribution to _The igraph development team_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWhverMTZZKgEpUuTK117m


---
_Generated by [Claude Code](https://claude.ai/code/session_01WWhverMTZZKgEpUuTK117m)_